### PR TITLE
Phase 19: fix Pi stream-json parser to match actual --mode json schema

### DIFF
--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -177,33 +177,52 @@ export function renderPayload(req: HarnessRequest): string {
 }
 
 /**
- * Translate one pi stream-json line into a HarnessChunk. Handles both
- * `{"type":"X", "data":{...}}` and `{"type":"X", ...flat}` shapes since
- * the schema isn't tightly documented and may vary by Pi version.
+ * Translate one pi stream-json line into a HarnessChunk.
+ *
+ * Schema (verified against pi v0.67.x with `--mode json`):
+ *
+ *   {"type":"message_update",
+ *    "assistantMessageEvent":{
+ *       "type":"text_delta"|"thinking_delta"|"tool_use_*"|...,
+ *       "contentIndex": N,
+ *       "delta": "...",     // for *_delta events
+ *       "partial": {...},
+ *    },
+ *    "message": {...}}
+ *
+ *   {"type":"turn_end", ...}
+ *   {"type":"agent_end", ...}
+ *   {"type":"session", ...}    // emitted at startup
+ *   {"type":"message_start"|"message_end", ...}
+ *
+ * Only `assistantMessageEvent.type === "text_delta"` events contribute
+ * to the assistant's reply. `thinking_delta` events are the model's
+ * chain-of-thought and must be excluded — they'd otherwise leak the
+ * model's reasoning into the user-facing reply.
+ *
+ * Tool execution events (when they appear in the schema for tool-using
+ * runs) would map to progress chunks here. Not yet observed in the
+ * --print --mode json output for plain conversational turns.
  *
  * Exported for testing.
  */
 export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
   if (typeof parsed !== "object" || parsed === null) return undefined;
   const obj = parsed as Record<string, unknown>;
-  const type = obj.type;
-  if (typeof type !== "string") return undefined;
-  const data = isObject(obj.data) ? obj.data : obj;
+  if (obj.type !== "message_update") return undefined;
 
-  if (type === "message_update") {
-    const td = data.text_delta;
-    if (typeof td === "string" && td.length > 0) {
-      return { type: "text", text: td };
+  const ame = obj.assistantMessageEvent;
+  if (!isObject(ame)) return undefined;
+
+  if (ame.type === "text_delta") {
+    const delta = ame.delta;
+    if (typeof delta === "string" && delta.length > 0) {
+      return { type: "text", text: delta };
     }
   }
 
-  if (type === "tool_execution_start") {
-    const name =
-      (typeof data.tool_name === "string" && data.tool_name) ||
-      (typeof data.name === "string" && data.name) ||
-      "tool";
-    return { type: "progress", note: `running ${name}` };
-  }
+  // tool_use_start (or whatever pi names it for this version) would map to
+  // a progress chunk here when we observe it in the wild.
 
   return undefined;
 }

--- a/tests/fixtures/fake-pi.sh
+++ b/tests/fixtures/fake-pi.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Fake pi CLI used by tests/harnesses-pi.test.ts.
 #
-# Selects behavior via FAKE_PI_MODE. Pi takes the payload as its last
-# positional arg; we don't validate it here.
+# Schema mirrors what `pi --print --mode json` actually emits as of
+# pi v0.67.x: text_delta lives in assistantMessageEvent.delta, not
+# data.text_delta.
 #
 # Modes:
-#   normal   — emit text deltas + tool_execution events + turn_end, exit 0
+#   normal   — emit thinking + text deltas + turn_end, exit 0
 #   error    — exit 1
 #   notfound — exit 127
 #   hang     — sleep forever (for the timeout test)
@@ -14,12 +15,21 @@ mode="${FAKE_PI_MODE:-normal}"
 
 case "$mode" in
   normal)
+    printf '%s\n' '{"type":"session","version":3,"id":"abc"}'
     printf '%s\n' '{"type":"agent_start"}'
-    printf '%s\n' '{"type":"message_update","data":{"text_delta":"hello "}}'
-    printf '%s\n' '{"type":"message_update","data":{"text_delta":"world"}}'
-    printf '%s\n' '{"type":"tool_execution_start","data":{"tool_name":"bash"}}'
-    printf '%s\n' '{"type":"tool_execution_end"}'
-    printf '%s\n' '{"type":"turn_end"}'
+    printf '%s\n' '{"type":"turn_start"}'
+    # Thinking deltas — must be IGNORED by the parser.
+    printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"thinking_start","contentIndex":0,"partial":{}},"message":{}}'
+    printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"think","partial":{}},"message":{}}'
+    printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"thinking_end","contentIndex":0,"content":"think","partial":{}},"message":{}}'
+    # Real text deltas — the parser should emit these as text chunks.
+    printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"text_start","contentIndex":1,"partial":{}},"message":{}}'
+    printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":"hello ","partial":{}},"message":{}}'
+    printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":"world","partial":{}},"message":{}}'
+    printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":1,"content":"hello world","partial":{}},"message":{}}'
+    printf '%s\n' '{"type":"message_end","message":{}}'
+    printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
+    printf '%s\n' '{"type":"agent_end","messages":[]}'
     exit 0
     ;;
   error)

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -62,50 +62,76 @@ describe("renderPayload (Pi)", () => {
 });
 
 describe("parsePiEvent", () => {
-  test("extracts text_delta from message_update via data.text_delta", () => {
+  test("extracts text_delta from message_update.assistantMessageEvent.delta", () => {
     const c = parsePiEvent({
       type: "message_update",
-      data: { text_delta: "hi" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 1,
+        delta: "hi",
+        partial: {},
+      },
+      message: {},
     });
     expect(c).toEqual({ type: "text", text: "hi" });
   });
 
-  test("also handles message_update with text_delta at the top level", () => {
+  test("ignores thinking_delta — those are the model's chain-of-thought, not the reply", () => {
     const c = parsePiEvent({
       type: "message_update",
-      text_delta: "hi",
+      assistantMessageEvent: {
+        type: "thinking_delta",
+        contentIndex: 0,
+        delta: "internal reasoning",
+        partial: {},
+      },
+      message: {},
     });
-    expect(c).toEqual({ type: "text", text: "hi" });
+    expect(c).toBeUndefined();
   });
 
-  test("turns tool_execution_start into a progress chunk naming the tool", () => {
-    const c = parsePiEvent({
-      type: "tool_execution_start",
-      data: { tool_name: "bash" },
-    });
-    expect(c).toEqual({ type: "progress", note: "running bash" });
+  test("ignores text_start / text_end / thinking_start / thinking_end markers", () => {
+    for (const ameType of [
+      "text_start",
+      "text_end",
+      "thinking_start",
+      "thinking_end",
+    ]) {
+      expect(
+        parsePiEvent({
+          type: "message_update",
+          assistantMessageEvent: { type: ameType, contentIndex: 0 },
+          message: {},
+        }),
+      ).toBeUndefined();
+    }
   });
 
-  test("falls back to data.name for tool_execution_start when tool_name is missing", () => {
-    const c = parsePiEvent({
-      type: "tool_execution_start",
-      data: { name: "edit" },
-    });
-    expect(c).toEqual({ type: "progress", note: "running edit" });
-  });
-
-  test("ignores agent_start, tool_execution_end, turn_end, and unknown types", () => {
-    expect(parsePiEvent({ type: "agent_start" })).toBeUndefined();
-    expect(parsePiEvent({ type: "tool_execution_end" })).toBeUndefined();
-    expect(parsePiEvent({ type: "turn_end" })).toBeUndefined();
-    expect(parsePiEvent({ type: "unknown" })).toBeUndefined();
+  test("ignores session / agent_start / turn_start / turn_end / agent_end / message_start / message_end", () => {
+    for (const t of [
+      "session",
+      "agent_start",
+      "turn_start",
+      "turn_end",
+      "agent_end",
+      "message_start",
+      "message_end",
+    ]) {
+      expect(parsePiEvent({ type: t })).toBeUndefined();
+    }
   });
 
   test("ignores empty text_delta", () => {
     expect(
       parsePiEvent({
         type: "message_update",
-        data: { text_delta: "" },
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 1,
+          delta: "",
+          partial: {},
+        },
+        message: {},
       }),
     ).toBeUndefined();
   });
@@ -115,6 +141,8 @@ describe("parsePiEvent", () => {
     expect(parsePiEvent("string")).toBeUndefined();
     expect(parsePiEvent({})).toBeUndefined();
     expect(parsePiEvent({ type: 42 })).toBeUndefined();
+    // message_update with no assistantMessageEvent
+    expect(parsePiEvent({ type: "message_update" })).toBeUndefined();
   });
 });
 
@@ -140,21 +168,15 @@ const mkHarness = (overrides: Partial<{ maxPayloadBytes: number }> = {}) =>
   });
 
 describe("PiHarness.invoke (subprocess)", () => {
-  test("normal exit: text chunks + progress chunk + done with finalText", async () => {
+  test("normal exit: text chunks (thinking ignored) + done with finalText", async () => {
     process.env.FAKE_PI_MODE = "normal";
     const chunks = await collect(mkHarness().invoke(newRequest()));
     const texts = chunks.filter((c) => c.type === "text");
-    const progress = chunks.filter((c) => c.type === "progress");
     const dones = chunks.filter((c) => c.type === "done");
     expect(texts.map((c) => (c as { text: string }).text)).toEqual([
       "hello ",
       "world",
     ]);
-    expect(progress).toHaveLength(1);
-    expect(progress[0]).toMatchObject({
-      type: "progress",
-      note: "running bash",
-    });
     expect(dones).toHaveLength(1);
     expect(dones[0]).toMatchObject({
       type: "done",


### PR DESCRIPTION
## Summary

**Bug**: every message routed to the Pi harness came back as \`(no reply)\` on Telegram. \`parsePiEvent\` was looking for text deltas at \`obj.data.text_delta\` — what I had assumed based on the phantomops bridge documentation — but that is **not** what \`pi --print --mode json\` actually emits.

**Real schema** (verified by capturing live output from \`pi --print --mode json\` on kw-openclaw):

\`\`\`json
{"type":"message_update",
 "assistantMessageEvent":{
   "type":"text_delta",
   "contentIndex":1,
   "delta":"hello",
   "partial":{...}
 },
 "message":{...}}
\`\`\`

\`assistantMessageEvent.type\` is also one of \`thinking_delta\`, \`text_start\`, \`text_end\`, \`thinking_start\`, \`thinking_end\`. Top-level event types include \`session\`, \`agent_start\`, \`turn_start\`, \`message_start\`, \`message_end\`, \`turn_end\`, \`agent_end\`.

## Fix

Rewrite \`parsePiEvent\` to extract from \`assistantMessageEvent.delta\` when \`assistantMessageEvent.type === "text_delta"\`. **Crucially, ignore \`thinking_delta\`** — that's the model's chain-of-thought (deepseek-style reasoning content) and would leak into the user-facing reply.

\`tests/fixtures/fake-pi.sh\` updated to emit the real shape, including thinking events that the parser must skip.

Tool execution events for tool-using turns would map to progress chunks here when we observe them in the wild. None appeared in the captured sample; deferred until they do.

## Test plan

- [x] \`bun test\` — 169 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- New parsePiEvent tests: text_delta extraction, thinking_delta excluded, marker events ignored, top-level event types ignored, empty-delta handling, malformed input.

## Reproduction

Before this PR (with chain set to \`pi → claude\`):
\`\`\`
[Telegram] Andrew: Hello Kai
[Telegram] Kai: (no reply)
\`\`\`

After this PR + a \`systemctl --user restart phantombot\`, Pi will return text. Verified manually on kw-openclaw via \`pi --print --mode json\` capture.