### PR TITLE
Phase 16: install auto-sets XDG_RUNTIME_DIR + DBUS when linger is enabled

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -14,8 +14,10 @@ import { basename } from "node:path";
 import {
   BunSystemctlRunner,
   defaultUnitPath,
+  ensureUserSystemdEnv,
   installPhantombotUnit,
-  userSystemdAvailable,
+  type SystemctlRunner,
+  type UserSystemdEnv,
 } from "../lib/systemd.ts";
 import type { WriteSink } from "../lib/io.ts";
 
@@ -25,9 +27,9 @@ export interface RunInstallInput {
   out?: WriteSink;
   err?: WriteSink;
   /** Override systemctl runner for testing. */
-  systemctl?: ConstructorParameters<typeof BunSystemctlRunner> extends []
-    ? import("../lib/systemd.ts").SystemctlRunner
-    : never;
+  systemctl?: SystemctlRunner;
+  /** Override systemd-env detection for testing. */
+  ensureSystemdEnv?: () => UserSystemdEnv;
 }
 
 export async function runInstall(input: RunInstallInput = {}): Promise<number> {
@@ -43,14 +45,17 @@ export async function runInstall(input: RunInstallInput = {}): Promise<number> {
     return 2;
   }
 
-  if (!userSystemdAvailable()) {
-    err.write(
-      "no user-level systemd bus available (XDG_RUNTIME_DIR not set).\n" +
-        "If this is a headless service account (no login session), enable linger first:\n" +
-        `  sudo loginctl enable-linger ${process.env.USER ?? "$USER"}\n` +
-        "then re-run `phantombot install`.\n",
-    );
+  const sysEnv = input.ensureSystemdEnv
+    ? input.ensureSystemdEnv()
+    : ensureUserSystemdEnv();
+  if (!sysEnv.ready) {
+    err.write(`no user-level systemd bus available: ${sysEnv.reason}\n`);
     return 2;
+  }
+  if (sysEnv.autoSet) {
+    out.write(
+      `auto-detected XDG_RUNTIME_DIR=${sysEnv.runtimeDir} (linger is enabled)\n`,
+    );
   }
 
   const unitPath = input.unitPath ?? defaultUnitPath();

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -8,17 +8,19 @@ import { defineCommand } from "citty";
 import {
   BunSystemctlRunner,
   defaultUnitPath,
+  ensureUserSystemdEnv,
   uninstallPhantombotUnit,
-  userSystemdAvailable,
+  type SystemctlRunner,
+  type UserSystemdEnv,
 } from "../lib/systemd.ts";
 import type { WriteSink } from "../lib/io.ts";
-import type { SystemctlRunner } from "../lib/systemd.ts";
 
 export interface RunUninstallInput {
   unitPath?: string;
   systemctl?: SystemctlRunner;
   out?: WriteSink;
   err?: WriteSink;
+  ensureSystemdEnv?: () => UserSystemdEnv;
 }
 
 export async function runUninstall(
@@ -27,9 +29,17 @@ export async function runUninstall(
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
 
-  if (!userSystemdAvailable()) {
+  const sysEnv = input.ensureSystemdEnv
+    ? input.ensureSystemdEnv()
+    : ensureUserSystemdEnv();
+  if (!sysEnv.ready) {
     err.write(
-      "no user-level systemd bus available; skipping systemctl calls.\n",
+      `no user-level systemd bus available: ${sysEnv.reason}\n` +
+        "skipping systemctl calls and just removing the unit file (if any).\n",
+    );
+  } else if (sysEnv.autoSet) {
+    out.write(
+      `auto-detected XDG_RUNTIME_DIR=${sysEnv.runtimeDir}\n`,
     );
   }
 

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -151,11 +151,77 @@ export async function uninstallPhantombotUnit(
   return { removed: true };
 }
 
+export interface UserSystemdEnv {
+  /** True if we have (or set) XDG_RUNTIME_DIR pointing at a valid runtime dir. */
+  ready: boolean;
+  /** True if phantombot set the env vars itself rather than inheriting them. */
+  autoSet: boolean;
+  /** Resolved value of XDG_RUNTIME_DIR (the directory). */
+  runtimeDir?: string;
+  /** Populated when ready=false. */
+  reason?: string;
+}
+
+export interface EnsureUserSystemdEnvOptions {
+  /** Override the current uid (for testing). */
+  uid?: number;
+  /**
+   * Override the runtime dir to check. Defaults to `/run/user/<uid>`.
+   * Useful in tests so we don't depend on the host's actual /run/user.
+   */
+  runtimeDir?: string;
+  /** existsSync override (for testing). */
+  exists?: (path: string) => boolean;
+  /** mutable env to read/write (for testing). Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+}
+
 /**
- * Returns true if the user-level systemd bus is reachable. Returns false
- * when there's no user session and linger isn't enabled — typical for
- * headless service accounts.
+ * Make the user-level systemd bus reachable for subprocesses we spawn.
+ *
+ * If XDG_RUNTIME_DIR is already set in env (e.g. real ssh / machinectl
+ * shell session), do nothing.
+ *
+ * Otherwise — typical when reaching kai via `sudo su -`, where PAM does
+ * not propagate XDG_RUNTIME_DIR to the target user — derive it from
+ * `/run/user/<uid>`. If that directory exists (it will when linger is
+ * enabled), set both XDG_RUNTIME_DIR and DBUS_SESSION_BUS_ADDRESS so
+ * `systemctl --user` can find the bus. Subprocesses inherit the env.
+ *
+ * If the directory doesn't exist, linger isn't on (or the user manager
+ * isn't running) — return ready=false with a helpful reason.
  */
-export function userSystemdAvailable(): boolean {
-  return Boolean(process.env.XDG_RUNTIME_DIR);
+export function ensureUserSystemdEnv(
+  opts: EnsureUserSystemdEnvOptions = {},
+): UserSystemdEnv {
+  const env = opts.env ?? process.env;
+  const exists = opts.exists ?? existsSync;
+
+  if (env.XDG_RUNTIME_DIR) {
+    return { ready: true, autoSet: false, runtimeDir: env.XDG_RUNTIME_DIR };
+  }
+
+  const uid = opts.uid ?? process.getuid?.();
+  if (uid === undefined) {
+    return {
+      ready: false,
+      autoSet: false,
+      reason: "cannot determine current uid (process.getuid() unavailable)",
+    };
+  }
+
+  const runtimeDir = opts.runtimeDir ?? `/run/user/${uid}`;
+  if (!exists(runtimeDir)) {
+    return {
+      ready: false,
+      autoSet: false,
+      reason: `${runtimeDir} does not exist — enable linger first: sudo loginctl enable-linger ${env.USER ?? "$USER"}`,
+    };
+  }
+
+  env.XDG_RUNTIME_DIR = runtimeDir;
+  if (!env.DBUS_SESSION_BUS_ADDRESS) {
+    env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${runtimeDir}/bus`;
+  }
+  return { ready: true, autoSet: true, runtimeDir };
 }

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -13,6 +13,7 @@ import { runUninstall } from "../src/cli/uninstall.ts";
 import type {
   SystemctlResult,
   SystemctlRunner,
+  UserSystemdEnv,
 } from "../src/lib/systemd.ts";
 
 class FakeSystemctl implements SystemctlRunner {
@@ -36,19 +37,30 @@ class CaptureStream {
 
 let workdir: string;
 let unitPath: string;
-let savedXdg: string | undefined;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-install-"));
   unitPath = join(workdir, "phantombot.service");
-  savedXdg = process.env.XDG_RUNTIME_DIR;
-  process.env.XDG_RUNTIME_DIR = "/run/user/1000";
 });
 
 afterEach(async () => {
-  if (savedXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
-  else process.env.XDG_RUNTIME_DIR = savedXdg;
   await rm(workdir, { recursive: true, force: true });
+});
+
+const sysEnvReady = (): UserSystemdEnv => ({
+  ready: true,
+  autoSet: false,
+  runtimeDir: "/run/user/1000",
+});
+const sysEnvAutoSet = (): UserSystemdEnv => ({
+  ready: true,
+  autoSet: true,
+  runtimeDir: "/run/user/1003",
+});
+const sysEnvMissing = (): UserSystemdEnv => ({
+  ready: false,
+  autoSet: false,
+  reason: "/run/user/1003 does not exist — enable linger first: sudo loginctl enable-linger kai",
 });
 
 describe("runInstall", () => {
@@ -62,14 +74,14 @@ describe("runInstall", () => {
       systemctl: sys,
       out,
       err,
+      ensureSystemdEnv: sysEnvReady,
     });
     expect(code).toBe(2);
     expect(err.text).toContain("compiled binary");
     expect(sys.calls).toEqual([]);
   });
 
-  test("rejects when XDG_RUNTIME_DIR is unset (no user systemd bus)", async () => {
-    delete process.env.XDG_RUNTIME_DIR;
+  test("rejects when systemd env detection fails (linger disabled)", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     const sys = new FakeSystemctl();
@@ -79,9 +91,29 @@ describe("runInstall", () => {
       systemctl: sys,
       out,
       err,
+      ensureSystemdEnv: sysEnvMissing,
     });
     expect(code).toBe(2);
+    expect(err.text).toContain("no user-level systemd bus available");
     expect(err.text).toContain("loginctl enable-linger");
+  });
+
+  test("auto-set message printed when systemd env is auto-detected", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const sys = new FakeSystemctl();
+    const code = await runInstall({
+      binPath: "/usr/local/bin/phantombot",
+      unitPath,
+      systemctl: sys,
+      out,
+      err,
+      ensureSystemdEnv: sysEnvAutoSet,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain(
+      "auto-detected XDG_RUNTIME_DIR=/run/user/1003",
+    );
   });
 
   test("happy path writes unit + runs reload/enable/start, returns 0", async () => {
@@ -94,6 +126,7 @@ describe("runInstall", () => {
       systemctl: sys,
       out,
       err,
+      ensureSystemdEnv: sysEnvReady,
     });
     expect(code).toBe(0);
     expect(sys.calls.map((a) => a.join(" "))).toEqual([
@@ -102,6 +135,8 @@ describe("runInstall", () => {
       "--user start phantombot.service",
     ]);
     expect(out.text).toContain("journalctl --user -u phantombot");
+    // No auto-set message when env was already set.
+    expect(out.text).not.toContain("auto-detected");
   });
 });
 
@@ -115,6 +150,7 @@ describe("runUninstall", () => {
       systemctl: sys,
       out,
       err,
+      ensureSystemdEnv: sysEnvReady,
     });
     expect(code).toBe(0);
     expect(sys.calls.map((a) => a.join(" "))).toEqual([
@@ -123,5 +159,20 @@ describe("runUninstall", () => {
       "--user daemon-reload",
     ]);
     expect(out.text).toContain("uninstall complete");
+  });
+
+  test("warns and continues with file removal when systemd env is missing", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const sys = new FakeSystemctl();
+    const code = await runUninstall({
+      unitPath,
+      systemctl: sys,
+      out,
+      err,
+      ensureSystemdEnv: sysEnvMissing,
+    });
+    expect(code).toBe(0);
+    expect(err.text).toContain("no user-level systemd bus available");
   });
 });

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -10,6 +10,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  ensureUserSystemdEnv,
   generateSystemdUnit,
   installPhantombotUnit,
   uninstallPhantombotUnit,
@@ -119,6 +120,79 @@ describe("installPhantombotUnit", () => {
     expect(err.text).toContain("systemctl --user daemon-reload failed");
     // Did NOT proceed to enable / start.
     expect(sys.calls).toHaveLength(1);
+  });
+});
+
+describe("ensureUserSystemdEnv", () => {
+  test("returns ready+autoSet=false when XDG_RUNTIME_DIR is already set", () => {
+    const env = { XDG_RUNTIME_DIR: "/run/user/1000" } as NodeJS.ProcessEnv;
+    const r = ensureUserSystemdEnv({ env });
+    expect(r).toEqual({
+      ready: true,
+      autoSet: false,
+      runtimeDir: "/run/user/1000",
+    });
+    // Did not modify env (no DBUS_SESSION_BUS_ADDRESS injected).
+    expect(env.DBUS_SESSION_BUS_ADDRESS).toBeUndefined();
+  });
+
+  test("auto-sets env vars when /run/user/<uid> exists and XDG isn't set", () => {
+    const env: NodeJS.ProcessEnv = { USER: "kai" };
+    const r = ensureUserSystemdEnv({
+      env,
+      uid: 1003,
+      exists: (p) => p === "/run/user/1003",
+    });
+    expect(r).toMatchObject({
+      ready: true,
+      autoSet: true,
+      runtimeDir: "/run/user/1003",
+    });
+    expect(env.XDG_RUNTIME_DIR).toBe("/run/user/1003");
+    expect(env.DBUS_SESSION_BUS_ADDRESS).toBe(
+      "unix:path=/run/user/1003/bus",
+    );
+  });
+
+  test("does not overwrite an existing DBUS_SESSION_BUS_ADDRESS", () => {
+    const env: NodeJS.ProcessEnv = {
+      USER: "kai",
+      DBUS_SESSION_BUS_ADDRESS: "unix:path=/custom/bus",
+    };
+    ensureUserSystemdEnv({
+      env,
+      uid: 1003,
+      exists: () => true,
+    });
+    expect(env.DBUS_SESSION_BUS_ADDRESS).toBe("unix:path=/custom/bus");
+  });
+
+  test("returns ready=false with linger hint when /run/user/<uid> doesn't exist", () => {
+    const env: NodeJS.ProcessEnv = { USER: "kai" };
+    const r = ensureUserSystemdEnv({
+      env,
+      uid: 1003,
+      exists: () => false,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.autoSet).toBe(false);
+    expect(r.reason).toContain("/run/user/1003 does not exist");
+    expect(r.reason).toContain("enable-linger kai");
+    // Env unchanged.
+    expect(env.XDG_RUNTIME_DIR).toBeUndefined();
+  });
+
+  test("uses runtimeDir override when provided", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const r = ensureUserSystemdEnv({
+      env,
+      uid: 1003,
+      runtimeDir: "/tmp/fake-runtime",
+      exists: (p) => p === "/tmp/fake-runtime",
+    });
+    expect(r.ready).toBe(true);
+    expect(r.runtimeDir).toBe("/tmp/fake-runtime");
+    expect(env.XDG_RUNTIME_DIR).toBe("/tmp/fake-runtime");
   });
 });
 


### PR DESCRIPTION
## Summary

When you \`sudo su - kai\` (the typical headless service-account flow), PAM does not propagate \`XDG_RUNTIME_DIR\` to the target user — so \`phantombot install\` previously errored with "no user-level systemd bus available" even though \`loginctl enable-linger kai\` was correctly enabled.

**Fix**: replace \`userSystemdAvailable()\` with \`ensureUserSystemdEnv()\`:

1. If \`XDG_RUNTIME_DIR\` is already set in env → use it.
2. Otherwise derive \`/run/user/<uid>\` and stat it. If present (linger on + user manager running), set \`XDG_RUNTIME_DIR\` AND \`DBUS_SESSION_BUS_ADDRESS\` in \`process.env\` so the \`systemctl\` subprocess inherits them. Print "auto-detected XDG_RUNTIME_DIR=…" so the user sees what happened.
3. If the directory doesn't exist → \`ready: false\` with the existing linger hint.

Both \`install\` and \`uninstall\` accept an \`ensureSystemdEnv\` injection so tests don't depend on the host's actual \`/run/user\` state.

After this, \`sudo su - kai && phantombot install\` works without any manual env exports.

## Test plan

- [x] \`bun test\` — 163 pass / 1 skip / 0 fail in 884ms (added 7 tests)
- [x] \`bun tsc --noEmit\` — clean
- New tests: \`ensureUserSystemdEnv\` (already-set / auto-set / DBUS preserved / missing-runtime-dir / runtimeDir override) + install command (auto-set output, missing-env reason).