### PR TITLE
Phase 18: restart hint + interactive prompt after config changes

### DIFF
--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -11,6 +11,7 @@ import * as p from "@clack/prompts";
 
 import { type Config, loadConfig } from "../config.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
 
 export type HarnessId = "claude" | "pi";
 export const SUPPORTED_HARNESSES: ReadonlyArray<HarnessId> = ["claude", "pi"];
@@ -58,11 +59,13 @@ export async function applyHarnessChain(
 
 interface RunInput {
   config?: Config;
+  serviceControl?: ServiceControl;
 }
 
 export async function runHarness(input: RunInput = {}): Promise<number> {
   const config = input.config ?? (await loadConfig());
   const availability = await detectAvailability(config);
+  const svc = input.serviceControl ?? defaultServiceControl();
 
   p.intro("Configure the harness chain");
 
@@ -115,9 +118,42 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
   if (fallbackPick !== "none") chain.push(fallbackPick as HarnessId);
 
   await applyHarnessChain(config.configPath, chain);
+  p.note(
+    `harness chain: ${chain.join(" → ")}\nsaved to ${config.configPath}`,
+    "Saved",
+  );
 
-  p.outro(`harness chain: ${chain.join(" → ")} (saved to ${config.configPath})`);
+  await maybePromptRestart(svc);
+
+  p.outro("done");
   return 0;
+}
+
+/**
+ * Shared post-apply hook for the config-mutating TUIs. If phantombot is
+ * currently running under systemd, offer to restart it inline so the
+ * change takes effect.
+ */
+export async function maybePromptRestart(
+  svc: ServiceControl,
+): Promise<void> {
+  if (!(await svc.isActive())) return;
+  const restart = await p.confirm({
+    message: "phantombot is currently running. Restart to apply changes?",
+    initialValue: true,
+  });
+  if (p.isCancel(restart) || !restart) {
+    p.note(
+      "skipped — restart later with: systemctl --user restart phantombot",
+      "Restart",
+    );
+    return;
+  }
+  const r = await svc.restart();
+  p.note(
+    r.ok ? "restarted" : `restart failed: ${r.stderr ?? "unknown"}`,
+    "Restart",
+  );
 }
 
 export default defineCommand({

--- a/src/cli/import-persona.ts
+++ b/src/cli/import-persona.ts
@@ -21,6 +21,7 @@ import {
 } from "../importer/openclaw.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
 import { parseOpenClawTelegram } from "./telegram.ts";
 
 export interface RunImportPersonaInput {
@@ -35,6 +36,8 @@ export interface RunImportPersonaInput {
   config?: Config;
   /** Override the openclaw.json path the sniff looks at. */
   openclawConfigPath?: string;
+  /** Override service-control for testing. */
+  serviceControl?: ServiceControl;
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -98,6 +101,14 @@ export async function runImportPersona(
         `\n(no openclaw telegram config at ${openclawJsonPath}; skipping)\n`,
       );
     }
+  }
+
+  const svc = input.serviceControl ?? defaultServiceControl();
+  if (await svc.isActive()) {
+    out.write(
+      "\nphantombot is currently running. Restart to pick up the imported persona/config:\n" +
+        "  systemctl --user restart phantombot\n",
+    );
   }
 
   return 0;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -13,6 +13,7 @@ import { basename } from "node:path";
 
 import {
   BunSystemctlRunner,
+  buildSystemctlEnv,
   defaultUnitPath,
   ensureUserSystemdEnv,
   installPhantombotUnit,
@@ -21,18 +22,6 @@ import {
 } from "../lib/systemd.ts";
 import type { WriteSink } from "../lib/io.ts";
 
-function buildSubEnv(sysEnv: UserSystemdEnv): NodeJS.ProcessEnv {
-  // Spread process.env — but Bun.spawn may not see runtime mutations,
-  // so explicitly re-stamp the values we know systemctl needs.
-  const env: NodeJS.ProcessEnv = { ...process.env };
-  if (sysEnv.runtimeDir) {
-    env.XDG_RUNTIME_DIR = sysEnv.runtimeDir;
-    if (!env.DBUS_SESSION_BUS_ADDRESS) {
-      env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${sysEnv.runtimeDir}/bus`;
-    }
-  }
-  return env;
-}
 
 export interface RunInstallInput {
   binPath?: string;
@@ -72,7 +61,8 @@ export async function runInstall(input: RunInstallInput = {}): Promise<number> {
   }
 
   const unitPath = input.unitPath ?? defaultUnitPath();
-  const systemctl = input.systemctl ?? new BunSystemctlRunner(buildSubEnv(sysEnv));
+  const systemctl =
+    input.systemctl ?? new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
 
   const result = await installPhantombotUnit({
     binPath,

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -13,8 +13,10 @@ import * as p from "@clack/prompts";
 
 import { type Config, loadConfig } from "../config.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
 import { telegramGetMe, type GetMeResult } from "../lib/telegramApi.ts";
 import type { WriteSink } from "../lib/io.ts";
+import { maybePromptRestart } from "./harness.ts";
 
 export interface TelegramTuiInputs {
   token: string;
@@ -58,12 +60,14 @@ interface RunInput {
   config?: Config;
   /** Override the validator for testing. */
   validateToken?: (token: string) => Promise<GetMeResult>;
+  serviceControl?: ServiceControl;
   out?: WriteSink;
 }
 
 export async function runTelegram(input: RunInput = {}): Promise<number> {
   const config = input.config ?? (await loadConfig());
   const validate = input.validateToken ?? telegramGetMe;
+  const svc = input.serviceControl ?? defaultServiceControl();
 
   p.intro("Configure the Telegram channel");
 
@@ -129,14 +133,18 @@ export async function runTelegram(input: RunInput = {}): Promise<number> {
     pollTimeoutS: 30,
     allowedUserIds,
   });
-
-  p.outro(
-    `wrote [channels.telegram] to ${config.configPath}\n` +
-      `bot: @${me.username}\n` +
+  p.note(
+    `bot: @${me.username}\n` +
       `allowed users: ${
         allowedUserIds.length === 0 ? "(any)" : allowedUserIds.join(", ")
-      }`,
+      }\n` +
+      `saved to ${config.configPath}`,
+    "Saved",
   );
+
+  await maybePromptRestart(svc);
+
+  p.outro("done");
   return 0;
 }
 

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -7,6 +7,7 @@ import { defineCommand } from "citty";
 
 import {
   BunSystemctlRunner,
+  buildSystemctlEnv,
   defaultUnitPath,
   ensureUserSystemdEnv,
   uninstallPhantombotUnit,
@@ -14,17 +15,6 @@ import {
   type UserSystemdEnv,
 } from "../lib/systemd.ts";
 import type { WriteSink } from "../lib/io.ts";
-
-function buildSubEnv(sysEnv: UserSystemdEnv): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env };
-  if (sysEnv.runtimeDir) {
-    env.XDG_RUNTIME_DIR = sysEnv.runtimeDir;
-    if (!env.DBUS_SESSION_BUS_ADDRESS) {
-      env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${sysEnv.runtimeDir}/bus`;
-    }
-  }
-  return env;
-}
 
 export interface RunUninstallInput {
   unitPath?: string;
@@ -56,7 +46,7 @@ export async function runUninstall(
 
   const unitPath = input.unitPath ?? defaultUnitPath();
   const systemctl =
-    input.systemctl ?? new BunSystemctlRunner(buildSubEnv(sysEnv));
+    input.systemctl ?? new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
 
   await uninstallPhantombotUnit({ unitPath, systemctl, out, err });
   out.write("uninstall complete\n");

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -90,6 +90,65 @@ export class BunSystemctlRunner implements SystemctlRunner {
   }
 }
 
+/**
+ * Build the env we hand to BunSystemctlRunner. Spread process.env, then
+ * overlay XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS from the
+ * UserSystemdEnv result. Bun.spawn doesn't pick up runtime mutations to
+ * process.env, so we have to construct the env explicitly here.
+ */
+export function buildSystemctlEnv(
+  sysEnv: UserSystemdEnv,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (sysEnv.runtimeDir) {
+    env.XDG_RUNTIME_DIR = sysEnv.runtimeDir;
+    if (!env.DBUS_SESSION_BUS_ADDRESS) {
+      env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${sysEnv.runtimeDir}/bus`;
+    }
+  }
+  return env;
+}
+
+export interface ServiceControl {
+  /** True iff `systemctl --user is-active phantombot.service` returns "active". */
+  isActive(): Promise<boolean>;
+  /** Restart the phantombot service. Returns ok=false on failure. */
+  restart(): Promise<{ ok: boolean; stderr?: string }>;
+}
+
+/**
+ * Default ServiceControl backed by real systemctl + ensureUserSystemdEnv.
+ * Returns `isActive: false` when systemd isn't reachable (no linger / no
+ * runtime dir) so callers can treat "service unknown" the same as
+ * "service not running" — they don't need to print a restart hint.
+ */
+export function defaultServiceControl(): ServiceControl {
+  return {
+    async isActive() {
+      const sysEnv = ensureUserSystemdEnv();
+      if (!sysEnv.ready) return false;
+      const r = await new BunSystemctlRunner(buildSystemctlEnv(sysEnv)).run([
+        "--user",
+        "is-active",
+        PHANTOMBOT_UNIT_NAME,
+      ]);
+      return r.exitCode === 0 && r.stdout.trim() === "active";
+    },
+    async restart() {
+      const sysEnv = ensureUserSystemdEnv();
+      if (!sysEnv.ready) return { ok: false, stderr: sysEnv.reason };
+      const r = await new BunSystemctlRunner(buildSystemctlEnv(sysEnv)).run([
+        "--user",
+        "restart",
+        PHANTOMBOT_UNIT_NAME,
+      ]);
+      return r.exitCode === 0
+        ? { ok: true }
+        : { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
+    },
+  };
+}
+
 export interface InstallOptions {
   binPath: string;
   unitPath: string;

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -9,6 +9,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runImportPersona } from "../src/cli/import-persona.ts";
 import type { Config } from "../src/config.ts";
+import type { ServiceControl } from "../src/lib/systemd.ts";
+
+const svcInactive: ServiceControl = {
+  isActive: async () => false,
+  restart: async () => ({ ok: true }),
+};
+const svcActive: ServiceControl = {
+  isActive: async () => true,
+  restart: async () => ({ ok: true }),
+};
 
 class CaptureStream {
   chunks: string[] = [];
@@ -50,6 +60,43 @@ afterEach(async () => {
   await rm(workdir, { recursive: true, force: true });
 });
 
+describe("runImportPersona — restart hint", () => {
+  test("prints restart hint when phantombot.service is active", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    await runImportPersona({
+      source,
+      as: "robbie",
+      config,
+      openclawConfigPath: join(workdir, "missing.json"),
+      noTelegram: true,
+      serviceControl: svcActive,
+      out,
+      err,
+    });
+    expect(out.text).toContain(
+      "phantombot is currently running",
+    );
+    expect(out.text).toContain("systemctl --user restart phantombot");
+  });
+
+  test("does NOT print restart hint when phantombot.service is inactive", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    await runImportPersona({
+      source,
+      as: "robbie",
+      config,
+      openclawConfigPath: join(workdir, "missing.json"),
+      noTelegram: true,
+      serviceControl: svcInactive,
+      out,
+      err,
+    });
+    expect(out.text).not.toContain("phantombot is currently running");
+  });
+});
+
 describe("runImportPersona — telegram sniff", () => {
   test("imports telegram block from openclaw.json when present", async () => {
     const openclawPath = join(workdir, "openclaw.json");
@@ -75,6 +122,7 @@ describe("runImportPersona — telegram sniff", () => {
       as: "robbie",
       config,
       openclawConfigPath: openclawPath,
+      serviceControl: svcInactive,
       out,
       err,
     });
@@ -94,6 +142,7 @@ describe("runImportPersona — telegram sniff", () => {
       as: "robbie",
       config,
       openclawConfigPath: join(workdir, "missing.json"),
+      serviceControl: svcInactive,
       out,
       err,
     });
@@ -122,6 +171,7 @@ describe("runImportPersona — telegram sniff", () => {
       config,
       openclawConfigPath: openclawPath,
       noTelegram: true,
+      serviceControl: svcInactive,
       out,
       err,
     });

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -10,6 +10,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildSystemctlEnv,
   ensureUserSystemdEnv,
   generateSystemdUnit,
   installPhantombotUnit,
@@ -138,6 +139,58 @@ describe("BunSystemctlRunner constructor env", () => {
     const { BunSystemctlRunner } = require("../src/lib/systemd.ts");
     const r = new BunSystemctlRunner({ XDG_RUNTIME_DIR: "/run/user/1003" });
     expect(r).toBeDefined();
+  });
+});
+
+describe("buildSystemctlEnv", () => {
+  test("spreads process.env and overlays XDG/DBUS from sysEnv.runtimeDir", () => {
+    // Clear any inherited DBUS so we can verify the auto-set path.
+    const savedDbus = process.env.DBUS_SESSION_BUS_ADDRESS;
+    delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    try {
+      const env = buildSystemctlEnv({
+        ready: true,
+        autoSet: true,
+        runtimeDir: "/run/user/1003",
+      });
+      expect(env.XDG_RUNTIME_DIR).toBe("/run/user/1003");
+      expect(env.DBUS_SESSION_BUS_ADDRESS).toBe(
+        "unix:path=/run/user/1003/bus",
+      );
+      // Sanity: non-XDG keys from process.env are preserved.
+      expect(typeof env.PATH).toBe("string");
+    } finally {
+      if (savedDbus === undefined)
+        delete process.env.DBUS_SESSION_BUS_ADDRESS;
+      else process.env.DBUS_SESSION_BUS_ADDRESS = savedDbus;
+    }
+  });
+
+  test("does not overwrite an inherited DBUS_SESSION_BUS_ADDRESS", () => {
+    const saved = process.env.DBUS_SESSION_BUS_ADDRESS;
+    process.env.DBUS_SESSION_BUS_ADDRESS = "unix:path=/custom/bus";
+    try {
+      const env = buildSystemctlEnv({
+        ready: true,
+        autoSet: true,
+        runtimeDir: "/run/user/1003",
+      });
+      expect(env.DBUS_SESSION_BUS_ADDRESS).toBe("unix:path=/custom/bus");
+    } finally {
+      if (saved === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+      else process.env.DBUS_SESSION_BUS_ADDRESS = saved;
+    }
+  });
+
+  test("leaves XDG/DBUS unset when sysEnv has no runtimeDir", () => {
+    const saved = process.env.XDG_RUNTIME_DIR;
+    delete process.env.XDG_RUNTIME_DIR;
+    try {
+      const env = buildSystemctlEnv({ ready: false, autoSet: false });
+      expect(env.XDG_RUNTIME_DIR).toBeUndefined();
+    } finally {
+      if (saved !== undefined) process.env.XDG_RUNTIME_DIR = saved;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

After \`phantombot harness\`, \`telegram\`, or \`import-persona\` writes the config file, check whether \`phantombot.service\` is currently active and either:
- **TUI commands (harness / telegram)**: prompt inline "phantombot is running. Restart now?" — yes runs \`systemctl --user restart phantombot\` and reports; no prints the manual command.
- **import-persona (non-interactive)**: print a one-liner hint to stderr.

## New library bits (in \`src/lib/systemd.ts\`)

- \`buildSystemctlEnv(sysEnv)\` — DRY helper that spreads \`process.env\` and overlays \`XDG_RUNTIME_DIR\` / \`DBUS_SESSION_BUS_ADDRESS\` from the autodetect. Used by install / uninstall and the new ServiceControl.
- \`ServiceControl\` interface + \`defaultServiceControl()\` — wraps \`systemctl --user is-active|restart\`. Returns \`isActive: false\` silently when systemd isn't reachable so non-systemd environments don't see spurious hints.

\`maybePromptRestart()\` in \`harness.ts\` — shared by both TUIs.

## Cleanup

\`install.ts\` and \`uninstall.ts\` now use \`buildSystemctlEnv\` (removes a duplicated \`buildSubEnv\` helper from each).

## Test plan

- [x] \`bun test\` — 170 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- New tests: \`buildSystemctlEnv\` (spread+overlay, preserve existing DBUS, no-runtime-dir); \`runImportPersona\` restart-hint (active = hint printed, inactive = silent).

## Notes

The TUI restart prompt uses \`@clack/prompts\` confirm. The interactive flow is verified manually; the helper that decides whether to prompt is testable via \`ServiceControl\` injection.