### PR TITLE
Phase 2: persona loader accepts BOOT.md/SOUL.md/IDENTITY.md naming

### DIFF
--- a/src/persona/loader.ts
+++ b/src/persona/loader.ts
@@ -1,42 +1,86 @@
 /**
- * Read persona files (BOOT.md, MEMORY.md, etc.) from an agent directory.
+ * Read persona files from an agent directory.
  *
- * Agent layout convention (matches the OpenClaw conventions used in
- * ~/clawd/ so persona files can be moved across without edits):
+ * Phantombot accepts both naming conventions in use across the OpenClaw
+ * ecosystem so personas can move freely between systems:
  *
- *   <agentDir>/
- *     BOOT.md       — identity, role, response style. Required.
- *     MEMORY.md     — durable notes the persona always sees. Optional.
- *     tools.md      — descriptive list of tools the harness should use
- *                     (NOT a tool-call schema — just hints in markdown).
- *                     Optional.
+ *   identity (required) — first match wins:
+ *     BOOT.md     (Robbie convention; original phantombot placeholders use this)
+ *     SOUL.md     (modern OpenClaw)
+ *     IDENTITY.md (modern OpenClaw)
+ *
+ *   persistent memory (optional):
+ *     MEMORY.md
+ *
+ *   tools / hints (optional) — first match wins:
+ *     tools.md
+ *     AGENTS.md   (modern OpenClaw)
  *
  * Anything else under the agent dir is ignored by the loader but available
- * to the harness's own tools (the harness's working directory is set to
- * agentDir, so e.g. claude can `Read` arbitrary files there).
+ * to the harness's own tools — the harness's working directory is set to
+ * agentDir, so e.g. claude can `Read` arbitrary files there.
  */
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+const IDENTITY_FILES = ["BOOT.md", "SOUL.md", "IDENTITY.md"] as const;
+const MEMORY_FILES = ["MEMORY.md"] as const;
+const TOOLS_FILES = ["tools.md", "AGENTS.md"] as const;
+
 export interface PersonaFiles {
-  boot: string; // required
+  /** Identity content (from BOOT.md / SOUL.md / IDENTITY.md). */
+  boot: string;
+  /** Always-in-context notes (from MEMORY.md). */
   memory?: string;
+  /** Tool / capability hints (from tools.md / AGENTS.md). */
   tools?: string;
+
+  /** Filename the identity content was loaded from (diagnostic). */
+  identitySource: string;
+  /** Filename the memory content was loaded from, if any (diagnostic). */
+  memorySource?: string;
+  /** Filename the tools content was loaded from, if any (diagnostic). */
+  toolsSource?: string;
+}
+
+export class PersonaNotFoundError extends Error {
+  constructor(agentDir: string) {
+    super(
+      `No identity file found in ${agentDir}. Expected one of: ${IDENTITY_FILES.join(", ")}`,
+    );
+    this.name = "PersonaNotFoundError";
+  }
 }
 
 export async function loadPersona(agentDir: string): Promise<PersonaFiles> {
-  const boot = await readFile(join(agentDir, "BOOT.md"), "utf8");
-  const memory = await tryRead(join(agentDir, "MEMORY.md"));
-  const tools = await tryRead(join(agentDir, "tools.md"));
-  return { boot, memory, tools };
+  const identity = await tryReadFirst(agentDir, IDENTITY_FILES);
+  if (!identity) throw new PersonaNotFoundError(agentDir);
+
+  const memory = await tryReadFirst(agentDir, MEMORY_FILES);
+  const tools = await tryReadFirst(agentDir, TOOLS_FILES);
+
+  return {
+    boot: identity.content,
+    identitySource: identity.source,
+    memory: memory?.content,
+    memorySource: memory?.source,
+    tools: tools?.content,
+    toolsSource: tools?.source,
+  };
 }
 
-async function tryRead(path: string): Promise<string | undefined> {
-  try {
-    return await readFile(path, "utf8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-    throw err;
+async function tryReadFirst(
+  dir: string,
+  names: readonly string[],
+): Promise<{ content: string; source: string } | undefined> {
+  for (const name of names) {
+    try {
+      const content = await readFile(join(dir, name), "utf8");
+      return { content, source: name };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
   }
+  return undefined;
 }

--- a/tests/persona.test.ts
+++ b/tests/persona.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the persona loader.
+ *
+ * Covers both the legacy BOOT.md / MEMORY.md / tools.md naming (Robbie
+ * convention used by the original phantombot placeholders) and the newer
+ * OpenClaw SOUL.md / IDENTITY.md / AGENTS.md naming.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PersonaNotFoundError,
+  loadPersona,
+} from "../src/persona/loader.ts";
+
+let agentDir: string;
+
+beforeEach(async () => {
+  agentDir = await mkdtemp(join(tmpdir(), "phantombot-persona-"));
+});
+
+afterEach(async () => {
+  await rm(agentDir, { recursive: true, force: true });
+});
+
+async function write(name: string, content: string): Promise<void> {
+  await writeFile(join(agentDir, name), content, "utf8");
+}
+
+describe("loadPersona — identity file naming", () => {
+  test("loads BOOT.md (Robbie convention)", async () => {
+    await write("BOOT.md", "# I am Robbie");
+    const p = await loadPersona(agentDir);
+    expect(p.boot).toBe("# I am Robbie");
+    expect(p.identitySource).toBe("BOOT.md");
+  });
+
+  test("loads SOUL.md (modern OpenClaw)", async () => {
+    await write("SOUL.md", "# Soul");
+    const p = await loadPersona(agentDir);
+    expect(p.boot).toBe("# Soul");
+    expect(p.identitySource).toBe("SOUL.md");
+  });
+
+  test("loads IDENTITY.md (modern OpenClaw)", async () => {
+    await write("IDENTITY.md", "# Identity");
+    const p = await loadPersona(agentDir);
+    expect(p.boot).toBe("# Identity");
+    expect(p.identitySource).toBe("IDENTITY.md");
+  });
+
+  test("BOOT.md wins over SOUL.md when both exist", async () => {
+    await write("BOOT.md", "from BOOT");
+    await write("SOUL.md", "from SOUL");
+    const p = await loadPersona(agentDir);
+    expect(p.boot).toBe("from BOOT");
+    expect(p.identitySource).toBe("BOOT.md");
+  });
+
+  test("SOUL.md wins over IDENTITY.md when BOOT.md is absent", async () => {
+    await write("SOUL.md", "from SOUL");
+    await write("IDENTITY.md", "from IDENTITY");
+    const p = await loadPersona(agentDir);
+    expect(p.boot).toBe("from SOUL");
+    expect(p.identitySource).toBe("SOUL.md");
+  });
+
+  test("throws PersonaNotFoundError when no identity file exists", async () => {
+    await write("MEMORY.md", "just memory");
+    await write("tools.md", "just tools");
+    expect(loadPersona(agentDir)).rejects.toThrow(PersonaNotFoundError);
+  });
+});
+
+describe("loadPersona — memory file", () => {
+  test("loads MEMORY.md when present", async () => {
+    await write("BOOT.md", "id");
+    await write("MEMORY.md", "I remember things");
+    const p = await loadPersona(agentDir);
+    expect(p.memory).toBe("I remember things");
+    expect(p.memorySource).toBe("MEMORY.md");
+  });
+
+  test("memory is undefined when MEMORY.md is absent", async () => {
+    await write("BOOT.md", "id");
+    const p = await loadPersona(agentDir);
+    expect(p.memory).toBeUndefined();
+    expect(p.memorySource).toBeUndefined();
+  });
+});
+
+describe("loadPersona — tools file naming", () => {
+  test("loads tools.md when present", async () => {
+    await write("BOOT.md", "id");
+    await write("tools.md", "shell, ssh, etc");
+    const p = await loadPersona(agentDir);
+    expect(p.tools).toBe("shell, ssh, etc");
+    expect(p.toolsSource).toBe("tools.md");
+  });
+
+  test("loads AGENTS.md when present", async () => {
+    await write("BOOT.md", "id");
+    await write("AGENTS.md", "agent hints");
+    const p = await loadPersona(agentDir);
+    expect(p.tools).toBe("agent hints");
+    expect(p.toolsSource).toBe("AGENTS.md");
+  });
+
+  test("tools.md wins over AGENTS.md when both exist", async () => {
+    await write("BOOT.md", "id");
+    await write("tools.md", "from tools");
+    await write("AGENTS.md", "from AGENTS");
+    const p = await loadPersona(agentDir);
+    expect(p.tools).toBe("from tools");
+    expect(p.toolsSource).toBe("tools.md");
+  });
+
+  test("tools is undefined when neither file is present", async () => {
+    await write("BOOT.md", "id");
+    const p = await loadPersona(agentDir);
+    expect(p.tools).toBeUndefined();
+    expect(p.toolsSource).toBeUndefined();
+  });
+});
+
+describe("loadPersona — full mixed persona", () => {
+  test("loads all three slots from a SOUL/MEMORY/AGENTS persona", async () => {
+    await write("SOUL.md", "soul content");
+    await write("MEMORY.md", "memory content");
+    await write("AGENTS.md", "agents content");
+    const p = await loadPersona(agentDir);
+    expect(p).toEqual({
+      boot: "soul content",
+      identitySource: "SOUL.md",
+      memory: "memory content",
+      memorySource: "MEMORY.md",
+      tools: "agents content",
+      toolsSource: "AGENTS.md",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Persona loader now tries identity files in priority order: \`BOOT.md\` → \`SOUL.md\` → \`IDENTITY.md\`. Tools file naming likewise: \`tools.md\` → \`AGENTS.md\`.
- A persona can move between phantombot and OpenClaw (any era) without renaming.
- Adds \`identitySource\` / \`memorySource\` / \`toolsSource\` diagnostic fields naming which file each slot came from (used later by \`phantombot doctor\` and \`import-persona\`).
- Throws \`PersonaNotFoundError\` when no identity file exists.

## Test plan

- [x] \`bun test\` — 15 pass / 0 fail (added 13 new tests in \`tests/persona.test.ts\`)
- Tests cover each naming variant, priority order, missing-identity error path, and a fully-mixed SOUL/MEMORY/AGENTS persona.