### PR TITLE
Phase 13: Telegram channel adapter

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,0 +1,248 @@
+/**
+ * Telegram channel adapter.
+ *
+ * Long-polls Telegram's getUpdates, dispatches each text message through
+ * runTurn, and sends the assistant reply back via sendMessage. Per-chat
+ * memory uses conversation key `telegram:<chatId>` so DMs and groups are
+ * isolated from the CLI's `cli:default` history.
+ *
+ * Streaming: we send `sendChatAction(typing)` at the start of each turn so
+ * the user sees "Phantom is typing…" while the harness runs, then post the
+ * final reply as one message. Live token-by-token edits would be nicer but
+ * Telegram rate-limits edits at ~1/sec — not worth the complexity for v1.
+ *
+ * Auth gating: if `allowedUserIds` is empty, anyone who DMs the bot is
+ * answered. We log a warning at startup so this isn't accidental.
+ */
+
+import type { Config } from "../config.ts";
+import type { Harness } from "../harnesses/types.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { log } from "../lib/logger.ts";
+import type { MemoryStore } from "../memory/store.ts";
+import { runTurn } from "../orchestrator/turn.ts";
+
+export interface TelegramMessage {
+  updateId: number;
+  chatId: number;
+  fromUserId: number;
+  fromUsername?: string;
+  text: string;
+}
+
+export interface TelegramTransport {
+  /** Long-poll Telegram for updates from `offset`. Returns parsed updates and the new offset. */
+  getUpdates(
+    offset: number,
+    timeoutS: number,
+  ): Promise<{ updates: TelegramMessage[]; nextOffset: number }>;
+  sendMessage(chatId: number, text: string): Promise<void>;
+  sendTyping(chatId: number): Promise<void>;
+}
+
+/**
+ * Real HTTP transport against api.telegram.org.
+ */
+export class HttpTelegramTransport implements TelegramTransport {
+  constructor(private readonly token: string) {}
+
+  async getUpdates(
+    offset: number,
+    timeoutS: number,
+  ): Promise<{ updates: TelegramMessage[]; nextOffset: number }> {
+    const url = `https://api.telegram.org/bot${this.token}/getUpdates?offset=${offset}&timeout=${timeoutS}&allowed_updates=%5B%22message%22%5D`;
+    const res = await fetch(url, {
+      // The fetch timeout should be slightly longer than the long-poll timeout
+      // so the server has a chance to actually return; Bun fetch has no built-in
+      // timeout — the long-poll naturally bounds it.
+    });
+    if (!res.ok) {
+      log.warn("telegram: getUpdates non-OK", { status: res.status });
+      return { updates: [], nextOffset: offset };
+    }
+    const body = (await res.json()) as {
+      ok?: boolean;
+      result?: TelegramRawUpdate[];
+      description?: string;
+    };
+    if (!body.ok) {
+      log.warn("telegram: getUpdates not ok", { description: body.description });
+      return { updates: [], nextOffset: offset };
+    }
+    return parseGetUpdatesResult(body.result ?? [], offset);
+  }
+
+  async sendMessage(chatId: number, text: string): Promise<void> {
+    const url = `https://api.telegram.org/bot${this.token}/sendMessage`;
+    // Telegram caps message length at 4096 chars. Truncate gracefully.
+    const safe = text.length > 4000 ? text.slice(0, 4000) + "\n…[truncated]" : text;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: safe }),
+    });
+    if (!res.ok) {
+      log.warn("telegram: sendMessage non-OK", {
+        chatId,
+        status: res.status,
+      });
+    }
+  }
+
+  async sendTyping(chatId: number): Promise<void> {
+    const url = `https://api.telegram.org/bot${this.token}/sendChatAction`;
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, action: "typing" }),
+    }).catch(() => {
+      /* typing indicator is best-effort */
+    });
+  }
+}
+
+interface TelegramRawUpdate {
+  update_id?: number;
+  message?: {
+    chat?: { id?: number };
+    from?: { id?: number; username?: string };
+    text?: string;
+  };
+}
+
+/**
+ * Pure parser exposed for testing. Consumes Telegram getUpdates result
+ * objects and returns only the message-with-text updates we care about.
+ */
+export function parseGetUpdatesResult(
+  raw: TelegramRawUpdate[],
+  fallbackOffset: number,
+): { updates: TelegramMessage[]; nextOffset: number } {
+  const updates: TelegramMessage[] = [];
+  let nextOffset = fallbackOffset;
+  for (const u of raw) {
+    if (typeof u.update_id === "number") {
+      nextOffset = Math.max(nextOffset, u.update_id + 1);
+    }
+    const msg = u.message;
+    if (
+      typeof u.update_id === "number" &&
+      msg &&
+      typeof msg.chat?.id === "number" &&
+      typeof msg.from?.id === "number" &&
+      typeof msg.text === "string" &&
+      msg.text.length > 0
+    ) {
+      updates.push({
+        updateId: u.update_id,
+        chatId: msg.chat.id,
+        fromUserId: msg.from.id,
+        fromUsername: msg.from.username,
+        text: msg.text,
+      });
+    }
+  }
+  return { updates, nextOffset };
+}
+
+export interface RunTelegramServerInput {
+  config: Config;
+  memory: MemoryStore;
+  harnesses: Harness[];
+  agentDir: string;
+  persona: string;
+  transport: TelegramTransport;
+  /** Stop after one polling cycle. For tests. */
+  oneShot?: boolean;
+  /** Signal to stop the loop cleanly. */
+  signal?: AbortSignal;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+/**
+ * The long-poll loop. Returns when signal is aborted, or after one
+ * iteration if oneShot is set. Otherwise runs forever.
+ */
+export async function runTelegramServer(
+  input: RunTelegramServerInput,
+): Promise<void> {
+  const tg = input.config.channels.telegram!;
+  const allowedSet = new Set(tg.allowedUserIds);
+  const checkAllowed = (userId: number): boolean =>
+    allowedSet.size === 0 || allowedSet.has(userId);
+
+  if (allowedSet.size === 0) {
+    log.warn(
+      "telegram: no allowed_user_ids configured — anyone who DMs the bot is answered",
+    );
+  }
+
+  let offset = 0;
+
+  do {
+    if (input.signal?.aborted) return;
+
+    const { updates, nextOffset } = await input.transport.getUpdates(
+      offset,
+      tg.pollTimeoutS,
+    );
+    offset = nextOffset;
+
+    for (const msg of updates) {
+      if (input.signal?.aborted) return;
+
+      if (!checkAllowed(msg.fromUserId)) {
+        log.info("telegram: rejecting unauthorized user", {
+          fromUserId: msg.fromUserId,
+          fromUsername: msg.fromUsername,
+        });
+        continue;
+      }
+
+      log.info("telegram: incoming", {
+        chatId: msg.chatId,
+        fromUserId: msg.fromUserId,
+        fromUsername: msg.fromUsername,
+        textLength: msg.text.length,
+      });
+
+      void input.transport.sendTyping(msg.chatId);
+
+      let reply = "";
+      let errored: string | undefined;
+      try {
+        for await (const chunk of runTurn({
+          persona: input.persona,
+          conversation: `telegram:${msg.chatId}`,
+          userMessage: msg.text,
+          agentDir: input.agentDir,
+          harnesses: input.harnesses,
+          memory: input.memory,
+          timeoutMs: input.config.turnTimeoutMs,
+        })) {
+          if (chunk.type === "text") reply += chunk.text;
+          if (chunk.type === "done") reply = chunk.finalText;
+          if (chunk.type === "error") errored = chunk.error;
+        }
+      } catch (e) {
+        errored = (e as Error).message;
+        log.error("telegram: turn threw", { error: errored });
+      }
+
+      const outText = errored
+        ? `(error: ${errored})`
+        : reply.length > 0
+          ? reply
+          : "(no reply)";
+      try {
+        await input.transport.sendMessage(msg.chatId, outText);
+      } catch (e) {
+        log.error("telegram: sendMessage failed", {
+          error: (e as Error).message,
+          chatId: msg.chatId,
+        });
+      }
+    }
+  } while (!input.oneShot);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,6 +12,7 @@ import setDefaultPersonaCmd from "./set-default-persona.ts";
 import historyCmd from "./history.ts";
 import configCmd from "./config.ts";
 import doctorCmd from "./doctor.ts";
+import serveCmd from "./serve.ts";
 
 export const mainCommand = defineCommand({
   meta: {
@@ -29,5 +30,6 @@ export const mainCommand = defineCommand({
     history: historyCmd,
     config: configCmd,
     doctor: doctorCmd,
+    serve: serveCmd,
   },
 });

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,0 +1,132 @@
+/**
+ * `phantombot serve [--telegram]` — long-running channel listener.
+ *
+ * Telegram is the only channel for v1. Other channels (signal, googlechat)
+ * can land later by adding flags + adapter classes. The flag-based dispatch
+ * keeps `phantombot` itself a single command rather than introducing a
+ * `serve <channel>` sub-subcommand layer.
+ */
+
+import { defineCommand } from "citty";
+import { existsSync } from "node:fs";
+
+import {
+  HttpTelegramTransport,
+  runTelegramServer,
+} from "../channels/telegram.ts";
+import { type Config, loadConfig, personaDir } from "../config.ts";
+import { ClaudeHarness } from "../harnesses/claude.ts";
+import { PiHarness } from "../harnesses/pi.ts";
+import type { Harness } from "../harnesses/types.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { openMemoryStore } from "../memory/store.ts";
+
+export interface RunServeInput {
+  telegram?: boolean;
+  /** Override config for testing. */
+  config?: Config;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runServe(input: RunServeInput): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+
+  if (!input.telegram) {
+    err.write("specify a channel: --telegram\n");
+    return 2;
+  }
+
+  const config = input.config ?? (await loadConfig());
+  const tg = config.channels.telegram;
+  if (!tg) {
+    err.write(
+      "no telegram bot token configured. Set TELEGRAM_BOT_TOKEN or [channels.telegram].token in config.toml\n",
+    );
+    return 2;
+  }
+
+  const persona = config.defaultPersona;
+  const agentDir = personaDir(config, persona);
+  if (!existsSync(agentDir)) {
+    err.write(`persona '${persona}' not found at ${agentDir}\n`);
+    err.write(
+      "import one with `phantombot import-persona <openclaw-agent-dir>`\n",
+    );
+    return 2;
+  }
+
+  const harnesses = buildHarnessChain(config, err);
+  if (harnesses.length === 0) {
+    err.write("no harnesses configured\n");
+    return 2;
+  }
+
+  const memory = await openMemoryStore(config.memoryDbPath);
+  const transport = new HttpTelegramTransport(tg.token);
+
+  out.write(
+    `phantombot serve --telegram — persona: ${persona}, harnesses: ${config.harnesses.chain.join(",")}\n`,
+  );
+  out.write(`long-poll timeout: ${tg.pollTimeoutS}s; ` +
+    `allowed users: ${tg.allowedUserIds.length === 0 ? "ANY (no allowlist)" : tg.allowedUserIds.join(",")}\n`);
+  out.write("Ctrl-C to stop.\n");
+
+  const ac = new AbortController();
+  const onSig = () => ac.abort();
+  process.on("SIGINT", onSig);
+  process.on("SIGTERM", onSig);
+
+  try {
+    await runTelegramServer({
+      config,
+      memory,
+      harnesses,
+      agentDir,
+      persona,
+      transport,
+      signal: ac.signal,
+      out,
+      err,
+    });
+  } finally {
+    process.off("SIGINT", onSig);
+    process.off("SIGTERM", onSig);
+    await memory.close();
+  }
+  return 0;
+}
+
+function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
+  const harnesses: Harness[] = [];
+  for (const id of config.harnesses.chain) {
+    if (id === "claude") {
+      harnesses.push(new ClaudeHarness(config.harnesses.claude));
+    } else if (id === "pi") {
+      harnesses.push(new PiHarness(config.harnesses.pi));
+    } else {
+      err.write(`warning: unknown harness '${id}', skipping\n`);
+    }
+  }
+  return harnesses;
+}
+
+export default defineCommand({
+  meta: {
+    name: "serve",
+    description:
+      "Run a long-lived channel listener (currently --telegram only). Stays in the foreground; daemonize via systemd or nohup.",
+  },
+  args: {
+    telegram: {
+      type: "boolean",
+      description: "Listen on Telegram via long-poll.",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const code = await runServe({ telegram: Boolean(args.telegram) });
+    process.exitCode = code;
+  },
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,16 @@ export interface Config {
     claude: { bin: string; model: string; fallbackModel: string };
     pi: { bin: string; maxPayloadBytes: number };
   };
+
+  channels: {
+    telegram?: {
+      token: string;
+      /** Long-poll timeout in seconds (1..50). Default 30. */
+      pollTimeoutS: number;
+      /** If non-empty, only these Telegram numeric user IDs can talk to the bot. */
+      allowedUserIds: number[];
+    };
+  };
 }
 
 export function xdgConfigHome(): string {
@@ -60,6 +70,8 @@ export async function loadConfig(): Promise<Config> {
   const tomlHarnesses = (toml.harnesses ?? {}) as Record<string, unknown>;
   const tomlClaude = (tomlHarnesses.claude ?? {}) as Record<string, unknown>;
   const tomlPi = (tomlHarnesses.pi ?? {}) as Record<string, unknown>;
+  const tomlChannels = (toml.channels ?? {}) as Record<string, unknown>;
+  const tomlTelegram = (tomlChannels.telegram ?? {}) as Record<string, unknown>;
 
   return {
     defaultPersona:
@@ -122,7 +134,49 @@ export async function loadConfig(): Promise<Config> {
           1_500_000,
       },
     },
+
+    channels: {
+      telegram: buildTelegramConfig(tomlTelegram),
+    },
   };
+}
+
+function buildTelegramConfig(
+  tomlTelegram: Record<string, unknown>,
+): Config["channels"]["telegram"] {
+  const token =
+    process.env.TELEGRAM_BOT_TOKEN ?? asString(tomlTelegram.token);
+  if (!token) return undefined;
+
+  const pollTimeoutS = clampPollTimeout(
+    asInt(process.env.PHANTOMBOT_TELEGRAM_POLL_S) ??
+      asInt(tomlTelegram.poll_timeout_s) ??
+      30,
+  );
+
+  const allowedFromEnv = process.env.PHANTOMBOT_TELEGRAM_ALLOWED_USERS
+    ?.split(",")
+    .map((s) => Number(s.trim()))
+    .filter((n) => Number.isInteger(n));
+  const allowedFromToml = asIntArray(tomlTelegram.allowed_user_ids);
+  const allowedUserIds = allowedFromEnv ?? allowedFromToml ?? [];
+
+  return { token, pollTimeoutS, allowedUserIds };
+}
+
+function clampPollTimeout(s: number): number {
+  if (!Number.isFinite(s)) return 30;
+  return Math.max(1, Math.min(50, Math.floor(s)));
+}
+
+function asIntArray(v: unknown): number[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: number[] = [];
+  for (const x of v) {
+    const n = asInt(x);
+    if (n !== undefined) out.push(n);
+  }
+  return out;
 }
 
 /** Resolve the on-disk directory for a named persona. */

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Tests for the Telegram channel adapter.
+ *
+ * Three layers:
+ *   1. parseGetUpdatesResult — pure parser, exhaustive shape coverage.
+ *   2. runTelegramServer with a fake transport + scripted harness — verifies
+ *      end-to-end flow without HTTP or subprocesses.
+ *   3. runServe — early-exit failure paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseGetUpdatesResult,
+  type TelegramMessage,
+  type TelegramTransport,
+  runTelegramServer,
+} from "../src/channels/telegram.ts";
+import { runServe } from "../src/cli/serve.ts";
+import type { Config } from "../src/config.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessRequest,
+} from "../src/harnesses/types.ts";
+import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+class FakeTransport implements TelegramTransport {
+  /** Set this before calling getUpdates; it's drained on first call. */
+  pendingUpdates: TelegramMessage[] = [];
+  sent: Array<{ chatId: number; text: string }> = [];
+  typing: number[] = [];
+  async getUpdates(
+    offset: number,
+    _timeoutS: number,
+  ): Promise<{ updates: TelegramMessage[]; nextOffset: number }> {
+    const updates = this.pendingUpdates.splice(0);
+    // Real Telegram getUpdates blocks server-side. Simulate that with a
+    // small macrotask delay when there are no updates so the runtime's
+    // setTimeout-based AbortControllers can fire (a microtask-only loop
+    // can starve them).
+    if (updates.length === 0) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    const nextOffset =
+      updates.length > 0
+        ? Math.max(...updates.map((u) => u.updateId)) + 1
+        : offset;
+    return { updates, nextOffset };
+  }
+  async sendMessage(chatId: number, text: string): Promise<void> {
+    this.sent.push({ chatId, text });
+  }
+  async sendTyping(chatId: number): Promise<void> {
+    this.typing.push(chatId);
+  }
+}
+
+class ScriptedHarness implements Harness {
+  invocations = 0;
+  lastRequest?: HarnessRequest;
+  constructor(
+    public readonly id: string,
+    private readonly script: HarnessChunk[],
+  ) {}
+  async available(): Promise<boolean> {
+    return true;
+  }
+  async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    this.invocations++;
+    this.lastRequest = req;
+    for (const c of this.script) yield c;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseGetUpdatesResult
+// ---------------------------------------------------------------------------
+
+describe("parseGetUpdatesResult", () => {
+  test("extracts text messages and advances offset", () => {
+    const raw = [
+      {
+        update_id: 100,
+        message: {
+          chat: { id: 1 },
+          from: { id: 42, username: "alice" },
+          text: "hi",
+        },
+      },
+      {
+        update_id: 101,
+        message: {
+          chat: { id: 1 },
+          from: { id: 42 },
+          text: "again",
+        },
+      },
+    ];
+    const r = parseGetUpdatesResult(raw, 0);
+    expect(r.updates).toEqual([
+      {
+        updateId: 100,
+        chatId: 1,
+        fromUserId: 42,
+        fromUsername: "alice",
+        text: "hi",
+      },
+      {
+        updateId: 101,
+        chatId: 1,
+        fromUserId: 42,
+        fromUsername: undefined,
+        text: "again",
+      },
+    ]);
+    expect(r.nextOffset).toBe(102);
+  });
+
+  test("skips non-message updates (e.g., callback_query) but still advances offset", () => {
+    const raw = [
+      { update_id: 200, callback_query: {} },
+      {
+        update_id: 201,
+        message: {
+          chat: { id: 1 },
+          from: { id: 42 },
+          text: "hello",
+        },
+      },
+    ];
+    const r = parseGetUpdatesResult(raw, 0);
+    expect(r.updates).toHaveLength(1);
+    expect(r.updates[0]?.text).toBe("hello");
+    expect(r.nextOffset).toBe(202);
+  });
+
+  test("skips messages without text (e.g., photos, stickers)", () => {
+    const raw = [
+      {
+        update_id: 300,
+        message: {
+          chat: { id: 1 },
+          from: { id: 42 },
+        },
+      },
+    ];
+    const r = parseGetUpdatesResult(raw, 0);
+    expect(r.updates).toEqual([]);
+    expect(r.nextOffset).toBe(301);
+  });
+
+  test("preserves prior offset when no updates", () => {
+    const r = parseGetUpdatesResult([], 555);
+    expect(r.nextOffset).toBe(555);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runTelegramServer end-to-end (fake transport)
+// ---------------------------------------------------------------------------
+
+let workdir: string;
+let memory: MemoryStore;
+let agentDir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-tg-"));
+  agentDir = join(workdir, "personas", "phantom");
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(join(agentDir, "BOOT.md"), "# Phantom", "utf8");
+  memory = await openMemoryStore(":memory:");
+});
+
+afterEach(async () => {
+  await memory.close();
+  await rm(workdir, { recursive: true, force: true });
+});
+
+const baseConfig = (
+  overrides: Partial<Config["channels"]["telegram"]> = {},
+): Config => ({
+  defaultPersona: "phantom",
+  turnTimeoutMs: 5_000,
+  personasDir: join(workdir, "personas"),
+  memoryDbPath: join(workdir, "memory.sqlite"),
+  configPath: join(workdir, "config.toml"),
+  harnesses: {
+    chain: ["claude"],
+    claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+    pi: { bin: "pi", maxPayloadBytes: 1_000_000 },
+  },
+  channels: {
+    telegram: {
+      token: "fake-token",
+      pollTimeoutS: 30,
+      allowedUserIds: [],
+      ...overrides,
+    },
+  },
+});
+
+describe("runTelegramServer (fake transport)", () => {
+  test("dispatches a message through runTurn and replies on Telegram", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      fromUsername: "alice",
+      text: "hello",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "hi " },
+      { type: "text", text: "alice" },
+      { type: "done", finalText: "hi alice" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.typing).toEqual([1001]);
+    expect(transport.sent).toEqual([{ chatId: 1001, text: "hi alice" }]);
+    expect(harness.invocations).toBe(1);
+    expect(harness.lastRequest?.userMessage).toBe("hello");
+
+    // Persisted to telegram:1001 namespace, NOT cli:default.
+    const tgTurns = await memory.recentTurns("phantom", "telegram:1001", 10);
+    expect(tgTurns).toEqual([
+      { role: "user", text: "hello" },
+      { role: "assistant", text: "hi alice" },
+    ]);
+    const cliTurns = await memory.recentTurns("phantom", "cli:default", 10);
+    expect(cliTurns).toEqual([]);
+  });
+
+  test("rejects messages from non-allowed users when allowlist is set", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 99,
+      text: "hi",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ allowedUserIds: [42] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toEqual([]);
+    expect(transport.typing).toEqual([]);
+  });
+
+  test("allowed users still get answered when allowlist is set", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hi",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "yes" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ allowedUserIds: [42] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(1);
+    expect(transport.sent).toEqual([{ chatId: 1001, text: "yes" }]);
+  });
+
+  test("on harness error, sends error message back to chat", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hi",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "error", error: "rate limited", recoverable: false },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(transport.sent).toEqual([
+      { chatId: 1001, text: "(error: rate limited)" },
+    ]);
+    // Should NOT have persisted on error.
+    const turns = await memory.recentTurns("phantom", "telegram:1001", 10);
+    expect(turns).toEqual([]);
+  });
+
+  test("isolates conversations by chatId", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push(
+      {
+        updateId: 1,
+        chatId: 100,
+        fromUserId: 42,
+        text: "from chat A",
+      },
+      {
+        updateId: 2,
+        chatId: 200,
+        fromUserId: 42,
+        text: "from chat B",
+      },
+    );
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    const a = await memory.recentTurns("phantom", "telegram:100", 10);
+    const b = await memory.recentTurns("phantom", "telegram:200", 10);
+    expect(a.map((t) => t.text)).toEqual(["from chat A", "ok"]);
+    expect(b.map((t) => t.text)).toEqual(["from chat B", "ok"]);
+  });
+
+  test("aborts cleanly when signal fires (no oneShot)", async () => {
+    const transport = new FakeTransport();
+    const ac = new AbortController();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    // Fire abort almost immediately so the loop exits on the second poll.
+    setTimeout(() => ac.abort(), 50);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      signal: ac.signal,
+    });
+    expect(harness.invocations).toBe(0); // no updates ever queued
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runServe — failure paths (success path is covered by the server test above)
+// ---------------------------------------------------------------------------
+
+describe("runServe", () => {
+  test("returns 2 when --telegram is not set", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runServe({ out, err });
+    expect(code).toBe(2);
+    expect(err.text).toContain("specify a channel");
+  });
+
+  test("returns 2 when telegram token is not configured", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runServe({
+      telegram: true,
+      config: { ...baseConfig(), channels: {} },
+      out,
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("no telegram bot token configured");
+  });
+
+  test("returns 2 when the persona dir doesn't exist", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    await rm(agentDir, { recursive: true, force: true });
+    const code = await runServe({
+      telegram: true,
+      config: baseConfig(),
+      out,
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("persona 'phantom' not found");
+  });
+});

--- a/tests/cli-ask.test.ts
+++ b/tests/cli-ask.test.ts
@@ -47,6 +47,7 @@ beforeEach(async () => {
       claude: { bin: FAKE_CLAUDE, model: "test", fallbackModel: "" },
       pi: { bin: "pi", maxPayloadBytes: 1_000_000 },
     },
+    channels: {},
   };
 
   savedFakeMode = process.env.FAKE_CLAUDE_MODE;

--- a/tests/cli-management.test.ts
+++ b/tests/cli-management.test.ts
@@ -49,6 +49,7 @@ beforeEach(async () => {
       claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
       pi: { bin: "pi", maxPayloadBytes: 1_500_000 },
     },
+    channels: {},
   };
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -27,6 +27,7 @@ describe("phantombot CLI dispatcher", () => {
       "history",
       "import-persona",
       "list-personas",
+      "serve",
       "set-default-persona",
     ]);
   });

--- a/tests/repl.test.ts
+++ b/tests/repl.test.ts
@@ -56,6 +56,7 @@ beforeEach(async () => {
       claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
       pi: { bin: "pi", maxPayloadBytes: 1_000_000 },
     },
+    channels: {},
   };
 });
 


### PR DESCRIPTION
## Summary

Adds the first inbound channel since the v1 daemon cleanup. \`phantombot serve --telegram\` long-polls \`getUpdates\` and dispatches each text message through \`runTurn\` with conversation key \`telegram:<chatId>\` so DMs and groups have their own memory namespace, isolated from CLI history.

## Files

- \`src/channels/telegram.ts\` — \`TelegramTransport\` interface + \`HttpTelegramTransport\` (real api.telegram.org client) + \`parseGetUpdatesResult\` (pure parser) + \`runTelegramServer\` (long-poll loop)
- \`src/cli/serve.ts\` — new \`phantombot serve --telegram\` subcommand; wires SIGINT/SIGTERM to AbortController for clean shutdown
- \`src/cli/index.ts\` — registers \`serve\` in the dispatcher
- \`src/config.ts\` — new \`[channels.telegram]\` block: \`token\` (or \`TELEGRAM_BOT_TOKEN\` env var), \`poll_timeout_s\` (default 30, clamped 1..50), \`allowed_user_ids\` (empty = anyone, startup warning)

## Send strategy

- \`sendChatAction(typing)\` per turn so the user sees "typing…"
- Final reply as one \`sendMessage\`; no live edits (Telegram rate-limits edits ~1/sec)
- Truncate at 4000 chars (Telegram cap is 4096)
- On harness error, send "(error: …)" back to chat
- On harness error, do **not** persist (consistent with \`runTurn\` semantics)

## Test plan

- [x] \`bun test\` — 143 pass / 1 skip / 0 fail in 911ms (added 13 new tests)
- [x] \`bun tsc --noEmit\` — clean
- Tests cover parser shape coverage; end-to-end dispatch + reply + memory persistence to \`telegram:<id>\`; allowlist accept/reject; chat-id isolation; clean abort via AbortController; early-exit failures (no --telegram flag, no token, missing persona).

## Notes

- Allowlist is opt-in via \`allowed_user_ids\`. Empty = anyone who DMs the bot is answered; a startup warning is logged so this isn't accidental.
- Bot stays in foreground; daemonize via systemd or \`nohup phantombot serve --telegram &\`.