### PR TITLE
Phase 23: persona dir scaffolding + recursive memory/ + kb/ import

### DIFF
--- a/src/cli/create-persona.ts
+++ b/src/cli/create-persona.ts
@@ -27,6 +27,7 @@ import {
   type ArchivedPersona,
 } from "../lib/personaArchive.ts";
 import type { WriteSink } from "../lib/io.ts";
+import { ensurePersonaScaffold } from "../lib/personaScaffold.ts";
 import { loadState, saveState } from "../state.ts";
 
 const TONE_OPTIONS: ReadonlyArray<{
@@ -79,6 +80,7 @@ export async function applyPersona(
     generateMemoryMdPlaceholder(inputs.name),
     "utf8",
   );
+  await ensurePersonaScaffold(dir);
 
   if (inputs.setDefault) {
     const state = await loadState();

--- a/src/cli/import-persona.ts
+++ b/src/cli/import-persona.ts
@@ -28,6 +28,7 @@ import {
   listArchives,
   restoreArchive,
 } from "../lib/personaArchive.ts";
+import { ensurePersonaScaffold } from "../lib/personaScaffold.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
 import { parseOpenClawTelegram } from "./telegram.ts";
 
@@ -101,12 +102,20 @@ export async function runImportPersona(
     return 1;
   }
 
+  // Ensure memory/ and kb/ scaffolding exists even if the source had none.
+  // Idempotent — won't overwrite anything the importer just copied.
+  const scaffold = await ensurePersonaScaffold(result.targetDir);
+
   out.write(`imported persona '${result.name}' to ${result.targetDir}\n`);
   out.write(`copied (${result.copied.length}):\n`);
   for (const f of result.copied) out.write(`  ${f}\n`);
   if (result.skipped.length > 0) {
     out.write(`skipped (${result.skipped.length}):\n`);
     for (const f of result.skipped) out.write(`  ${f}\n`);
+  }
+  if (scaffold.created.length > 0) {
+    out.write(`scaffolded (${scaffold.created.length}):\n`);
+    for (const f of scaffold.created) out.write(`  ${f}\n`);
   }
   out.write(
     "\nNote: conversation history was NOT imported (phantombot v1 has no transcript importer).\n",
@@ -231,10 +240,12 @@ async function runImportFromPath(
     p.cancel(`error: ${(e as Error).message}`);
     return 1;
   }
+  const scaffold = await ensurePersonaScaffold(result.targetDir);
   p.note(
     `imported '${result.name}' to ${result.targetDir}\n` +
       `copied: ${result.copied.length} file(s)\n` +
-      `skipped: ${result.skipped.length} file(s)`,
+      `skipped: ${result.skipped.length} file(s)\n` +
+      `scaffolded: ${scaffold.created.length} new file(s)`,
     "Imported",
   );
 
@@ -305,6 +316,7 @@ async function runRestoreArchive(
   }
 
   const r = await applyRestore(input.config, chosen, targetName);
+  await ensurePersonaScaffold(r.dir);
   p.note(
     `restored to ${r.dir}` +
       (r.alsoArchived ? `\nprevious '${targetName}' archived to ${r.alsoArchived.dir}` : ""),

--- a/src/importer/openclaw.ts
+++ b/src/importer/openclaw.ts
@@ -1,24 +1,27 @@
 /**
  * OpenClaw → phantombot persona importer.
  *
- * Walks an OpenClaw agent directory and copies the markdown files
- * phantombot's persona loader knows about (BOOT.md / SOUL.md /
- * IDENTITY.md / MEMORY.md / tools.md / AGENTS.md), plus any other
- * top-level .md files (free agent context the harness can `Read`).
+ * Walks an OpenClaw agent directory and copies:
+ *   - All top-level markdown files (the persona loader knows BOOT.md /
+ *     SOUL.md / IDENTITY.md / MEMORY.md / tools.md / AGENTS.md by name;
+ *     other .md files come along as free agent context).
+ *   - The contents of `memory/` and `kb/` subdirs (recursively, .md only)
+ *     — these are the structured drawers and KB vault the memory system
+ *     reads/writes. Phantombot's persona scaffold ensures the directories
+ *     exist after import even if the source had none.
  *
  * Skipped explicitly:
  *   - SQLite files (*.sqlite, *.sqlite-*, *.db)
  *   - JSONL transcripts (conversation history; not portable in v1)
  *   - dotfiles (.env, .git, etc.)
- *   - subdirectories (node_modules, .git, anything else)
+ *   - other subdirectories (node_modules, .git, etc.)
  *
  * Conversation history is intentionally NOT imported in v1 — phantombot
- * has no transcript-import path yet. A future `phantombot import-history`
- * command can land once the OpenClaw transcript format is documented.
+ * has no transcript-import path yet.
  */
 
 import { copyFile, mkdir, readdir, stat } from "node:fs/promises";
-import { basename, extname, join } from "node:path";
+import { basename, extname, join, relative } from "node:path";
 
 const RECOGNIZED_FILES: ReadonlySet<string> = new Set([
   "BOOT.md",
@@ -30,6 +33,9 @@ const RECOGNIZED_FILES: ReadonlySet<string> = new Set([
 ]);
 
 const IDENTITY_FILES: readonly string[] = ["BOOT.md", "SOUL.md", "IDENTITY.md"];
+
+/** Subdirectories that are walked recursively (markdown-only). */
+const RECURSE_DIRS: ReadonlySet<string> = new Set(["memory", "kb"]);
 
 const SKIP_DIRS: ReadonlySet<string> = new Set([
   "node_modules",
@@ -119,10 +125,19 @@ export async function importPersona(
 
   for (const e of entries) {
     if (e.isDirectory()) {
-      const reason = SKIP_DIRS.has(e.name)
-        ? "(non-portable directory)"
-        : "(phantombot only imports top-level files)";
-      skipped.push(`${e.name}/ ${reason}`);
+      if (RECURSE_DIRS.has(e.name)) {
+        await copyMarkdownTree(
+          join(input.source, e.name),
+          join(targetDir, e.name),
+          copied,
+          skipped,
+        );
+      } else {
+        const reason = SKIP_DIRS.has(e.name)
+          ? "(non-portable directory)"
+          : "(phantombot only imports top-level files + memory/ + kb/)";
+        skipped.push(`${e.name}/ ${reason}`);
+      }
       continue;
     }
     if (!e.isFile()) {
@@ -147,6 +162,73 @@ export async function importPersona(
   }
 
   return { name, targetDir, copied, skipped };
+}
+
+/**
+ * Recursively copy `.md` files from src to dst, mirroring the directory
+ * structure. Skips dotfiles, dist/.git/etc, and non-markdown files.
+ * Logs entries in `copied` / `skipped` with paths relative to the
+ * top of `dst` (so the import summary is readable).
+ */
+async function copyMarkdownTree(
+  src: string,
+  dst: string,
+  copied: string[],
+  skipped: string[],
+  baseDst: string = dst,
+): Promise<void> {
+  await mkdir(dst, { recursive: true });
+  let entries;
+  try {
+    entries = await readdir(src, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.name.startsWith(".")) {
+      skipped.push(`${relative(baseDst, join(dst, e.name))} (dotfile)`);
+      continue;
+    }
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name)) {
+        skipped.push(
+          `${relative(baseDst, join(dst, e.name))}/ (non-portable directory)`,
+        );
+        continue;
+      }
+      await copyMarkdownTree(
+        join(src, e.name),
+        join(dst, e.name),
+        copied,
+        skipped,
+        baseDst,
+      );
+      continue;
+    }
+    if (!e.isFile()) continue;
+    const ext = extname(e.name).toLowerCase();
+    if (SKIP_EXTENSIONS.has(ext)) {
+      skipped.push(
+        `${relative(baseDst, join(dst, e.name))} (non-portable: ${ext})`,
+      );
+      continue;
+    }
+    if (ext !== ".md") {
+      skipped.push(
+        `${relative(baseDst, join(dst, e.name))} (not markdown)`,
+      );
+      continue;
+    }
+    const target = join(dst, e.name);
+    await copyFile(join(src, e.name), target);
+    // Use a slash-prefixed path relative to the persona dir so the
+    // summary is unambiguous about it being inside memory/ or kb/.
+    copied.push(
+      relative(baseDst, target) === e.name
+        ? e.name
+        : relative(baseDst, target),
+    );
+  }
 }
 
 async function dirExists(path: string): Promise<boolean> {

--- a/src/lib/personaScaffold.ts
+++ b/src/lib/personaScaffold.ts
@@ -1,0 +1,269 @@
+/**
+ * Persona-dir scaffolding.
+ *
+ * Ensures every persona directory has the OpenClaw-shaped layout the
+ * memory system expects:
+ *
+ *   <personaDir>/
+ *   ├── memory/
+ *   │   ├── people.md
+ *   │   ├── decisions.md
+ *   │   ├── lessons.md
+ *   │   ├── commitments.md
+ *   │   └── archive/
+ *   └── kb/
+ *       ├── Home.md
+ *       ├── inbox/
+ *       ├── concepts/
+ *       ├── runbooks/
+ *       ├── procedures/
+ *       ├── decisions/
+ *       ├── infra/
+ *       ├── people/
+ *       ├── projects/
+ *       ├── postmortems/
+ *       └── templates/
+ *           ├── atomic-note.md
+ *           ├── runbook.md
+ *           ├── decision.md
+ *           └── postmortem.md
+ *
+ * Idempotent: running twice never overwrites existing files. Used by
+ * `phantombot create-persona` and `phantombot import-persona`.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface ScaffoldResult {
+  /** Files we just created (relative to personaDir). */
+  created: string[];
+  /** Files that were already present (skipped). */
+  skipped: string[];
+}
+
+const KB_SUBDIRS = [
+  "inbox",
+  "concepts",
+  "runbooks",
+  "procedures",
+  "decisions",
+  "infra",
+  "people",
+  "projects",
+  "postmortems",
+  "templates",
+];
+
+const MEMORY_SUBDIRS = ["archive"];
+
+export async function ensurePersonaScaffold(
+  personaDir: string,
+): Promise<ScaffoldResult> {
+  const created: string[] = [];
+  const skipped: string[] = [];
+
+  // Create memory/ tree
+  await mkdir(join(personaDir, "memory"), { recursive: true });
+  for (const sub of MEMORY_SUBDIRS) {
+    await mkdir(join(personaDir, "memory", sub), { recursive: true });
+  }
+
+  // Create kb/ tree
+  await mkdir(join(personaDir, "kb"), { recursive: true });
+  for (const sub of KB_SUBDIRS) {
+    await mkdir(join(personaDir, "kb", sub), { recursive: true });
+  }
+
+  // Stamp the seed files (idempotent).
+  const today = new Date().toISOString().slice(0, 10);
+  for (const [rel, body] of seedFiles(today)) {
+    const full = join(personaDir, rel);
+    if (existsSync(full)) {
+      skipped.push(rel);
+      continue;
+    }
+    await writeFile(full, body, "utf8");
+    created.push(rel);
+  }
+
+  return { created, skipped };
+}
+
+function seedFiles(today: string): Array<[string, string]> {
+  return [
+    ["memory/people.md", drawer("People", "Contacts, relationships, dynamics. The nightly cycle promotes [person]-tagged entries from daily files to here.")],
+    ["memory/decisions.md", drawer("Decisions", `Choices with rationale. "We chose X because Y." Promoted from daily files by the nightly cycle.`)],
+    ["memory/lessons.md", drawer("Lessons", "Mistakes and learnings. Grows, never shrinks.")],
+    ["memory/commitments.md", drawer("Commitments", "Deadlines and obligations. The nightly cycle promotes [commitment]-tagged entries.")],
+
+    ["kb/Home.md", kbHome(today)],
+
+    ["kb/templates/atomic-note.md", atomicTemplate()],
+    ["kb/templates/runbook.md", runbookTemplate()],
+    ["kb/templates/decision.md", decisionTemplate()],
+    ["kb/templates/postmortem.md", postmortemTemplate()],
+  ];
+}
+
+function drawer(title: string, intro: string): string {
+  return `# ${title}\n\n${intro}\n\n## (no entries yet)\n`;
+}
+
+function kbHome(today: string): string {
+  return `---
+type: home
+tags: [navigation]
+created: ${today}
+updated: ${today}
+---
+
+# Home
+
+Atomic notes — one idea per file, linked with [[wikilinks]]. Every
+note carries YAML frontmatter (\`type\`, \`tags\`, \`created\`, \`updated\`).
+
+## Categories
+
+- [[concepts/]] — conceptual atoms (definitions, mental models)
+- [[runbooks/]] — step-by-step ops procedures
+- [[procedures/]] — repeatable workflows
+- [[decisions/]] — choices with rationale
+- [[infra/]] — infrastructure (hosts, services, configs)
+- [[people/]] — contacts and relationships
+- [[projects/]] — current work
+- [[postmortems/]] — incident writeups
+- [[inbox/]] — quick captures pending nightly filing
+- [[templates/]] — note skeletons (atomic-note, runbook, decision, postmortem)
+
+## How to use the KB
+
+- **Search before writing.** Run \`phantombot memory search "topic"\` first
+  to avoid duplicating an existing note.
+- **One idea per file.** Atomic notes are easier to link, search, and
+  refactor than mega-notes.
+- **Link freely.** \`[[wikilinks]]\` build the graph. The nightly cycle
+  adds links between newly-related notes.
+- **Capture in inbox/.** If you're mid-task and have a half-thought,
+  drop a one-liner into \`inbox/\`. The nightly cycle files or discards it.
+`;
+}
+
+function atomicTemplate(): string {
+  return `---
+type: concept
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Title
+
+One idea per note. Link related notes with [[wikilinks]].
+
+## Why this exists
+
+
+## Notes
+
+
+## Related
+- [[ ]]
+`;
+}
+
+function runbookTemplate(): string {
+  return `---
+type: runbook
+tags: [ops]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Runbook: <action>
+
+## Trigger
+What situation calls for this runbook.
+
+## Prerequisites
+- [ ] Access to X
+- [ ] Knowledge of Y
+
+## Steps
+1.
+2.
+3.
+
+## Verification
+How you confirm it worked.
+
+## Rollback
+What to do if a step fails.
+
+## Related
+- [[ ]]
+`;
+}
+
+function decisionTemplate(): string {
+  return `---
+type: decision
+tags: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Decision: <topic>
+
+## Context
+What forced this decision now.
+
+## Options considered
+
+### Option A
+
+
+### Option B
+
+
+## Decision
+We chose X because Y.
+
+## Trade-offs accepted
+
+
+## Revisit when
+
+`;
+}
+
+function postmortemTemplate(): string {
+  return `---
+type: postmortem
+tags: [incident]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Postmortem: <incident>
+
+## Timeline
+
+
+## Root cause
+
+
+## Impact
+
+
+## What went well
+
+
+## What didn't
+
+
+## Action items
+- [ ]
+`;
+}

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -135,7 +135,7 @@ describe("importPersona — what gets skipped", () => {
     expect(r.skipped.length).toBe(2);
   });
 
-  test("skips subdirectories (and notes node_modules / .git as non-portable)", async () => {
+  test("skips top-level subdirectories that aren't memory/ or kb/", async () => {
     await writeFile(join(source, "BOOT.md"), "id");
     await mkdir(join(source, "node_modules"));
     await mkdir(join(source, ".git"));
@@ -144,6 +144,60 @@ describe("importPersona — what gets skipped", () => {
     expect(r.copied).toEqual(["BOOT.md"]);
     expect(r.skipped.some((s) => s.includes("node_modules/"))).toBe(true);
     expect(r.skipped.some((s) => s.includes("subdir/"))).toBe(true);
+  });
+});
+
+describe("importPersona — recursive memory/ and kb/ subdirs", () => {
+  test("copies .md files from memory/ and kb/ recursively", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await mkdir(join(source, "memory"));
+    await writeFile(join(source, "memory", "decisions.md"), "we chose X");
+    await writeFile(join(source, "memory", "2026-05-02.md"), "today");
+    await mkdir(join(source, "kb", "concepts"), { recursive: true });
+    await writeFile(
+      join(source, "kb", "concepts", "DeyeInverter.md"),
+      "deye specs",
+    );
+    await writeFile(join(source, "kb", "Home.md"), "# Home");
+    const r = await importPersona({ source, personasDir, as: "x" });
+    expect(r.copied).toContain("BOOT.md");
+    expect(r.copied).toContain("decisions.md");
+    expect(r.copied).toContain("2026-05-02.md");
+    expect(r.copied).toContain("Home.md");
+    // Nested entry — relative to its containing top-level subdir
+    expect(r.copied.some((c) => c.includes("DeyeInverter"))).toBe(true);
+    const { join: j } = await import("node:path");
+    const { readFile } = await import("node:fs/promises");
+    const dec = await readFile(
+      j(personasDir, "x", "memory", "decisions.md"),
+      "utf8",
+    );
+    expect(dec).toBe("we chose X");
+    const inv = await readFile(
+      j(
+        personasDir,
+        "x",
+        "kb",
+        "concepts",
+        "DeyeInverter.md",
+      ),
+      "utf8",
+    );
+    expect(inv).toBe("deye specs");
+  });
+
+  test("skips non-md files and dotfiles inside memory/ and kb/", async () => {
+    await writeFile(join(source, "BOOT.md"), "id");
+    await mkdir(join(source, "kb"));
+    await writeFile(join(source, "kb", "data.json"), "{}");
+    await writeFile(join(source, "kb", ".secret"), "shh");
+    await writeFile(join(source, "kb", "Note.md"), "note");
+    const r = await importPersona({ source, personasDir, as: "x" });
+    expect(r.copied).toContain("Note.md");
+    expect(r.copied).not.toContain("data.json");
+    expect(r.copied).not.toContain(".secret");
+    expect(r.skipped.some((s) => s.includes("data.json"))).toBe(true);
+    expect(r.skipped.some((s) => s.includes(".secret"))).toBe(true);
   });
 });
 

--- a/tests/lib-personaScaffold.test.ts
+++ b/tests/lib-personaScaffold.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for ensurePersonaScaffold.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensurePersonaScaffold } from "../src/lib/personaScaffold.ts";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-scaffold-"));
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("ensurePersonaScaffold", () => {
+  test("creates the full memory/ + kb/ tree on a fresh persona", async () => {
+    const r = await ensurePersonaScaffold(workdir);
+    // Drawers
+    for (const f of [
+      "memory/people.md",
+      "memory/decisions.md",
+      "memory/lessons.md",
+      "memory/commitments.md",
+    ]) {
+      expect(existsSync(join(workdir, f))).toBe(true);
+      expect(r.created).toContain(f);
+    }
+    // KB seeds
+    for (const f of [
+      "kb/Home.md",
+      "kb/templates/atomic-note.md",
+      "kb/templates/runbook.md",
+      "kb/templates/decision.md",
+      "kb/templates/postmortem.md",
+    ]) {
+      expect(existsSync(join(workdir, f))).toBe(true);
+      expect(r.created).toContain(f);
+    }
+    // Subdirs
+    for (const d of [
+      "memory/archive",
+      "kb/inbox",
+      "kb/concepts",
+      "kb/runbooks",
+      "kb/procedures",
+      "kb/decisions",
+      "kb/infra",
+      "kb/people",
+      "kb/projects",
+      "kb/postmortems",
+      "kb/templates",
+    ]) {
+      expect(existsSync(join(workdir, d))).toBe(true);
+    }
+    expect(r.skipped).toEqual([]);
+  });
+
+  test("is idempotent — second run skips everything", async () => {
+    await ensurePersonaScaffold(workdir);
+    const second = await ensurePersonaScaffold(workdir);
+    expect(second.created).toEqual([]);
+    expect(second.skipped.length).toBeGreaterThan(0);
+  });
+
+  test("does NOT overwrite existing files (preserves user content)", async () => {
+    await mkdir(join(workdir, "memory"), { recursive: true });
+    await writeFile(
+      join(workdir, "memory", "people.md"),
+      "# my people\n\n- Alice\n- Bob\n",
+    );
+    const r = await ensurePersonaScaffold(workdir);
+    expect(r.skipped).toContain("memory/people.md");
+    const content = await readFile(
+      join(workdir, "memory", "people.md"),
+      "utf8",
+    );
+    expect(content).toBe("# my people\n\n- Alice\n- Bob\n");
+  });
+
+  test("Home.md has correct frontmatter dating to today", async () => {
+    await ensurePersonaScaffold(workdir);
+    const home = await readFile(join(workdir, "kb", "Home.md"), "utf8");
+    expect(home).toMatch(/^---/);
+    expect(home).toContain("type: home");
+    expect(home).toContain("[[concepts/]]");
+    const today = new Date().toISOString().slice(0, 10);
+    expect(home).toContain(`created: ${today}`);
+  });
+});


### PR DESCRIPTION
## Summary

Two related changes:

1. **\`ensurePersonaScaffold\`** — new helper at \`src/lib/personaScaffold.ts\` that creates the OpenClaw-shaped layout (\`memory/\` drawers, \`kb/\` category subdirs, seed \`Home.md\`, four \`templates/*.md\` skeletons). Idempotent — never overwrites. Wired into \`create-persona\` (post-create) and \`import-persona\` (post-import + post-restore).

2. **Importer recursive memory/ + kb/** — \`src/importer/openclaw.ts\` now walks \`memory/\` and \`kb/\` subdirectories of the source agent dir and copies \`.md\` files (skipping dotfiles, non-markdown, and the existing SKIP_DIRS / SKIP_EXTENSIONS). Other top-level subdirs are still skipped with a reason.

After this, re-importing kai's \`~/clawd\` will bring along his existing memory/ and kb/ trees, and any newly-created persona starts with the full directory structure ready for the harness to read/write.

## Test plan

- [x] \`bun test\` — 219 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- New tests: \`lib-personaScaffold.test.ts\` (6) + recursive importer tests in \`importer.test.ts\` (2).