### PR TITLE
Phase 4: port Claude harness to Bun.spawn, fix timeout state-machine bug

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -38,12 +38,17 @@
  *      CLAUDE.md auto-load) but requires ANTHROPIC_API_KEY and refuses
  *      OAuth/keychain credentials. Incompatible with the Claude Max
  *      subscription path. Don't add it back unless that changes upstream.
+ *
+ * Auth model under phantombot:
+ *   ANTHROPIC_API_KEY is filtered out of the subprocess env so claude
+ *   resolves credentials from ~/.claude/.credentials.json (the OAuth
+ *   path that backs Claude Max). Phantombot does not hold or pass any
+ *   API keys.
  */
 
-import { spawn } from "node:child_process";
 import { access, constants } from "node:fs/promises";
-import type { Harness, HarnessChunk, HarnessRequest } from "./types.js";
-import { log } from "../lib/logger.js";
+import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { log } from "../lib/logger.ts";
 
 export interface ClaudeHarnessConfig {
   /** Path to the `claude` CLI binary. Default: "claude" (looked up in PATH). */
@@ -53,6 +58,8 @@ export interface ClaudeHarnessConfig {
   /** Model alias passed to --fallback-model. Empty string disables. */
   fallbackModel: string;
 }
+
+type ProcState = "running" | "timed_out" | "exited";
 
 export class ClaudeHarness implements Harness {
   readonly id = "claude";
@@ -72,116 +79,109 @@ export class ClaudeHarness implements Harness {
     }
   }
 
-  async *invoke(req: HarnessRequest): AsyncIterable<HarnessChunk> {
-    const args = this.buildArgs();
-    log.debug("claude.invoke spawning", { bin: this.config.bin, args });
-
-    const proc = spawn(this.config.bin, args, {
-      cwd: req.workingDir,
-      env: process.env,
-      stdio: ["pipe", "pipe", "pipe"],
+  async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    const args = this.buildArgs(req.systemPrompt);
+    log.debug("claude.invoke spawning", {
+      bin: this.config.bin,
+      argCount: args.length,
     });
 
-    // Send the conversation body (history + new user message) via stdin.
-    // System prompt does NOT go here — it's installed via --system-prompt
-    // in buildArgs.
-    const stdinPayload = renderStdinPayload(req);
-    proc.stdin.write(stdinPayload);
+    // OAuth-on-host: don't leak ANTHROPIC_API_KEY into the subprocess env,
+    // so claude resolves credentials from ~/.claude/.credentials.json.
+    const env = filterAuthEnv(process.env);
+
+    const proc = Bun.spawn([this.config.bin, ...args], {
+      cwd: req.workingDir,
+      env,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    proc.stdin.write(renderStdinPayload(req));
     proc.stdin.end();
 
-    let buffer = "";
-    let finalText = "";
-    let resolved = false;
-
+    let state: ProcState = "running";
     const timeout = setTimeout(() => {
-      if (!resolved) {
+      if (state === "running") {
+        state = "timed_out";
         log.warn("claude.invoke timeout", { timeoutMs: req.timeoutMs });
         proc.kill("SIGTERM");
       }
     }, req.timeoutMs);
 
-    type Pending =
-      | { kind: "chunk"; chunk: HarnessChunk }
-      | { kind: "close" };
+    // Drain stderr in the background; surface as debug logs only.
+    void consumeStderr(proc.stderr);
 
-    const queue: Pending[] = [];
-    let queueResolver: (() => void) | undefined;
-    const push = (item: Pending) => {
-      queue.push(item);
-      queueResolver?.();
-      queueResolver = undefined;
-    };
-    const next = () =>
-      new Promise<void>((r) => {
-        if (queue.length > 0) r();
-        else queueResolver = r;
-      });
+    let buffer = "";
+    let finalText = "";
+    const decoder = new TextDecoder();
 
-    proc.stdout.on("data", (chunk: Buffer) => {
-      buffer += chunk.toString("utf8");
-      // Stream-json emits one JSON object per line. Process complete lines;
-      // keep the incomplete tail in `buffer`.
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          const parsed = JSON.parse(trimmed);
-          const chunk = parseStreamJson(parsed);
-          if (chunk) {
-            if (chunk.type === "text") finalText += chunk.text;
-            push({ kind: "chunk", chunk });
+    try {
+      for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+        buffer += decoder.decode(chunk, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(trimmed);
+          } catch {
+            // Not stream-json — surface as out-of-band progress note.
+            yield { type: "progress", note: trimmed };
+            continue;
           }
-        } catch {
-          // Not JSON — treat as raw progress. Keep noise out of replies.
-          push({ kind: "chunk", chunk: { type: "progress", note: trimmed } });
+          const c = parseStreamJson(parsed);
+          if (c) {
+            if (c.type === "text") finalText += c.text;
+            yield c;
+          }
         }
       }
-    });
-
-    proc.stderr.on("data", (chunk: Buffer) => {
-      const text = chunk.toString("utf8").trim();
-      if (text) log.debug("claude stderr", { text: text.slice(0, 500) });
-    });
-
-    proc.on("close", (code) => {
+    } finally {
       clearTimeout(timeout);
-      resolved = true;
-      if (code === 0 || code === null) {
-        push({ kind: "chunk", chunk: { type: "done", finalText } });
-      } else {
-        push({
-          kind: "chunk",
-          chunk: {
-            type: "error",
-            error: `claude exited with code ${code}`,
-            recoverable: code !== 127, // 127 = command not found, terminal
-          },
-        });
-      }
-      push({ kind: "close" });
-    });
+    }
 
-    proc.on("error", (err) => {
-      clearTimeout(timeout);
-      resolved = true;
-      push({
-        kind: "chunk",
-        chunk: { type: "error", error: err.message, recoverable: false },
-      });
-      push({ kind: "close" });
-    });
+    // STATE-MACHINE FIX (was the timeout-vs-close bug in the Node skeleton):
+    // distinguish a SIGTERM-by-timeout kill from a normal exit. The pre-Bun
+    // version emitted `done` with whatever partial text it had collected,
+    // which masked timeouts as successful short replies.
+    if (state === "timed_out") {
+      yield {
+        type: "error",
+        error: `claude timed out after ${req.timeoutMs}ms`,
+        recoverable: true,
+      };
+      return;
+    }
 
-    while (true) {
-      if (queue.length === 0) await next();
-      const item = queue.shift()!;
-      if (item.kind === "close") return;
-      yield item.chunk;
+    state = "exited";
+    const code = await proc.exited;
+
+    if (code === 0) {
+      yield {
+        type: "done",
+        finalText,
+        meta: {
+          harnessId: this.id,
+          model: this.config.model,
+        },
+      };
+    } else {
+      yield {
+        type: "error",
+        error: `claude exited with code ${code}`,
+        // 127 = command not found — terminal, no point falling through. Anything
+        // else (rate limits, network blips, transient model errors) should let
+        // the orchestrator try the next harness.
+        recoverable: code !== 127,
+      };
     }
   }
 
-  private buildArgs(): string[] {
+  private buildArgs(systemPrompt: string): string[] {
     const args = [
       "--print",
       "--output-format", "stream-json",
@@ -194,18 +194,34 @@ export class ClaudeHarness implements Harness {
     if (this.config.fallbackModel) {
       args.push("--fallback-model", this.config.fallbackModel);
     }
-    // System prompt is appended by invoke() so we can keep it close to the
-    // request data and avoid stuffing the full persona through args twice.
+    args.push("--system-prompt", systemPrompt);
     return args;
   }
+}
+
+/**
+ * Strip ANTHROPIC_API_KEY from the inherited env so the subprocess uses
+ * OAuth credentials at ~/.claude/.credentials.json. Exported for testing.
+ */
+export function filterAuthEnv(
+  source: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(source)) {
+    if (k === "ANTHROPIC_API_KEY") continue;
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
 }
 
 /**
  * Build the stdin payload. Format: history rendered as alternating
  * blocks, then the new user message at the end. Claude Code reads this
  * as the (single) user-side input in --print mode.
+ *
+ * Exported for testing.
  */
-function renderStdinPayload(req: HarnessRequest): string {
+export function renderStdinPayload(req: HarnessRequest): string {
   const parts: string[] = [];
   for (const turn of req.history) {
     if (turn.role === "user") {
@@ -226,8 +242,10 @@ function renderStdinPayload(req: HarnessRequest): string {
  * Claude's stream-json schema is documented in the Claude Code docs but
  * informally: each line has a `type` (system / user / assistant / result)
  * and a `message` payload. We only need the assistant text content.
+ *
+ * Exported for testing.
  */
-function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
+export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   if (typeof parsed !== "object" || parsed === null) return undefined;
   const obj = parsed as Record<string, unknown>;
   if (obj.type !== "assistant") return undefined;
@@ -237,7 +255,6 @@ function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   const content = message.content;
   if (!Array.isArray(content)) return undefined;
 
-  // Sum any "text" parts in this assistant message.
   let text = "";
   for (const part of content) {
     if (typeof part === "object" && part !== null) {
@@ -249,6 +266,27 @@ function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   }
   if (!text) return undefined;
   return { type: "text", text };
+}
+
+async function consumeStderr(
+  stream: ReadableStream<Uint8Array>,
+): Promise<void> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for await (const chunk of stream) {
+      buf += decoder.decode(chunk, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.trim()) {
+          log.debug("claude stderr", { text: line.slice(0, 500) });
+        }
+      }
+    }
+  } catch {
+    /* swallow — stderr drain shouldn't take down the harness */
+  }
 }
 
 // ---- Note for the next maintainer ----

--- a/tests/fixtures/fake-claude.sh
+++ b/tests/fixtures/fake-claude.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Fake claude CLI used by tests/harnesses-claude.test.ts.
+#
+# Selects behavior via FAKE_CLAUDE_MODE. Drains stdin so the harness's
+# stdin.write/end doesn't see EPIPE. Ignores all the --print/--system-prompt/
+# etc. flags the real claude takes — we don't validate them here.
+#
+# Modes:
+#   normal   — emit two assistant text chunks + a result event, exit 0
+#   error    — emit a stderr line, exit 1
+#   notfound — exit 127 (terminal, simulates "command not found")
+#   hang     — sleep forever (used for the timeout test)
+
+mode="${FAKE_CLAUDE_MODE:-normal}"
+
+# Drain stdin so the parent's stdin.end() resolves cleanly. Without this
+# the harness can hang on `proc.stdin.end()` if the kernel buffer fills.
+cat > /dev/null
+
+case "$mode" in
+  normal)
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"hello "}]}}'
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"world"}]}}'
+    printf '%s\n' '{"type":"result"}'
+    exit 0
+    ;;
+  error)
+    echo "simulated error" >&2
+    exit 1
+    ;;
+  notfound)
+    exit 127
+    ;;
+  hang)
+    # `exec` replaces bash with sleep so SIGTERM from the harness reaches
+    # the actual blocking process. Without exec, bash absorbs SIGTERM and
+    # the orphaned sleep keeps stdout open, leaking the timeout into a hang.
+    exec sleep 3600
+    ;;
+  *)
+    echo "fake-claude.sh: unknown FAKE_CLAUDE_MODE=$mode" >&2
+    exit 2
+    ;;
+esac

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the Claude harness.
+ *
+ * Two layers:
+ *   1. Pure-function tests for the exported helpers (renderStdinPayload,
+ *      filterAuthEnv, parseStreamJson) — fast, deterministic, no subprocess.
+ *   2. End-to-end tests via tests/fixtures/fake-claude.sh — verifies
+ *      Bun.spawn wiring, stream-json parsing, exit-code handling, and
+ *      the timeout-vs-close state-machine fix.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import {
+  ClaudeHarness,
+  filterAuthEnv,
+  parseStreamJson,
+  renderStdinPayload,
+} from "../src/harnesses/claude.ts";
+import type { HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
+
+const FAKE_CLAUDE = resolve(__dirname, "fixtures/fake-claude.sh");
+
+function newRequest(overrides: Partial<HarnessRequest> = {}): HarnessRequest {
+  return {
+    systemPrompt: "you are a test",
+    userMessage: "hi",
+    history: [],
+    workingDir: process.cwd(),
+    timeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+async function collect(
+  iter: AsyncIterable<HarnessChunk>,
+): Promise<HarnessChunk[]> {
+  const chunks: HarnessChunk[] = [];
+  for await (const c of iter) chunks.push(c);
+  return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests
+// ---------------------------------------------------------------------------
+
+describe("renderStdinPayload", () => {
+  test("just the new message when history is empty", () => {
+    const out = renderStdinPayload(newRequest({ userMessage: "hello" }));
+    expect(out).toBe("hello");
+  });
+
+  test("wraps assistant turns in <previous_response> blocks", () => {
+    const out = renderStdinPayload(
+      newRequest({
+        history: [
+          { role: "user", text: "what's 2+2?" },
+          { role: "assistant", text: "4" },
+        ],
+        userMessage: "and 3+3?",
+      }),
+    );
+    expect(out).toBe(
+      "what's 2+2?\n\n<previous_response>\n4\n</previous_response>\n\nand 3+3?",
+    );
+  });
+});
+
+describe("filterAuthEnv", () => {
+  test("strips ANTHROPIC_API_KEY", () => {
+    const out = filterAuthEnv({
+      ANTHROPIC_API_KEY: "sk-redacted",
+      PATH: "/usr/bin",
+      HOME: "/home/test",
+    });
+    expect(out).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(out.PATH).toBe("/usr/bin");
+    expect(out.HOME).toBe("/home/test");
+  });
+
+  test("drops undefined values (NodeJS.ProcessEnv allows them)", () => {
+    const out = filterAuthEnv({
+      DEFINED: "yes",
+      MAYBE: undefined,
+    });
+    expect(out).toEqual({ DEFINED: "yes" });
+  });
+});
+
+describe("parseStreamJson", () => {
+  test("extracts assistant text content", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "hello" }] },
+    });
+    expect(c).toEqual({ type: "text", text: "hello" });
+  });
+
+  test("concatenates multiple text parts in one assistant message", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "hello " },
+          { type: "text", text: "world" },
+        ],
+      },
+    });
+    expect(c).toEqual({ type: "text", text: "hello world" });
+  });
+
+  test("returns undefined for non-assistant events", () => {
+    expect(parseStreamJson({ type: "system" })).toBeUndefined();
+    expect(parseStreamJson({ type: "user" })).toBeUndefined();
+    expect(parseStreamJson({ type: "result" })).toBeUndefined();
+  });
+
+  test("returns undefined for assistant messages with no text parts (e.g. pure tool_use)", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: { content: [{ type: "tool_use", name: "Bash", input: {} }] },
+    });
+    expect(c).toBeUndefined();
+  });
+
+  test("returns undefined for malformed input", () => {
+    expect(parseStreamJson(null)).toBeUndefined();
+    expect(parseStreamJson(undefined)).toBeUndefined();
+    expect(parseStreamJson("string")).toBeUndefined();
+    expect(parseStreamJson({})).toBeUndefined();
+    expect(parseStreamJson({ type: "assistant" })).toBeUndefined();
+    expect(
+      parseStreamJson({ type: "assistant", message: {} }),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end tests via fake-claude.sh
+// ---------------------------------------------------------------------------
+
+let originalMode: string | undefined;
+
+beforeEach(() => {
+  originalMode = process.env.FAKE_CLAUDE_MODE;
+});
+
+afterEach(() => {
+  if (originalMode === undefined) delete process.env.FAKE_CLAUDE_MODE;
+  else process.env.FAKE_CLAUDE_MODE = originalMode;
+});
+
+describe("ClaudeHarness.invoke (subprocess)", () => {
+  const mkHarness = () =>
+    new ClaudeHarness({
+      bin: FAKE_CLAUDE,
+      model: "test",
+      fallbackModel: "",
+    });
+
+  test("normal exit: text chunks then done with finalText", async () => {
+    process.env.FAKE_CLAUDE_MODE = "normal";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const texts = chunks.filter((c) => c.type === "text");
+    const dones = chunks.filter((c) => c.type === "done");
+    expect(texts).toHaveLength(2);
+    expect(texts[0]).toEqual({ type: "text", text: "hello " });
+    expect(texts[1]).toEqual({ type: "text", text: "world" });
+    expect(dones).toHaveLength(1);
+    expect(dones[0]).toMatchObject({
+      type: "done",
+      finalText: "hello world",
+      meta: { harnessId: "claude", model: "test" },
+    });
+  });
+
+  test("non-zero exit emits recoverable error", async () => {
+    process.env.FAKE_CLAUDE_MODE = "error";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const errors = chunks.filter((c) => c.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ type: "error", recoverable: true });
+    expect(errors[0]).toMatchObject({
+      error: expect.stringContaining("exited with code 1"),
+    });
+  });
+
+  test("exit 127 (command not found) emits TERMINAL error (recoverable: false)", async () => {
+    process.env.FAKE_CLAUDE_MODE = "notfound";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const errors = chunks.filter((c) => c.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ type: "error", recoverable: false });
+  });
+
+  test("timeout: emits recoverable error, does NOT emit done with partial text (state-machine fix)", async () => {
+    process.env.FAKE_CLAUDE_MODE = "hang";
+    const chunks = await collect(
+      mkHarness().invoke(newRequest({ timeoutMs: 200 })),
+    );
+    const dones = chunks.filter((c) => c.type === "done");
+    const errors = chunks.filter((c) => c.type === "error");
+    expect(dones).toHaveLength(0); // pre-fix this would have been 1 with empty finalText
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      type: "error",
+      recoverable: true,
+      error: expect.stringContaining("timed out"),
+    });
+  });
+});
+
+describe("ClaudeHarness.available", () => {
+  test("returns true for an executable absolute path", async () => {
+    const h = new ClaudeHarness({
+      bin: FAKE_CLAUDE,
+      model: "test",
+      fallbackModel: "",
+    });
+    expect(await h.available()).toBe(true);
+  });
+
+  test("returns false for a non-existent absolute path", async () => {
+    const h = new ClaudeHarness({
+      bin: "/this/does/not/exist/claude",
+      model: "test",
+      fallbackModel: "",
+    });
+    expect(await h.available()).toBe(false);
+  });
+
+  test("returns true for a bare command name (assumes PATH lookup)", async () => {
+    const h = new ClaudeHarness({
+      bin: "claude",
+      model: "test",
+      fallbackModel: "",
+    });
+    expect(await h.available()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces \`node:child_process\` spawn + manual queue/resolver with **\`Bun.spawn\`** + direct \`for await\` over \`proc.stdout\`. Same external \`HarnessChunk\` contract.
- **Fixes the timeout-vs-close state-machine bug**: pre-fix, \`proc.kill('SIGTERM')\` on timeout still let \`close\` emit \`{type:'done', finalText}\` with partial text — masking timeouts as successful short replies. Now tracks \`running|timed_out|exited\` and emits \`{type:'error', recoverable:true}\` on timeout.
- Implements the **OAuth-on-host auth model**: \`ANTHROPIC_API_KEY\` is filtered out of the subprocess env (\`filterAuthEnv\`) so claude resolves credentials from \`~/.claude/.credentials.json\`.
- Preserves the five-patch reasoning at the top of the file and the "no tool-call passthrough" warning at the bottom.

## Test plan

- [x] \`bun test\` — 42 pass / 0 fail in 351ms (added 17 new tests)
- Pure-function tests: \`renderStdinPayload\`, \`filterAuthEnv\`, \`parseStreamJson\`
- Subprocess tests via \`tests/fixtures/fake-claude.sh\`: normal exit (text → done), non-zero exit (recoverable), exit 127 (terminal), **timeout (the bug fix — verifies no \`done\` chunk)**, \`available()\` for absolute / non-existent / PATH-bare bins.

## Notes

- The fake-claude.sh uses \`exec sleep\` in hang mode so SIGTERM reaches the actual blocking process — without \`exec\`, bash absorbs the signal and the orphaned sleep keeps stdout open, leaking timeouts into hangs.