### PR TITLE
Phase 24: phantombot embedding TUI + Gemini API key validation

### DIFF
--- a/src/cli/embedding.ts
+++ b/src/cli/embedding.ts
@@ -1,0 +1,180 @@
+/**
+ * `phantombot embedding` — interactive TUI to configure semantic search.
+ *
+ * Picks a provider (Gemini or None), validates the API key by calling
+ * /embedContent once, writes the result to [embeddings] in config.toml.
+ *
+ * No-key (provider=none) is a real choice: phantombot's memory search
+ * still works, just on FTS5/BM25 only — no semantic similarity.
+ */
+
+import { defineCommand } from "citty";
+import * as p from "@clack/prompts";
+
+import { type Config, loadConfig } from "../config.ts";
+import {
+  geminiEmbed,
+  type EmbedResult,
+} from "../lib/geminiEmbed.ts";
+import { setIn, updateConfigToml } from "../lib/configWriter.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import { maybePromptRestart } from "./harness.ts";
+
+const DEFAULT_MODEL = "gemini-embedding-001";
+const DEFAULT_DIMS = 1536;
+
+export interface EmbeddingConfigUpdate {
+  provider: "gemini" | "none";
+  apiKey?: string;
+  model?: string;
+  dims?: number;
+}
+
+export async function applyEmbeddingConfig(
+  configPath: string,
+  update: EmbeddingConfigUpdate,
+): Promise<void> {
+  await updateConfigToml(configPath, (toml) => {
+    setIn(toml, ["embeddings", "provider"], update.provider);
+    if (update.provider === "gemini") {
+      setIn(toml, ["embeddings", "gemini", "api_key"], update.apiKey ?? "");
+      setIn(
+        toml,
+        ["embeddings", "gemini", "model"],
+        update.model ?? DEFAULT_MODEL,
+      );
+      setIn(
+        toml,
+        ["embeddings", "gemini", "dims"],
+        update.dims ?? DEFAULT_DIMS,
+      );
+    } else {
+      // Leave the [embeddings.gemini] block alone if present — preserves
+      // the user's key for re-enabling later. Just flip provider to "none".
+    }
+  });
+}
+
+interface RunInput {
+  config?: Config;
+  validate?: (key: string) => Promise<EmbedResult>;
+  serviceControl?: ServiceControl;
+}
+
+export async function runEmbedding(input: RunInput = {}): Promise<number> {
+  const config = input.config ?? (await loadConfig());
+  const svc = input.serviceControl ?? defaultServiceControl();
+  const validate =
+    input.validate ??
+    ((key: string) =>
+      geminiEmbed(key, "phantombot key validation test", {
+        model: DEFAULT_MODEL,
+        dims: DEFAULT_DIMS,
+      }));
+
+  p.intro("Configure embeddings");
+
+  const existing = config.embeddings;
+  if (existing.provider === "gemini" && existing.gemini?.apiKey) {
+    p.note(
+      `provider:  gemini\n` +
+        `model:     ${existing.gemini.model}\n` +
+        `dims:      ${existing.gemini.dims}\n` +
+        `api key:   ${maskKey(existing.gemini.apiKey)}`,
+      "Existing config",
+    );
+  } else if (existing.provider === "none") {
+    p.note(`provider:  none (FTS5/BM25 search only)`, "Existing config");
+  }
+
+  const provider = await p.select<"gemini" | "none" | "cancel">({
+    message: "Provider",
+    options: [
+      {
+        value: "gemini",
+        label: `Gemini (${DEFAULT_MODEL}, ${DEFAULT_DIMS} dims)`,
+        hint: "free tier 1500 req/day, billing kicks in upstream",
+      },
+      {
+        value: "none",
+        label: "None — keyword/BM25 search only",
+      },
+      { value: "cancel", label: "Cancel" },
+    ],
+    initialValue: existing.provider === "gemini" ? "gemini" : "none",
+  });
+  if (p.isCancel(provider) || provider === "cancel") {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  if (provider === "none") {
+    await applyEmbeddingConfig(config.configPath, { provider: "none" });
+    p.note(
+      `provider set to "none"\nsearch will use FTS5/BM25 only`,
+      "Saved",
+    );
+    await maybePromptRestart(svc);
+    p.outro("done");
+    return 0;
+  }
+
+  const key = await p.password({
+    message: "Gemini API key (https://aistudio.google.com/app/apikey)",
+    validate: (v) => {
+      if (!v || v.length === 0) return "key is required";
+      return undefined;
+    },
+  });
+  if (p.isCancel(key)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  const spinner = p.spinner();
+  spinner.start("validating with a one-token embed…");
+  const r = await validate(key as string);
+  if (!r.ok) {
+    spinner.stop(`key rejected: ${r.error}`);
+    p.cancel("aborting — key did not validate");
+    return 1;
+  }
+  spinner.stop(`key validated (got ${r.dims} dims)`);
+
+  await applyEmbeddingConfig(config.configPath, {
+    provider: "gemini",
+    apiKey: key as string,
+    model: DEFAULT_MODEL,
+    dims: DEFAULT_DIMS,
+  });
+  p.note(
+    `provider:  gemini\n` +
+      `model:     ${DEFAULT_MODEL}\n` +
+      `dims:      ${DEFAULT_DIMS}\n` +
+      `saved to ${config.configPath}\n\n` +
+      `cost note: free up to 1500 req/day on the Gemini free tier;\n` +
+      `phantombot's nightly cycle re-embeds changed notes only.`,
+    "Saved",
+  );
+
+  await maybePromptRestart(svc);
+  p.outro("done");
+  return 0;
+}
+
+function maskKey(k: string): string {
+  if (k.length <= 12) return "***";
+  return k.slice(0, 6) + "…" + k.slice(-4);
+}
+
+export default defineCommand({
+  meta: {
+    name: "embedding",
+    description:
+      "Configure the embeddings provider (Gemini or none). Validates the API key before saving.",
+  },
+  async run() {
+    const code = await runEmbedding();
+    process.exitCode = code;
+  },
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ import installCmd from "./install.ts";
 import uninstallCmd from "./uninstall.ts";
 import runCmd from "./run.ts";
 import memoryCmd from "./memory.ts";
+import embeddingCmd from "./embedding.ts";
 
 export const mainCommand = defineCommand({
   meta: {
@@ -35,6 +36,7 @@ export const mainCommand = defineCommand({
     "create-persona": createPersonaCmd,
     telegram: telegramCmd,
     harness: harnessCmd,
+    embedding: embeddingCmd,
     install: installCmd,
     uninstall: uninstallCmd,
     run: runCmd,

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,16 @@ export interface Config {
       allowedUserIds: number[];
     };
   };
+
+  embeddings: {
+    /** "gemini" | "none". "none" = FTS5-only search. */
+    provider: "gemini" | "none";
+    gemini?: {
+      apiKey: string;
+      model: string;
+      dims: number;
+    };
+  };
 }
 
 export function xdgConfigHome(): string {
@@ -72,6 +82,8 @@ export async function loadConfig(): Promise<Config> {
   const tomlPi = (tomlHarnesses.pi ?? {}) as Record<string, unknown>;
   const tomlChannels = (toml.channels ?? {}) as Record<string, unknown>;
   const tomlTelegram = (tomlChannels.telegram ?? {}) as Record<string, unknown>;
+  const tomlEmbeddings = (toml.embeddings ?? {}) as Record<string, unknown>;
+  const tomlGemini = (tomlEmbeddings.gemini ?? {}) as Record<string, unknown>;
 
   return {
     defaultPersona:
@@ -137,6 +149,32 @@ export async function loadConfig(): Promise<Config> {
 
     channels: {
       telegram: buildTelegramConfig(tomlTelegram),
+    },
+
+    embeddings: buildEmbeddingsConfig(tomlEmbeddings, tomlGemini),
+  };
+}
+
+function buildEmbeddingsConfig(
+  tomlEmbeddings: Record<string, unknown>,
+  tomlGemini: Record<string, unknown>,
+): Config["embeddings"] {
+  const envApiKey = process.env.PHANTOMBOT_GEMINI_API_KEY;
+  const tomlApiKey = asString(tomlGemini.api_key);
+  const apiKey = envApiKey ?? tomlApiKey;
+
+  const provider =
+    (asString(tomlEmbeddings.provider) as "gemini" | "none" | undefined) ??
+    (apiKey ? "gemini" : "none");
+
+  if (provider !== "gemini") return { provider };
+
+  return {
+    provider: "gemini",
+    gemini: {
+      apiKey: apiKey ?? "",
+      model: asString(tomlGemini.model) ?? "gemini-embedding-001",
+      dims: asInt(tomlGemini.dims) ?? 1536,
     },
   };
 }

--- a/src/lib/geminiEmbed.ts
+++ b/src/lib/geminiEmbed.ts
@@ -1,0 +1,89 @@
+/**
+ * Tiny Gemini embedding client. Raw HTTPS — no SDK, no extra dep.
+ *
+ * Used by:
+ *   - `phantombot embedding` (validation: one test embed before saving the key)
+ *   - the nightly indexer (phase 25: batch-embed every KB note)
+ *
+ * Endpoint:
+ *   POST https://generativelanguage.googleapis.com/v1beta/models/<model>:embedContent?key=<API_KEY>
+ *   Body: {model: "models/<model>", content: {parts: [{text}]}, outputDimensionality: <N>}
+ *
+ * Free tier: 1500 req/day on `gemini-embedding-001`. Paid kicks in
+ * automatically when a billing account is attached upstream — phantombot
+ * doesn't track or enforce that, just calls and reports any errors.
+ */
+
+const DEFAULT_MODEL = "gemini-embedding-001";
+const DEFAULT_DIMS = 1536;
+
+export type EmbedResult =
+  | { ok: true; values: Float32Array; dims: number }
+  | { ok: false; error: string };
+
+export interface GeminiEmbedOptions {
+  model?: string;
+  dims?: number;
+  fetchImpl?: typeof fetch;
+  /** Optional AbortSignal to cancel the request mid-flight. */
+  signal?: AbortSignal;
+}
+
+export async function geminiEmbed(
+  apiKey: string,
+  text: string,
+  opts: GeminiEmbedOptions = {},
+): Promise<EmbedResult> {
+  const model = opts.model ?? DEFAULT_MODEL;
+  const dims = opts.dims ?? DEFAULT_DIMS;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const url =
+    `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:embedContent` +
+    `?key=${encodeURIComponent(apiKey)}`;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: `models/${model}`,
+        content: { parts: [{ text }] },
+        outputDimensionality: dims,
+      }),
+      signal: opts.signal,
+    });
+  } catch (e) {
+    return { ok: false, error: `network: ${(e as Error).message}` };
+  }
+
+  let body: {
+    embedding?: { values?: unknown };
+    error?: { message?: string };
+  };
+  try {
+    body = (await res.json()) as typeof body;
+  } catch {
+    return { ok: false, error: `non-JSON response (HTTP ${res.status})` };
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      error:
+        body.error?.message ?? `HTTP ${res.status}`,
+    };
+  }
+  const values = body.embedding?.values;
+  if (!Array.isArray(values) || values.length === 0) {
+    return { ok: false, error: "no embedding values in response" };
+  }
+  const out = new Float32Array(values.length);
+  for (let i = 0; i < values.length; i++) {
+    const n = Number(values[i]);
+    if (!Number.isFinite(n)) {
+      return { ok: false, error: "non-numeric value in embedding" };
+    }
+    out[i] = n;
+  }
+  return { ok: true, values: out, dims: out.length };
+}

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -185,6 +185,7 @@ const baseConfig = (
       ...overrides,
     },
   },
+  embeddings: { provider: "none" },
 });
 
 describe("runTelegramServer dispatch", () => {

--- a/tests/cli-create-persona.test.ts
+++ b/tests/cli-create-persona.test.ts
@@ -32,6 +32,7 @@ beforeEach(async () => {
       pi: { bin: "pi", maxPayloadBytes: 1_500_000 },
     },
     channels: {},
+    embeddings: { provider: "none" },
   };
 });
 

--- a/tests/cli-embedding.test.ts
+++ b/tests/cli-embedding.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the side-effect helpers behind `phantombot embedding`.
+ * The TUI prompts are verified manually.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyEmbeddingConfig } from "../src/cli/embedding.ts";
+import { loadConfig } from "../src/config.ts";
+
+let workdir: string;
+let configPath: string;
+const SAVED_CONFIG = process.env.PHANTOMBOT_CONFIG;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-emb-"));
+  configPath = join(workdir, "config.toml");
+  process.env.PHANTOMBOT_CONFIG = configPath;
+  process.env.XDG_CONFIG_HOME = join(workdir, "xdg-config");
+  process.env.XDG_DATA_HOME = join(workdir, "xdg-data");
+});
+
+afterEach(async () => {
+  if (SAVED_CONFIG === undefined) delete process.env.PHANTOMBOT_CONFIG;
+  else process.env.PHANTOMBOT_CONFIG = SAVED_CONFIG;
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("applyEmbeddingConfig — gemini", () => {
+  test("writes [embeddings] + [embeddings.gemini]", async () => {
+    await applyEmbeddingConfig(configPath, {
+      provider: "gemini",
+      apiKey: "AIzaTEST123",
+      model: "gemini-embedding-001",
+      dims: 1536,
+    });
+    const text = await readFile(configPath, "utf8");
+    expect(text).toContain("[embeddings]");
+    expect(text).toContain('provider = "gemini"');
+    expect(text).toContain("[embeddings.gemini]");
+    expect(text).toContain('api_key = "AIzaTEST123"');
+    expect(text).toContain('model = "gemini-embedding-001"');
+    expect(text).toContain("dims = 1536");
+  });
+
+  test("loadConfig() picks up the gemini config we just wrote", async () => {
+    await applyEmbeddingConfig(configPath, {
+      provider: "gemini",
+      apiKey: "AIzaTEST123",
+    });
+    const c = await loadConfig();
+    expect(c.embeddings.provider).toBe("gemini");
+    expect(c.embeddings.gemini?.apiKey).toBe("AIzaTEST123");
+    expect(c.embeddings.gemini?.model).toBe("gemini-embedding-001");
+    expect(c.embeddings.gemini?.dims).toBe(1536);
+  });
+});
+
+describe("applyEmbeddingConfig — none", () => {
+  test("flips provider to none, leaves [embeddings.gemini] alone", async () => {
+    await applyEmbeddingConfig(configPath, {
+      provider: "gemini",
+      apiKey: "AIzaTEST123",
+    });
+    await applyEmbeddingConfig(configPath, { provider: "none" });
+    const text = await readFile(configPath, "utf8");
+    expect(text).toContain('provider = "none"');
+    // Old gemini block preserved so re-enabling doesn't require re-validating
+    expect(text).toContain('api_key = "AIzaTEST123"');
+
+    const c = await loadConfig();
+    expect(c.embeddings.provider).toBe("none");
+    // gemini sub-config not exposed when provider is none.
+    expect(c.embeddings.gemini).toBeUndefined();
+  });
+});
+
+describe("config inference", () => {
+  test("if api_key is set via env but no provider in toml, infers gemini", async () => {
+    const SAVED_KEY = process.env.PHANTOMBOT_GEMINI_API_KEY;
+    process.env.PHANTOMBOT_GEMINI_API_KEY = "AIzaENV_KEY";
+    try {
+      const c = await loadConfig();
+      expect(c.embeddings.provider).toBe("gemini");
+      expect(c.embeddings.gemini?.apiKey).toBe("AIzaENV_KEY");
+    } finally {
+      if (SAVED_KEY === undefined) {
+        delete process.env.PHANTOMBOT_GEMINI_API_KEY;
+      } else {
+        process.env.PHANTOMBOT_GEMINI_API_KEY = SAVED_KEY;
+      }
+    }
+  });
+
+  test("with no api_key anywhere, defaults to provider=none", async () => {
+    const SAVED_KEY = process.env.PHANTOMBOT_GEMINI_API_KEY;
+    delete process.env.PHANTOMBOT_GEMINI_API_KEY;
+    try {
+      const c = await loadConfig();
+      expect(c.embeddings.provider).toBe("none");
+    } finally {
+      if (SAVED_KEY !== undefined) {
+        process.env.PHANTOMBOT_GEMINI_API_KEY = SAVED_KEY;
+      }
+    }
+  });
+});

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -57,6 +57,7 @@ beforeEach(async () => {
       pi: { bin: "pi", maxPayloadBytes: 1_500_000 },
     },
     channels: {},
+    embeddings: { provider: "none" },
   };
 });
 

--- a/tests/cli-memory.test.ts
+++ b/tests/cli-memory.test.ts
@@ -53,6 +53,7 @@ beforeEach(async () => {
       pi: { bin: "pi", maxPayloadBytes: 1_500_000 },
     },
     channels: {},
+    embeddings: { provider: "none" },
   };
 });
 

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -44,6 +44,7 @@ beforeEach(async () => {
       pi: { bin: "pi", maxPayloadBytes: 1_000_000 },
     },
     channels: {},
+    embeddings: { provider: "none" },
   };
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -21,6 +21,7 @@ describe("phantombot CLI dispatcher", () => {
     const names = Object.keys(subs).sort();
     expect(names).toEqual([
       "create-persona",
+      "embedding",
       "harness",
       "import-persona",
       "install",

--- a/tests/lib-geminiEmbed.test.ts
+++ b/tests/lib-geminiEmbed.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the Gemini embedding client (mocked fetch — no network).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { geminiEmbed } from "../src/lib/geminiEmbed.ts";
+
+function fakeFetch(
+  body: unknown,
+  status = 200,
+): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+describe("geminiEmbed", () => {
+  test("ok=true returns Float32Array of the right length", async () => {
+    const r = await geminiEmbed("k", "hello", {
+      fetchImpl: fakeFetch({
+        embedding: { values: Array.from({ length: 1536 }, () => 0.1) },
+      }),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.values).toBeInstanceOf(Float32Array);
+    expect(r.values.length).toBe(1536);
+    expect(r.dims).toBe(1536);
+    expect(Math.abs(r.values[0]! - 0.1)).toBeLessThan(0.0001);
+  });
+
+  test("ok=false returns Gemini's error message on 4xx", async () => {
+    const r = await geminiEmbed("badkey", "hello", {
+      fetchImpl: fakeFetch(
+        { error: { message: "API key not valid. Please pass a valid API key." } },
+        400,
+      ),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("API key not valid");
+  });
+
+  test("ok=false on HTTP error without body.error", async () => {
+    const r = await geminiEmbed("k", "x", {
+      fetchImpl: fakeFetch({}, 500),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("HTTP 500");
+  });
+
+  test("ok=false on network error", async () => {
+    const failing = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const r = await geminiEmbed("k", "x", { fetchImpl: failing });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("network");
+  });
+
+  test("ok=false on missing embedding", async () => {
+    const r = await geminiEmbed("k", "x", {
+      fetchImpl: fakeFetch({}),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("no embedding");
+  });
+
+  test("ok=false on non-numeric values in embedding", async () => {
+    const r = await geminiEmbed("k", "x", {
+      fetchImpl: fakeFetch({ embedding: { values: ["a", "b"] } }),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("non-numeric");
+  });
+});


### PR DESCRIPTION
## Summary

\`phantombot embedding\` — interactive TUI to configure semantic search:

\`\`\`
> Provider:
  ▸ Gemini (gemini-embedding-001, 1536 dims)
    None — keyword/BM25 search only
    Cancel

> Gemini API key (https://aistudio.google.com/app/apikey):
  ▸ ••••••••

[validating with a one-token embed…]
✓ key validated (got 1536 dims)
\`\`\`

For Gemini: validates the key by calling \`embedContent\` once before saving. For None: flips \`provider="none"\` but PRESERVES the existing \`[embeddings.gemini]\` block so re-enabling later doesn't need re-validating.

## New library

\`src/lib/geminiEmbed.ts\` — raw HTTPS client, no SDK dep. \`{ok:true, values:Float32Array, dims}\` or \`{ok:false, error}\`. Accepts an optional \`AbortSignal\` so the eventual nightly batch-embedder can cancel mid-flight.

## Config schema added

\`\`\`toml
[embeddings]
provider = "gemini"  # or "none"

[embeddings.gemini]
api_key = "..."
model = "gemini-embedding-001"
dims = 1536
\`\`\`

Resolution priority for the API key: \`PHANTOMBOT_GEMINI_API_KEY\` env > \`config.toml\` > none. Provider auto-infers to \`"gemini"\` if a key is found anywhere; otherwise defaults to \`"none"\`.

## Test plan

- [x] \`bun test\` — 230 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- New tests: 6 \`lib-geminiEmbed\` (mocked fetch — success, 4xx with body.error, 5xx, network, missing embedding, non-numeric) + 5 \`cli-embedding\` (write block, loadConfig round-trip, switch to none preserves block, env-var inference, default-to-none).

## Notes

This PR doesn't yet USE embeddings — it just sets up the key. Phase 25 wires \`memory index\` to actually call the embedder and stores vectors in the existing \`note_embeddings\` table the FTS5 schema reserved.