### PR TITLE
Phase 15: pass AbortSignal into Telegram getUpdates so Ctrl-C is instant

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -31,10 +31,16 @@ export interface TelegramMessage {
 }
 
 export interface TelegramTransport {
-  /** Long-poll Telegram for updates from `offset`. Returns parsed updates and the new offset. */
+  /**
+   * Long-poll Telegram for updates from `offset`. Returns parsed updates
+   * and the new offset. The optional `signal` cancels the in-flight HTTP
+   * call so SIGINT during a 30-second long-poll exits in milliseconds
+   * instead of waiting out the full timeout.
+   */
   getUpdates(
     offset: number,
     timeoutS: number,
+    signal?: AbortSignal,
   ): Promise<{ updates: TelegramMessage[]; nextOffset: number }>;
   sendMessage(chatId: number, text: string): Promise<void>;
   sendTyping(chatId: number): Promise<void>;
@@ -49,13 +55,23 @@ export class HttpTelegramTransport implements TelegramTransport {
   async getUpdates(
     offset: number,
     timeoutS: number,
+    signal?: AbortSignal,
   ): Promise<{ updates: TelegramMessage[]; nextOffset: number }> {
     const url = `https://api.telegram.org/bot${this.token}/getUpdates?offset=${offset}&timeout=${timeoutS}&allowed_updates=%5B%22message%22%5D`;
-    const res = await fetch(url, {
-      // The fetch timeout should be slightly longer than the long-poll timeout
-      // so the server has a chance to actually return; Bun fetch has no built-in
-      // timeout — the long-poll naturally bounds it.
-    });
+    let res: Response;
+    try {
+      res = await fetch(url, { signal });
+    } catch (e) {
+      // AbortError is the expected path on Ctrl-C; just return empty so the
+      // caller's next signal check exits the loop.
+      if ((e as Error).name === "AbortError") {
+        return { updates: [], nextOffset: offset };
+      }
+      log.warn("telegram: getUpdates fetch failed", {
+        error: (e as Error).message,
+      });
+      return { updates: [], nextOffset: offset };
+    }
     if (!res.ok) {
       log.warn("telegram: getUpdates non-OK", { status: res.status });
       return { updates: [], nextOffset: offset };
@@ -186,6 +202,7 @@ export async function runTelegramServer(
     const { updates, nextOffset } = await input.transport.getUpdates(
       offset,
       tg.pollTimeoutS,
+      input.signal,
     );
     offset = nextOffset;
 

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Tests for the Telegram channel adapter.
+ *
+ * Three layers:
+ *   1. parseGetUpdatesResult — pure parser, exhaustive shape coverage.
+ *   2. runTelegramServer with a fake transport + scripted harness — verifies
+ *      end-to-end flow without HTTP or subprocesses.
+ *   3. HttpTelegramTransport AbortSignal handling — verifies that an
+ *      in-flight long-poll is cancelled cleanly when the signal fires.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  HttpTelegramTransport,
+  parseGetUpdatesResult,
+  type TelegramMessage,
+  type TelegramTransport,
+  runTelegramServer,
+} from "../src/channels/telegram.ts";
+import type { Config } from "../src/config.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessRequest,
+} from "../src/harnesses/types.ts";
+import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
+
+class FakeTransport implements TelegramTransport {
+  pendingUpdates: TelegramMessage[] = [];
+  sent: Array<{ chatId: number; text: string }> = [];
+  typing: number[] = [];
+  receivedSignals: Array<AbortSignal | undefined> = [];
+  async getUpdates(
+    offset: number,
+    _timeoutS: number,
+    signal?: AbortSignal,
+  ): Promise<{ updates: TelegramMessage[]; nextOffset: number }> {
+    this.receivedSignals.push(signal);
+    const updates = this.pendingUpdates.splice(0);
+    if (updates.length === 0) {
+      // Mirror real long-poll behavior so setTimeout-based AbortControllers
+      // can fire between iterations.
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    const nextOffset =
+      updates.length > 0
+        ? Math.max(...updates.map((u) => u.updateId)) + 1
+        : offset;
+    return { updates, nextOffset };
+  }
+  async sendMessage(chatId: number, text: string): Promise<void> {
+    this.sent.push({ chatId, text });
+  }
+  async sendTyping(chatId: number): Promise<void> {
+    this.typing.push(chatId);
+  }
+}
+
+class ScriptedHarness implements Harness {
+  invocations = 0;
+  lastRequest?: HarnessRequest;
+  constructor(
+    public readonly id: string,
+    private readonly script: HarnessChunk[],
+  ) {}
+  async available(): Promise<boolean> {
+    return true;
+  }
+  async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    this.invocations++;
+    this.lastRequest = req;
+    for (const c of this.script) yield c;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseGetUpdatesResult
+// ---------------------------------------------------------------------------
+
+describe("parseGetUpdatesResult", () => {
+  test("extracts text messages and advances offset", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 100,
+          message: {
+            chat: { id: 1 },
+            from: { id: 42, username: "alice" },
+            text: "hi",
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates).toEqual([
+      {
+        updateId: 100,
+        chatId: 1,
+        fromUserId: 42,
+        fromUsername: "alice",
+        text: "hi",
+      },
+    ]);
+    expect(r.nextOffset).toBe(101);
+  });
+
+  test("skips messages without text", () => {
+    const r = parseGetUpdatesResult(
+      [{ update_id: 200, message: { chat: { id: 1 }, from: { id: 42 } } }],
+      0,
+    );
+    expect(r.updates).toEqual([]);
+    expect(r.nextOffset).toBe(201);
+  });
+
+  test("preserves prior offset on empty result", () => {
+    expect(parseGetUpdatesResult([], 555).nextOffset).toBe(555);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runTelegramServer end-to-end (fake transport)
+// ---------------------------------------------------------------------------
+
+let workdir: string;
+let memory: MemoryStore;
+let agentDir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-tg-"));
+  agentDir = join(workdir, "personas", "phantom");
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(join(agentDir, "BOOT.md"), "# Phantom", "utf8");
+  memory = await openMemoryStore(":memory:");
+});
+
+afterEach(async () => {
+  await memory.close();
+  await rm(workdir, { recursive: true, force: true });
+});
+
+const baseConfig = (
+  overrides: Partial<NonNullable<Config["channels"]["telegram"]>> = {},
+): Config => ({
+  defaultPersona: "phantom",
+  turnTimeoutMs: 5_000,
+  personasDir: join(workdir, "personas"),
+  memoryDbPath: join(workdir, "memory.sqlite"),
+  configPath: join(workdir, "config.toml"),
+  harnesses: {
+    chain: ["claude"],
+    claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+    pi: { bin: "pi", maxPayloadBytes: 1_000_000 },
+  },
+  channels: {
+    telegram: {
+      token: "fake-token",
+      pollTimeoutS: 30,
+      allowedUserIds: [],
+      ...overrides,
+    },
+  },
+});
+
+describe("runTelegramServer dispatch", () => {
+  test("dispatches a message through runTurn and replies via Telegram", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      fromUsername: "alice",
+      text: "hello",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "hi alice" },
+      { type: "done", finalText: "hi alice" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.typing).toEqual([1001]);
+    expect(transport.sent).toEqual([{ chatId: 1001, text: "hi alice" }]);
+    const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
+    expect(stored).toEqual([
+      { role: "user", text: "hello" },
+      { role: "assistant", text: "hi alice" },
+    ]);
+  });
+
+  test("rejects messages from non-allowed users when allowlist is set", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 99,
+      text: "hi",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "x" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ allowedUserIds: [42] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toEqual([]);
+  });
+
+  test("isolates conversations by chatId", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push(
+      { updateId: 1, chatId: 100, fromUserId: 42, text: "from A" },
+      { updateId: 2, chatId: 200, fromUserId: 42, text: "from B" },
+    );
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    const a = await memory.recentTurns("phantom", "telegram:100", 10);
+    const b = await memory.recentTurns("phantom", "telegram:200", 10);
+    expect(a.map((t) => t.text)).toEqual(["from A", "ok"]);
+    expect(b.map((t) => t.text)).toEqual(["from B", "ok"]);
+  });
+
+  test("on harness error sends an error message and does not persist", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hi",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "error", error: "boom", recoverable: false },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(transport.sent).toEqual([{ chatId: 1001, text: "(error: boom)" }]);
+    expect(await memory.recentTurns("phantom", "telegram:1001", 10)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AbortSignal plumbing
+// ---------------------------------------------------------------------------
+
+describe("runTelegramServer AbortSignal", () => {
+  test("passes the signal through to transport.getUpdates", async () => {
+    const transport = new FakeTransport();
+    const ac = new AbortController();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    setTimeout(() => ac.abort(), 30);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      signal: ac.signal,
+    });
+    expect(transport.receivedSignals.length).toBeGreaterThan(0);
+    expect(transport.receivedSignals[0]).toBe(ac.signal);
+  });
+});
+
+describe("HttpTelegramTransport AbortSignal", () => {
+  test("aborted fetch returns empty result without throwing", async () => {
+    // Replace globalThis.fetch with one that throws AbortError immediately
+    // when the supplied signal is already aborted.
+    const originalFetch = globalThis.fetch;
+    try {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (
+        _url: string | URL | Request,
+        init?: RequestInit,
+      ) => {
+        if (init?.signal?.aborted) {
+          const e = new Error("aborted");
+          e.name = "AbortError";
+          throw e;
+        }
+        // Otherwise wait ~50ms then check again
+        await new Promise((r) => setTimeout(r, 50));
+        if (init?.signal?.aborted) {
+          const e = new Error("aborted");
+          e.name = "AbortError";
+          throw e;
+        }
+        return new Response(
+          JSON.stringify({ ok: true, result: [] }),
+          { status: 200 },
+        );
+      }) as unknown as typeof fetch;
+
+      const ac = new AbortController();
+      ac.abort();
+      const t = new HttpTelegramTransport("anything");
+      const r = await t.getUpdates(0, 30, ac.signal);
+      expect(r.updates).toEqual([]);
+      expect(r.nextOffset).toBe(0);
+    } finally {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

\`runTelegramServer\` checked \`input.signal.aborted\` at the top of each iteration, but the in-flight \`fetch()\` inside \`HttpTelegramTransport.getUpdates\` didn't receive the signal — so Ctrl-C had to wait out the 30-second long-poll before the next signal check exited the loop. Visible to the user as "took a while" before \`phantombot run\` actually stopped.

## Fix

- \`TelegramTransport.getUpdates(offset, timeoutS, signal?)\` — added optional \`AbortSignal\` to the interface
- \`HttpTelegramTransport.getUpdates\` passes the signal to \`fetch\` and catches \`AbortError\` (returns empty result so the next iteration's signal check exits without throwing)
- \`runTelegramServer\` plumbs \`input.signal\` through to \`transport.getUpdates\`

## Test plan

- [x] \`bun test\` — 156 pass / 1 skip / 0 fail in 792ms (added 8 new tests)
- [x] \`bun tsc --noEmit\` — clean
- Restores \`tests/channels-telegram.test.ts\` (it had been removed in phase 14 with a note "folded into the run cmd" — that fold never actually happened, leaving runTelegramServer untested).
- Tests cover: parser shape coverage, end-to-end dispatch + reply + memory persistence, allowlist accept/reject, chat-id isolation, error-no-persist, AbortSignal plumbing into the transport, and \`HttpTelegramTransport\`'s AbortError path with a mocked fetch.

## Notes

After this lands, Ctrl-C in \`phantombot run\` should exit in < 100 ms instead of waiting up to the long-poll timeout.