### PR TITLE
Phase 10: orchestrator pre-spawn skip on maxPayloadBytes

### DIFF
--- a/src/orchestrator/fallback.ts
+++ b/src/orchestrator/fallback.ts
@@ -4,10 +4,17 @@
  *
  * Yields chunks from whichever harness ends up handling the turn. The
  * caller doesn't need to know which one won; it just consumes the stream.
+ *
+ * Pre-spawn precheck: if a harness declares maxPayloadBytes and the turn
+ * would exceed it, the orchestrator skips that harness without spawning
+ * a subprocess. This matters for Pi, which takes its payload via argv
+ * and is bounded by Linux ARG_MAX. The skip is treated as a recoverable
+ * error so the chain falls through to the next harness (typically claude,
+ * which has no payload ceiling).
  */
 
-import type { Harness, HarnessChunk, HarnessRequest } from "../harnesses/types.js";
-import { log } from "../lib/logger.js";
+import type { Harness, HarnessChunk, HarnessRequest } from "../harnesses/types.ts";
+import { log } from "../lib/logger.ts";
 
 export async function* runWithFallback(
   chain: Harness[],
@@ -22,36 +29,66 @@ export async function* runWithFallback(
     return;
   }
 
+  const estimatedBytes = estimatePayloadBytes(req);
+
   for (let i = 0; i < chain.length; i++) {
     const harness = chain[i]!;
-    log.info("orchestrator: trying harness", { harnessId: harness.id, attempt: i + 1, of: chain.length });
+    const isLast = i === chain.length - 1;
+
+    if (
+      harness.maxPayloadBytes !== undefined &&
+      estimatedBytes > harness.maxPayloadBytes
+    ) {
+      if (!isLast) {
+        log.warn(
+          "orchestrator: skipping harness — payload exceeds maxPayloadBytes",
+          {
+            harnessId: harness.id,
+            estimatedBytes,
+            maxPayloadBytes: harness.maxPayloadBytes,
+          },
+        );
+        continue;
+      }
+      yield {
+        type: "error",
+        error: `payload ${estimatedBytes} bytes exceeds ${harness.id}'s maxPayloadBytes ${harness.maxPayloadBytes} (no remaining harnesses)`,
+        recoverable: false,
+      };
+      return;
+    }
+
+    log.info("orchestrator: trying harness", {
+      harnessId: harness.id,
+      attempt: i + 1,
+      of: chain.length,
+    });
 
     let succeeded = false;
     let recoverableError = false;
 
     for await (const chunk of harness.invoke(req)) {
       if (chunk.type === "error") {
-        if (chunk.recoverable && i < chain.length - 1) {
-          log.warn("orchestrator: harness recoverable error, falling through", {
-            harnessId: harness.id,
-            error: chunk.error,
-          });
+        if (chunk.recoverable && !isLast) {
+          log.warn(
+            "orchestrator: harness recoverable error, falling through",
+            {
+              harnessId: harness.id,
+              error: chunk.error,
+            },
+          );
           recoverableError = true;
           break;
         }
-        // terminal error or last harness in chain — surface to caller
         yield chunk;
         return;
       }
       yield chunk;
-      if (chunk.type === "done") {
-        succeeded = true;
-      }
+      if (chunk.type === "done") succeeded = true;
     }
 
     if (succeeded) return;
     if (!recoverableError) {
-      // Stream ended without 'done' or 'error' — treat as terminal.
       yield {
         type: "error",
         error: `harness ${harness.id} ended without 'done' or 'error'`,
@@ -60,4 +97,24 @@ export async function* runWithFallback(
       return;
     }
   }
+}
+
+/**
+ * Estimate the rendered payload size for the precheck. Sums the system
+ * prompt, every history turn, the new user message, plus a constant
+ * per turn for the `<previous_response>` wrapper bytes. Conservative —
+ * actual Pi argv may include a few additional flag bytes which this
+ * doesn't account for, but the slack is well under the typical budget.
+ *
+ * Exported for testing.
+ */
+export function estimatePayloadBytes(req: HarnessRequest): number {
+  let total = Buffer.byteLength(req.systemPrompt, "utf8");
+  for (const turn of req.history) {
+    total += Buffer.byteLength(turn.text, "utf8");
+    total += turn.role === "assistant" ? 36 : 0; // <previous_response>...</previous_response> markers
+    total += 2; // joiner newlines
+  }
+  total += Buffer.byteLength(req.userMessage, "utf8");
+  return total;
 }

--- a/tests/orchestrator-fallback.test.ts
+++ b/tests/orchestrator-fallback.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the runWithFallback orchestrator — focused on the
+ * maxPayloadBytes precheck added in phase 10. Existing fallback
+ * behavior (recoverable error → next harness, terminal error stops)
+ * is exercised indirectly by tests/orchestrator-turn.test.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  estimatePayloadBytes,
+  runWithFallback,
+} from "../src/orchestrator/fallback.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessRequest,
+} from "../src/harnesses/types.ts";
+
+class FakeHarness implements Harness {
+  invocations = 0;
+  constructor(
+    public readonly id: string,
+    private readonly script: HarnessChunk[],
+    public readonly maxPayloadBytes?: number,
+  ) {}
+  async available(): Promise<boolean> {
+    return true;
+  }
+  async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    this.invocations++;
+    for (const c of this.script) yield c;
+  }
+}
+
+function newRequest(overrides: Partial<HarnessRequest> = {}): HarnessRequest {
+  return {
+    systemPrompt: "system prompt",
+    userMessage: "user msg",
+    history: [],
+    workingDir: process.cwd(),
+    timeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+async function collect(
+  iter: AsyncIterable<HarnessChunk>,
+): Promise<HarnessChunk[]> {
+  const out: HarnessChunk[] = [];
+  for await (const c of iter) out.push(c);
+  return out;
+}
+
+describe("estimatePayloadBytes", () => {
+  test("counts system prompt + user message", () => {
+    const bytes = estimatePayloadBytes(
+      newRequest({ systemPrompt: "abcd", userMessage: "ef" }),
+    );
+    expect(bytes).toBe(6);
+  });
+
+  test("counts history turns + wrapper bytes for assistant turns", () => {
+    const req = newRequest({
+      systemPrompt: "",
+      userMessage: "",
+      history: [
+        { role: "user", text: "hi" },           // 2 + 0 wrapper + 2 joiner = 4
+        { role: "assistant", text: "hello" },   // 5 + 36 wrapper + 2 joiner = 43
+      ],
+    });
+    expect(estimatePayloadBytes(req)).toBe(4 + 43);
+  });
+});
+
+describe("runWithFallback — maxPayloadBytes precheck", () => {
+  test("skips a harness whose budget is exceeded and falls through to the next", async () => {
+    const tiny = new FakeHarness("tiny", [
+      { type: "done", finalText: "should not run" },
+    ], 5);
+    const big = new FakeHarness("big", [
+      { type: "text", text: "ok" },
+      { type: "done", finalText: "ok" },
+    ]);
+    const chunks = await collect(
+      runWithFallback([tiny, big], newRequest({ systemPrompt: "long enough to blow tiny's budget" })),
+    );
+    expect(tiny.invocations).toBe(0);
+    expect(big.invocations).toBe(1);
+    expect(chunks.map((c) => c.type)).toEqual(["text", "done"]);
+  });
+
+  test("does not skip when payload is within budget", async () => {
+    const claude = new FakeHarness("claude", [
+      { type: "done", finalText: "ok" },
+    ], 1_000_000);
+    const chunks = await collect(
+      runWithFallback([claude], newRequest({ systemPrompt: "tiny" })),
+    );
+    expect(claude.invocations).toBe(1);
+    expect(chunks.map((c) => c.type)).toEqual(["done"]);
+  });
+
+  test("emits a terminal error when the LAST harness exceeds its budget", async () => {
+    const onlyOne = new FakeHarness("only", [
+      { type: "done", finalText: "x" },
+    ], 5);
+    const chunks = await collect(
+      runWithFallback([onlyOne], newRequest({ systemPrompt: "way too long for budget" })),
+    );
+    expect(onlyOne.invocations).toBe(0);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatchObject({
+      type: "error",
+      recoverable: false,
+      error: expect.stringContaining("exceeds"),
+    });
+  });
+
+  test("harness without maxPayloadBytes is never skipped on size grounds", async () => {
+    const unbounded = new FakeHarness("unbounded", [
+      { type: "done", finalText: "x" },
+    ]); // no maxPayloadBytes
+    const chunks = await collect(
+      runWithFallback(
+        [unbounded],
+        newRequest({ systemPrompt: "x".repeat(10_000_000) }),
+      ),
+    );
+    expect(unbounded.invocations).toBe(1);
+    expect(chunks.map((c) => c.type)).toEqual(["done"]);
+  });
+});

--- a/tests/probe-pi-argmax.test.ts
+++ b/tests/probe-pi-argmax.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Manual probe — finds Pi's effective argv ceiling. Gated behind
+ * RUN_PI_PROBE=1 so it doesn't run in normal test invocations (and
+ * because it requires a real `pi` binary on PATH).
+ *
+ *   RUN_PI_PROBE=1 bun test tests/probe-pi-argmax.test.ts
+ *
+ * Use the result to tune harnesses.pi.maxPayloadBytes in config.toml.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { PiHarness } from "../src/harnesses/pi.ts";
+import type { HarnessRequest } from "../src/harnesses/types.ts";
+
+const RUN = process.env.RUN_PI_PROBE === "1";
+
+describe.skipIf(!RUN)("Pi ARG_MAX probe", () => {
+  test("finds the largest payload pi will accept without spawn-EBIG", async () => {
+    const harness = new PiHarness({
+      bin: process.env.PHANTOMBOT_PI_BIN ?? "pi",
+      maxPayloadBytes: Number.MAX_SAFE_INTEGER, // disable internal precheck
+    });
+
+    // Sweep payload sizes in 50 KB steps from 50 KB to 2 MB.
+    const sizes = [
+      50_000, 100_000, 250_000, 500_000, 1_000_000, 1_500_000, 2_000_000,
+    ];
+
+    let lastSucceeded = 0;
+    for (const sz of sizes) {
+      const padding = "x".repeat(sz);
+      const req: HarnessRequest = {
+        systemPrompt: "you are pi",
+        userMessage: padding,
+        history: [],
+        workingDir: process.cwd(),
+        timeoutMs: 30_000,
+      };
+
+      let result: "ok" | "error" = "ok";
+      try {
+        for await (const chunk of harness.invoke(req)) {
+          if (chunk.type === "error") {
+            result = "error";
+            // eslint-disable-next-line no-console
+            console.log(
+              `[probe] size=${sz} ERROR ${chunk.error} (recoverable=${chunk.recoverable})`,
+            );
+            break;
+          }
+          if (chunk.type === "done") {
+            // eslint-disable-next-line no-console
+            console.log(`[probe] size=${sz} OK (done)`);
+            break;
+          }
+        }
+      } catch (e) {
+        result = "error";
+        // eslint-disable-next-line no-console
+        console.log(`[probe] size=${sz} THROW ${(e as Error).message}`);
+      }
+
+      if (result === "ok") lastSucceeded = sz;
+      else break;
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`[probe] last size pi accepted: ${lastSucceeded} bytes`);
+    expect(lastSucceeded).toBeGreaterThan(0);
+  }, 600_000); // 10-minute test timeout for the sweep
+});


### PR DESCRIPTION
## Summary

- \`runWithFallback\` estimates rendered payload size up front; skips harnesses whose \`maxPayloadBytes\` is too small without spawning a subprocess.
- Skip is a recoverable error → chain falls through to the next harness (typically \`claude\`, which has no ceiling).
- LAST-harness-too-small case emits a terminal error rather than silent no-op.
- \`estimatePayloadBytes\` exported for testing.

## Tests added

- [x] \`bun test\` — 118 pass / 1 skip / 0 fail in 799ms (added 6 new tests)
- estimate calculation; skip + fallthrough; within-budget no-skip; terminal error on last harness; unbounded harness immune.

## Probe added

- \`tests/probe-pi-argmax.test.ts\` — manual probe (gated \`RUN_PI_PROBE=1\`). Sweeps argv sizes against real \`pi\` to find the ceiling. Output goes to console; use to tune \`harnesses.pi.max_payload_bytes\` in \`config.toml\`.