### PR TITLE
Phase 6: phantombot ask end-to-end (config + claude wiring)

### DIFF
--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -1,4 +1,121 @@
+/**
+ * `phantombot ask` — one-shot turn.
+ *
+ * Loads config, resolves the persona dir, opens memory, builds the harness
+ * chain, runs one turn through the orchestrator, and streams the assistant
+ * reply to stdout. Progress notes are dropped (re-enable later if --verbose
+ * is added). Errors land on stderr and set a non-zero exit code.
+ *
+ * The bulk of the work is in `runAsk`, exported for testing without going
+ * through process.argv / Citty.
+ */
+
 import { defineCommand } from "citty";
+import { existsSync } from "node:fs";
+
+import { type Config, loadConfig, personaDir } from "../config.ts";
+import { ClaudeHarness } from "../harnesses/claude.ts";
+import type { Harness } from "../harnesses/types.ts";
+import { openMemoryStore } from "../memory/store.ts";
+import { runTurn } from "../orchestrator/turn.ts";
+
+export interface WriteSink {
+  write(chunk: string | Uint8Array): boolean | void;
+}
+
+export interface RunAskInput {
+  message: string;
+  persona?: string;
+  noHistory?: boolean;
+  /** stdout sink — defaults to process.stdout. */
+  out?: WriteSink;
+  /** stderr sink — defaults to process.stderr. */
+  err?: WriteSink;
+  /** Override config loading (mainly for tests). */
+  config?: Config;
+}
+
+export async function runAsk(input: RunAskInput): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+
+  const config = input.config ?? (await loadConfig());
+  const personaName = input.persona ?? config.defaultPersona;
+  const dir = personaDir(config, personaName);
+
+  if (!existsSync(dir)) {
+    err.write(`persona '${personaName}' not found at ${dir}\n`);
+    err.write(
+      `run \`phantombot import-persona <openclaw-agent-dir> --as ${personaName}\` to set it up\n`,
+    );
+    return 2;
+  }
+
+  const harnesses = buildHarnessChain(config, err);
+  if (harnesses.length === 0) {
+    err.write("no harnesses configured (config.harnesses.chain is empty)\n");
+    return 2;
+  }
+
+  const memory = await openMemoryStore(config.memoryDbPath);
+
+  let exitCode = 0;
+  let sawDone = false;
+
+  try {
+    for await (const chunk of runTurn({
+      persona: personaName,
+      conversation: "cli:default",
+      userMessage: input.message,
+      agentDir: dir,
+      harnesses,
+      memory,
+      timeoutMs: config.turnTimeoutMs,
+      noHistory: input.noHistory,
+    })) {
+      switch (chunk.type) {
+        case "text":
+          out.write(chunk.text);
+          break;
+        case "progress":
+          // Quiet by default. A future --verbose flag can surface these.
+          break;
+        case "done":
+          out.write("\n");
+          sawDone = true;
+          break;
+        case "error":
+          err.write(`error: ${chunk.error}\n`);
+          exitCode = 1;
+          break;
+      }
+    }
+  } finally {
+    await memory.close();
+  }
+
+  // Defensive: a stream that ends without `done` or `error` is a harness bug.
+  if (!sawDone && exitCode === 0) exitCode = 1;
+  return exitCode;
+}
+
+function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
+  const harnesses: Harness[] = [];
+  for (const id of config.harnesses.chain) {
+    if (id === "claude") {
+      harnesses.push(new ClaudeHarness(config.harnesses.claude));
+    } else if (id === "pi") {
+      // Pi harness lands in phase 9. Skip with a warning so users running
+      // ahead of that phase aren't blocked from using claude.
+      err.write(
+        "warning: pi harness not yet implemented (phase 9), skipping\n",
+      );
+    } else {
+      err.write(`warning: unknown harness '${id}', skipping\n`);
+    }
+  }
+  return harnesses;
+}
 
 export default defineCommand({
   meta: {
@@ -21,8 +138,12 @@ export default defineCommand({
       default: false,
     },
   },
-  async run() {
-    console.error("ask: not yet implemented (phase 6)");
-    process.exitCode = 1;
+  async run({ args }) {
+    const code = await runAsk({
+      message: String(args.message),
+      persona: args.persona ? String(args.persona) : undefined,
+      noHistory: Boolean(args["no-history"]),
+    });
+    process.exitCode = code;
   },
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,88 +1,156 @@
 /**
- * Config loading. Single source of truth for env-var names and defaults.
+ * Config loader. Single source of truth for paths, harness binaries, and
+ * the harness chain order.
  *
- * Keep this thin: every option has a default or fails loudly on startup.
- * Don't read process.env from anywhere else in the codebase.
+ * Resolution priority (highest wins):
+ *   1. Env vars (PHANTOMBOT_*)
+ *   2. TOML config at $XDG_CONFIG_HOME/phantombot/config.toml
+ *      (override path with PHANTOMBOT_CONFIG)
+ *   3. Built-in defaults
+ *
+ * The config file is optional — phantombot runs with built-in defaults if
+ * it doesn't exist.
  */
 
-import { resolve } from "node:path";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parse as parseToml } from "smol-toml";
 
 export interface Config {
-  agentDir: string;
-  memoryDb: string;
-
-  channels: {
-    telegram?: { token: string };
-    signal?: { url: string; number: string };
-    googlechat?: { serviceAccountPath: string; projectId: string };
-  };
+  /** Persona used by `ask`/`chat` when --persona is omitted. */
+  defaultPersona: string;
+  /** Per-harness wall-clock timeout in milliseconds. */
+  turnTimeoutMs: number;
+  /** Directory holding `<persona>/` subdirs. */
+  personasDir: string;
+  /** Path to the SQLite memory store file. */
+  memoryDbPath: string;
+  /** Path to the config file we loaded (whether it existed or not). */
+  configPath: string;
 
   harnesses: {
-    chain: string[]; // order = primary -> last fallback
+    /** Order = primary → fallback. Recognized ids: "claude", "pi". */
+    chain: string[];
     claude: { bin: string; model: string; fallbackModel: string };
-    codex: { bin: string; model: string };
-    gemini: { bin: string; model: string };
-    pi: { bin: string; model: string };
+    pi: { bin: string; maxPayloadBytes: number };
   };
-
-  turnTimeoutMs: number;
-  logLevel: string;
 }
 
-function env(name: string, fallback: string): string;
-function env(name: string, fallback?: undefined): string | undefined;
-function env(name: string, fallback?: string): string | undefined {
-  const v = process.env[name];
-  if (v === undefined || v === "") return fallback;
-  return v;
+export function xdgConfigHome(): string {
+  return process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+}
+export function xdgDataHome(): string {
+  return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
 }
 
-export function loadConfig(): Config {
-  const agentDir = resolve(env("PHANTOMBOT_AGENT_DIR", "./agents/phantom"));
-  const memoryDb = resolve(env("PHANTOMBOT_MEMORY_DB", "./data/memory.sqlite"));
+const DEFAULT_HARNESS_CHAIN = ["claude"] as const;
 
-  const channels: Config["channels"] = {};
-  const tg = env("TELEGRAM_BOT_TOKEN");
-  if (tg) channels.telegram = { token: tg };
+export async function loadConfig(): Promise<Config> {
+  const configPath =
+    process.env.PHANTOMBOT_CONFIG ??
+    join(xdgConfigHome(), "phantombot", "config.toml");
 
-  const sigUrl = env("SIGNAL_CLI_URL");
-  const sigNumber = env("SIGNAL_CLI_NUMBER");
-  if (sigUrl && sigNumber) channels.signal = { url: sigUrl, number: sigNumber };
+  const toml = await tryReadToml(configPath);
 
-  const gcSa = env("GOOGLE_CHAT_SERVICE_ACCOUNT");
-  const gcProj = env("GOOGLE_CHAT_PROJECT_ID");
-  if (gcSa && gcProj) channels.googlechat = { serviceAccountPath: gcSa, projectId: gcProj };
+  const dataDir = join(xdgDataHome(), "phantombot");
 
-  const chain = env("PHANTOMBOT_HARNESS_CHAIN", "claude,codex,gemini,pi")
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+  const tomlHarnesses = (toml.harnesses ?? {}) as Record<string, unknown>;
+  const tomlClaude = (tomlHarnesses.claude ?? {}) as Record<string, unknown>;
+  const tomlPi = (tomlHarnesses.pi ?? {}) as Record<string, unknown>;
 
   return {
-    agentDir,
-    memoryDb,
-    channels,
+    defaultPersona:
+      process.env.PHANTOMBOT_DEFAULT_PERSONA ??
+      asString(toml.default_persona) ??
+      "phantom",
+
+    turnTimeoutMs:
+      asInt(process.env.PHANTOMBOT_TURN_TIMEOUT_MS) ??
+      (asInt(toml.turn_timeout_s) !== undefined
+        ? asInt(toml.turn_timeout_s)! * 1000
+        : undefined) ??
+      600_000,
+
+    personasDir:
+      process.env.PHANTOMBOT_PERSONAS_DIR ??
+      asString(toml.personas_dir) ??
+      join(dataDir, "personas"),
+
+    memoryDbPath:
+      process.env.PHANTOMBOT_MEMORY_DB ??
+      asString(toml.memory_db) ??
+      join(dataDir, "memory.sqlite"),
+
+    configPath,
+
     harnesses: {
-      chain,
+      chain:
+        process.env.PHANTOMBOT_HARNESS_CHAIN
+          ?.split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0) ??
+        asStringArray(tomlHarnesses.chain) ??
+        [...DEFAULT_HARNESS_CHAIN],
+
       claude: {
-        bin: env("PHANTOMBOT_CLAUDE_BIN", "claude"),
-        model: env("PHANTOMBOT_CLAUDE_MODEL", "opus"),
-        fallbackModel: env("PHANTOMBOT_CLAUDE_FALLBACK_MODEL", "sonnet"),
+        bin:
+          process.env.PHANTOMBOT_CLAUDE_BIN ??
+          asString(tomlClaude.bin) ??
+          "claude",
+        model:
+          process.env.PHANTOMBOT_CLAUDE_MODEL ??
+          asString(tomlClaude.model) ??
+          "opus",
+        fallbackModel:
+          process.env.PHANTOMBOT_CLAUDE_FALLBACK_MODEL ??
+          asString(tomlClaude.fallback_model) ??
+          "sonnet",
       },
-      codex: {
-        bin: env("PHANTOMBOT_CODEX_BIN", "codex"),
-        model: env("PHANTOMBOT_CODEX_MODEL", ""),
-      },
-      gemini: {
-        bin: env("PHANTOMBOT_GEMINI_BIN", "gemini"),
-        model: env("PHANTOMBOT_GEMINI_MODEL", ""),
-      },
+
       pi: {
-        bin: env("PHANTOMBOT_PI_BIN", "pi"),
-        model: env("PHANTOMBOT_PI_MODEL", ""),
+        bin:
+          process.env.PHANTOMBOT_PI_BIN ??
+          asString(tomlPi.bin) ??
+          "pi",
+        maxPayloadBytes:
+          asInt(process.env.PHANTOMBOT_PI_MAX_PAYLOAD) ??
+          asInt(tomlPi.max_payload_bytes) ??
+          1_500_000,
       },
     },
-    turnTimeoutMs: Number(env("PHANTOMBOT_TURN_TIMEOUT_MS", "600000")),
-    logLevel: env("PHANTOMBOT_LOG_LEVEL", "info"),
   };
+}
+
+/** Resolve the on-disk directory for a named persona. */
+export function personaDir(config: Config, name: string): string {
+  return join(config.personasDir, name);
+}
+
+async function tryReadToml(path: string): Promise<Record<string, unknown>> {
+  try {
+    const content = await readFile(path, "utf8");
+    return parseToml(content) as Record<string, unknown>;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function asInt(v: unknown): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v)) return Math.floor(v);
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? Math.floor(n) : undefined;
+  }
+  return undefined;
+}
+
+function asStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  return v.every((x) => typeof x === "string") ? (v as string[]) : undefined;
 }

--- a/tests/cli-ask.test.ts
+++ b/tests/cli-ask.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Integration test for `phantombot ask` — exercises runAsk against the
+ * real ClaudeHarness pointed at tests/fixtures/fake-claude.sh, a real
+ * SQLite memory store on disk, and a real persona dir on disk.
+ *
+ * The Citty `defineCommand` wrapper is trivial; the work is in runAsk.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve, join } from "node:path";
+import { runAsk } from "../src/cli/ask.ts";
+import type { Config } from "../src/config.ts";
+
+const FAKE_CLAUDE = resolve(__dirname, "fixtures/fake-claude.sh");
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+let workdir: string;
+let config: Config;
+let savedFakeMode: string | undefined;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-ask-"));
+  const personaDir = join(workdir, "personas", "phantom");
+  await mkdir(personaDir, { recursive: true });
+  await writeFile(join(personaDir, "BOOT.md"), "# I am Phantom", "utf8");
+
+  config = {
+    defaultPersona: "phantom",
+    turnTimeoutMs: 5_000,
+    personasDir: join(workdir, "personas"),
+    memoryDbPath: join(workdir, "memory.sqlite"),
+    configPath: join(workdir, "config.toml"),
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: FAKE_CLAUDE, model: "test", fallbackModel: "" },
+      pi: { bin: "pi", maxPayloadBytes: 1_000_000 },
+    },
+  };
+
+  savedFakeMode = process.env.FAKE_CLAUDE_MODE;
+});
+
+afterEach(async () => {
+  if (savedFakeMode === undefined) delete process.env.FAKE_CLAUDE_MODE;
+  else process.env.FAKE_CLAUDE_MODE = savedFakeMode;
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("runAsk — happy path", () => {
+  test("prints text chunks to stdout, ends with a newline, exit 0", async () => {
+    process.env.FAKE_CLAUDE_MODE = "normal";
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runAsk({
+      message: "hi",
+      out,
+      err,
+      config,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toBe("hello world\n");
+    expect(err.text).toBe("");
+  });
+
+  test("persists user + assistant turns to the configured SQLite db", async () => {
+    process.env.FAKE_CLAUDE_MODE = "normal";
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    await runAsk({ message: "hi", out, err, config });
+    // Open a fresh memory store against the same file to verify persistence.
+    const { openMemoryStore } = await import("../src/memory/store.ts");
+    const m = await openMemoryStore(config.memoryDbPath);
+    const turns = await m.recentTurns("phantom", "cli:default", 10);
+    await m.close();
+    expect(turns).toEqual([
+      { role: "user", text: "hi" },
+      { role: "assistant", text: "hello world" },
+    ]);
+  });
+
+  test("loads prior history into the harness on subsequent invocations", async () => {
+    process.env.FAKE_CLAUDE_MODE = "normal";
+    const out1 = new CaptureStream();
+    const err1 = new CaptureStream();
+    await runAsk({ message: "first", out: out1, err: err1, config });
+    const out2 = new CaptureStream();
+    const err2 = new CaptureStream();
+    await runAsk({ message: "second", out: out2, err: err2, config });
+
+    const { openMemoryStore } = await import("../src/memory/store.ts");
+    const m = await openMemoryStore(config.memoryDbPath);
+    const turns = await m.recentTurns("phantom", "cli:default", 10);
+    await m.close();
+    expect(turns.map((t) => `${t.role}:${t.text}`)).toEqual([
+      "user:first",
+      "assistant:hello world",
+      "user:second",
+      "assistant:hello world",
+    ]);
+  });
+});
+
+describe("runAsk — failure paths", () => {
+  test("missing persona dir returns exit 2 with helpful message", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runAsk({
+      message: "hi",
+      persona: "doesnotexist",
+      out,
+      err,
+      config,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("persona 'doesnotexist' not found");
+    expect(err.text).toContain("import-persona");
+    expect(out.text).toBe("");
+    // Memory file should not have been touched.
+    await expect(readFile(config.memoryDbPath, "utf8")).rejects.toThrow();
+  });
+
+  test("harness error returns exit 1 and does NOT persist", async () => {
+    process.env.FAKE_CLAUDE_MODE = "error";
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runAsk({ message: "hi", out, err, config });
+    expect(code).toBe(1);
+    expect(err.text).toContain("error:");
+
+    const { openMemoryStore } = await import("../src/memory/store.ts");
+    const m = await openMemoryStore(config.memoryDbPath);
+    const turns = await m.recentTurns("phantom", "cli:default", 10);
+    await m.close();
+    expect(turns).toEqual([]);
+  });
+
+  test("empty harness chain returns exit 2", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runAsk({
+      message: "hi",
+      out,
+      err,
+      config: { ...config, harnesses: { ...config.harnesses, chain: [] } },
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("no harnesses configured");
+  });
+});
+
+describe("runAsk — noHistory", () => {
+  test("does not persist when noHistory is set", async () => {
+    process.env.FAKE_CLAUDE_MODE = "normal";
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    await runAsk({ message: "isolated", noHistory: true, out, err, config });
+
+    const { openMemoryStore } = await import("../src/memory/store.ts");
+    const m = await openMemoryStore(config.memoryDbPath);
+    const turns = await m.recentTurns("phantom", "cli:default", 10);
+    await m.close();
+    expect(turns).toEqual([]);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for config loading.
+ *
+ * Covers: default values when no config file exists, TOML overlay, env-var
+ * overrides take priority, XDG path resolution.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig, personaDir } from "../src/config.ts";
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  "PHANTOMBOT_CONFIG",
+  "PHANTOMBOT_DEFAULT_PERSONA",
+  "PHANTOMBOT_PERSONAS_DIR",
+  "PHANTOMBOT_MEMORY_DB",
+  "PHANTOMBOT_TURN_TIMEOUT_MS",
+  "PHANTOMBOT_HARNESS_CHAIN",
+  "PHANTOMBOT_CLAUDE_BIN",
+  "PHANTOMBOT_CLAUDE_MODEL",
+  "PHANTOMBOT_CLAUDE_FALLBACK_MODEL",
+  "PHANTOMBOT_PI_BIN",
+  "PHANTOMBOT_PI_MAX_PAYLOAD",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+];
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-config-"));
+  // Snapshot and clear all relevant env vars so each test starts clean.
+  for (const k of ENV_KEYS) {
+    SAVED_ENV[k] = process.env[k];
+    delete process.env[k];
+  }
+  // Point XDG dirs at the temp work dir so we don't collide with the user's real config.
+  process.env.XDG_CONFIG_HOME = join(workdir, "config");
+  process.env.XDG_DATA_HOME = join(workdir, "data");
+});
+
+afterEach(async () => {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("loadConfig — defaults (no file)", () => {
+  test("returns built-in defaults when no config file exists", async () => {
+    const c = await loadConfig();
+    expect(c.defaultPersona).toBe("phantom");
+    expect(c.turnTimeoutMs).toBe(600_000);
+    expect(c.harnesses.chain).toEqual(["claude"]);
+    expect(c.harnesses.claude).toEqual({
+      bin: "claude",
+      model: "opus",
+      fallbackModel: "sonnet",
+    });
+    expect(c.harnesses.pi).toEqual({
+      bin: "pi",
+      maxPayloadBytes: 1_500_000,
+    });
+  });
+
+  test("XDG paths resolve to ~/.config and ~/.local/share by default", async () => {
+    const c = await loadConfig();
+    expect(c.personasDir).toBe(join(workdir, "data", "phantombot", "personas"));
+    expect(c.memoryDbPath).toBe(join(workdir, "data", "phantombot", "memory.sqlite"));
+    expect(c.configPath).toBe(join(workdir, "config", "phantombot", "config.toml"));
+  });
+});
+
+describe("loadConfig — TOML overlay", () => {
+  test("reads values from config.toml when present", async () => {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(
+      join(cfgDir, "config.toml"),
+      `default_persona = "robbie"
+turn_timeout_s = 120
+
+[harnesses]
+chain = ["pi", "claude"]
+
+[harnesses.claude]
+model = "sonnet"
+fallback_model = ""
+
+[harnesses.pi]
+bin = "/opt/pi/pi"
+max_payload_bytes = 500000
+`,
+      "utf8",
+    );
+    const c = await loadConfig();
+    expect(c.defaultPersona).toBe("robbie");
+    expect(c.turnTimeoutMs).toBe(120_000);
+    expect(c.harnesses.chain).toEqual(["pi", "claude"]);
+    expect(c.harnesses.claude.model).toBe("sonnet");
+    expect(c.harnesses.claude.fallbackModel).toBe("");
+    expect(c.harnesses.pi.bin).toBe("/opt/pi/pi");
+    expect(c.harnesses.pi.maxPayloadBytes).toBe(500_000);
+  });
+});
+
+describe("loadConfig — env overrides", () => {
+  test("env vars take priority over TOML", async () => {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(
+      join(cfgDir, "config.toml"),
+      `default_persona = "from-toml"
+[harnesses.claude]
+model = "from-toml"
+`,
+      "utf8",
+    );
+    process.env.PHANTOMBOT_DEFAULT_PERSONA = "from-env";
+    process.env.PHANTOMBOT_CLAUDE_MODEL = "from-env";
+    const c = await loadConfig();
+    expect(c.defaultPersona).toBe("from-env");
+    expect(c.harnesses.claude.model).toBe("from-env");
+  });
+
+  test("PHANTOMBOT_HARNESS_CHAIN parses comma-separated list", async () => {
+    process.env.PHANTOMBOT_HARNESS_CHAIN = "claude, pi";
+    const c = await loadConfig();
+    expect(c.harnesses.chain).toEqual(["claude", "pi"]);
+  });
+
+  test("PHANTOMBOT_CONFIG overrides the config file path", async () => {
+    const altPath = join(workdir, "alt-config.toml");
+    await writeFile(altPath, `default_persona = "from-alt"`, "utf8");
+    process.env.PHANTOMBOT_CONFIG = altPath;
+    const c = await loadConfig();
+    expect(c.defaultPersona).toBe("from-alt");
+    expect(c.configPath).toBe(altPath);
+  });
+});
+
+describe("personaDir", () => {
+  test("joins personasDir + name", async () => {
+    process.env.PHANTOMBOT_PERSONAS_DIR = "/tmp/personas";
+    const c = await loadConfig();
+    expect(personaDir(c, "robbie")).toBe("/tmp/personas/robbie");
+  });
+});


### PR DESCRIPTION
## Summary

- **First user-facing command works.** \`phantombot ask "msg"\` loads persona, opens memory, runs claude, streams reply, persists turn.
- **Config layer landed:** TOML at \`\$XDG_CONFIG_HOME/phantombot/config.toml\` with env-var overrides (\`PHANTOMBOT_*\`) and built-in defaults. Optional file — phantombot runs with no config.
- **Output streaming:** text chunks → stdout, errors → stderr, exit 1 on failure / exit 2 on missing persona or empty chain.
- **runAsk is testable:** exported separate from Citty wrapper, accepts a \`WriteSink\` so tests pass capture buffers in.

## Test plan

- [x] \`bun test\` — 64 pass / 0 fail in 466ms (added 14 new tests)
- Config: defaults, TOML overlay, env priority, comma-list parsing, alt config path, personaDir helper.
- ask happy path: stdout output ends in newline, exit 0; turns persist to SQLite; second invocation sees first invocation's history.
- ask failure paths: missing persona → exit 2 with helpful message; harness error → exit 1, no persistence; empty harness chain → exit 2.
- ask \`noHistory\` flag: skips both load and persist.

## Notes

- Pi harness still skipped with a warning when it appears in the chain — lands in phase 9.
- Vector-search slot in the system prompt remains empty (deferred per plan).