### PR TITLE
Phase 21: refresh Telegram typing + per-turn observability log

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -172,6 +172,13 @@ export interface RunTelegramServerInput {
   oneShot?: boolean;
   /** Signal to stop the loop cleanly. */
   signal?: AbortSignal;
+  /**
+   * How often to refresh the "typing…" indicator while a turn is in
+   * flight. Telegram's chat-action lasts only ~5s, so without refresh
+   * the indicator disappears after ~5s and the user thinks the bot
+   * stopped responding. Default 4000 ms. Tests use a smaller value.
+   */
+  typingRefreshMs?: number;
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -217,17 +224,28 @@ export async function runTelegramServer(
         continue;
       }
 
+      const startedAt = Date.now();
       log.info("telegram: incoming", {
         chatId: msg.chatId,
         fromUserId: msg.fromUserId,
         fromUsername: msg.fromUsername,
         textLength: msg.text.length,
+        persona: input.persona,
       });
 
+      // Send typing immediately, then refresh every typingRefreshMs while
+      // the harness works. Telegram's typing indicator lasts ~5s; without
+      // this the user sees "typing…" disappear and assumes the bot died.
       void input.transport.sendTyping(msg.chatId);
+      const refreshMs = input.typingRefreshMs ?? 4000;
+      const typingTimer = setInterval(() => {
+        void input.transport.sendTyping(msg.chatId);
+      }, refreshMs);
 
       let reply = "";
       let errored: string | undefined;
+      let progressCount = 0;
+      let chosenHarness: string | undefined;
       try {
         for await (const chunk of runTurn({
           persona: input.persona,
@@ -239,12 +257,29 @@ export async function runTelegramServer(
           timeoutMs: input.config.turnTimeoutMs,
         })) {
           if (chunk.type === "text") reply += chunk.text;
-          if (chunk.type === "done") reply = chunk.finalText;
+          if (chunk.type === "progress") {
+            progressCount++;
+            log.debug("telegram: progress", {
+              chatId: msg.chatId,
+              note: chunk.note.slice(0, 200),
+            });
+          }
+          if (chunk.type === "done") {
+            reply = chunk.finalText;
+            const meta = chunk.meta as
+              | { harnessId?: unknown }
+              | undefined;
+            if (typeof meta?.harnessId === "string") {
+              chosenHarness = meta.harnessId;
+            }
+          }
           if (chunk.type === "error") errored = chunk.error;
         }
       } catch (e) {
         errored = (e as Error).message;
         log.error("telegram: turn threw", { error: errored });
+      } finally {
+        clearInterval(typingTimer);
       }
 
       const outText = errored
@@ -260,6 +295,15 @@ export async function runTelegramServer(
           chatId: msg.chatId,
         });
       }
+
+      log.info("telegram: complete", {
+        chatId: msg.chatId,
+        durationMs: Date.now() - startedAt,
+        replyChars: outText.length,
+        progressEvents: progressCount,
+        harness: chosenHarness ?? (errored ? "(error)" : "(unknown)"),
+        ok: !errored,
+      });
     }
   } while (!input.oneShot);
 }

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -76,6 +76,28 @@ class ScriptedHarness implements Harness {
   }
 }
 
+/**
+ * A harness that pauses for `holdMs` between yielding the first text chunk
+ * and the done chunk — used to verify typing-indicator refresh behavior.
+ */
+class SlowHarness implements Harness {
+  invocations = 0;
+  constructor(
+    public readonly id: string,
+    private readonly holdMs: number,
+  ) {}
+  async available(): Promise<boolean> {
+    return true;
+  }
+  async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    this.invocations++;
+    yield { type: "text", text: "thinking…" };
+    await new Promise((r) => setTimeout(r, this.holdMs));
+    yield { type: "text", text: "done" };
+    yield { type: "done", finalText: "thinking…done", meta: { harnessId: this.id } };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // parseGetUpdatesResult
 // ---------------------------------------------------------------------------
@@ -294,6 +316,66 @@ describe("runTelegramServer AbortSignal", () => {
     });
     expect(transport.receivedSignals.length).toBeGreaterThan(0);
     expect(transport.receivedSignals[0]).toBe(ac.signal);
+  });
+});
+
+describe("runTelegramServer typing refresh", () => {
+  test("refreshes the typing indicator while a slow harness is working", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hi",
+    });
+    // Hold the harness for 250ms so we get >1 typing refresh at 50ms cadence.
+    const harness = new SlowHarness("slow", 250);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      typingRefreshMs: 50,
+      oneShot: true,
+    });
+    // 1 initial sendTyping + at least 2 refresh ticks during the 250ms hold.
+    // We don't assert an exact count to stay scheduling-tolerant; > 2 is the contract.
+    expect(transport.typing.length).toBeGreaterThan(2);
+    // All typing calls were for the right chat
+    expect(transport.typing.every((c) => c === 1001)).toBe(true);
+    // The reply was sent.
+    expect(transport.sent).toEqual([
+      { chatId: 1001, text: "thinking…done" },
+    ]);
+  });
+
+  test("clears the typing interval when the turn completes (no stray refreshes after)", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hi",
+    });
+    const harness = new ScriptedHarness("fast", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      typingRefreshMs: 50,
+      oneShot: true,
+    });
+    const baseline = transport.typing.length;
+    // Wait longer than the refresh interval — no further typing should appear.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(transport.typing.length).toBe(baseline);
   });
 });
 


### PR DESCRIPTION
## Summary

Two related fixes for "the bot looks like it stopped responding":

### 1. Typing refresh

Telegram's \`sendChatAction(typing)\` lasts only ~5 seconds. Long turns made the indicator disappear, so the user assumed phantombot had given up even though work was still in flight. Now we send typing immediately AND every \`typingRefreshMs\` (default 4000 ms) until the turn completes. \`clearInterval\` in \`finally\` guarantees no stray refreshes after the reply lands.

### 2. Per-turn completion log

Adds \`telegram: complete\` at info level when each turn finishes:

\`\`\`json
{"level":"info","msg":"telegram: complete",
 "chatId":7995070089,"durationMs":12500,"replyChars":182,
 "progressEvents":3,"harness":"pi","ok":true}
\`\`\`

Also adds \`persona\` to \`telegram: incoming\` and routes harness progress chunks to \`log.debug\` (visible with \`PHANTOMBOT_LOG_LEVEL=debug\`).

\`journalctl --user -u phantombot -f\` now shows a clear incoming → progress... → complete cycle per message with timing.

## Test plan

- [x] \`bun test\` — 189 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- New tests: typing-refresh during a slow (250 ms) harness verifies > 2 typing calls; cleanup test verifies no stray refresh 150 ms after the turn ends.