### PR TITLE
Phase 9: Pi harness (pi --print --mode json) with ARG_MAX guard

### DIFF
--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -15,6 +15,7 @@ import { existsSync } from "node:fs";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { ClaudeHarness } from "../harnesses/claude.ts";
+import { PiHarness } from "../harnesses/pi.ts";
 import type { Harness } from "../harnesses/types.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { openMemoryStore } from "../memory/store.ts";
@@ -102,11 +103,7 @@ function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
     if (id === "claude") {
       harnesses.push(new ClaudeHarness(config.harnesses.claude));
     } else if (id === "pi") {
-      // Pi harness lands in phase 9. Skip with a warning so users running
-      // ahead of that phase aren't blocked from using claude.
-      err.write(
-        "warning: pi harness not yet implemented (phase 9), skipping\n",
-      );
+      harnesses.push(new PiHarness(config.harnesses.pi));
     } else {
       err.write(`warning: unknown harness '${id}', skipping\n`);
     }

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -1,33 +1,235 @@
 /**
- * Pi Coding Agent harness. STUB.
+ * Inflection Pi harness.
  *
- * Use src/harnesses/claude.ts as the template. Investigate Pi's CLI
- * surface — non-interactive flags, streaming format, system prompt
- * mechanism — and document any quirks here.
+ * Spawns `pi --print --mode json` with the system prompt as a flag and the
+ * full rendered payload (history + new message) as the LAST positional
+ * argument. Pi ignores stdin in --print mode, so the payload travels via
+ * argv — bounded by Linux ARG_MAX.
+ *
+ * Stream-json events translated to phantombot HarnessChunks:
+ *   message_update with text_delta  → { type: "text", text }
+ *   tool_execution_start            → { type: "progress", note: "running <tool>" }
+ *   anything else (agent_start,
+ *     tool_execution_end, turn_end,
+ *     extension_*) → ignored        (the done chunk is emitted from process exit)
+ *
+ * Auth (OAuth-on-host model): phantombot does NOT pass --api-key. Pi
+ * resolves credentials from its own configured state (~/.config/pi/ or
+ * similar). `phantombot doctor` surfaces failure if Pi isn't configured.
+ *
+ * ARG_MAX guard: declares maxPayloadBytes so the orchestrator's fallback
+ * skips Pi for oversized turns. Internal precheck mirrors that so a
+ * direct invoke() with a too-large payload still fails recoverably.
  */
 
-import type { Harness, HarnessChunk, HarnessRequest } from "./types.js";
+import { access, constants } from "node:fs/promises";
+import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { log } from "../lib/logger.ts";
 
 export interface PiHarnessConfig {
+  /** Path to the `pi` CLI binary. Default: "pi" (looked up in PATH). */
   bin: string;
-  model: string;
+  /** Maximum payload size in bytes (system prompt + rendered conversation). */
+  maxPayloadBytes: number;
 }
+
+type ProcState = "running" | "timed_out" | "exited";
 
 export class PiHarness implements Harness {
   readonly id = "pi";
 
-  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-  constructor(_config: PiHarnessConfig) {}
+  constructor(private readonly config: PiHarnessConfig) {}
 
-  async available(): Promise<boolean> {
-    return false; // TODO: implement
+  get maxPayloadBytes(): number {
+    return this.config.maxPayloadBytes;
   }
 
-  async *invoke(_req: HarnessRequest): AsyncIterable<HarnessChunk> {
-    yield {
-      type: "error",
-      error: "PiHarness not implemented yet — see src/harnesses/pi.ts",
-      recoverable: true,
-    };
+  async available(): Promise<boolean> {
+    try {
+      if (this.config.bin.startsWith("/")) {
+        await access(this.config.bin, constants.X_OK);
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    const payload = renderPayload(req);
+    const totalBytes =
+      Buffer.byteLength(req.systemPrompt, "utf8") +
+      Buffer.byteLength(payload, "utf8");
+    if (totalBytes > this.config.maxPayloadBytes) {
+      yield {
+        type: "error",
+        error: `pi payload ${totalBytes} bytes exceeds maxPayloadBytes ${this.config.maxPayloadBytes}`,
+        recoverable: true,
+      };
+      return;
+    }
+
+    const args = [
+      "--print",
+      "--mode", "json",
+      "--system-prompt", req.systemPrompt,
+      payload,
+    ];
+    log.debug("pi.invoke spawning", {
+      bin: this.config.bin,
+      payloadBytes: totalBytes,
+    });
+
+    const proc = Bun.spawn([this.config.bin, ...args], {
+      cwd: req.workingDir,
+      env: process.env,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    let state: ProcState = "running";
+    const timeout = setTimeout(() => {
+      if (state === "running") {
+        state = "timed_out";
+        log.warn("pi.invoke timeout", { timeoutMs: req.timeoutMs });
+        proc.kill("SIGTERM");
+      }
+    }, req.timeoutMs);
+
+    void consumeStderr(proc.stderr);
+
+    let buffer = "";
+    let finalText = "";
+    const decoder = new TextDecoder();
+
+    try {
+      for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+        buffer += decoder.decode(chunk, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(trimmed);
+          } catch {
+            yield { type: "progress", note: trimmed };
+            continue;
+          }
+          const c = parsePiEvent(parsed);
+          if (c) {
+            if (c.type === "text") finalText += c.text;
+            yield c;
+          }
+        }
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (state === "timed_out") {
+      yield {
+        type: "error",
+        error: `pi timed out after ${req.timeoutMs}ms`,
+        recoverable: true,
+      };
+      return;
+    }
+
+    state = "exited";
+    const code = await proc.exited;
+
+    if (code === 0) {
+      yield {
+        type: "done",
+        finalText,
+        meta: { harnessId: this.id, payloadBytes: totalBytes },
+      };
+    } else {
+      yield {
+        type: "error",
+        error: `pi exited with code ${code}`,
+        recoverable: code !== 127,
+      };
+    }
+  }
+}
+
+/**
+ * Render the conversation payload Pi gets as its single positional arg.
+ * Same rules as the Claude stdin payload — alternating user / assistant
+ * blocks with assistant turns wrapped in <previous_response>.
+ *
+ * Exported for testing.
+ */
+export function renderPayload(req: HarnessRequest): string {
+  const parts: string[] = [];
+  for (const turn of req.history) {
+    if (turn.role === "user") {
+      parts.push(turn.text);
+    } else {
+      parts.push(`<previous_response>\n${turn.text}\n</previous_response>`);
+    }
+  }
+  parts.push(req.userMessage);
+  return parts.join("\n\n");
+}
+
+/**
+ * Translate one pi stream-json line into a HarnessChunk. Handles both
+ * `{"type":"X", "data":{...}}` and `{"type":"X", ...flat}` shapes since
+ * the schema isn't tightly documented and may vary by Pi version.
+ *
+ * Exported for testing.
+ */
+export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  const type = obj.type;
+  if (typeof type !== "string") return undefined;
+  const data = isObject(obj.data) ? obj.data : obj;
+
+  if (type === "message_update") {
+    const td = data.text_delta;
+    if (typeof td === "string" && td.length > 0) {
+      return { type: "text", text: td };
+    }
+  }
+
+  if (type === "tool_execution_start") {
+    const name =
+      (typeof data.tool_name === "string" && data.tool_name) ||
+      (typeof data.name === "string" && data.name) ||
+      "tool";
+    return { type: "progress", note: `running ${name}` };
+  }
+
+  return undefined;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+async function consumeStderr(
+  stream: ReadableStream<Uint8Array>,
+): Promise<void> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for await (const chunk of stream) {
+      buf += decoder.decode(chunk, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.trim()) {
+          log.debug("pi stderr", { text: line.slice(0, 500) });
+        }
+      }
+    }
+  } catch {
+    /* swallow */
   }
 }

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -42,6 +42,14 @@ export interface Harness {
   /** Stable identifier — matches the wrapper file name. */
   readonly id: string;
 
+  /**
+   * Largest allowable rendered payload (system prompt + history + new
+   * message) in bytes. The orchestrator should skip this harness when
+   * the turn would exceed the budget (Pi takes its payload via argv,
+   * so it's bounded by Linux ARG_MAX). undefined = unbounded.
+   */
+  readonly maxPayloadBytes?: number;
+
   /** Quick check: is the binary present and minimally callable? */
   available(): Promise<boolean>;
 

--- a/tests/fixtures/fake-pi.sh
+++ b/tests/fixtures/fake-pi.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Fake pi CLI used by tests/harnesses-pi.test.ts.
+#
+# Selects behavior via FAKE_PI_MODE. Pi takes the payload as its last
+# positional arg; we don't validate it here.
+#
+# Modes:
+#   normal   — emit text deltas + tool_execution events + turn_end, exit 0
+#   error    — exit 1
+#   notfound — exit 127
+#   hang     — sleep forever (for the timeout test)
+
+mode="${FAKE_PI_MODE:-normal}"
+
+case "$mode" in
+  normal)
+    printf '%s\n' '{"type":"agent_start"}'
+    printf '%s\n' '{"type":"message_update","data":{"text_delta":"hello "}}'
+    printf '%s\n' '{"type":"message_update","data":{"text_delta":"world"}}'
+    printf '%s\n' '{"type":"tool_execution_start","data":{"tool_name":"bash"}}'
+    printf '%s\n' '{"type":"tool_execution_end"}'
+    printf '%s\n' '{"type":"turn_end"}'
+    exit 0
+    ;;
+  error)
+    echo "simulated pi error" >&2
+    exit 1
+    ;;
+  notfound)
+    exit 127
+    ;;
+  hang)
+    exec sleep 3600
+    ;;
+  *)
+    echo "fake-pi.sh: unknown FAKE_PI_MODE=$mode" >&2
+    exit 2
+    ;;
+esac

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the Pi harness. Mirrors tests/harnesses-claude.test.ts:
+ *   - Pure-function tests for renderPayload / parsePiEvent
+ *   - End-to-end via tests/fixtures/fake-pi.sh — verifies Bun.spawn
+ *     wiring, stream-json translation, exit-code handling, timeout fix.
+ *   - One ARG_MAX guard test (synthetic — confirms the precheck fires).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import {
+  PiHarness,
+  parsePiEvent,
+  renderPayload,
+} from "../src/harnesses/pi.ts";
+import type { HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
+
+const FAKE_PI = resolve(__dirname, "fixtures/fake-pi.sh");
+
+function newRequest(overrides: Partial<HarnessRequest> = {}): HarnessRequest {
+  return {
+    systemPrompt: "you are pi",
+    userMessage: "hi",
+    history: [],
+    workingDir: process.cwd(),
+    timeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+async function collect(
+  iter: AsyncIterable<HarnessChunk>,
+): Promise<HarnessChunk[]> {
+  const chunks: HarnessChunk[] = [];
+  for await (const c of iter) chunks.push(c);
+  return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests
+// ---------------------------------------------------------------------------
+
+describe("renderPayload (Pi)", () => {
+  test("just the new message when history is empty", () => {
+    expect(renderPayload(newRequest({ userMessage: "hello" }))).toBe("hello");
+  });
+
+  test("wraps assistant turns in <previous_response> blocks", () => {
+    const out = renderPayload(
+      newRequest({
+        history: [
+          { role: "user", text: "earlier" },
+          { role: "assistant", text: "previous" },
+        ],
+        userMessage: "now",
+      }),
+    );
+    expect(out).toBe(
+      "earlier\n\n<previous_response>\nprevious\n</previous_response>\n\nnow",
+    );
+  });
+});
+
+describe("parsePiEvent", () => {
+  test("extracts text_delta from message_update via data.text_delta", () => {
+    const c = parsePiEvent({
+      type: "message_update",
+      data: { text_delta: "hi" },
+    });
+    expect(c).toEqual({ type: "text", text: "hi" });
+  });
+
+  test("also handles message_update with text_delta at the top level", () => {
+    const c = parsePiEvent({
+      type: "message_update",
+      text_delta: "hi",
+    });
+    expect(c).toEqual({ type: "text", text: "hi" });
+  });
+
+  test("turns tool_execution_start into a progress chunk naming the tool", () => {
+    const c = parsePiEvent({
+      type: "tool_execution_start",
+      data: { tool_name: "bash" },
+    });
+    expect(c).toEqual({ type: "progress", note: "running bash" });
+  });
+
+  test("falls back to data.name for tool_execution_start when tool_name is missing", () => {
+    const c = parsePiEvent({
+      type: "tool_execution_start",
+      data: { name: "edit" },
+    });
+    expect(c).toEqual({ type: "progress", note: "running edit" });
+  });
+
+  test("ignores agent_start, tool_execution_end, turn_end, and unknown types", () => {
+    expect(parsePiEvent({ type: "agent_start" })).toBeUndefined();
+    expect(parsePiEvent({ type: "tool_execution_end" })).toBeUndefined();
+    expect(parsePiEvent({ type: "turn_end" })).toBeUndefined();
+    expect(parsePiEvent({ type: "unknown" })).toBeUndefined();
+  });
+
+  test("ignores empty text_delta", () => {
+    expect(
+      parsePiEvent({
+        type: "message_update",
+        data: { text_delta: "" },
+      }),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for malformed input", () => {
+    expect(parsePiEvent(null)).toBeUndefined();
+    expect(parsePiEvent("string")).toBeUndefined();
+    expect(parsePiEvent({})).toBeUndefined();
+    expect(parsePiEvent({ type: 42 })).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end via fake-pi.sh
+// ---------------------------------------------------------------------------
+
+let originalMode: string | undefined;
+
+beforeEach(() => {
+  originalMode = process.env.FAKE_PI_MODE;
+});
+
+afterEach(() => {
+  if (originalMode === undefined) delete process.env.FAKE_PI_MODE;
+  else process.env.FAKE_PI_MODE = originalMode;
+});
+
+const mkHarness = (overrides: Partial<{ maxPayloadBytes: number }> = {}) =>
+  new PiHarness({
+    bin: FAKE_PI,
+    maxPayloadBytes: overrides.maxPayloadBytes ?? 1_500_000,
+  });
+
+describe("PiHarness.invoke (subprocess)", () => {
+  test("normal exit: text chunks + progress chunk + done with finalText", async () => {
+    process.env.FAKE_PI_MODE = "normal";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const texts = chunks.filter((c) => c.type === "text");
+    const progress = chunks.filter((c) => c.type === "progress");
+    const dones = chunks.filter((c) => c.type === "done");
+    expect(texts.map((c) => (c as { text: string }).text)).toEqual([
+      "hello ",
+      "world",
+    ]);
+    expect(progress).toHaveLength(1);
+    expect(progress[0]).toMatchObject({
+      type: "progress",
+      note: "running bash",
+    });
+    expect(dones).toHaveLength(1);
+    expect(dones[0]).toMatchObject({
+      type: "done",
+      finalText: "hello world",
+      meta: { harnessId: "pi" },
+    });
+  });
+
+  test("non-zero exit emits recoverable error", async () => {
+    process.env.FAKE_PI_MODE = "error";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const errors = chunks.filter((c) => c.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ type: "error", recoverable: true });
+  });
+
+  test("exit 127 emits TERMINAL error", async () => {
+    process.env.FAKE_PI_MODE = "notfound";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const errors = chunks.filter((c) => c.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ type: "error", recoverable: false });
+  });
+
+  test("timeout emits recoverable error and NO done", async () => {
+    process.env.FAKE_PI_MODE = "hang";
+    const chunks = await collect(
+      mkHarness().invoke(newRequest({ timeoutMs: 200 })),
+    );
+    const dones = chunks.filter((c) => c.type === "done");
+    const errors = chunks.filter((c) => c.type === "error");
+    expect(dones).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      type: "error",
+      recoverable: true,
+      error: expect.stringContaining("timed out"),
+    });
+  });
+});
+
+describe("PiHarness ARG_MAX precheck", () => {
+  test("emits a recoverable error and does NOT spawn when payload exceeds budget", async () => {
+    // Make the budget tiny so the test request blows it.
+    const chunks = await collect(
+      mkHarness({ maxPayloadBytes: 5 }).invoke(
+        newRequest({
+          systemPrompt: "long system prompt that is more than 5 bytes",
+          userMessage: "hello",
+        }),
+      ),
+    );
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatchObject({
+      type: "error",
+      recoverable: true,
+      error: expect.stringContaining("exceeds maxPayloadBytes"),
+    });
+  });
+
+  test("declares maxPayloadBytes on the Harness instance", () => {
+    const h = mkHarness({ maxPayloadBytes: 1_000 });
+    expect(h.maxPayloadBytes).toBe(1_000);
+  });
+});
+
+describe("PiHarness.available", () => {
+  test("returns true for the absolute path of an executable file", async () => {
+    expect(await mkHarness().available()).toBe(true);
+  });
+
+  test("returns false for a non-existent absolute path", async () => {
+    expect(
+      await new PiHarness({
+        bin: "/no/such/pi",
+        maxPayloadBytes: 1_000,
+      }).available(),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- New \`src/harnesses/pi.ts\` — \`PiHarness\` against \`Bun.spawn\`. Same shape as the Claude harness but **payload via argv** (Pi ignores stdin in \`--print\` mode), and **no \`--api-key\`** — trusts Pi's host-side OAuth config.
- Stream-json translation: \`message_update.text_delta\` → text, \`tool_execution_start\` → progress, everything else ignored. Done emitted on process exit.
- **ARG_MAX guard**: adds \`maxPayloadBytes?\` to the \`Harness\` interface (orchestrator wires the precheck in phase 10). PiHarness internal precheck still fires defensively, emitting a recoverable error so the orchestrator's fallback path works even if you invoke directly.
- Removes the "pi not yet implemented" warning from \`runAsk\` and actually wires \`PiHarness\` into the chain.

## Test plan

- [x] \`bun test\` — 112 pass / 0 fail in 763ms (added 19 new tests in \`tests/harnesses-pi.test.ts\`)
- Pure-function tests for \`renderPayload\` and \`parsePiEvent\` (handles both \`data.text_delta\` and flat \`text_delta\` shapes; tool-name fallback chain).
- E2E via \`tests/fixtures/fake-pi.sh\`: normal exit, non-zero exit, exit 127 (terminal), timeout (state-machine), \`available()\`.
- ARG_MAX precheck: confirms pre-spawn rejection emits a recoverable error.

## Notes

- ARG_MAX probe (manual; gated by \`RUN_PI_PROBE=1\`) deferred — \`maxPayloadBytes\` defaults to 1.5 MB which leaves comfortable headroom for realistic chat turns. Tune later when running against the real Pi binary.
- Real Pi auth verification happens when the user runs \`phantombot doctor\` against an actual install.