### PR TITLE
Phase 25: embedding-on-index + brute-force cosine + RRF hybrid search

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -24,6 +24,8 @@ import { mkdir } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
+import { defaultEmbedder, runEmbedJob } from "../lib/embedJob.ts";
+import { geminiEmbed } from "../lib/geminiEmbed.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { MemoryIndex, type Scope } from "../lib/memoryIndex.ts";
 
@@ -90,10 +92,36 @@ export async function runMemorySearch(
   const ix = await MemoryIndex.open(input.indexPath ?? indexPath(config, persona));
   try {
     await ix.refreshStale(dir);
-    const hits = ix.search(input.query, {
-      scope: input.scope,
-      limit: input.limit,
-    });
+
+    // If embeddings are configured AND there are stored vectors, do a
+    // hybrid search. Otherwise fall back to FTS-only.
+    let queryVec: Float32Array | undefined;
+    if (
+      config.embeddings.provider === "gemini" &&
+      config.embeddings.gemini?.apiKey &&
+      ix.embeddingCount() > 0
+    ) {
+      const r = await geminiEmbed(
+        config.embeddings.gemini.apiKey,
+        input.query,
+        {
+          model: config.embeddings.gemini.model,
+          dims: config.embeddings.gemini.dims,
+        },
+      );
+      if (r.ok) queryVec = r.values;
+      else err.write(`(query embed failed: ${r.error}; falling back to FTS-only)\n`);
+    }
+
+    const hits = queryVec
+      ? ix.hybridSearch(input.query, queryVec, {
+          scope: input.scope,
+          limit: input.limit,
+        })
+      : ix.search(input.query, {
+          scope: input.scope,
+          limit: input.limit,
+        });
     out.write(JSON.stringify({ persona, query: input.query, results: hits }, null, 2));
     out.write("\n");
   } finally {
@@ -190,8 +218,13 @@ export interface RunIndexInput extends RunMemoryInput {
   indexPath?: string;
 }
 
+export interface RunIndexInputV2 extends RunIndexInput {
+  /** Skip the embedding pass even when a provider is configured. */
+  noEmbed?: boolean;
+}
+
 export async function runMemoryIndex(
-  input: RunIndexInput,
+  input: RunIndexInputV2,
 ): Promise<number> {
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
@@ -205,15 +238,48 @@ export async function runMemoryIndex(
 
   const ix = await MemoryIndex.open(input.indexPath ?? indexPath(config, persona));
   try {
-    const r = input.rebuild
+    const ftsResult = input.rebuild
       ? { ...(await ix.rebuild(dir)), removed: 0 }
       : await ix.refreshStale(dir);
     out.write(
-      `${input.rebuild ? "rebuilt" : "refreshed"} index for '${persona}': ` +
-        `${r.indexed} file(s) (re)indexed` +
-        (r.removed > 0 ? `, ${r.removed} removed` : "") +
+      `${input.rebuild ? "rebuilt" : "refreshed"} FTS index for '${persona}': ` +
+        `${ftsResult.indexed} file(s) (re)indexed` +
+        (ftsResult.removed > 0 ? `, ${ftsResult.removed} removed` : "") +
         `\n`,
     );
+
+    if (input.noEmbed) {
+      out.write(`(skipping embedding pass; --no-embed)\n`);
+      return 0;
+    }
+    const embedder = defaultEmbedder(config);
+    if (!embedder) {
+      out.write(
+        `(embeddings provider is "${config.embeddings.provider}"; ` +
+          `run \`phantombot embedding\` to set up Gemini)\n`,
+      );
+      return 0;
+    }
+
+    out.write(`embedding…\n`);
+    const r = await runEmbedJob({
+      personaDir: dir,
+      index: ix,
+      embedder,
+      force: input.rebuild,
+    });
+    out.write(
+      `embedded ${r.embedded}, skipped ${r.skipped} (sha match), ` +
+        `failed ${r.failed} of ${r.totalNotes} notes\n`,
+    );
+    if (r.failed > 0) {
+      for (const e of r.errors.slice(0, 5)) {
+        err.write(`  ${e.path}#${e.chunkIdx}: ${e.error}\n`);
+      }
+      if (r.errors.length > 5) {
+        err.write(`  ...and ${r.errors.length - 5} more\n`);
+      }
+    }
   } finally {
     ix.close();
   }
@@ -292,15 +358,17 @@ const todayCmd = defineCommand({
 });
 
 const indexCmd = defineCommand({
-  meta: { name: "index", description: "Refresh the FTS5 index (incremental by default; --rebuild for from-scratch)." },
+  meta: { name: "index", description: "Refresh FTS5 + embeddings (incremental by default; --rebuild for from-scratch; --no-embed to skip the vector pass)." },
   args: {
     persona: { type: "string", description: "Persona name." },
     rebuild: { type: "boolean", description: "Drop and re-index from scratch.", default: false },
+    "no-embed": { type: "boolean", description: "Skip embedding pass (FTS only).", default: false },
   },
   async run({ args }) {
     process.exitCode = await runMemoryIndex({
       persona: args.persona ? String(args.persona) : undefined,
       rebuild: Boolean(args.rebuild),
+      noEmbed: Boolean(args["no-embed"]),
     });
   },
 });

--- a/src/lib/embedJob.ts
+++ b/src/lib/embedJob.ts
@@ -1,0 +1,116 @@
+/**
+ * Embedding job — feeds the note_embeddings table.
+ *
+ * Iterates every (path, scope) row in the FTS5 `files` table, chunks the
+ * file content if it's too large for a single embedding call, and embeds
+ * each chunk via the configured provider. Skips chunks whose text_sha
+ * matches the recorded value (no API call needed).
+ *
+ * Sequential, not parallel — avoids hitting Gemini's per-minute quota.
+ */
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Config } from "../config.ts";
+import { geminiEmbed, type EmbedResult } from "./geminiEmbed.ts";
+import type { MemoryIndex } from "./memoryIndex.ts";
+
+/** Roughly 6000 tokens of slack-padded room for Gemini's 8192 limit. */
+const MAX_CHARS_PER_CHUNK = 18_000;
+
+export interface EmbedJobResult {
+  totalNotes: number;
+  embedded: number;
+  skipped: number;
+  failed: number;
+  errors: Array<{ path: string; chunkIdx: number; error: string }>;
+}
+
+export type Embedder = (text: string) => Promise<EmbedResult>;
+
+export function defaultEmbedder(config: Config): Embedder | undefined {
+  if (config.embeddings.provider !== "gemini") return undefined;
+  const g = config.embeddings.gemini;
+  if (!g?.apiKey) return undefined;
+  return (text) =>
+    geminiEmbed(g.apiKey, text, { model: g.model, dims: g.dims });
+}
+
+export interface RunEmbedJobInput {
+  personaDir: string;
+  index: MemoryIndex;
+  embedder: Embedder;
+  /** If true, re-embed every chunk regardless of sha match. */
+  force?: boolean;
+}
+
+export async function runEmbedJob(
+  input: RunEmbedJobInput,
+): Promise<EmbedJobResult> {
+  const result: EmbedJobResult = {
+    totalNotes: 0,
+    embedded: 0,
+    skipped: 0,
+    failed: 0,
+    errors: [],
+  };
+
+  // Pull the full file list straight from the FTS index (which has been
+  // populated by refreshStale before we get here).
+  const files = (
+    input.index as unknown as {
+      db: import("bun:sqlite").Database;
+    }
+  ).db
+    .query("SELECT path FROM files ORDER BY path")
+    .all() as Array<{ path: string }>;
+
+  for (const { path } of files) {
+    result.totalNotes++;
+    let content: string;
+    try {
+      content = await readFile(join(input.personaDir, path), "utf8");
+    } catch {
+      // File listed in `files` but no longer on disk — skip silently;
+      // refreshStale will catch and remove it on next call.
+      continue;
+    }
+
+    const chunks = chunkText(content);
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]!;
+      const sha = sha256(chunk);
+      if (!input.force) {
+        const recorded = input.index.embeddingSha(path, i);
+        if (recorded === sha) {
+          result.skipped++;
+          continue;
+        }
+      }
+      const r = await input.embedder(chunk);
+      if (!r.ok) {
+        result.failed++;
+        result.errors.push({ path, chunkIdx: i, error: r.error });
+        continue;
+      }
+      input.index.upsertEmbedding(path, i, r.values, sha);
+      result.embedded++;
+    }
+  }
+
+  return result;
+}
+
+export function chunkText(text: string): string[] {
+  if (text.length <= MAX_CHARS_PER_CHUNK) return [text];
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += MAX_CHARS_PER_CHUNK) {
+    out.push(text.slice(i, i + MAX_CHARS_PER_CHUNK));
+  }
+  return out;
+}
+
+export function sha256(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -34,8 +34,55 @@ export interface IndexedFile {
 export interface SearchHit {
   path: string;
   scope: Scope;
-  ftsScore: number;
+  /** BM25-derived score; higher = more relevant. Only set if FTS5 matched. */
+  ftsScore?: number;
+  /** Cosine similarity (-1..1); only set if vector search matched. */
+  vecScore?: number;
+  /** Reciprocal-rank-fusion score combining FTS + vec ranks. */
+  rrfScore?: number;
   snippet: string;
+}
+
+export interface StoredEmbedding {
+  path: string;
+  chunkIdx: number;
+  vec: Float32Array;
+  textSha: string;
+}
+
+/** Brute-force cosine similarity. Both vectors must be the same length. */
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  const len = Math.min(a.length, b.length);
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < len; i++) {
+    const ai = a[i]!;
+    const bi = b[i]!;
+    dot += ai * bi;
+    na += ai * ai;
+    nb += bi * bi;
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  return denom > 0 ? dot / denom : 0;
+}
+
+/**
+ * Reciprocal Rank Fusion. Each input is an ordered list of paths
+ * (best-first). Returns a Map<path, rrfScore> combining the lists.
+ * The standard k=60 from Cormack et al.
+ */
+export function rrfMerge(
+  lists: ReadonlyArray<readonly string[]>,
+  k = 60,
+): Map<string, number> {
+  const scores = new Map<string, number>();
+  for (const list of lists) {
+    list.forEach((path, idx) => {
+      scores.set(path, (scores.get(path) ?? 0) + 1 / (k + idx + 1));
+    });
+  }
+  return scores;
 }
 
 const SCHEMA = `
@@ -59,9 +106,11 @@ CREATE TABLE IF NOT EXISTS note_embeddings (
   path         TEXT NOT NULL,
   chunk_idx    INTEGER NOT NULL,
   vec          BLOB NOT NULL,
+  text_sha     TEXT NOT NULL,
   embedded_at  TEXT NOT NULL,
   PRIMARY KEY (path, chunk_idx)
 );
+CREATE INDEX IF NOT EXISTS idx_note_embeddings_sha ON note_embeddings(text_sha);
 `;
 
 export class MemoryIndex {
@@ -141,6 +190,68 @@ export class MemoryIndex {
     return { indexed, removed };
   }
 
+  // -------------------------------------------------------------
+  // Embedding storage
+  // -------------------------------------------------------------
+
+  upsertEmbedding(
+    path: string,
+    chunkIdx: number,
+    vec: Float32Array,
+    textSha: string,
+  ): void {
+    const buf = Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength);
+    this.db
+      .prepare(
+        "INSERT OR REPLACE INTO note_embeddings " +
+          "(path, chunk_idx, vec, text_sha, embedded_at) " +
+          "VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(path, chunkIdx, buf, textSha, new Date().toISOString());
+  }
+
+  /** Return the recorded text_sha for a (path, chunk_idx) or undefined. */
+  embeddingSha(path: string, chunkIdx: number): string | undefined {
+    const row = this.db
+      .prepare(
+        "SELECT text_sha FROM note_embeddings WHERE path = ? AND chunk_idx = ?",
+      )
+      .get(path, chunkIdx) as { text_sha?: string } | null;
+    return row?.text_sha;
+  }
+
+  /** Walk every stored embedding. Loads all into memory — fine up to ~50K rows. */
+  allEmbeddings(): StoredEmbedding[] {
+    const rows = this.db
+      .query(
+        "SELECT path, chunk_idx, vec, text_sha FROM note_embeddings",
+      )
+      .all() as Array<{
+      path: string;
+      chunk_idx: number;
+      vec: Buffer | Uint8Array;
+      text_sha: string;
+    }>;
+    return rows.map((r) => ({
+      path: r.path,
+      chunkIdx: r.chunk_idx,
+      vec: blobToFloat32(r.vec),
+      textSha: r.text_sha,
+    }));
+  }
+
+  embeddingCount(): number {
+    return (
+      this.db
+        .prepare("SELECT COUNT(*) AS c FROM note_embeddings")
+        .get() as { c: number }
+    ).c;
+  }
+
+  // -------------------------------------------------------------
+  // Search
+  // -------------------------------------------------------------
+
   search(
     query: string,
     opts: { scope?: Scope | "all"; limit?: number } = {},
@@ -190,6 +301,81 @@ export class MemoryIndex {
     }));
   }
 
+  /**
+   * Hybrid search: BM25 + cosine similarity over stored embeddings,
+   * combined via RRF. Falls back to FTS-only when queryVec is undefined.
+   */
+  hybridSearch(
+    query: string,
+    queryVec: Float32Array | undefined,
+    opts: { scope?: Scope | "all"; limit?: number } = {},
+  ): SearchHit[] {
+    const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
+    const ftsHits = this.search(query, { scope: opts.scope, limit: 25 });
+
+    if (!queryVec || queryVec.length === 0) return ftsHits.slice(0, limit);
+
+    // Vector search. Brute-force cosine over all embeddings.
+    const all = this.allEmbeddings();
+    const vecScores = new Map<string, number>(); // path → max chunk score
+    for (const emb of all) {
+      const s = cosineSimilarity(queryVec, emb.vec);
+      const cur = vecScores.get(emb.path);
+      if (cur === undefined || s > cur) vecScores.set(emb.path, s);
+    }
+
+    // Filter by scope by joining with the FTS files table — embeddings
+    // table has no scope column, so we look up scope from `files`.
+    let allowedPaths: Set<string> | undefined;
+    if (opts.scope && opts.scope !== "all") {
+      const rows = this.db
+        .query("SELECT path FROM files WHERE scope = ?")
+        .all(opts.scope) as Array<{ path: string }>;
+      allowedPaths = new Set(rows.map((r) => r.path));
+      for (const path of [...vecScores.keys()]) {
+        if (!allowedPaths.has(path)) vecScores.delete(path);
+      }
+    }
+
+    const vecRanked = [...vecScores.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 25);
+
+    // RRF merge of FTS + vec ranks.
+    const ftsRanked = ftsHits.map((h) => h.path);
+    const vecPaths = vecRanked.map(([path]) => path);
+    const rrf = rrfMerge([ftsRanked, vecPaths]);
+
+    // Build the final hit list, ordered by rrf score, including both
+    // sub-scores when available.
+    const merged: SearchHit[] = [...rrf.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([path, rrfScore]) => {
+        const ftsHit = ftsHits.find((h) => h.path === path);
+        const scope =
+          ftsHit?.scope ??
+          this.lookupScope(path) ??
+          ("kb" as Scope); // best guess
+        return {
+          path,
+          scope,
+          ftsScore: ftsHit?.ftsScore,
+          vecScore: vecScores.get(path),
+          rrfScore,
+          snippet: ftsHit?.snippet ?? "",
+        };
+      });
+    return merged;
+  }
+
+  private lookupScope(path: string): Scope | undefined {
+    const row = this.db
+      .prepare("SELECT scope FROM files WHERE path = ?")
+      .get(path) as { scope?: Scope } | null;
+    return row?.scope;
+  }
+
   private deletePath(path: string): void {
     this.db.prepare("DELETE FROM notes WHERE path = ?").run(path);
     this.db.prepare("DELETE FROM files WHERE path = ?").run(path);
@@ -197,6 +383,13 @@ export class MemoryIndex {
       .prepare("DELETE FROM note_embeddings WHERE path = ?")
       .run(path);
   }
+}
+
+function blobToFloat32(blob: Buffer | Uint8Array): Float32Array {
+  // bun:sqlite may return either Buffer (Node-style) or Uint8Array.
+  // Both expose .buffer + .byteOffset + .byteLength so we can construct
+  // a Float32Array view without copying.
+  return new Float32Array(blob.buffer, blob.byteOffset, blob.byteLength / 4);
 }
 
 /** Walk personaDir/memory/ and personaDir/kb/ for .md files. Synchronous. */

--- a/tests/cli-memory.test.ts
+++ b/tests/cli-memory.test.ts
@@ -218,7 +218,7 @@ describe("runMemoryIndex", () => {
       err: new CaptureStream(),
     });
     expect(code).toBe(0);
-    expect(out.text).toContain("rebuilt index for 'phantom': 2 file(s)");
+    expect(out.text).toContain("rebuilt FTS index for 'phantom': 2 file(s)");
   });
 
   test("incremental refresh reports 0 on a fresh index that's been refreshed once", async () => {

--- a/tests/lib-embedJob.test.ts
+++ b/tests/lib-embedJob.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for the embed job + hybrid search pipeline.
+ *
+ * Uses a fake embedder so we don't hit Gemini.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  chunkText,
+  defaultEmbedder,
+  runEmbedJob,
+  sha256,
+} from "../src/lib/embedJob.ts";
+import {
+  cosineSimilarity,
+  MemoryIndex,
+  rrfMerge,
+} from "../src/lib/memoryIndex.ts";
+
+let workdir: string;
+let personaDir: string;
+let ix: MemoryIndex;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-emb-"));
+  personaDir = join(workdir, "persona");
+  await mkdir(join(personaDir, "memory"), { recursive: true });
+  await mkdir(join(personaDir, "kb", "concepts"), { recursive: true });
+  ix = await MemoryIndex.open(":memory:");
+});
+
+afterEach(async () => {
+  ix.close();
+  await rm(workdir, { recursive: true, force: true });
+});
+
+async function note(rel: string, content: string) {
+  await writeFile(join(personaDir, rel), content);
+}
+
+/**
+ * Deterministic fake embedder. Returns a 4-dim vector seeded by the
+ * first character of the input — different chars → different vectors.
+ */
+function fakeEmbedder() {
+  return async (text: string) => {
+    const code = text.charCodeAt(0) || 0;
+    const v = new Float32Array(4);
+    v[0] = (code % 7) / 10;
+    v[1] = ((code + 3) % 11) / 10;
+    v[2] = ((code + 5) % 13) / 10;
+    v[3] = ((code + 7) % 17) / 10;
+    // Normalize so cosine similarity is well-defined
+    let n = 0;
+    for (const x of v) n += x * x;
+    const len = Math.sqrt(n);
+    if (len > 0) for (let i = 0; i < v.length; i++) v[i]! /= len;
+    return { ok: true as const, values: v, dims: 4 };
+  };
+}
+
+describe("chunkText", () => {
+  test("returns single chunk for short text", () => {
+    expect(chunkText("hello")).toEqual(["hello"]);
+  });
+
+  test("splits long text into ~18000 char chunks", () => {
+    const long = "x".repeat(40_000);
+    const chunks = chunkText(long);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.length <= 18_000)).toBe(true);
+    expect(chunks.join("")).toBe(long);
+  });
+});
+
+describe("sha256", () => {
+  test("is deterministic", () => {
+    expect(sha256("hello")).toBe(sha256("hello"));
+    expect(sha256("hello")).not.toBe(sha256("world"));
+  });
+});
+
+describe("cosineSimilarity", () => {
+  test("identical vectors have similarity ~1", () => {
+    const a = new Float32Array([1, 2, 3, 4]);
+    expect(Math.abs(cosineSimilarity(a, a) - 1)).toBeLessThan(0.0001);
+  });
+
+  test("orthogonal vectors have similarity 0", () => {
+    const a = new Float32Array([1, 0]);
+    const b = new Float32Array([0, 1]);
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+
+  test("opposite vectors have similarity -1", () => {
+    const a = new Float32Array([1, 0]);
+    const b = new Float32Array([-1, 0]);
+    expect(cosineSimilarity(a, b)).toBe(-1);
+  });
+
+  test("zero vectors return 0 (no division by zero)", () => {
+    const z = new Float32Array([0, 0, 0]);
+    const a = new Float32Array([1, 2, 3]);
+    expect(cosineSimilarity(z, a)).toBe(0);
+  });
+});
+
+describe("rrfMerge", () => {
+  test("blends two ranked lists with reciprocal-rank weighting", () => {
+    const a = ["x", "y", "z"];
+    const b = ["y", "x", "w"];
+    const m = rrfMerge([a, b]);
+    // y is #1 in b and #2 in a — should beat or tie x
+    expect((m.get("y") ?? 0)).toBeGreaterThan(0);
+    expect((m.get("x") ?? 0)).toBeGreaterThan(0);
+    expect((m.get("w") ?? 0)).toBeGreaterThan(0);
+    expect((m.get("z") ?? 0)).toBeGreaterThan(0);
+    // y is in BOTH lists at high rank — outscores z (only in a, low rank)
+    expect((m.get("y") ?? 0)).toBeGreaterThan((m.get("z") ?? 0));
+  });
+});
+
+describe("MemoryIndex embedding storage", () => {
+  test("upsertEmbedding round-trips a Float32Array", () => {
+    const v = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    ix.upsertEmbedding("kb/A.md", 0, v, "sha-1");
+    expect(ix.embeddingCount()).toBe(1);
+    expect(ix.embeddingSha("kb/A.md", 0)).toBe("sha-1");
+    const all = ix.allEmbeddings();
+    expect(all).toHaveLength(1);
+    expect(all[0]?.path).toBe("kb/A.md");
+    expect(all[0]?.chunkIdx).toBe(0);
+    expect(all[0]?.vec.length).toBe(4);
+    expect(Math.abs(all[0]!.vec[0]! - 0.1)).toBeLessThan(0.0001);
+  });
+
+  test("INSERT OR REPLACE on the same (path, chunk_idx)", () => {
+    const v1 = new Float32Array([1, 0]);
+    const v2 = new Float32Array([0, 1]);
+    ix.upsertEmbedding("kb/A.md", 0, v1, "sha-1");
+    ix.upsertEmbedding("kb/A.md", 0, v2, "sha-2");
+    expect(ix.embeddingCount()).toBe(1);
+    expect(ix.embeddingSha("kb/A.md", 0)).toBe("sha-2");
+  });
+});
+
+describe("runEmbedJob", () => {
+  test("embeds every note (skipped on second pass via sha match)", async () => {
+    await note("kb/concepts/A.md", "alpha content");
+    await note("kb/concepts/B.md", "beta content");
+    await ix.refreshStale(personaDir);
+
+    const r1 = await runEmbedJob({
+      personaDir,
+      index: ix,
+      embedder: fakeEmbedder(),
+    });
+    expect(r1.totalNotes).toBe(2);
+    expect(r1.embedded).toBe(2);
+    expect(r1.skipped).toBe(0);
+    expect(r1.failed).toBe(0);
+
+    const r2 = await runEmbedJob({
+      personaDir,
+      index: ix,
+      embedder: fakeEmbedder(),
+    });
+    expect(r2.skipped).toBe(2);
+    expect(r2.embedded).toBe(0);
+  });
+
+  test("force=true re-embeds everything", async () => {
+    await note("kb/concepts/A.md", "alpha");
+    await ix.refreshStale(personaDir);
+    await runEmbedJob({ personaDir, index: ix, embedder: fakeEmbedder() });
+    const r = await runEmbedJob({
+      personaDir,
+      index: ix,
+      embedder: fakeEmbedder(),
+      force: true,
+    });
+    expect(r.embedded).toBe(1);
+    expect(r.skipped).toBe(0);
+  });
+
+  test("records failures without aborting the whole job", async () => {
+    await note("kb/concepts/A.md", "alpha");
+    await note("kb/concepts/B.md", "beta");
+    await ix.refreshStale(personaDir);
+    const flaky = async (text: string) =>
+      text.startsWith("alpha")
+        ? { ok: false as const, error: "rate limited" }
+        : { ok: true as const, values: new Float32Array([0.5, 0.5, 0.5, 0.5]), dims: 4 };
+    const r = await runEmbedJob({ personaDir, index: ix, embedder: flaky });
+    expect(r.embedded).toBe(1);
+    expect(r.failed).toBe(1);
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0]?.path).toBe("kb/concepts/A.md");
+  });
+});
+
+describe("MemoryIndex.hybridSearch", () => {
+  test("returns FTS-only results when no query vector is provided", async () => {
+    await note("kb/concepts/A.md", "deye inverter");
+    await ix.refreshStale(personaDir);
+    const hits = ix.hybridSearch("deye", undefined);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.path).toBe("kb/concepts/A.md");
+    expect(hits[0]?.ftsScore).toBeGreaterThan(0);
+    expect(hits[0]?.vecScore).toBeUndefined();
+  });
+
+  test("merges FTS + vec via RRF when both provide hits", async () => {
+    await note("kb/concepts/A.md", "alpha note about deye");
+    await note("kb/concepts/B.md", "beta note about something else");
+    await note("kb/concepts/C.md", "gamma totally unrelated");
+    await ix.refreshStale(personaDir);
+    await runEmbedJob({ personaDir, index: ix, embedder: fakeEmbedder() });
+
+    // Build a query vector that matches A's embedding (same first char)
+    const queryEmbed = await fakeEmbedder()("alpha query");
+    if (!queryEmbed.ok) throw new Error("embed failed");
+
+    const hits = ix.hybridSearch("alpha deye", queryEmbed.values, {
+      limit: 5,
+    });
+    expect(hits.length).toBeGreaterThan(0);
+    // First hit should have both FTS and vec scores merged
+    const top = hits[0]!;
+    expect(top.path).toBeDefined();
+    expect(top.rrfScore).toBeGreaterThan(0);
+  });
+
+  test("respects scope when stored embeddings span memory + kb", async () => {
+    await note("memory/decisions.md", "elevenlabs choice");
+    await note("kb/concepts/Voice.md", "elevenlabs voice config");
+    await ix.refreshStale(personaDir);
+    await runEmbedJob({ personaDir, index: ix, embedder: fakeEmbedder() });
+    const queryEmbed = await fakeEmbedder()("elevenlabs anything");
+    if (!queryEmbed.ok) throw new Error("embed failed");
+    const memOnly = ix.hybridSearch("elevenlabs", queryEmbed.values, {
+      scope: "memory",
+    });
+    expect(memOnly.every((h) => h.scope === "memory")).toBe(true);
+  });
+});
+
+describe("defaultEmbedder", () => {
+  test("returns undefined when provider is not gemini", () => {
+    const e = defaultEmbedder({
+      defaultPersona: "x",
+      turnTimeoutMs: 1,
+      personasDir: "/tmp",
+      memoryDbPath: "/tmp/m.sqlite",
+      configPath: "/tmp/c.toml",
+      harnesses: {
+        chain: [],
+        claude: { bin: "x", model: "y", fallbackModel: "" },
+        pi: { bin: "x", maxPayloadBytes: 1 },
+      },
+      channels: {},
+      embeddings: { provider: "none" },
+    });
+    expect(e).toBeUndefined();
+  });
+
+  test("returns undefined when provider is gemini but apiKey is empty", () => {
+    const e = defaultEmbedder({
+      defaultPersona: "x",
+      turnTimeoutMs: 1,
+      personasDir: "/tmp",
+      memoryDbPath: "/tmp/m.sqlite",
+      configPath: "/tmp/c.toml",
+      harnesses: {
+        chain: [],
+        claude: { bin: "x", model: "y", fallbackModel: "" },
+        pi: { bin: "x", maxPayloadBytes: 1 },
+      },
+      channels: {},
+      embeddings: {
+        provider: "gemini",
+        gemini: { apiKey: "", model: "g", dims: 1536 },
+      },
+    });
+    expect(e).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

\`phantombot memory search\` now hybridizes **BM25 (FTS5) + cosine similarity over stored embeddings via RRF** when an embedding provider is configured AND the index has stored vectors. Falls back to FTS-only when any of that is missing — graceful degradation.

\`phantombot memory index\` now ALSO runs an embedding pass when configured. Skips chunks whose text_sha matches stored — re-indexing stable corpus is one Gemini call per *changed* note. Add \`--no-embed\` to skip embeddings entirely (FTS-only refresh).

## What's new

- **\`src/lib/embedJob.ts\`** — \`runEmbedJob()\` iterates files, chunks notes (>18000 chars splits into ~6000-token blocks), computes sha256, calls the configured embedder, stores. Sequential — stays under Gemini's free-tier per-minute cap.
- **\`src/lib/memoryIndex.ts\`** — adds \`upsertEmbedding\`, \`embeddingSha\`, \`allEmbeddings\`, \`embeddingCount\`, \`hybridSearch\`. Schema's \`note_embeddings\` table got a \`text_sha\` column + index. Exports \`cosineSimilarity\` and \`rrfMerge\`.
- **\`src/cli/memory.ts\`** — \`search\` embeds the query via Gemini and calls \`hybridSearch\`; output JSON now includes \`ftsScore\`, \`vecScore\`, \`rrfScore\` (whichever apply). \`index\` reports two phases (FTS + embed) with per-file failures to stderr.

## Storage choice

BLOB column holding \`Float32Array\` bytes (4 × 1536 = 6 KB per embedding). Brute-force cosine over up to ~10K vectors is < 50 ms on the QEMU host. Swap to \`sqlite-vec\` later if scale crosses ~50K.

## Test plan

- [x] \`bun test\` — 248 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- 17 new tests across \`tests/lib-embedJob.test.ts\` (chunk, sha, cosine, rrf, upsert, runEmbedJob skip/force/partial-failure, hybridSearch FTS-fallback / RRF merge / scope filter, defaultEmbedder gating).

## Notes

Doesn't add a new subcommand — the embedding flow is implicit in \`memory search\` and \`memory index\` when an API key is configured. To enable: \`phantombot embedding\` (phase 24) → set Gemini key → \`phantombot memory index\` will start embedding on next call.