### PR TITLE
Phase 3: SQLite-backed memory store on bun:sqlite

### DIFF
--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,53 +1,160 @@
 /**
- * Memory store. STUB.
+ * Memory store. SQLite-backed via bun:sqlite (no native compile, no extra deps).
  *
- * Plan: SQLite + sqlite-vec for vector search.
+ * Schema is one table:
+ *   turns(id, persona, conversation, role, text, created_at)
  *
- * The store needs four operations:
- *   - appendTurn(conversationId, role, text, ts)
- *   - getRecentTurns(conversationId, n)
- *   - vectorSearch(query, k)         // top-k semantically similar past turns
- *   - close()
+ * Turns are scoped by (persona, conversation). The conversation key is
+ * 'cli:default' for v1 — phantombot is a single-operator CLI tool, so all
+ * CLI invocations share one conversation per persona. Per-channel scoping
+ * (telegram:1234, signal:abc) is reserved for a future channels phase.
  *
- * Don't add an ORM. SQL strings are fine for this volume. Don't add a
- * migrations framework either — schema_version pragma + a switch in the
- * constructor handles it.
- *
- * If sqlite-vec is awkward to install or use, fall back to literal full-text
- * search via SQLite FTS5. Phantom's memory volume is low; an exhaustive scan
- * over a year of conversation is fine.
+ * Vector / FTS retrieval is deferred — the interface intentionally has no
+ * vectorSearch() method. When/if added, prefer SQLite FTS5 (built into
+ * the bun:sqlite-bundled sqlite) before reaching for sqlite-vec.
  */
 
-export interface StoredTurn {
-  conversationId: string;
-  role: "user" | "assistant";
+import { Database } from "bun:sqlite";
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export type Role = "user" | "assistant";
+
+export interface Turn {
+  id: number;
+  persona: string;
+  conversation: string;
+  role: Role;
   text: string;
-  timestamp: Date;
+  createdAt: Date;
+}
+
+export interface AppendTurnInput {
+  persona: string;
+  conversation: string;
+  role: Role;
+  text: string;
 }
 
 export interface MemoryStore {
-  appendTurn(turn: StoredTurn): Promise<void>;
-  getRecentTurns(conversationId: string, n: number): Promise<StoredTurn[]>;
-  vectorSearch(query: string, k: number): Promise<StoredTurn[]>;
+  /** Persist one turn. Auto-stamps created_at to "now" UTC. */
+  appendTurn(turn: AppendTurnInput): Promise<void>;
+  /** Most recent N turns within (persona, conversation), oldest first. */
+  recentTurns(
+    persona: string,
+    conversation: string,
+    n: number,
+  ): Promise<Array<{ role: Role; text: string }>>;
+  /** Most recent N turns across all conversations for one persona, full rows, oldest first. */
+  recentTurnsForDisplay(persona: string, n: number): Promise<Turn[]>;
+  /** Close the underlying SQLite connection. Safe to call once; idempotent thereafter. */
   close(): Promise<void>;
 }
 
-export async function openMemoryStore(_path: string): Promise<MemoryStore> {
-  // TODO: open SQLite, run schema migration, return implementation
-  return new NotYetImplementedStore();
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS turns (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  persona      TEXT NOT NULL,
+  conversation TEXT NOT NULL,
+  role         TEXT NOT NULL CHECK (role IN ('user','assistant')),
+  text         TEXT NOT NULL,
+  created_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_turns_persona_conv_time
+  ON turns (persona, conversation, created_at);
+CREATE INDEX IF NOT EXISTS idx_turns_persona_time
+  ON turns (persona, created_at);
+`;
+
+interface RawDisplayRow {
+  id: number;
+  persona: string;
+  conversation: string;
+  role: Role;
+  text: string;
+  created_at: string;
 }
 
-class NotYetImplementedStore implements MemoryStore {
-  async appendTurn(_turn: StoredTurn): Promise<void> {
-    /* no-op until implemented */
+class SqliteMemoryStore implements MemoryStore {
+  private appendStmt;
+  private recentStmt;
+  private recentDisplayStmt;
+  private closed = false;
+
+  constructor(private db: Database) {
+    db.exec(SCHEMA);
+    this.appendStmt = db.prepare(
+      "INSERT INTO turns (persona, conversation, role, text, created_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    // Inner query gets most-recent-N descending; outer flips back to chronological.
+    this.recentStmt = db.prepare(
+      `SELECT role, text FROM (
+         SELECT id, role, text, created_at
+         FROM turns
+         WHERE persona = ? AND conversation = ?
+         ORDER BY created_at DESC, id DESC
+         LIMIT ?
+       ) ORDER BY created_at ASC, id ASC`,
+    );
+    this.recentDisplayStmt = db.prepare(
+      `SELECT id, persona, conversation, role, text, created_at FROM (
+         SELECT id, persona, conversation, role, text, created_at
+         FROM turns
+         WHERE persona = ?
+         ORDER BY created_at DESC, id DESC
+         LIMIT ?
+       ) ORDER BY created_at ASC, id ASC`,
+    );
   }
-  async getRecentTurns(_conversationId: string, _n: number): Promise<StoredTurn[]> {
-    return [];
+
+  async appendTurn(t: AppendTurnInput): Promise<void> {
+    this.appendStmt.run(
+      t.persona,
+      t.conversation,
+      t.role,
+      t.text,
+      new Date().toISOString(),
+    );
   }
-  async vectorSearch(_query: string, _k: number): Promise<StoredTurn[]> {
-    return [];
+
+  async recentTurns(
+    persona: string,
+    conversation: string,
+    n: number,
+  ): Promise<Array<{ role: Role; text: string }>> {
+    return this.recentStmt.all(persona, conversation, n) as Array<{
+      role: Role;
+      text: string;
+    }>;
   }
+
+  async recentTurnsForDisplay(persona: string, n: number): Promise<Turn[]> {
+    const rows = this.recentDisplayStmt.all(persona, n) as RawDisplayRow[];
+    return rows.map((r) => ({
+      id: r.id,
+      persona: r.persona,
+      conversation: r.conversation,
+      role: r.role,
+      text: r.text,
+      createdAt: new Date(r.created_at),
+    }));
+  }
+
   async close(): Promise<void> {
-    /* no-op */
+    if (this.closed) return;
+    this.closed = true;
+    this.db.close();
   }
+}
+
+export async function openMemoryStore(path: string): Promise<MemoryStore> {
+  if (path !== ":memory:") {
+    await mkdir(dirname(path), { recursive: true });
+  }
+  const db = new Database(path, { create: true });
+  // WAL keeps reads non-blocking even though phantombot is single-process —
+  // useful if `phantombot history` is run while a `phantombot chat` REPL is open.
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  return new SqliteMemoryStore(db);
 }

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the SQLite-backed memory store. Uses an in-memory database
+ * (":memory:") per test so there's no filesystem cleanup needed.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { type MemoryStore, openMemoryStore } from "../src/memory/store.ts";
+
+let store: MemoryStore;
+
+beforeEach(async () => {
+  store = await openMemoryStore(":memory:");
+});
+
+afterEach(async () => {
+  await store.close();
+});
+
+async function append(
+  persona: string,
+  conversation: string,
+  role: "user" | "assistant",
+  text: string,
+): Promise<void> {
+  await store.appendTurn({ persona, conversation, role, text });
+}
+
+describe("MemoryStore.appendTurn / recentTurns", () => {
+  test("returns empty array when nothing has been written", async () => {
+    const turns = await store.recentTurns("phantom", "cli:default", 10);
+    expect(turns).toEqual([]);
+  });
+
+  test("appends one turn and reads it back", async () => {
+    await append("phantom", "cli:default", "user", "hello");
+    const turns = await store.recentTurns("phantom", "cli:default", 10);
+    expect(turns).toEqual([{ role: "user", text: "hello" }]);
+  });
+
+  test("returns turns in chronological order, oldest first", async () => {
+    await append("phantom", "cli:default", "user", "first");
+    await append("phantom", "cli:default", "assistant", "second");
+    await append("phantom", "cli:default", "user", "third");
+    const turns = await store.recentTurns("phantom", "cli:default", 10);
+    expect(turns).toEqual([
+      { role: "user", text: "first" },
+      { role: "assistant", text: "second" },
+      { role: "user", text: "third" },
+    ]);
+  });
+
+  test("respects the LIMIT N (returns the N most recent, still chronological)", async () => {
+    for (let i = 1; i <= 5; i++) {
+      await append("phantom", "cli:default", "user", `msg ${i}`);
+    }
+    const turns = await store.recentTurns("phantom", "cli:default", 3);
+    expect(turns).toEqual([
+      { role: "user", text: "msg 3" },
+      { role: "user", text: "msg 4" },
+      { role: "user", text: "msg 5" },
+    ]);
+  });
+
+  test("scopes by (persona, conversation) — different persona is isolated", async () => {
+    await append("phantom", "cli:default", "user", "phantom turn");
+    await append("robbie", "cli:default", "user", "robbie turn");
+    const phantom = await store.recentTurns("phantom", "cli:default", 10);
+    const robbie = await store.recentTurns("robbie", "cli:default", 10);
+    expect(phantom).toEqual([{ role: "user", text: "phantom turn" }]);
+    expect(robbie).toEqual([{ role: "user", text: "robbie turn" }]);
+  });
+
+  test("scopes by (persona, conversation) — different conversation is isolated", async () => {
+    await append("phantom", "cli:default", "user", "default conv");
+    await append("phantom", "telegram:42", "user", "tg conv");
+    const def = await store.recentTurns("phantom", "cli:default", 10);
+    const tg = await store.recentTurns("phantom", "telegram:42", 10);
+    expect(def).toEqual([{ role: "user", text: "default conv" }]);
+    expect(tg).toEqual([{ role: "user", text: "tg conv" }]);
+  });
+});
+
+describe("MemoryStore.recentTurnsForDisplay", () => {
+  test("returns full Turn objects with id, conversation, createdAt", async () => {
+    await append("phantom", "cli:default", "user", "hi");
+    await append("phantom", "cli:default", "assistant", "hello");
+    const turns = await store.recentTurnsForDisplay("phantom", 10);
+    expect(turns).toHaveLength(2);
+    expect(turns[0]?.role).toBe("user");
+    expect(turns[0]?.text).toBe("hi");
+    expect(turns[0]?.conversation).toBe("cli:default");
+    expect(turns[0]?.persona).toBe("phantom");
+    expect(turns[0]?.createdAt).toBeInstanceOf(Date);
+    expect(typeof turns[0]?.id).toBe("number");
+  });
+
+  test("returns turns across all conversations for one persona, chronological", async () => {
+    await append("phantom", "cli:default", "user", "cli msg");
+    await append("phantom", "telegram:42", "user", "tg msg");
+    const turns = await store.recentTurnsForDisplay("phantom", 10);
+    expect(turns.map((t) => t.text)).toEqual(["cli msg", "tg msg"]);
+  });
+
+  test("scopes to the requested persona", async () => {
+    await append("phantom", "cli:default", "user", "phantom");
+    await append("robbie", "cli:default", "user", "robbie");
+    const phantom = await store.recentTurnsForDisplay("phantom", 10);
+    expect(phantom).toHaveLength(1);
+    expect(phantom[0]?.text).toBe("phantom");
+  });
+});
+
+describe("MemoryStore.close", () => {
+  test("close is idempotent — calling twice does not throw", async () => {
+    await store.close();
+    await expect(store.close()).resolves.toBeUndefined();
+  });
+});
+
+describe("MemoryStore — persistence to a real file", () => {
+  test("data survives close + reopen of the same db file", async () => {
+    const tmp = `/tmp/phantombot-memory-test-${Date.now()}.sqlite`;
+    const a = await openMemoryStore(tmp);
+    await a.appendTurn({
+      persona: "phantom",
+      conversation: "cli:default",
+      role: "user",
+      text: "remember me",
+    });
+    await a.close();
+    const b = await openMemoryStore(tmp);
+    const turns = await b.recentTurns("phantom", "cli:default", 10);
+    expect(turns).toEqual([{ role: "user", text: "remember me" }]);
+    await b.close();
+    await Bun.file(tmp).delete?.();
+  });
+});


### PR DESCRIPTION
## Summary

- Implements \`MemoryStore\` against \`bun:sqlite\` — no native compile, no extra deps.
- Schema: one table \`turns(id, persona, conversation, role, text, created_at)\` with composite indexes on \`(persona, conversation, created_at)\` and \`(persona, created_at)\`.
- Operations: \`appendTurn\`, \`recentTurns(persona, conversation, n)\`, \`recentTurnsForDisplay(persona, n)\`, \`close\` (idempotent).
- WAL mode enabled so \`phantombot history\` can run while a \`phantombot chat\` REPL is open.
- Vector / FTS retrieval is deferred — interface intentionally has no \`vectorSearch()\` method.

## Test plan

- [x] \`bun test\` — 26 pass / 0 fail (added 11 new tests in \`tests/memory.test.ts\`)
- Tests cover: empty store, append + read, chronological ordering, LIMIT N respects most-recent, persona scoping, conversation scoping, full Turn shape, close idempotency, file-backed round-trip.