### PR TITLE
Phase 7: OpenClaw persona importer + phantombot import-persona

### DIFF
--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -16,12 +16,9 @@ import { existsSync } from "node:fs";
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { ClaudeHarness } from "../harnesses/claude.ts";
 import type { Harness } from "../harnesses/types.ts";
+import type { WriteSink } from "../lib/io.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
-
-export interface WriteSink {
-  write(chunk: string | Uint8Array): boolean | void;
-}
 
 export interface RunAskInput {
   message: string;

--- a/src/cli/import-persona.ts
+++ b/src/cli/import-persona.ts
@@ -1,10 +1,68 @@
+/**
+ * `phantombot import-persona` — copy an OpenClaw agent directory into
+ * phantombot's personas dir so it can be used by `ask` / `chat`.
+ *
+ * The work is in src/importer/openclaw.ts; this file is the Citty wrapper.
+ */
+
 import { defineCommand } from "citty";
+import { loadConfig } from "../config.ts";
+import {
+  type ImportPersonaResult,
+  importPersona,
+} from "../importer/openclaw.ts";
+import type { WriteSink } from "../lib/io.ts";
+
+export interface RunImportPersonaInput {
+  source: string;
+  as?: string;
+  overwrite?: boolean;
+  /** Override personas root (defaults to config.personasDir). */
+  personasDir?: string;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runImportPersona(
+  input: RunImportPersonaInput,
+): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+
+  const personasDir =
+    input.personasDir ?? (await loadConfig()).personasDir;
+
+  let result: ImportPersonaResult;
+  try {
+    result = await importPersona({
+      source: input.source,
+      personasDir,
+      as: input.as,
+      overwrite: input.overwrite,
+    });
+  } catch (e) {
+    err.write(`error: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  out.write(`imported persona '${result.name}' to ${result.targetDir}\n`);
+  out.write(`copied (${result.copied.length}):\n`);
+  for (const f of result.copied) out.write(`  ${f}\n`);
+  if (result.skipped.length > 0) {
+    out.write(`skipped (${result.skipped.length}):\n`);
+    for (const f of result.skipped) out.write(`  ${f}\n`);
+  }
+  out.write(
+    "\nNote: conversation history was NOT imported (phantombot v1 has no transcript importer).\n",
+  );
+  return 0;
+}
 
 export default defineCommand({
   meta: {
     name: "import-persona",
     description:
-      "Import a persona from an OpenClaw agent directory. Copies BOOT.md / SOUL.md / IDENTITY.md / MEMORY.md / tools.md / AGENTS.md and any other markdown files into the phantombot personas dir.",
+      "Import a persona from an OpenClaw agent directory. Copies BOOT.md / SOUL.md / IDENTITY.md / MEMORY.md / tools.md / AGENTS.md and any other top-level .md files into the phantombot personas dir.",
   },
   args: {
     path: {
@@ -23,8 +81,12 @@ export default defineCommand({
       default: false,
     },
   },
-  async run() {
-    console.error("import-persona: not yet implemented (phase 7)");
-    process.exitCode = 1;
+  async run({ args }) {
+    const code = await runImportPersona({
+      source: String(args.path),
+      as: args.as ? String(args.as) : undefined,
+      overwrite: Boolean(args.overwrite),
+    });
+    process.exitCode = code;
   },
 });

--- a/src/importer/openclaw.ts
+++ b/src/importer/openclaw.ts
@@ -1,0 +1,159 @@
+/**
+ * OpenClaw → phantombot persona importer.
+ *
+ * Walks an OpenClaw agent directory and copies the markdown files
+ * phantombot's persona loader knows about (BOOT.md / SOUL.md /
+ * IDENTITY.md / MEMORY.md / tools.md / AGENTS.md), plus any other
+ * top-level .md files (free agent context the harness can `Read`).
+ *
+ * Skipped explicitly:
+ *   - SQLite files (*.sqlite, *.sqlite-*, *.db)
+ *   - JSONL transcripts (conversation history; not portable in v1)
+ *   - dotfiles (.env, .git, etc.)
+ *   - subdirectories (node_modules, .git, anything else)
+ *
+ * Conversation history is intentionally NOT imported in v1 — phantombot
+ * has no transcript-import path yet. A future `phantombot import-history`
+ * command can land once the OpenClaw transcript format is documented.
+ */
+
+import { copyFile, mkdir, readdir, stat } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+
+const RECOGNIZED_FILES: ReadonlySet<string> = new Set([
+  "BOOT.md",
+  "SOUL.md",
+  "IDENTITY.md",
+  "MEMORY.md",
+  "tools.md",
+  "AGENTS.md",
+]);
+
+const IDENTITY_FILES: readonly string[] = ["BOOT.md", "SOUL.md", "IDENTITY.md"];
+
+const SKIP_DIRS: ReadonlySet<string> = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  "target",
+]);
+
+const SKIP_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".sqlite",
+  ".sqlite-journal",
+  ".sqlite-wal",
+  ".sqlite-shm",
+  ".db",
+  ".jsonl",
+]);
+
+const VALID_NAME = /^[a-zA-Z0-9_-]+$/;
+
+export interface ImportPersonaInput {
+  /** Path to the OpenClaw (or phantombot-shaped) agent directory. */
+  source: string;
+  /** Personas root directory (typically config.personasDir). */
+  personasDir: string;
+  /** Override target persona name. Defaults to basename(source). */
+  as?: string;
+  /** Replace an existing persona of the same name. */
+  overwrite?: boolean;
+}
+
+export interface ImportPersonaResult {
+  /** Final persona name. */
+  name: string;
+  /** Directory the files were copied into. */
+  targetDir: string;
+  /** Filenames copied, in source-listing order. */
+  copied: string[];
+  /** Entries skipped (with a reason annotation). */
+  skipped: string[];
+}
+
+export async function importPersona(
+  input: ImportPersonaInput,
+): Promise<ImportPersonaResult> {
+  let srcStat;
+  try {
+    srcStat = await stat(input.source);
+  } catch {
+    throw new Error(`source path does not exist: ${input.source}`);
+  }
+  if (!srcStat.isDirectory()) {
+    throw new Error(`source path is not a directory: ${input.source}`);
+  }
+
+  const entries = await readdir(input.source, { withFileTypes: true });
+
+  const hasIdentity = entries.some(
+    (e) => e.isFile() && IDENTITY_FILES.includes(e.name),
+  );
+  if (!hasIdentity) {
+    throw new Error(
+      `no identity file in source (expected one of: ${IDENTITY_FILES.join(", ")}): ${input.source}`,
+    );
+  }
+
+  const name = input.as ?? basename(input.source);
+  if (!VALID_NAME.test(name)) {
+    throw new Error(
+      `invalid persona name '${name}' — use letters, digits, '-', or '_'`,
+    );
+  }
+
+  const targetDir = join(input.personasDir, name);
+  if (await dirExists(targetDir)) {
+    if (!input.overwrite) {
+      throw new Error(
+        `persona '${name}' already exists at ${targetDir} (use --overwrite to replace)`,
+      );
+    }
+  }
+
+  await mkdir(targetDir, { recursive: true });
+
+  const copied: string[] = [];
+  const skipped: string[] = [];
+
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      const reason = SKIP_DIRS.has(e.name)
+        ? "(non-portable directory)"
+        : "(phantombot only imports top-level files)";
+      skipped.push(`${e.name}/ ${reason}`);
+      continue;
+    }
+    if (!e.isFile()) {
+      skipped.push(`${e.name} (not a regular file)`);
+      continue;
+    }
+    if (e.name.startsWith(".")) {
+      skipped.push(`${e.name} (dotfile)`);
+      continue;
+    }
+    const ext = extname(e.name).toLowerCase();
+    if (SKIP_EXTENSIONS.has(ext)) {
+      skipped.push(`${e.name} (non-portable: ${ext})`);
+      continue;
+    }
+    if (RECOGNIZED_FILES.has(e.name) || ext === ".md") {
+      await copyFile(join(input.source, e.name), join(targetDir, e.name));
+      copied.push(e.name);
+    } else {
+      skipped.push(`${e.name} (not markdown)`);
+    }
+  }
+
+  return { name, targetDir, copied, skipped };
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/io.ts
+++ b/src/lib/io.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared minimal IO interfaces for CLI commands.
+ *
+ * Subcommands take WriteSink instead of NodeJS.WriteStream so tests can
+ * pass capture buffers without faking the full WriteStream API.
+ */
+
+export interface WriteSink {
+  write(chunk: string | Uint8Array): boolean | void;
+}

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the OpenClaw → phantombot persona importer.
+ *
+ * Exercises both the importPersona() pure function and the runImportPersona()
+ * CLI wrapper. Uses real temp directories so file-copy semantics, dotfile
+ * exclusion, and subdir skipping are all verified end-to-end.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runImportPersona } from "../src/cli/import-persona.ts";
+import {
+  type ImportPersonaResult,
+  importPersona,
+} from "../src/importer/openclaw.ts";
+
+let workdir: string;
+let source: string;
+let personasDir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-importer-"));
+  source = join(workdir, "openclaw-agent");
+  personasDir = join(workdir, "personas");
+  await mkdir(source, { recursive: true });
+  await mkdir(personasDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await readFile(p, "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("importPersona — happy path", () => {
+  test("copies BOOT.md / MEMORY.md / tools.md (Robbie convention)", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await writeFile(join(source, "MEMORY.md"), "mem");
+    await writeFile(join(source, "tools.md"), "tools");
+
+    const r = await importPersona({
+      source,
+      personasDir,
+      as: "robbie",
+    });
+
+    expect(r.name).toBe("robbie");
+    expect(r.targetDir).toBe(join(personasDir, "robbie"));
+    expect(r.copied.sort()).toEqual(["BOOT.md", "MEMORY.md", "tools.md"]);
+    expect(r.skipped).toEqual([]);
+    expect(await fileExists(join(r.targetDir, "BOOT.md"))).toBe(true);
+    expect(await fileExists(join(r.targetDir, "MEMORY.md"))).toBe(true);
+    expect(await fileExists(join(r.targetDir, "tools.md"))).toBe(true);
+  });
+
+  test("copies SOUL.md / IDENTITY.md / AGENTS.md (modern OpenClaw)", async () => {
+    await writeFile(join(source, "SOUL.md"), "soul");
+    await writeFile(join(source, "AGENTS.md"), "agents");
+    const r = await importPersona({ source, personasDir, as: "modern" });
+    expect(r.copied.sort()).toEqual(["AGENTS.md", "SOUL.md"]);
+  });
+
+  test("copies bonus .md files (free agent context)", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await writeFile(join(source, "playbook.md"), "extra");
+    await writeFile(join(source, "notes.md"), "more");
+    const r = await importPersona({ source, personasDir, as: "x" });
+    expect(r.copied.sort()).toEqual([
+      "BOOT.md",
+      "notes.md",
+      "playbook.md",
+    ]);
+  });
+
+  test("derives persona name from source basename when --as omitted", async () => {
+    const named = join(workdir, "robbie");
+    await mkdir(named);
+    await writeFile(join(named, "BOOT.md"), "id");
+    const r = await importPersona({ source: named, personasDir });
+    expect(r.name).toBe("robbie");
+  });
+});
+
+describe("importPersona — what gets skipped", () => {
+  test("skips dotfiles", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await writeFile(join(source, ".env"), "secret=1");
+    const r = await importPersona({ source, personasDir, as: "x" });
+    expect(r.copied).toEqual(["BOOT.md"]);
+    expect(r.skipped.some((s) => s.includes(".env"))).toBe(true);
+  });
+
+  test("skips SQLite files", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await writeFile(join(source, "memory.sqlite"), "binary");
+    await writeFile(join(source, "memory.sqlite-journal"), "binary");
+    const r = await importPersona({ source, personasDir, as: "x" });
+    expect(r.copied).toEqual(["BOOT.md"]);
+    expect(r.skipped.some((s) => s.includes(".sqlite"))).toBe(true);
+  });
+
+  test("skips JSONL transcripts", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await writeFile(join(source, "history.jsonl"), "{}");
+    const r = await importPersona({ source, personasDir, as: "x" });
+    expect(r.skipped.some((s) => s.includes("history.jsonl"))).toBe(true);
+  });
+
+  test("skips non-markdown files", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await writeFile(join(source, "config.toml"), "key=val");
+    await writeFile(join(source, "script.sh"), "#!/bin/bash");
+    const r = await importPersona({ source, personasDir, as: "x" });
+    expect(r.copied).toEqual(["BOOT.md"]);
+    expect(r.skipped.length).toBe(2);
+  });
+
+  test("skips subdirectories (and notes node_modules / .git as non-portable)", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await mkdir(join(source, "node_modules"));
+    await mkdir(join(source, ".git"));
+    await mkdir(join(source, "subdir"));
+    const r = await importPersona({ source, personasDir, as: "x" });
+    expect(r.copied).toEqual(["BOOT.md"]);
+    expect(r.skipped.some((s) => s.includes("node_modules/"))).toBe(true);
+    expect(r.skipped.some((s) => s.includes("subdir/"))).toBe(true);
+  });
+});
+
+describe("importPersona — error paths", () => {
+  test("throws when source does not exist", async () => {
+    expect(
+      importPersona({
+        source: join(workdir, "nope"),
+        personasDir,
+        as: "x",
+      }),
+    ).rejects.toThrow(/source path does not exist/);
+  });
+
+  test("throws when source is a file, not a directory", async () => {
+    const f = join(workdir, "afile.md");
+    await writeFile(f, "");
+    expect(
+      importPersona({ source: f, personasDir, as: "x" }),
+    ).rejects.toThrow(/not a directory/);
+  });
+
+  test("throws when source has no identity file", async () => {
+    await writeFile(join(source, "MEMORY.md"), "just memory");
+    expect(
+      importPersona({ source, personasDir, as: "x" }),
+    ).rejects.toThrow(/no identity file/);
+  });
+
+  test("throws on invalid persona name", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    expect(
+      importPersona({ source, personasDir, as: "has spaces" }),
+    ).rejects.toThrow(/invalid persona name/);
+  });
+
+  test("throws when target persona exists and --overwrite is not set", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await mkdir(join(personasDir, "x"));
+    expect(
+      importPersona({ source, personasDir, as: "x" }),
+    ).rejects.toThrow(/already exists/);
+  });
+
+  test("--overwrite replaces an existing persona", async () => {
+    await writeFile(join(source, "BOOT.md"), "new id");
+    await mkdir(join(personasDir, "x"));
+    await writeFile(join(personasDir, "x", "BOOT.md"), "old id");
+    const r: ImportPersonaResult = await importPersona({
+      source,
+      personasDir,
+      as: "x",
+      overwrite: true,
+    });
+    const copiedContent = await readFile(
+      join(r.targetDir, "BOOT.md"),
+      "utf8",
+    );
+    expect(copiedContent).toBe("new id");
+  });
+});
+
+describe("runImportPersona — CLI wrapper", () => {
+  test("prints summary on success and returns 0", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runImportPersona({
+      source,
+      as: "x",
+      personasDir,
+      out,
+      err,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("imported persona 'x'");
+    expect(out.text).toContain("BOOT.md");
+    expect(out.text).toContain("conversation history was NOT imported");
+    expect(err.text).toBe("");
+  });
+
+  test("returns 1 and writes error to stderr on failure", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runImportPersona({
+      source: join(workdir, "nope"),
+      as: "x",
+      personasDir,
+      out,
+      err,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("error:");
+    expect(out.text).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- New \`src/importer/openclaw.ts\` exposing \`importPersona\` — pure function that copies an OpenClaw agent dir into phantombot's personas dir.
- New \`src/cli/import-persona.ts\` — Citty wrapper that prints a summary on success.
- Extracts shared \`WriteSink\` to \`src/lib/io.ts\` so all CLI commands share the same test-friendly contract.

## What's copied vs skipped

**Copied:**
- All recognized files: \`BOOT.md\` / \`SOUL.md\` / \`IDENTITY.md\` / \`MEMORY.md\` / \`tools.md\` / \`AGENTS.md\`
- Any other top-level \`.md\` files (free agent context the harness can \`Read\`)

**Skipped (with explicit reason in the summary):**
- Dotfiles (\`.env\`, \`.git\`, etc.)
- SQLite / SQLite-WAL / SQLite-journal files
- JSONL transcripts
- Subdirectories (\`node_modules\`, anything else)
- Anything that isn't markdown

**Deferred:** conversation history. Phantombot v1 has no transcript importer.

## Test plan

- [x] \`bun test\` — 81 pass / 0 fail in 511ms (added 17 new tests)
- Tests cover: all three naming conventions, basename-derived names, error paths (missing source, not-a-dir, no-identity, invalid name, collision without --overwrite), \`--overwrite\` replacement, and CLI summary output.