### PR TITLE
Phase 22: phantombot memory subcommand + per-persona FTS5 index

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import harnessCmd from "./harness.ts";
 import installCmd from "./install.ts";
 import uninstallCmd from "./uninstall.ts";
 import runCmd from "./run.ts";
+import memoryCmd from "./memory.ts";
 
 export const mainCommand = defineCommand({
   meta: {
@@ -37,5 +38,6 @@ export const mainCommand = defineCommand({
     install: installCmd,
     uninstall: uninstallCmd,
     run: runCmd,
+    memory: memoryCmd,
   },
 });

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,0 +1,321 @@
+/**
+ * `phantombot memory` — tools for the harness's own use.
+ *
+ * Subcommands the harness can call from its Bash tool:
+ *
+ *   phantombot memory search "<query>" [--scope memory|kb|all] [--limit N]
+ *                              JSON to stdout: hits with path, snippet, score
+ *   phantombot memory get <path>
+ *                              cat a persona-relative file (validates path
+ *                              is inside personasDir/<persona>/)
+ *   phantombot memory list <subdir>
+ *                              list files in a persona-relative subdir
+ *   phantombot memory today
+ *                              print today's daily-file path (creates the
+ *                              directory if missing — returns the path
+ *                              unconditionally so the harness can write to it)
+ *   phantombot memory index [--rebuild]
+ *                              rebuild the FTS5 index (incremental by default)
+ */
+
+import { defineCommand } from "citty";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+import { type Config, loadConfig, personaDir } from "../config.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { MemoryIndex, type Scope } from "../lib/memoryIndex.ts";
+
+function indexPath(_config: Config, persona: string): string {
+  // One index file per persona — easier to rebuild a single persona without
+  // touching others, and easier to reason about scope.
+  return join(
+    process.env.XDG_DATA_HOME || join(process.env.HOME ?? "", ".local/share"),
+    "phantombot",
+    "memory-index",
+    `${persona}.sqlite`,
+  );
+}
+
+function resolvePersonaDir(config: Config, persona?: string): {
+  persona: string;
+  dir: string;
+} {
+  const name = persona ?? config.defaultPersona;
+  return { persona: name, dir: personaDir(config, name) };
+}
+
+/**
+ * Validate that `relPath` resolves to a file/dir INSIDE the persona dir.
+ * Refuses absolute paths and `..` traversals so the harness can't
+ * accidentally read/write outside the agent's workspace.
+ */
+function safeJoin(personaDir: string, relPath: string): string | null {
+  if (isAbsolute(relPath)) return null;
+  const candidate = resolve(personaDir, relPath);
+  const r = relative(personaDir, candidate);
+  if (r.startsWith("..") || isAbsolute(r)) return null;
+  return candidate;
+}
+
+export interface RunMemoryInput {
+  config?: Config;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export interface RunSearchInput extends RunMemoryInput {
+  query: string;
+  persona?: string;
+  scope?: Scope | "all";
+  limit?: number;
+  /** Override the index path for testing. */
+  indexPath?: string;
+}
+
+export async function runMemorySearch(
+  input: RunSearchInput,
+): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const config = input.config ?? (await loadConfig());
+  const { persona, dir } = resolvePersonaDir(config, input.persona);
+
+  if (!existsSync(dir)) {
+    err.write(`persona '${persona}' not found at ${dir}\n`);
+    return 2;
+  }
+
+  const ix = await MemoryIndex.open(input.indexPath ?? indexPath(config, persona));
+  try {
+    await ix.refreshStale(dir);
+    const hits = ix.search(input.query, {
+      scope: input.scope,
+      limit: input.limit,
+    });
+    out.write(JSON.stringify({ persona, query: input.query, results: hits }, null, 2));
+    out.write("\n");
+  } finally {
+    ix.close();
+  }
+  return 0;
+}
+
+export interface RunGetInput extends RunMemoryInput {
+  path: string;
+  persona?: string;
+}
+
+export async function runMemoryGet(input: RunGetInput): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const config = input.config ?? (await loadConfig());
+  const { dir } = resolvePersonaDir(config, input.persona);
+
+  const target = safeJoin(dir, input.path);
+  if (!target) {
+    err.write(`refusing path outside persona dir: ${input.path}\n`);
+    return 2;
+  }
+  if (!existsSync(target)) {
+    err.write(`not found: ${relative(dir, target)}\n`);
+    return 1;
+  }
+  const file = Bun.file(target);
+  out.write(await file.text());
+  return 0;
+}
+
+export interface RunListInput extends RunMemoryInput {
+  path: string;
+  persona?: string;
+}
+
+export async function runMemoryList(input: RunListInput): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const config = input.config ?? (await loadConfig());
+  const { dir } = resolvePersonaDir(config, input.persona);
+
+  const target = safeJoin(dir, input.path);
+  if (!target) {
+    err.write(`refusing path outside persona dir: ${input.path}\n`);
+    return 2;
+  }
+  if (!existsSync(target)) {
+    err.write(`not found: ${relative(dir, target)}\n`);
+    return 1;
+  }
+  const { readdir } = await import("node:fs/promises");
+  const entries = await readdir(target, { withFileTypes: true });
+  for (const e of entries) {
+    if (e.name.startsWith(".")) continue;
+    out.write(`${e.isDirectory() ? "d" : "f"}  ${e.name}\n`);
+  }
+  return 0;
+}
+
+export interface RunTodayInput extends RunMemoryInput {
+  persona?: string;
+  /** Override "today" for testing. ISO date YYYY-MM-DD. */
+  date?: string;
+}
+
+export async function runMemoryToday(
+  input: RunTodayInput,
+): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const config = input.config ?? (await loadConfig());
+  const { persona, dir } = resolvePersonaDir(config, input.persona);
+
+  if (!existsSync(dir)) {
+    err.write(`persona '${persona}' not found at ${dir}\n`);
+    return 2;
+  }
+
+  const date = input.date ?? new Date().toISOString().slice(0, 10);
+  const memDir = join(dir, "memory");
+  await mkdir(memDir, { recursive: true });
+  const path = join(memDir, `${date}.md`);
+  out.write(path);
+  out.write("\n");
+  return 0;
+}
+
+export interface RunIndexInput extends RunMemoryInput {
+  persona?: string;
+  rebuild?: boolean;
+  indexPath?: string;
+}
+
+export async function runMemoryIndex(
+  input: RunIndexInput,
+): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const config = input.config ?? (await loadConfig());
+  const { persona, dir } = resolvePersonaDir(config, input.persona);
+
+  if (!existsSync(dir)) {
+    err.write(`persona '${persona}' not found at ${dir}\n`);
+    return 2;
+  }
+
+  const ix = await MemoryIndex.open(input.indexPath ?? indexPath(config, persona));
+  try {
+    const r = input.rebuild
+      ? { ...(await ix.rebuild(dir)), removed: 0 }
+      : await ix.refreshStale(dir);
+    out.write(
+      `${input.rebuild ? "rebuilt" : "refreshed"} index for '${persona}': ` +
+        `${r.indexed} file(s) (re)indexed` +
+        (r.removed > 0 ? `, ${r.removed} removed` : "") +
+        `\n`,
+    );
+  } finally {
+    ix.close();
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Citty subcommand wiring
+// ---------------------------------------------------------------------------
+
+const searchCmd = defineCommand({
+  meta: { name: "search", description: "Hybrid (FTS5 today; +vec in phase 25) search across memory/ and kb/." },
+  args: {
+    query: {
+      type: "positional",
+      description: "What to search for.",
+      required: true,
+    },
+    persona: { type: "string", description: "Persona name (default: configured default)." },
+    scope: {
+      type: "string",
+      description: "memory | kb | all (default: all)",
+      default: "all",
+    },
+    limit: { type: "string", description: "max results (default 5)", default: "5" },
+  },
+  async run({ args }) {
+    const limit = Number(args.limit);
+    process.exitCode = await runMemorySearch({
+      query: String(args.query),
+      persona: args.persona ? String(args.persona) : undefined,
+      scope: (String(args.scope) as Scope | "all") ?? "all",
+      limit: Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 5,
+    });
+  },
+});
+
+const getCmd = defineCommand({
+  meta: { name: "get", description: "Cat a persona-relative file." },
+  args: {
+    path: { type: "positional", description: "Persona-relative path.", required: true },
+    persona: { type: "string", description: "Persona name." },
+  },
+  async run({ args }) {
+    process.exitCode = await runMemoryGet({
+      path: String(args.path),
+      persona: args.persona ? String(args.persona) : undefined,
+    });
+  },
+});
+
+const listCmd = defineCommand({
+  meta: { name: "list", description: "List files in a persona-relative subdir." },
+  args: {
+    path: { type: "positional", description: "Persona-relative subdir.", required: true },
+    persona: { type: "string", description: "Persona name." },
+  },
+  async run({ args }) {
+    process.exitCode = await runMemoryList({
+      path: String(args.path),
+      persona: args.persona ? String(args.persona) : undefined,
+    });
+  },
+});
+
+const todayCmd = defineCommand({
+  meta: { name: "today", description: "Print today's daily-file path (creates memory/ if absent)." },
+  args: {
+    persona: { type: "string", description: "Persona name." },
+  },
+  async run({ args }) {
+    process.exitCode = await runMemoryToday({
+      persona: args.persona ? String(args.persona) : undefined,
+    });
+  },
+});
+
+const indexCmd = defineCommand({
+  meta: { name: "index", description: "Refresh the FTS5 index (incremental by default; --rebuild for from-scratch)." },
+  args: {
+    persona: { type: "string", description: "Persona name." },
+    rebuild: { type: "boolean", description: "Drop and re-index from scratch.", default: false },
+  },
+  async run({ args }) {
+    process.exitCode = await runMemoryIndex({
+      persona: args.persona ? String(args.persona) : undefined,
+      rebuild: Boolean(args.rebuild),
+    });
+  },
+});
+
+export default defineCommand({
+  meta: {
+    name: "memory",
+    description:
+      "Memory tools the harness can call from its Bash loop (search, get, list, today, index).",
+  },
+  subCommands: {
+    search: searchCmd,
+    get: getCmd,
+    list: listCmd,
+    today: todayCmd,
+    index: indexCmd,
+  },
+});

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -1,0 +1,254 @@
+/**
+ * SQLite FTS5 index over a persona's memory/ and kb/ directories.
+ *
+ * One file per persona at <dataDir>/memory-index.sqlite, holding:
+ *   - notes      FTS5 virtual table (BM25-ranked content search)
+ *   - files      mtime + size cache for stale detection on incremental rebuild
+ *   - note_embeddings   (reserved — populated in phase 25, schema here so we
+ *                       don't have to migrate later)
+ *
+ * Updates: any phantombot memory search call does a quick stale-check
+ * (compare on-disk mtime with the index's recorded mtime per file) and
+ * incrementally re-indexes anything that changed. Cheap because FTS5
+ * insert is fast and we typically touch < 10 files per invocation.
+ *
+ * The vector embeddings (note_embeddings) are NOT touched here — they're
+ * managed by the nightly cycle (phase 25 onwards).
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+
+export type Scope = "memory" | "kb";
+
+export interface IndexedFile {
+  path: string; // relative to personaDir
+  scope: Scope;
+  mtimeMs: number;
+  size: number;
+}
+
+export interface SearchHit {
+  path: string;
+  scope: Scope;
+  ftsScore: number;
+  snippet: string;
+}
+
+const SCHEMA = `
+CREATE VIRTUAL TABLE IF NOT EXISTS notes USING fts5(
+  path UNINDEXED,
+  scope UNINDEXED,
+  content,
+  tokenize = 'porter unicode61'
+);
+
+CREATE TABLE IF NOT EXISTS files (
+  path        TEXT PRIMARY KEY,
+  scope       TEXT NOT NULL,
+  mtime_ms    INTEGER NOT NULL,
+  size        INTEGER NOT NULL,
+  indexed_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_files_scope ON files(scope);
+
+CREATE TABLE IF NOT EXISTS note_embeddings (
+  path         TEXT NOT NULL,
+  chunk_idx    INTEGER NOT NULL,
+  vec          BLOB NOT NULL,
+  embedded_at  TEXT NOT NULL,
+  PRIMARY KEY (path, chunk_idx)
+);
+`;
+
+export class MemoryIndex {
+  constructor(private readonly db: Database) {
+    db.exec(SCHEMA);
+    db.exec("PRAGMA journal_mode = WAL");
+  }
+
+  static async open(indexPath: string): Promise<MemoryIndex> {
+    if (indexPath !== ":memory:") {
+      await mkdir(dirname(indexPath), { recursive: true });
+    }
+    const db = new Database(indexPath, { create: true });
+    return new MemoryIndex(db);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  /**
+   * Rebuild from scratch — drop all rows in `notes` and `files` and
+   * re-walk personaDir/memory/ and personaDir/kb/. Safe to call on a
+   * fresh persona with no memory/kb dirs yet (returns 0 indexed).
+   */
+  async rebuild(personaDir: string): Promise<{ indexed: number }> {
+    this.db.exec("DELETE FROM notes; DELETE FROM files;");
+    return this.refreshStale(personaDir, /* forceAll */ true);
+  }
+
+  /**
+   * Incremental refresh — re-index any file whose mtime differs from the
+   * recorded mtime. Removes index entries for files that have been deleted
+   * from disk. Returns count of (re)indexed files.
+   */
+  async refreshStale(
+    personaDir: string,
+    forceAll = false,
+  ): Promise<{ indexed: number; removed: number }> {
+    const live = walkMarkdown(personaDir);
+    let indexed = 0;
+    let removed = 0;
+
+    const recorded = new Map<string, { mtimeMs: number }>();
+    for (const row of this.db
+      .query("SELECT path, mtime_ms FROM files")
+      .all() as Array<{ path: string; mtime_ms: number }>) {
+      recorded.set(row.path, { mtimeMs: row.mtime_ms });
+    }
+
+    const livePathSet = new Set(live.map((f) => f.path));
+    for (const recordedPath of recorded.keys()) {
+      if (!livePathSet.has(recordedPath)) {
+        this.deletePath(recordedPath);
+        removed++;
+      }
+    }
+
+    for (const f of live) {
+      const prev = recorded.get(f.path);
+      if (!forceAll && prev && prev.mtimeMs === f.mtimeMs) continue;
+      const content = await readFile(join(personaDir, f.path), "utf8");
+      this.deletePath(f.path);
+      this.db
+        .prepare(
+          "INSERT INTO notes (path, scope, content) VALUES (?, ?, ?)",
+        )
+        .run(f.path, f.scope, content);
+      this.db
+        .prepare(
+          "INSERT INTO files (path, scope, mtime_ms, size, indexed_at) " +
+            "VALUES (?, ?, ?, ?, ?)",
+        )
+        .run(f.path, f.scope, f.mtimeMs, f.size, new Date().toISOString());
+      indexed++;
+    }
+    return { indexed, removed };
+  }
+
+  search(
+    query: string,
+    opts: { scope?: Scope | "all"; limit?: number } = {},
+  ): SearchHit[] {
+    const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
+    const scope = opts.scope ?? "all";
+    if (!query.trim()) return [];
+
+    const ftsQuery = sanitizeFtsQuery(query);
+
+    const rows =
+      scope === "all"
+        ? (this.db
+            .query(
+              "SELECT path, scope, bm25(notes) AS rank, " +
+                "snippet(notes, 2, '«', '»', ' … ', 12) AS snip " +
+                "FROM notes WHERE content MATCH ? " +
+                "ORDER BY rank LIMIT ?",
+            )
+            .all(ftsQuery, limit) as Array<{
+            path: string;
+            scope: Scope;
+            rank: number;
+            snip: string;
+          }>)
+        : (this.db
+            .query(
+              "SELECT path, scope, bm25(notes) AS rank, " +
+                "snippet(notes, 2, '«', '»', ' … ', 12) AS snip " +
+                "FROM notes WHERE content MATCH ? AND scope = ? " +
+                "ORDER BY rank LIMIT ?",
+            )
+            .all(ftsQuery, scope, limit) as Array<{
+            path: string;
+            scope: Scope;
+            rank: number;
+            snip: string;
+          }>);
+
+    return rows.map((r) => ({
+      path: r.path,
+      scope: r.scope,
+      // bm25() in FTS5 is "lower is better"; flip the sign so callers can
+      // sort/threshold consistently with cosine sim later (higher = better).
+      ftsScore: -r.rank,
+      snippet: r.snip,
+    }));
+  }
+
+  private deletePath(path: string): void {
+    this.db.prepare("DELETE FROM notes WHERE path = ?").run(path);
+    this.db.prepare("DELETE FROM files WHERE path = ?").run(path);
+    this.db
+      .prepare("DELETE FROM note_embeddings WHERE path = ?")
+      .run(path);
+  }
+}
+
+/** Walk personaDir/memory/ and personaDir/kb/ for .md files. Synchronous. */
+export function walkMarkdown(personaDir: string): IndexedFile[] {
+  const out: IndexedFile[] = [];
+  for (const scope of ["memory", "kb"] as Scope[]) {
+    const root = join(personaDir, scope);
+    if (!existsSync(root)) continue;
+    walk(root, root, scope, out);
+  }
+  return out;
+}
+
+function walk(
+  root: string,
+  dir: string,
+  scope: Scope,
+  out: IndexedFile[],
+): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(root, full, scope, out);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+    const st = statSync(full);
+    out.push({
+      path: relative(dir.startsWith(root) ? dirname(root) : root, full),
+      scope,
+      mtimeMs: Math.floor(st.mtimeMs),
+      size: st.size,
+    });
+  }
+}
+
+/**
+ * Convert a free-form user query into something safe to pass to FTS5.
+ * Strips characters that have special meaning in the FTS query language
+ * (quotes, parens, etc.) and joins remaining tokens with implicit AND.
+ *
+ * Exported for testing.
+ */
+export function sanitizeFtsQuery(q: string): string {
+  // Allow letters, digits, underscore, hyphen, whitespace.
+  const cleaned = q
+    .replace(/[^A-Za-z0-9_\- ]+/g, " ")
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  if (cleaned.length === 0) return '""';
+  // Quote each token so we don't accidentally trigger NEAR/AND/etc.
+  return cleaned.map((t) => `"${t}"`).join(" ");
+}

--- a/tests/cli-memory.test.ts
+++ b/tests/cli-memory.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for the `phantombot memory` subcommand handlers (run* fns).
+ * The Citty wrappers themselves are trivial and not unit-tested.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  runMemoryGet,
+  runMemoryIndex,
+  runMemoryList,
+  runMemorySearch,
+  runMemoryToday,
+} from "../src/cli/memory.ts";
+import type { Config } from "../src/config.ts";
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+let workdir: string;
+let config: Config;
+let indexPath: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-mem-"));
+  await mkdir(join(workdir, "personas", "phantom", "memory"), {
+    recursive: true,
+  });
+  await mkdir(join(workdir, "personas", "phantom", "kb", "concepts"), {
+    recursive: true,
+  });
+  indexPath = join(workdir, "index.sqlite");
+  config = {
+    defaultPersona: "phantom",
+    turnTimeoutMs: 600_000,
+    personasDir: join(workdir, "personas"),
+    memoryDbPath: join(workdir, "memory.sqlite"),
+    configPath: join(workdir, "config.toml"),
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1_500_000 },
+    },
+    channels: {},
+  };
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+async function note(rel: string, content: string) {
+  await writeFile(join(workdir, "personas", "phantom", rel), content);
+}
+
+describe("runMemorySearch", () => {
+  test("returns JSON results for a matching query", async () => {
+    await note("kb/concepts/Foo.md", "deye inverter facts");
+    const out = new CaptureStream();
+    const code = await runMemorySearch({
+      query: "deye",
+      config,
+      indexPath,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    const parsed = JSON.parse(out.text);
+    expect(parsed.persona).toBe("phantom");
+    expect(parsed.query).toBe("deye");
+    expect(parsed.results.length).toBe(1);
+    expect(parsed.results[0].path).toBe("kb/concepts/Foo.md");
+  });
+
+  test("returns persona-not-found error and exit 2", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runMemorySearch({
+      query: "anything",
+      persona: "nope",
+      config,
+      indexPath,
+      out,
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("not found");
+  });
+
+  test("respects --scope memory|kb", async () => {
+    await note("memory/decisions.md", "telegram bot");
+    await note("kb/concepts/Telegram.md", "telegram api");
+    const out = new CaptureStream();
+    await runMemorySearch({
+      query: "telegram",
+      scope: "memory",
+      config,
+      indexPath,
+      out,
+      err: new CaptureStream(),
+    });
+    const parsed = JSON.parse(out.text);
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].scope).toBe("memory");
+  });
+});
+
+describe("runMemoryGet", () => {
+  test("cats a persona-relative file", async () => {
+    await note("kb/concepts/A.md", "# A\n\nbody");
+    const out = new CaptureStream();
+    const code = await runMemoryGet({
+      path: "kb/concepts/A.md",
+      config,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toBe("# A\n\nbody");
+  });
+
+  test("refuses absolute paths and traversals", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runMemoryGet({
+      path: "/etc/passwd",
+      config,
+      out,
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("refusing path outside persona dir");
+
+    const err2 = new CaptureStream();
+    const code2 = await runMemoryGet({
+      path: "../../../etc/passwd",
+      config,
+      out: new CaptureStream(),
+      err: err2,
+    });
+    expect(code2).toBe(2);
+    expect(err2.text).toContain("refusing path outside");
+  });
+
+  test("returns 1 when the file doesn't exist", async () => {
+    const err = new CaptureStream();
+    const code = await runMemoryGet({
+      path: "kb/concepts/MissingNote.md",
+      config,
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("not found");
+  });
+});
+
+describe("runMemoryList", () => {
+  test("lists files in a persona-relative dir, marks dirs vs files", async () => {
+    await note("kb/concepts/A.md", "");
+    await mkdir(
+      join(workdir, "personas", "phantom", "kb", "concepts", "subdir"),
+    );
+    const out = new CaptureStream();
+    const code = await runMemoryList({
+      path: "kb/concepts",
+      config,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("f  A.md");
+    expect(out.text).toContain("d  subdir");
+  });
+});
+
+describe("runMemoryToday", () => {
+  test("creates memory/ and prints YYYY-MM-DD.md path", async () => {
+    const out = new CaptureStream();
+    const code = await runMemoryToday({
+      config,
+      date: "2026-05-02",
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text.trim()).toBe(
+      join(workdir, "personas", "phantom", "memory", "2026-05-02.md"),
+    );
+    expect(existsSync(join(workdir, "personas", "phantom", "memory"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("runMemoryIndex", () => {
+  test("--rebuild reports the count of files re-indexed", async () => {
+    await note("kb/concepts/A.md", "alpha");
+    await note("kb/concepts/B.md", "beta");
+    const out = new CaptureStream();
+    const code = await runMemoryIndex({
+      config,
+      indexPath,
+      rebuild: true,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("rebuilt index for 'phantom': 2 file(s)");
+  });
+
+  test("incremental refresh reports 0 on a fresh index that's been refreshed once", async () => {
+    await note("kb/concepts/A.md", "alpha");
+    await runMemoryIndex({
+      config,
+      indexPath,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    const out = new CaptureStream();
+    await runMemoryIndex({
+      config,
+      indexPath,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(out.text).toContain("0 file(s)");
+  });
+});
+
+describe("integration — search picks up files written between calls", () => {
+  test("incremental search after adding a note returns the new note", async () => {
+    await note("kb/concepts/A.md", "alpha");
+    const out1 = new CaptureStream();
+    await runMemorySearch({
+      query: "alpha",
+      config,
+      indexPath,
+      out: out1,
+      err: new CaptureStream(),
+    });
+    expect(JSON.parse(out1.text).results).toHaveLength(1);
+
+    // Wait a millisecond so the new file's mtime > A.md's
+    await new Promise((r) => setTimeout(r, 5));
+    await note("kb/concepts/B.md", "alpha and beta");
+    const out2 = new CaptureStream();
+    await runMemorySearch({
+      query: "alpha",
+      config,
+      indexPath,
+      out: out2,
+      err: new CaptureStream(),
+    });
+    expect(JSON.parse(out2.text).results).toHaveLength(2);
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -24,6 +24,7 @@ describe("phantombot CLI dispatcher", () => {
       "harness",
       "import-persona",
       "install",
+      "memory",
       "run",
       "telegram",
       "uninstall",

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the FTS5 memory index.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  MemoryIndex,
+  sanitizeFtsQuery,
+  walkMarkdown,
+} from "../src/lib/memoryIndex.ts";
+
+let workdir: string;
+let personaDir: string;
+let ix: MemoryIndex;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-mi-"));
+  personaDir = join(workdir, "persona");
+  await mkdir(join(personaDir, "memory"), { recursive: true });
+  await mkdir(join(personaDir, "kb", "concepts"), { recursive: true });
+  await mkdir(join(personaDir, "kb", "infra"), { recursive: true });
+  ix = await MemoryIndex.open(":memory:");
+});
+
+afterEach(async () => {
+  ix.close();
+  await rm(workdir, { recursive: true, force: true });
+});
+
+async function note(rel: string, content: string) {
+  await writeFile(join(personaDir, rel), content);
+}
+
+describe("sanitizeFtsQuery", () => {
+  test("strips special chars and quotes each token", () => {
+    expect(sanitizeFtsQuery('hello world')).toBe('"hello" "world"');
+    expect(sanitizeFtsQuery('"quoted (paren)"')).toBe('"quoted" "paren"');
+    expect(sanitizeFtsQuery('a OR b')).toBe('"a" "OR" "b"');
+  });
+
+  test("returns empty-string sentinel on whitespace-only input", () => {
+    expect(sanitizeFtsQuery("   ")).toBe('""');
+    expect(sanitizeFtsQuery("")).toBe('""');
+  });
+
+  test("preserves digits and hyphens (so 'gpt-5' searches as one token)", () => {
+    expect(sanitizeFtsQuery("gpt-5 vs claude-4")).toBe(
+      '"gpt-5" "vs" "claude-4"',
+    );
+  });
+});
+
+describe("walkMarkdown", () => {
+  test("returns empty when memory/ and kb/ are empty", () => {
+    expect(walkMarkdown(personaDir)).toEqual([]);
+  });
+
+  test("walks memory/ and kb/ for .md files; skips non-md and dotfiles", async () => {
+    await note("memory/2026-05-01.md", "today");
+    await note("memory/people.md", "people");
+    await note("kb/concepts/Foo.md", "foo");
+    await note("kb/infra/.hidden.md", "hidden"); // skipped
+    await note("memory/notes.txt", "skipped");
+    const files = walkMarkdown(personaDir);
+    const paths = files.map((f) => f.path).sort();
+    expect(paths).toEqual([
+      "memory/2026-05-01.md",
+      "memory/people.md",
+      "kb/concepts/Foo.md",
+    ].sort());
+  });
+});
+
+describe("MemoryIndex.refreshStale", () => {
+  test("indexes everything on first run; reports removed=0", async () => {
+    await note("memory/decisions.md", "we chose deye for the inverter");
+    await note("kb/concepts/Inverter.md", "deye sun-12k spec");
+    const r = await ix.refreshStale(personaDir);
+    expect(r.indexed).toBe(2);
+    expect(r.removed).toBe(0);
+  });
+
+  test("re-indexes only modified files on subsequent runs", async () => {
+    await note("memory/a.md", "alpha");
+    await note("kb/concepts/B.md", "beta");
+    await ix.refreshStale(personaDir);
+    // Touch only a.md
+    await new Promise((r) => setTimeout(r, 5));
+    await note("memory/a.md", "alpha v2");
+    const r = await ix.refreshStale(personaDir);
+    expect(r.indexed).toBe(1);
+    expect(r.removed).toBe(0);
+  });
+
+  test("removes index entries for files that disappeared", async () => {
+    await note("memory/a.md", "alpha");
+    await note("kb/concepts/B.md", "beta");
+    await ix.refreshStale(personaDir);
+    await rm(join(personaDir, "memory/a.md"));
+    const r = await ix.refreshStale(personaDir);
+    expect(r.indexed).toBe(0);
+    expect(r.removed).toBe(1);
+  });
+});
+
+describe("MemoryIndex.search", () => {
+  test("returns BM25-ranked hits", async () => {
+    await note("kb/concepts/Inverter.md", "deye sun-12k inverter modbus");
+    await note("kb/concepts/Solar.md", "solar panels and the inverter");
+    await note("kb/concepts/Cat.md", "I have a cat named Lena");
+    await ix.refreshStale(personaDir);
+
+    const hits = ix.search("deye inverter");
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0]?.path).toBe("kb/concepts/Inverter.md");
+    expect(hits[0]?.scope).toBe("kb");
+    expect(hits[0]?.snippet).toContain("«");
+    // ftsScore is normalized to higher=better.
+    expect(hits[0]?.ftsScore).toBeGreaterThan(0);
+  });
+
+  test("scopes to memory or kb when requested", async () => {
+    await note("memory/decisions.md", "we chose elevenlabs for tts");
+    await note("kb/infra/Voice.md", "elevenlabs voice config");
+    await ix.refreshStale(personaDir);
+
+    const memOnly = ix.search("elevenlabs", { scope: "memory" });
+    expect(memOnly.map((h) => h.path)).toEqual(["memory/decisions.md"]);
+    const kbOnly = ix.search("elevenlabs", { scope: "kb" });
+    expect(kbOnly.map((h) => h.path)).toEqual(["kb/infra/Voice.md"]);
+  });
+
+  test("respects limit", async () => {
+    for (let i = 0; i < 10; i++) {
+      await note(`kb/concepts/N${i}.md`, "deye inverter test");
+    }
+    await ix.refreshStale(personaDir);
+    const hits = ix.search("deye", { limit: 3 });
+    expect(hits).toHaveLength(3);
+  });
+
+  test("returns [] for whitespace-only query", async () => {
+    await note("kb/concepts/A.md", "anything");
+    await ix.refreshStale(personaDir);
+    expect(ix.search("   ")).toEqual([]);
+  });
+});
+
+describe("MemoryIndex.rebuild", () => {
+  test("drops and re-walks; survives a previous run", async () => {
+    await note("kb/concepts/A.md", "first");
+    await ix.refreshStale(personaDir);
+    await note("kb/concepts/B.md", "second");
+    const r = await ix.rebuild(personaDir);
+    expect(r.indexed).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the OpenClaw-style memory port. Useful by itself (no API key needed) — semantic embeddings come in phase 25. Foundation for the heartbeat / nightly cycle / KB workflow in phases 23-28.

## What lands

- **\`src/lib/memoryIndex.ts\`** — SQLite FTS5 index over \`<personaDir>/memory/\` and \`<personaDir>/kb/\`. One DB per persona at \`\$XDG_DATA_HOME/phantombot/memory-index/<persona>.sqlite\`. Schema includes a reserved \`note_embeddings\` table so phase 25 doesn't need a migration.
- **\`src/cli/memory.ts\`** — five sub-subcommands the harness can call from Bash:

  \`\`\`
  phantombot memory search "<query>" [--scope memory|kb|all] [--limit N]
  phantombot memory get <persona-relative-path>
  phantombot memory list <persona-relative-subdir>
  phantombot memory today                        # path of today's daily file
  phantombot memory index [--rebuild]            # incremental by default
  \`\`\`

## Behavior highlights

- **Auto-incremental**: \`memory search\` calls \`refreshStale()\` first (mtime-based), so notes the harness wrote a moment ago show up on the next search without an explicit index step. FTS5 inserts are ~ms-class so it stays cheap.
- **Path safety**: \`safeJoin()\` refuses absolute paths and any \`..\` traversal so the harness can't read \`/etc/passwd\` by passing a relative-with-traversal path.
- **JSON output** for \`search\` so the harness can parse it with \`jq\` or just pipe into its own logic.
- **Hard error** (exit 2) on persona-not-found; **soft empty** (exit 0, empty results array) on no-match so the harness can branch on results length.

## Test plan

- [x] \`bun test\` — 213 pass / 1 skip / 0 fail in 1.37s (added 24 new tests across \`tests/lib-memoryIndex.test.ts\` and \`tests/cli-memory.test.ts\`)
- [x] \`bun tsc --noEmit\` — clean
- Tests cover: FTS5 ranking, sanitize regex, walk discovery (+ dotfile / non-md skipping), incremental refresh + rebuild, scope filtering, limit, persona-not-found, path traversal, get/list/today, integration across multiple search calls (newly-written notes appear).