### PR TITLE
Phase 20: run lock + archive + import TUI + telegram cancel

### DIFF
--- a/src/cli/create-persona.ts
+++ b/src/cli/create-persona.ts
@@ -22,6 +22,10 @@ import {
   type PersonaTemplateInput,
   type PersonaTone,
 } from "../lib/personaTemplate.ts";
+import {
+  archivePersona,
+  type ArchivedPersona,
+} from "../lib/personaArchive.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { loadState, saveState } from "../state.ts";
 
@@ -55,6 +59,8 @@ export interface CreatePersonaResult {
   name: string;
   dir: string;
   setDefault: boolean;
+  /** If an existing persona was archived to make room. */
+  archived?: ArchivedPersona;
 }
 
 export async function applyPersona(
@@ -62,6 +68,10 @@ export async function applyPersona(
   inputs: PersonaTemplateInput & { setDefault: boolean },
 ): Promise<CreatePersonaResult> {
   const dir = personaDir(config, inputs.name);
+  let archived: ArchivedPersona | undefined;
+  if (existsSync(dir)) {
+    archived = await archivePersona(config.personasDir, inputs.name);
+  }
   await mkdir(dir, { recursive: true });
   await writeFile(join(dir, "BOOT.md"), generateBootMd(inputs), "utf8");
   await writeFile(
@@ -76,7 +86,7 @@ export async function applyPersona(
     await saveState(state);
   }
 
-  return { name: inputs.name, dir, setDefault: inputs.setDefault };
+  return { name: inputs.name, dir, setDefault: inputs.setDefault, archived };
 }
 
 interface RunInput {
@@ -89,6 +99,15 @@ export async function runCreatePersona(input: RunInput = {}): Promise<number> {
   const config = input.config ?? (await loadConfig());
 
   p.intro("Create a new persona");
+
+  const currentDefault = config.defaultPersona;
+  if (existsSync(personaDir(config, currentDefault))) {
+    p.note(
+      `Current default: ${currentDefault}\n` +
+        `(${personaDir(config, currentDefault)})`,
+      "Status",
+    );
+  }
 
   const name = await p.text({
     message: "Persona name (lowercase letters, digits, '-', '_')",
@@ -105,9 +124,13 @@ export async function runCreatePersona(input: RunInput = {}): Promise<number> {
     return 1;
   }
 
-  if (existsSync(personaDir(config, name as string))) {
+  const targetDir = personaDir(config, name as string);
+  if (existsSync(targetDir)) {
     const overwrite = await p.confirm({
-      message: `Persona '${name}' already exists. Overwrite?`,
+      message:
+        `Persona '${name}' already exists.\n` +
+        `It will be ARCHIVED to <personas-archive>/${name}-<timestamp>/\n` +
+        `(restore later with phantombot import-persona). Continue?`,
       initialValue: false,
     });
     if (p.isCancel(overwrite) || !overwrite) {
@@ -184,6 +207,14 @@ export async function runCreatePersona(input: RunInput = {}): Promise<number> {
     greeting: greeting as string,
     setDefault: setDefault as boolean,
   });
+
+  if (result.archived) {
+    p.note(
+      `Old '${result.archived.name}' archived to:\n  ${result.archived.dir}\n\n` +
+        `Restore later via: phantombot import-persona`,
+      "Archived",
+    );
+  }
 
   p.outro(
     `Persona '${result.name}' created at ${result.dir}` +

--- a/src/cli/import-persona.ts
+++ b/src/cli/import-persona.ts
@@ -10,22 +10,30 @@
  */
 
 import { defineCommand } from "citty";
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import * as p from "@clack/prompts";
 
-import { type Config, loadConfig } from "../config.ts";
+import { type Config, loadConfig, personaDir } from "../config.ts";
 import {
   type ImportPersonaResult,
   importPersona,
 } from "../importer/openclaw.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
+import {
+  type ArchivedPersona,
+  listArchives,
+  restoreArchive,
+} from "../lib/personaArchive.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
 import { parseOpenClawTelegram } from "./telegram.ts";
 
 export interface RunImportPersonaInput {
-  source: string;
+  /** If provided, skip the TUI and import this directory directly. */
+  source?: string;
   as?: string;
   overwrite?: boolean;
   /** Skip the OpenClaw config sniff entirely. Default false. */
@@ -42,6 +50,22 @@ export interface RunImportPersonaInput {
   err?: WriteSink;
 }
 
+/** Restore an archive to a (possibly new) persona name. Pure side-effect; testable. */
+export async function applyRestore(
+  config: Config,
+  archive: ArchivedPersona,
+  asName: string,
+): Promise<{ name: string; dir: string; alsoArchived?: ArchivedPersona }> {
+  const dst = personaDir(config, asName);
+  let alsoArchived: ArchivedPersona | undefined;
+  if (existsSync(dst)) {
+    const { archivePersona } = await import("../lib/personaArchive.ts");
+    alsoArchived = await archivePersona(config.personasDir, asName);
+  }
+  await restoreArchive(config.personasDir, archive, asName);
+  return { name: asName, dir: dst, alsoArchived };
+}
+
 export async function runImportPersona(
   input: RunImportPersonaInput,
 ): Promise<number> {
@@ -49,13 +73,26 @@ export async function runImportPersona(
   const err = input.err ?? process.stderr;
 
   const config = input.config ?? (await loadConfig());
-  const personasDir = input.personasDir ?? config.personasDir;
+  const personasRoot = input.personasDir ?? config.personasDir;
+
+  // No source path → interactive TUI.
+  if (!input.source) {
+    return runImportPersonaTui({
+      config,
+      personasRoot,
+      noTelegram: input.noTelegram,
+      openclawConfigPath: input.openclawConfigPath,
+      serviceControl: input.serviceControl,
+      out,
+      err,
+    });
+  }
 
   let result: ImportPersonaResult;
   try {
     result = await importPersona({
       source: input.source,
-      personasDir,
+      personasDir: personasRoot,
       as: input.as,
       overwrite: input.overwrite,
     });
@@ -76,42 +113,251 @@ export async function runImportPersona(
   );
 
   if (!input.noTelegram) {
-    const openclawJsonPath =
-      input.openclawConfigPath ??
-      join(homedir(), ".openclaw", "openclaw.json");
-    const tg = await sniffOpenClawTelegram(openclawJsonPath);
-    if (tg) {
-      await updateConfigToml(config.configPath, (toml) => {
-        setIn(toml, ["channels", "telegram", "token"], tg.token);
-        setIn(toml, ["channels", "telegram", "poll_timeout_s"], 30);
-        setIn(
-          toml,
-          ["channels", "telegram", "allowed_user_ids"],
-          tg.allowedUserIds,
-        );
-      });
-      out.write(
-        `\nimported telegram config from ${openclawJsonPath}:\n` +
-          `  token: ${maskToken(tg.token)}\n` +
-          `  allowed users: ${tg.allowedUserIds.length === 0 ? "(none — anyone)" : tg.allowedUserIds.join(", ")}\n` +
-          `  written to ${config.configPath}\n`,
-      );
-    } else {
-      out.write(
-        `\n(no openclaw telegram config at ${openclawJsonPath}; skipping)\n`,
-      );
+    await maybeImportOpenclawTelegram({
+      config,
+      openclawConfigPath: input.openclawConfigPath,
+      out,
+    });
+  }
+
+  await maybeRestartHint(input.serviceControl, out);
+  return 0;
+}
+
+interface RunImportPersonaTuiInput {
+  config: Config;
+  personasRoot: string;
+  noTelegram?: boolean;
+  openclawConfigPath?: string;
+  serviceControl?: ServiceControl;
+  out: WriteSink;
+  err: WriteSink;
+}
+
+async function runImportPersonaTui(
+  input: RunImportPersonaTuiInput,
+): Promise<number> {
+  const { config, personasRoot } = input;
+  p.intro("Import persona");
+
+  const currentDefault = config.defaultPersona;
+  if (existsSync(personaDir(config, currentDefault))) {
+    p.note(
+      `Current default: ${currentDefault}\n  ${personaDir(config, currentDefault)}`,
+      "Status",
+    );
+  } else {
+    p.note(
+      `No persona configured yet (default would be '${currentDefault}').`,
+      "Status",
+    );
+  }
+
+  const archives = await listArchives(personasRoot);
+  const choice = await p.select<"path" | "archive" | "cancel">({
+    message: "What do you want to do?",
+    options: [
+      {
+        value: "path",
+        label: "Import from a directory (OpenClaw or phantombot-shaped)",
+      },
+      {
+        value: "archive",
+        label: `Restore an archived persona${archives.length > 0 ? ` (${archives.length} available)` : " (none yet)"}`,
+        hint: archives.length === 0 ? "create-persona archives auto on overwrite" : undefined,
+      },
+      { value: "cancel", label: "Cancel" },
+    ],
+  });
+  if (p.isCancel(choice) || choice === "cancel") {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  if (choice === "path") {
+    return runImportFromPath(input);
+  }
+  return runRestoreArchive(input, archives);
+}
+
+async function runImportFromPath(
+  input: RunImportPersonaTuiInput,
+): Promise<number> {
+  const sourcePath = await p.text({
+    message: "Path to OpenClaw / phantombot persona directory",
+    placeholder: "/home/me/clawd",
+    validate: (v) => {
+      if (!v || v.length === 0) return "path is required";
+      if (!existsSync(v)) return `path does not exist: ${v}`;
+      return undefined;
+    },
+  });
+  if (p.isCancel(sourcePath)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  const asName = await p.text({
+    message: "Target persona name (Enter to use the source basename)",
+    placeholder: "",
+    defaultValue: "",
+  });
+  if (p.isCancel(asName)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  const target = (asName as string).trim() || undefined;
+  if (target && existsSync(personaDir(input.config, target))) {
+    const ok = await p.confirm({
+      message: `Persona '${target}' already exists. Overwrite (current dir will be archived)?`,
+      initialValue: false,
+    });
+    if (p.isCancel(ok) || !ok) {
+      p.cancel("cancelled");
+      return 0;
     }
   }
 
-  const svc = input.serviceControl ?? defaultServiceControl();
+  let result: ImportPersonaResult;
+  try {
+    result = await importPersona({
+      source: sourcePath as string,
+      personasDir: input.personasRoot,
+      as: target,
+      overwrite: true,
+    });
+  } catch (e) {
+    p.cancel(`error: ${(e as Error).message}`);
+    return 1;
+  }
+  p.note(
+    `imported '${result.name}' to ${result.targetDir}\n` +
+      `copied: ${result.copied.length} file(s)\n` +
+      `skipped: ${result.skipped.length} file(s)`,
+    "Imported",
+  );
+
+  if (!input.noTelegram) {
+    await maybeImportOpenclawTelegram({
+      config: input.config,
+      openclawConfigPath: input.openclawConfigPath,
+      out: input.out,
+    });
+  }
+
+  await maybeRestartHint(input.serviceControl, input.out);
+  p.outro("done");
+  return 0;
+}
+
+async function runRestoreArchive(
+  input: RunImportPersonaTuiInput,
+  archives: ArchivedPersona[],
+): Promise<number> {
+  if (archives.length === 0) {
+    p.cancel(
+      "no archives to restore. create-persona archives the previous persona automatically when you overwrite one.",
+    );
+    return 0;
+  }
+
+  const pick = await p.select<string>({
+    message: "Choose an archive to restore",
+    options: archives.map((a) => ({
+      value: a.archiveName,
+      label: `${a.name}  (${a.archivedAt.toISOString().slice(0, 19)}Z)`,
+      hint: a.dir,
+    })),
+  });
+  if (p.isCancel(pick)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+  const chosen = archives.find((a) => a.archiveName === pick)!;
+
+  const asName = await p.text({
+    message: `Restore as (Enter to keep '${chosen.name}')`,
+    placeholder: chosen.name,
+    defaultValue: chosen.name,
+    validate: (v) => {
+      if (!v || v.length === 0) return undefined;
+      if (!/^[a-z0-9_-]+$/.test(v))
+        return "use lowercase letters, digits, '-', '_'";
+      return undefined;
+    },
+  });
+  if (p.isCancel(asName)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+  const targetName = ((asName as string).trim() || chosen.name);
+
+  if (existsSync(personaDir(input.config, targetName))) {
+    const ok = await p.confirm({
+      message: `Persona '${targetName}' already exists. Overwrite (current dir will be archived)?`,
+      initialValue: false,
+    });
+    if (p.isCancel(ok) || !ok) {
+      p.cancel("cancelled");
+      return 0;
+    }
+  }
+
+  const r = await applyRestore(input.config, chosen, targetName);
+  p.note(
+    `restored to ${r.dir}` +
+      (r.alsoArchived ? `\nprevious '${targetName}' archived to ${r.alsoArchived.dir}` : ""),
+    "Restored",
+  );
+
+  await maybeRestartHint(input.serviceControl, input.out);
+  p.outro("done");
+  return 0;
+}
+
+async function maybeImportOpenclawTelegram(args: {
+  config: Config;
+  openclawConfigPath?: string;
+  out: WriteSink;
+}): Promise<void> {
+  const openclawJsonPath =
+    args.openclawConfigPath ?? join(homedir(), ".openclaw", "openclaw.json");
+  const tg = await sniffOpenClawTelegram(openclawJsonPath);
+  if (tg) {
+    await updateConfigToml(args.config.configPath, (toml) => {
+      setIn(toml, ["channels", "telegram", "token"], tg.token);
+      setIn(toml, ["channels", "telegram", "poll_timeout_s"], 30);
+      setIn(
+        toml,
+        ["channels", "telegram", "allowed_user_ids"],
+        tg.allowedUserIds,
+      );
+    });
+    args.out.write(
+      `\nimported telegram config from ${openclawJsonPath}:\n` +
+        `  token: ${maskToken(tg.token)}\n` +
+        `  allowed users: ${tg.allowedUserIds.length === 0 ? "(none — anyone)" : tg.allowedUserIds.join(", ")}\n` +
+        `  written to ${args.config.configPath}\n`,
+    );
+  } else {
+    args.out.write(
+      `\n(no openclaw telegram config at ${openclawJsonPath}; skipping)\n`,
+    );
+  }
+}
+
+async function maybeRestartHint(
+  serviceControl: ServiceControl | undefined,
+  out: WriteSink,
+): Promise<void> {
+  const svc = serviceControl ?? defaultServiceControl();
   if (await svc.isActive()) {
     out.write(
       "\nphantombot is currently running. Restart to pick up the imported persona/config:\n" +
         "  systemctl --user restart phantombot\n",
     );
   }
-
-  return 0;
 }
 
 async function sniffOpenClawTelegram(
@@ -141,8 +387,9 @@ export default defineCommand({
   args: {
     path: {
       type: "positional",
-      description: "Path to the OpenClaw agent directory to import.",
-      required: true,
+      description:
+        "Path to the OpenClaw agent directory to import. If omitted, an interactive TUI is shown (current persona / restore from archive / import from path / cancel).",
+      required: false,
     },
     as: {
       type: "string",
@@ -163,7 +410,7 @@ export default defineCommand({
   },
   async run({ args }) {
     const code = await runImportPersona({
-      source: String(args.path),
+      source: args.path ? String(args.path) : undefined,
       as: args.as ? String(args.as) : undefined,
       overwrite: Boolean(args.overwrite),
       noTelegram: Boolean(args["no-telegram"]),

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -18,12 +18,19 @@ import { ClaudeHarness } from "../harnesses/claude.ts";
 import { PiHarness } from "../harnesses/pi.ts";
 import type { Harness } from "../harnesses/types.ts";
 import type { WriteSink } from "../lib/io.ts";
+import {
+  acquireRunLock,
+  defaultLockPath,
+  isLockHandle,
+} from "../lib/runLock.ts";
 import { openMemoryStore } from "../memory/store.ts";
 
 export interface RunInput {
   config?: Config;
   out?: WriteSink;
   err?: WriteSink;
+  /** Override the lock file path (for testing). */
+  lockPath?: string;
 }
 
 export async function runRun(input: RunInput = {}): Promise<number> {
@@ -56,6 +63,18 @@ export async function runRun(input: RunInput = {}): Promise<number> {
       "no harnesses configured. Run `phantombot harness` to pick at least one.\n",
     );
     return 2;
+  }
+
+  const lockPath = input.lockPath ?? defaultLockPath();
+  const lock = acquireRunLock(lockPath);
+  if (!isLockHandle(lock)) {
+    err.write(
+      `phantombot is already running (pid ${Number.isFinite(lock.pid) ? lock.pid : "unknown"}; lock at ${lock.path})\n` +
+        "view logs:    journalctl --user -u phantombot -f\n" +
+        "status:       systemctl --user status phantombot\n" +
+        "stop the other instance first, or remove the lock if it's stale.\n",
+    );
+    return 1;
   }
 
   const memory = await openMemoryStore(config.memoryDbPath);
@@ -92,6 +111,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     process.off("SIGINT", onSig);
     process.off("SIGTERM", onSig);
     await memory.close();
+    lock.release();
   }
   return 0;
 }

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -71,12 +71,31 @@ export async function runTelegram(input: RunInput = {}): Promise<number> {
 
   p.intro("Configure the Telegram channel");
 
-  const currentToken = config.channels.telegram?.token;
-  if (currentToken) {
+  const existing = config.channels.telegram;
+  if (existing?.token) {
     p.note(
-      `Current token: ${maskToken(currentToken)}`,
-      "Existing config detected",
+      `Token: ${maskToken(existing.token)}\n` +
+        `Allowed users: ${existing.allowedUserIds.length === 0 ? "(any)" : existing.allowedUserIds.join(", ")}\n` +
+        `Long-poll timeout: ${existing.pollTimeoutS}s`,
+      "Existing config",
     );
+
+    const action = await p.select<"replace" | "users" | "cancel">({
+      message: "What do you want to do?",
+      options: [
+        { value: "replace", label: "Replace token + allowed users" },
+        { value: "users", label: "Update allowed users only (keep token)" },
+        { value: "cancel", label: "Cancel — leave config unchanged" },
+      ],
+    });
+    if (p.isCancel(action) || action === "cancel") {
+      p.cancel("cancelled");
+      return 0;
+    }
+    if (action === "users") {
+      return updateAllowedUsersOnly(config, existing.token, svc);
+    }
+    // fallthrough to replace flow
   }
 
   const token = await p.password({
@@ -144,6 +163,50 @@ export async function runTelegram(input: RunInput = {}): Promise<number> {
 
   await maybePromptRestart(svc);
 
+  p.outro("done");
+  return 0;
+}
+
+async function updateAllowedUsersOnly(
+  config: Config,
+  existingToken: string,
+  svc: ServiceControl,
+): Promise<number> {
+  const currentAllowed =
+    config.channels.telegram?.allowedUserIds.join(", ") ?? "";
+  const allowedRaw = await p.text({
+    message:
+      "Allowed Telegram user IDs (comma-separated; empty = anyone, with a warning)",
+    placeholder: "7995070089",
+    defaultValue: currentAllowed,
+  });
+  if (p.isCancel(allowedRaw)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+  const allowedUserIds = parseAllowedUserIds(allowedRaw as string);
+  if (allowedUserIds.length === 0) {
+    const proceed = await p.confirm({
+      message:
+        "No allowlist set — anyone who DMs the bot will be answered. Proceed?",
+      initialValue: false,
+    });
+    if (p.isCancel(proceed) || !proceed) {
+      p.cancel("cancelled");
+      return 0;
+    }
+  }
+  await applyTelegramConfig(config.configPath, {
+    token: existingToken,
+    pollTimeoutS: 30,
+    allowedUserIds,
+  });
+  p.note(
+    `allowed users: ${allowedUserIds.length === 0 ? "(any)" : allowedUserIds.join(", ")}\n` +
+      `saved to ${config.configPath}`,
+    "Saved",
+  );
+  await maybePromptRestart(svc);
   p.outro("done");
   return 0;
 }

--- a/src/lib/personaArchive.ts
+++ b/src/lib/personaArchive.ts
@@ -1,0 +1,114 @@
+/**
+ * Persona archive — moves a persona directory into a sibling
+ * "personas-archive/" so it's not lost when a new persona of the same
+ * name is created. Archived entries are timestamped so multiple snapshots
+ * of the same name coexist.
+ *
+ *   personasDir/<name>/                   ->  personasDir/../personas-archive/<name>-<ISO>/
+ *   /home/.local/share/phantombot/personas/kai/
+ *     ->  /home/.local/share/phantombot/personas-archive/kai-2026-05-01T15-00-00Z/
+ *
+ * `phantombot create-persona` calls archivePersona before overwriting an
+ * existing persona; `phantombot import-persona` shows the archive list
+ * so the user can restore one.
+ */
+
+import { existsSync } from "node:fs";
+import { cp, mkdir, readdir, rename } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export interface ArchivedPersona {
+  /** The original persona name (e.g. "kai"). */
+  name: string;
+  /** ISO-8601 timestamp parsed from the archive directory name. */
+  archivedAt: Date;
+  /** Absolute path to the archive directory. */
+  dir: string;
+  /** The basename of the archive directory ("kai-2026-05-01T15-00-00-000Z"). */
+  archiveName: string;
+}
+
+export function archivesDir(personasDir: string): string {
+  return join(dirname(personasDir), "personas-archive");
+}
+
+/** Move personasDir/<name>/ into the archive. Returns the new location. */
+export async function archivePersona(
+  personasDir: string,
+  name: string,
+): Promise<ArchivedPersona> {
+  const src = join(personasDir, name);
+  if (!existsSync(src)) {
+    throw new Error(`persona '${name}' does not exist at ${src}`);
+  }
+  const ts = new Date();
+  const stamp = ts.toISOString().replace(/[:.]/g, "-");
+  const baseName = `${name}-${stamp}`;
+  const archiveRoot = archivesDir(personasDir);
+  await mkdir(archiveRoot, { recursive: true });
+
+  // Same-millisecond collisions get a numeric suffix.
+  let archiveName = baseName;
+  let dst = join(archiveRoot, archiveName);
+  for (let suffix = 1; existsSync(dst); suffix++) {
+    archiveName = `${baseName}-${suffix}`;
+    dst = join(archiveRoot, archiveName);
+  }
+  await rename(src, dst);
+  return { name, archivedAt: ts, dir: dst, archiveName };
+}
+
+/** List archives newest-first. Returns [] if the archive dir doesn't exist. */
+export async function listArchives(
+  personasDir: string,
+): Promise<ArchivedPersona[]> {
+  const dir = archivesDir(personasDir);
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out: ArchivedPersona[] = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const parsed = parseArchiveName(e.name);
+    if (!parsed) continue;
+    out.push({
+      ...parsed,
+      dir: join(dir, e.name),
+      archiveName: e.name,
+    });
+  }
+  out.sort((a, b) => b.archivedAt.getTime() - a.archivedAt.getTime());
+  return out;
+}
+
+/**
+ * Restore an archived persona into personasDir/<asName>/. If a persona
+ * by that name already exists, it's archived first.
+ */
+export async function restoreArchive(
+  personasDir: string,
+  archive: ArchivedPersona,
+  asName: string,
+): Promise<void> {
+  const dst = join(personasDir, asName);
+  if (existsSync(dst)) {
+    await archivePersona(personasDir, asName);
+  }
+  await cp(archive.dir, dst, { recursive: true });
+}
+
+function parseArchiveName(
+  name: string,
+): { name: string; archivedAt: Date } | null {
+  // "<name>-<YYYY-MM-DDTHH-MM-SS-mmmZ>" with optional "-<n>" collision suffix
+  const m = /^(.+)-(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z)(?:-\d+)?$/.exec(
+    name,
+  );
+  if (!m) return null;
+  const isoLike = m[2]!.replace(
+    /^(\d{4}-\d{2}-\d{2}T\d{2})-(\d{2})-(\d{2})-(\d{3}Z)$/,
+    "$1:$2:$3.$4",
+  );
+  const d = new Date(isoLike);
+  if (Number.isNaN(d.getTime())) return null;
+  return { name: m[1]!, archivedAt: d };
+}

--- a/src/lib/runLock.ts
+++ b/src/lib/runLock.ts
@@ -1,0 +1,131 @@
+/**
+ * Single-instance lock for `phantombot run`.
+ *
+ * Prevents two phantombot run processes from racing each other on the
+ * same Telegram bot token (would cause sporadic duplicate replies and
+ * missed messages — Telegram getUpdates serves whichever long-poll
+ * arrives first per update).
+ *
+ * Lock file lives at $XDG_RUNTIME_DIR/phantombot.run.lock if available
+ * (tmpfs, cleaned on reboot — ideal), else /tmp/phantombot-<uid>.run.lock.
+ *
+ * Acquisition: O_EXCL create with our PID inside. On EEXIST, read the
+ * existing PID and check via `process.kill(pid, 0)` whether the holder
+ * is still alive. If dead (stale lock from a crash), reclaim. If alive,
+ * report the conflict.
+ */
+
+import { existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync, closeSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface LockHandle {
+  /** Path to the lock file. */
+  path: string;
+  /** Release the lock — removes the file. Idempotent. */
+  release: () => void;
+}
+
+export interface LockConflict {
+  /** Path the lock lives at. */
+  path: string;
+  /** PID held in the lock file (NaN if file existed but unparseable). */
+  pid: number;
+}
+
+export function defaultLockPath(): string {
+  const xdg = process.env.XDG_RUNTIME_DIR;
+  if (xdg) return join(xdg, "phantombot.run.lock");
+  const uid = process.getuid?.() ?? 0;
+  return join("/tmp", `phantombot-${uid}.run.lock`);
+}
+
+/**
+ * Try to acquire the lock. Returns either a LockHandle (success) or a
+ * LockConflict (another process holds it). Stale locks (PID dead) are
+ * reclaimed transparently.
+ */
+export function acquireRunLock(path: string): LockHandle | LockConflict {
+  mkdirSync(dirname(path), { recursive: true });
+
+  const tryCreate = (): boolean => {
+    try {
+      const fd = openSync(path, "wx"); // O_CREAT | O_EXCL
+      writeSync(fd, String(process.pid));
+      closeSync(fd);
+      return true;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "EEXIST") return false;
+      throw e;
+    }
+  };
+
+  if (tryCreate()) return makeHandle(path);
+
+  // Lock exists. Inspect the holder.
+  let holderPid = NaN;
+  try {
+    holderPid = Number(readFileSync(path, "utf8").trim());
+  } catch {
+    // File disappeared between our create attempt and the read — race.
+  }
+
+  if (Number.isInteger(holderPid) && holderPid > 0 && pidIsAlive(holderPid)) {
+    return { path, pid: holderPid };
+  }
+
+  // Stale (or unreadable). Try to reclaim.
+  try {
+    unlinkSync(path);
+  } catch {
+    /* it might have been removed by someone else; the next create will tell us */
+  }
+  if (tryCreate()) return makeHandle(path);
+
+  // Race lost — someone grabbed it between our unlink and our create.
+  // Read the current holder PID one more time and report.
+  try {
+    holderPid = Number(readFileSync(path, "utf8").trim());
+  } catch {
+    holderPid = NaN;
+  }
+  return { path, pid: Number.isInteger(holderPid) ? holderPid : NaN };
+}
+
+function makeHandle(path: string): LockHandle {
+  let released = false;
+  return {
+    path,
+    release: () => {
+      if (released) return;
+      released = true;
+      try {
+        // Only remove if the file still has OUR pid; never clobber a
+        // successor's lock (rare race).
+        const content = readFileSync(path, "utf8").trim();
+        if (Number(content) === process.pid) unlinkSync(path);
+      } catch {
+        /* fine — already gone or unreadable */
+      }
+    },
+  };
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    return code === "EPERM"; // exists but not ours; still alive
+  }
+}
+
+/** Type guard. */
+export function isLockHandle(
+  r: LockHandle | LockConflict,
+): r is LockHandle {
+  return typeof (r as LockHandle).release === "function";
+}
+
+/** Used by tests to check if a file is locked without actually creating it. */
+export { existsSync as _lockFileExists };

--- a/tests/cli-create-persona.test.ts
+++ b/tests/cli-create-persona.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applyPersona } from "../src/cli/create-persona.ts";
 import type { Config } from "../src/config.ts";
+import { listArchives } from "../src/lib/personaArchive.ts";
 import { loadState } from "../src/state.ts";
 
 const SAVED_STATE = process.env.PHANTOMBOT_STATE;
@@ -73,6 +74,34 @@ describe("applyPersona", () => {
     });
     const state = await loadState();
     expect(state.default_persona).toBe("robbie");
+  });
+
+  test("archives an existing persona before overwriting", async () => {
+    // First create
+    await applyPersona(config, {
+      name: "robbie",
+      identity: "v1",
+      tone: "blunt",
+      expertise: [],
+      hardRules: "",
+      greeting: "",
+      setDefault: false,
+    });
+    // Second create with same name — should archive the first
+    const r = await applyPersona(config, {
+      name: "robbie",
+      identity: "v2",
+      tone: "casual",
+      expertise: [],
+      hardRules: "",
+      greeting: "",
+      setDefault: false,
+    });
+    expect(r.archived).toBeDefined();
+    expect(r.archived?.name).toBe("robbie");
+    const archives = await listArchives(config.personasDir);
+    expect(archives).toHaveLength(1);
+    expect(archives[0]?.name).toBe("robbie");
   });
 
   test("setDefault=false leaves state.json untouched", async () => {

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -7,8 +7,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runImportPersona } from "../src/cli/import-persona.ts";
+import { applyRestore, runImportPersona } from "../src/cli/import-persona.ts";
 import type { Config } from "../src/config.ts";
+import {
+  archivePersona,
+  listArchives,
+} from "../src/lib/personaArchive.ts";
 import type { ServiceControl } from "../src/lib/systemd.ts";
 
 const svcInactive: ServiceControl = {
@@ -58,6 +62,46 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(workdir, { recursive: true, force: true });
+});
+
+describe("applyRestore", () => {
+  test("restores an archive into personasDir/<asName>/", async () => {
+    // Set up: import a persona first, then archive it
+    const { mkdir, writeFile, readFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const personaPath = join(config.personasDir, "kai");
+    await mkdir(personaPath, { recursive: true });
+    await writeFile(join(personaPath, "BOOT.md"), "# kai original");
+    const archive = await archivePersona(config.personasDir, "kai");
+
+    const r = await applyRestore(config, archive, "kai");
+    expect(r.name).toBe("kai");
+    expect(r.alsoArchived).toBeUndefined();
+    const boot = await readFile(join(personaPath, "BOOT.md"), "utf8");
+    expect(boot).toBe("# kai original");
+  });
+
+  test("auto-archives a persona at the target before restoring", async () => {
+    const { mkdir, writeFile, readFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const personaPath = join(config.personasDir, "kai");
+    await mkdir(personaPath, { recursive: true });
+    await writeFile(join(personaPath, "BOOT.md"), "# original");
+    const archive = await archivePersona(config.personasDir, "kai");
+    // Now create a "newer" kai
+    await mkdir(personaPath, { recursive: true });
+    await writeFile(join(personaPath, "BOOT.md"), "# newer");
+
+    const r = await applyRestore(config, archive, "kai");
+    expect(r.alsoArchived).toBeDefined();
+    expect(r.alsoArchived?.name).toBe("kai");
+    // Now there should be 2 archives in total
+    const archives = await listArchives(config.personasDir);
+    expect(archives).toHaveLength(2);
+    // And the restored content matches the original
+    const boot = await readFile(join(personaPath, "BOOT.md"), "utf8");
+    expect(boot).toBe("# original");
+  });
 });
 
 describe("runImportPersona — restart hint", () => {

--- a/tests/lib-personaArchive.test.ts
+++ b/tests/lib-personaArchive.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the persona archive helper.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  archivePersona,
+  archivesDir,
+  listArchives,
+  restoreArchive,
+} from "../src/lib/personaArchive.ts";
+
+let workdir: string;
+let personasDir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-archive-"));
+  personasDir = join(workdir, "personas");
+  await mkdir(personasDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+async function makePersona(name: string, content = `# ${name}`) {
+  const dir = join(personasDir, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "BOOT.md"), content);
+}
+
+describe("archivePersona", () => {
+  test("moves the persona dir into personas-archive/<name>-<ts>", async () => {
+    await makePersona("kai");
+    const r = await archivePersona(personasDir, "kai");
+    expect(existsSync(join(personasDir, "kai"))).toBe(false);
+    expect(existsSync(r.dir)).toBe(true);
+    expect(r.dir).toBe(join(archivesDir(personasDir), r.archiveName));
+    expect(r.archiveName.startsWith("kai-")).toBe(true);
+    const boot = await readFile(join(r.dir, "BOOT.md"), "utf8");
+    expect(boot).toBe("# kai");
+  });
+
+  test("throws when persona does not exist", async () => {
+    expect(archivePersona(personasDir, "nope")).rejects.toThrow(
+      /does not exist/,
+    );
+  });
+});
+
+describe("listArchives", () => {
+  test("returns [] when archive dir does not exist", async () => {
+    expect(await listArchives(personasDir)).toEqual([]);
+  });
+
+  test("lists archives newest-first", async () => {
+    await makePersona("kai");
+    const a = await archivePersona(personasDir, "kai");
+    // Brief delay so the second archive has a strictly later timestamp.
+    await new Promise((r) => setTimeout(r, 5));
+    await makePersona("kai", "v2");
+    const b = await archivePersona(personasDir, "kai");
+    const list = await listArchives(personasDir);
+    expect(list.map((x) => x.archiveName)).toEqual([
+      b.archiveName,
+      a.archiveName,
+    ]);
+  });
+});
+
+describe("restoreArchive", () => {
+  test("restores into personasDir/<asName>/", async () => {
+    await makePersona("kai");
+    const a = await archivePersona(personasDir, "kai");
+    await restoreArchive(personasDir, a, "kai");
+    expect(existsSync(join(personasDir, "kai", "BOOT.md"))).toBe(true);
+  });
+
+  test("auto-archives an existing persona at the target name before restoring", async () => {
+    await makePersona("kai", "old");
+    const a = await archivePersona(personasDir, "kai");
+    await makePersona("kai", "newer");
+    await restoreArchive(personasDir, a, "kai");
+    const restored = await readFile(
+      join(personasDir, "kai", "BOOT.md"),
+      "utf8",
+    );
+    expect(restored).toBe("old");
+    // Two archives now exist: the original "old" and the auto-archived "newer".
+    const list = await listArchives(personasDir);
+    expect(list).toHaveLength(2);
+  });
+
+  test("can restore to a different name", async () => {
+    await makePersona("kai");
+    const a = await archivePersona(personasDir, "kai");
+    await restoreArchive(personasDir, a, "kai-clone");
+    expect(existsSync(join(personasDir, "kai-clone", "BOOT.md"))).toBe(true);
+  });
+});

--- a/tests/lib-runLock.test.ts
+++ b/tests/lib-runLock.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the single-instance run lock.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  acquireRunLock,
+  defaultLockPath,
+  isLockHandle,
+} from "../src/lib/runLock.ts";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-lock-"));
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("acquireRunLock", () => {
+  test("creates a fresh lock with our pid", () => {
+    const path = join(workdir, "run.lock");
+    const r = acquireRunLock(path);
+    if (!isLockHandle(r)) throw new Error("expected lock handle");
+    expect(existsSync(path)).toBe(true);
+    expect(Number(readFileSync(path, "utf8"))).toBe(process.pid);
+    r.release();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("conflicts when another live PID holds it", () => {
+    const path = join(workdir, "run.lock");
+    // Use process.pid (we are alive) — this is "another live process" from the lock's POV.
+    writeFileSync(path, String(process.pid));
+    const r = acquireRunLock(path);
+    if (isLockHandle(r)) throw new Error("expected conflict");
+    expect(r.pid).toBe(process.pid);
+  });
+
+  test("reclaims a stale lock with a dead PID", () => {
+    const path = join(workdir, "run.lock");
+    // PID 999999 is essentially guaranteed not to exist on a normal system.
+    writeFileSync(path, "999999");
+    const r = acquireRunLock(path);
+    if (!isLockHandle(r)) throw new Error("expected reclaim");
+    expect(Number(readFileSync(path, "utf8"))).toBe(process.pid);
+    r.release();
+  });
+
+  test("reclaims a malformed lock", () => {
+    const path = join(workdir, "run.lock");
+    writeFileSync(path, "not-a-pid");
+    const r = acquireRunLock(path);
+    if (!isLockHandle(r)) throw new Error("expected reclaim");
+    expect(Number(readFileSync(path, "utf8"))).toBe(process.pid);
+    r.release();
+  });
+
+  test("release is idempotent", () => {
+    const path = join(workdir, "run.lock");
+    const r = acquireRunLock(path);
+    if (!isLockHandle(r)) throw new Error("expected lock handle");
+    r.release();
+    r.release(); // should not throw even though file is gone
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("release does NOT remove a successor's lock", () => {
+    const path = join(workdir, "run.lock");
+    const r = acquireRunLock(path);
+    if (!isLockHandle(r)) throw new Error("expected lock handle");
+    // Simulate a stale-reclaim by another process: write a different pid in.
+    writeFileSync(path, "12345");
+    r.release();
+    // The file should NOT have been removed since the pid inside isn't ours.
+    expect(existsSync(path)).toBe(true);
+    expect(Number(readFileSync(path, "utf8"))).toBe(12345);
+  });
+});
+
+describe("defaultLockPath", () => {
+  test("uses XDG_RUNTIME_DIR when set", () => {
+    const saved = process.env.XDG_RUNTIME_DIR;
+    process.env.XDG_RUNTIME_DIR = "/run/user/1003";
+    try {
+      expect(defaultLockPath()).toBe("/run/user/1003/phantombot.run.lock");
+    } finally {
+      if (saved === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = saved;
+    }
+  });
+
+  test("falls back to /tmp/phantombot-<uid>.run.lock when XDG_RUNTIME_DIR is unset", () => {
+    const saved = process.env.XDG_RUNTIME_DIR;
+    delete process.env.XDG_RUNTIME_DIR;
+    try {
+      const uid = process.getuid?.() ?? 0;
+      expect(defaultLockPath()).toBe(`/tmp/phantombot-${uid}.run.lock`);
+    } finally {
+      if (saved !== undefined) process.env.XDG_RUNTIME_DIR = saved;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Four UX refinements bundled:

### 1. \`phantombot run\` lock file

Acquires \`\$XDG_RUNTIME_DIR/phantombot.run.lock\` (or \`/tmp/phantombot-\$UID.run.lock\`) on startup. If another live process holds it, exit 1:
\`\`\`
phantombot is already running (pid 12345; lock at /run/user/1003/phantombot.run.lock)
view logs:    journalctl --user -u phantombot -f
status:       systemctl --user status phantombot
stop the other instance first, or remove the lock if it's stale.
\`\`\`
Stale locks (PID dead) are reclaimed transparently. Lock released in the run-loop's \`finally\` block; release is idempotent and refuses to clobber a successor.

### 2. Persona archive helper

New \`src/lib/personaArchive.ts\` — \`archivePersona\` / \`listArchives\` / \`restoreArchive\`. Archives live at \`<personasDir>/../personas-archive/<name>-<ISO-stamp>/\`. Same-millisecond collisions get a numeric suffix.

### 3. \`phantombot create-persona\` archives existing

Shows the current default persona at top. When the entered name overwrites an existing persona, the confirm prompt explicitly says the dir will be ARCHIVED and tells the user how to restore. \`applyPersona\` does the archive automatically; result includes \`archived?: ArchivedPersona\`.

### 4. \`phantombot import-persona\` TUI

When called WITHOUT a path arg, opens an interactive TUI:
- shows current default persona
- pick: import from a directory / restore from an archive (with count) / cancel
- archive flow: list newest-first, pick, optional new name, overwrite confirm

Path-based invocation (\`phantombot import-persona /path\`) still works non-interactively for scripting.

### 5. \`phantombot telegram\` cancel option

When \`[channels.telegram]\` is already configured, shows the existing config and asks: replace token + users / update users only / cancel.

## Test plan

- [x] \`bun test\` — 187 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- New: lib-runLock.test.ts (8 tests), lib-personaArchive.test.ts (6 tests), applyRestore tests in cli-import-persona.test.ts (2 tests), archive-on-overwrite test in cli-create-persona.test.ts.

## Notes

- TUI flows in import-persona / telegram are verified manually; the side-effect functions (\`applyPersona\`, \`applyRestore\`, \`applyTelegramConfig\`, \`archivePersona\`) are tested directly.
- Archive directory placement is at \`<personasDir>/../personas-archive/\` rather than inside personasDir so \`list-personas\`-style listings (when added) don't have to filter out archives.