### PR TITLE
Phase 26: heartbeat job (mechanical, no LLM) + systemd timer

### DIFF
--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -1,0 +1,75 @@
+/**
+ * `phantombot heartbeat` — short, mechanical maintenance pass.
+ *
+ * Runs every 30 minutes via systemd timer (installed by `phantombot install`).
+ * No LLM call. See src/lib/heartbeat.ts for what it does.
+ */
+
+import { defineCommand } from "citty";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { type Config, loadConfig, personaDir } from "../config.ts";
+import { runHeartbeat } from "../lib/heartbeat.ts";
+import type { WriteSink } from "../lib/io.ts";
+
+function indexPath(persona: string): string {
+  return join(
+    process.env.XDG_DATA_HOME || join(process.env.HOME ?? "", ".local/share"),
+    "phantombot",
+    "memory-index",
+    `${persona}.sqlite`,
+  );
+}
+
+export interface RunHeartbeatCliInput {
+  config?: Config;
+  persona?: string;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runHeartbeatCli(
+  input: RunHeartbeatCliInput = {},
+): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const config = input.config ?? (await loadConfig());
+  const persona = input.persona ?? config.defaultPersona;
+  const dir = personaDir(config, persona);
+
+  if (!existsSync(dir)) {
+    err.write(`persona '${persona}' not found at ${dir}\n`);
+    return 2;
+  }
+
+  const r = await runHeartbeat({
+    personaDir: dir,
+    indexPath: indexPath(persona),
+  });
+  out.write(
+    `heartbeat ok: promoted ${r.promoted.length}, ` +
+      `stale ${r.staleRecent.length}, ` +
+      `indexed ${r.indexedFiles}\n`,
+  );
+  return 0;
+}
+
+export default defineCommand({
+  meta: {
+    name: "heartbeat",
+    description:
+      "Mechanical 30-min maintenance: promote tagged daily-file lines to drawers, scan ## Recent for staleness, refresh FTS index. No LLM call.",
+  },
+  args: {
+    persona: {
+      type: "string",
+      description: "Persona name (default: configured default).",
+    },
+  },
+  async run({ args }) {
+    process.exitCode = await runHeartbeatCli({
+      persona: args.persona ? String(args.persona) : undefined,
+    });
+  },
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import uninstallCmd from "./uninstall.ts";
 import runCmd from "./run.ts";
 import memoryCmd from "./memory.ts";
 import embeddingCmd from "./embedding.ts";
+import heartbeatCmd from "./heartbeat.ts";
 
 export const mainCommand = defineCommand({
   meta: {
@@ -41,5 +42,6 @@ export const mainCommand = defineCommand({
     uninstall: uninstallCmd,
     run: runCmd,
     memory: memoryCmd,
+    heartbeat: heartbeatCmd,
   },
 });

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -1,0 +1,177 @@
+/**
+ * Heartbeat job — mechanical maintenance, no LLM call.
+ *
+ * Runs every 30 minutes via systemd timer. Three things only:
+ *   1. Promote tagged lines from today's daily file into the matching
+ *      structured drawer. Dedup by text-equality so re-promotion of the
+ *      same line is a no-op.
+ *   2. Staleness scan of MEMORY.md's `## Recent` section — flag lines
+ *      whose embedded date is older than 48h. Logs warnings; does not
+ *      mutate.
+ *   3. Refresh the FTS5 index so newly-written notes are searchable
+ *      without waiting for the next manual `memory index`. Does NOT
+ *      run the embedding pass (that's the nightly cycle's job).
+ *
+ * The harness never sees this — heartbeat runs as its own short-lived
+ * process. Per the OpenClaw spec: "Heartbeat is mechanical, nightly is
+ * cognitive. Don't let the heartbeat write KB notes."
+ */
+
+import { existsSync } from "node:fs";
+import { appendFile, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { log } from "./logger.ts";
+import { MemoryIndex } from "./memoryIndex.ts";
+
+export interface HeartbeatResult {
+  promoted: { drawer: string; line: string }[];
+  staleRecent: { line: string; ageHours: number }[];
+  indexedFiles: number;
+  /** When the heartbeat ran. */
+  ranAt: Date;
+}
+
+const TAG_TO_DRAWER: Record<string, string> = {
+  decision: "memory/decisions.md",
+  decisions: "memory/decisions.md",
+  lesson: "memory/lessons.md",
+  lessons: "memory/lessons.md",
+  person: "memory/people.md",
+  people: "memory/people.md",
+  commitment: "memory/commitments.md",
+  commitments: "memory/commitments.md",
+};
+
+const TAG_PATTERN = /^\s*-?\s*\[([a-z]+)\]\s+(.+)$/i;
+
+export interface RunHeartbeatInput {
+  personaDir: string;
+  /** Override "today" for testing. ISO date YYYY-MM-DD. */
+  today?: string;
+  /** Override "now" for staleness scan (testing). */
+  now?: Date;
+  /** Optional MemoryIndex; if omitted, opens one at indexPath. */
+  index?: MemoryIndex;
+  /** Path to the FTS index file (used only if index isn't passed). */
+  indexPath?: string;
+}
+
+export async function runHeartbeat(
+  input: RunHeartbeatInput,
+): Promise<HeartbeatResult> {
+  const today = input.today ?? new Date().toISOString().slice(0, 10);
+  const now = input.now ?? new Date();
+
+  const promoted = await promoteTaggedLines(input.personaDir, today);
+  const staleRecent = await checkStaleness(input.personaDir, now);
+
+  // FTS-only refresh. Don't touch embeddings.
+  const ix = input.index ?? (input.indexPath ? await MemoryIndex.open(input.indexPath) : null);
+  let indexedFiles = 0;
+  if (ix) {
+    const r = await ix.refreshStale(input.personaDir);
+    indexedFiles = r.indexed;
+    if (!input.index) ix.close();
+  }
+
+  if (promoted.length > 0) {
+    log.info("heartbeat: promoted", { count: promoted.length });
+  }
+  if (staleRecent.length > 0) {
+    log.warn("heartbeat: stale items in ## Recent", {
+      count: staleRecent.length,
+      sample: staleRecent.slice(0, 3),
+    });
+  }
+
+  return { promoted, staleRecent, indexedFiles, ranAt: now };
+}
+
+/** Scan today's daily file for [tag] lines; append to matching drawer. */
+export async function promoteTaggedLines(
+  personaDir: string,
+  today: string,
+): Promise<HeartbeatResult["promoted"]> {
+  const dailyPath = join(personaDir, "memory", `${today}.md`);
+  if (!existsSync(dailyPath)) return [];
+
+  const text = await readFile(dailyPath, "utf8");
+  const lines = text.split("\n");
+  const promoted: HeartbeatResult["promoted"] = [];
+
+  // Cache drawer contents to avoid re-reading per line.
+  const drawerCache = new Map<string, string>();
+  const loadDrawer = async (rel: string): Promise<string> => {
+    if (drawerCache.has(rel)) return drawerCache.get(rel)!;
+    const p = join(personaDir, rel);
+    let content = "";
+    if (existsSync(p)) content = await readFile(p, "utf8");
+    drawerCache.set(rel, content);
+    return content;
+  };
+
+  for (const raw of lines) {
+    const m = TAG_PATTERN.exec(raw);
+    if (!m) continue;
+    const tag = m[1]!.toLowerCase();
+    const drawer = TAG_TO_DRAWER[tag];
+    if (!drawer) continue;
+    const cleanLine = raw.trim();
+    const existing = await loadDrawer(drawer);
+    if (existing.includes(cleanLine)) continue;
+
+    // Append under a date header. If today's header isn't there, add it.
+    const header = `## ${today}`;
+    let block = "";
+    if (!existing.includes(header)) {
+      block += `\n${header}\n\n`;
+    }
+    block += `- ${cleanLine}\n`;
+    await appendFile(join(personaDir, drawer), block, "utf8");
+    drawerCache.set(drawer, existing + block);
+    promoted.push({ drawer, line: cleanLine });
+  }
+  return promoted;
+}
+
+/** Scan MEMORY.md's ## Recent for date-stamped lines older than 48h. */
+export async function checkStaleness(
+  personaDir: string,
+  now: Date,
+  thresholdHours = 48,
+): Promise<HeartbeatResult["staleRecent"]> {
+  const memPath = join(personaDir, "MEMORY.md");
+  if (!existsSync(memPath)) return [];
+  const text = await readFile(memPath, "utf8");
+  const recent = extractRecentSection(text);
+  if (!recent) return [];
+
+  const out: HeartbeatResult["staleRecent"] = [];
+  for (const line of recent.split("\n")) {
+    const dateMatch = /(\d{4}-\d{2}-\d{2})/.exec(line);
+    if (!dateMatch) continue;
+    const lineDate = new Date(`${dateMatch[1]}T00:00:00Z`);
+    if (Number.isNaN(lineDate.getTime())) continue;
+    const ageHours = (now.getTime() - lineDate.getTime()) / 3_600_000;
+    if (ageHours >= thresholdHours) {
+      out.push({ line: line.trim(), ageHours: Math.round(ageHours) });
+    }
+  }
+  return out;
+}
+
+/** Extract the body of `## Recent` from MEMORY.md (between this header and the next). */
+export function extractRecentSection(memoryMd: string): string | undefined {
+  const lines = memoryMd.split("\n");
+  let inRecent = false;
+  const out: string[] = [];
+  for (const line of lines) {
+    if (/^##\s+Recent\b/i.test(line)) {
+      inRecent = true;
+      continue;
+    }
+    if (inRecent && /^##\s+/.test(line)) break;
+    if (inRecent) out.push(line);
+  }
+  return inRecent ? out.join("\n") : undefined;
+}

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -12,9 +12,19 @@ import { dirname, join } from "node:path";
 import type { WriteSink } from "./io.ts";
 
 export const PHANTOMBOT_UNIT_NAME = "phantombot.service";
+export const HEARTBEAT_SERVICE_NAME = "phantombot-heartbeat.service";
+export const HEARTBEAT_TIMER_NAME = "phantombot-heartbeat.timer";
 
 export function defaultUnitPath(): string {
   return join(homedir(), ".config", "systemd", "user", PHANTOMBOT_UNIT_NAME);
+}
+
+export function heartbeatServicePath(): string {
+  return join(homedir(), ".config", "systemd", "user", HEARTBEAT_SERVICE_NAME);
+}
+
+export function heartbeatTimerPath(): string {
+  return join(homedir(), ".config", "systemd", "user", HEARTBEAT_TIMER_NAME);
 }
 
 export interface SystemdUnitParams {
@@ -54,6 +64,36 @@ WantedBy=default.target
 function quoteArg(s: string): string {
   if (/^[A-Za-z0-9_/.\-]+$/.test(s)) return s;
   return `"${s.replace(/(["\\$`])/g, "\\$1")}"`;
+}
+
+/** Generate the heartbeat oneshot service body. */
+export function generateHeartbeatService(binPath: string): string {
+  const exec = [binPath, "heartbeat"].map(quoteArg).join(" ");
+  return `[Unit]
+Description=Phantombot heartbeat — mechanical 30-minute maintenance pass
+
+[Service]
+Type=oneshot
+ExecStart=${exec}
+StandardOutput=journal
+StandardError=journal
+`;
+}
+
+/** Generate the heartbeat timer body — fires every 30 minutes. */
+export function generateHeartbeatTimer(): string {
+  return `[Unit]
+Description=Phantombot heartbeat timer (every 30 min)
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=30min
+AccuracySec=1min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`;
 }
 
 export interface SystemctlResult {
@@ -165,10 +205,19 @@ export async function installPhantombotUnit(
   await writeFile(opts.unitPath, unit, "utf8");
   opts.out.write(`wrote unit file: ${opts.unitPath}\n`);
 
+  // Also write the heartbeat service + timer alongside.
+  const hbService = heartbeatServicePath();
+  const hbTimer = heartbeatTimerPath();
+  await writeFile(hbService, generateHeartbeatService(opts.binPath), "utf8");
+  await writeFile(hbTimer, generateHeartbeatTimer(), "utf8");
+  opts.out.write(`wrote heartbeat units: ${hbService} + ${hbTimer}\n`);
+
   for (const args of [
     ["--user", "daemon-reload"],
     ["--user", "enable", PHANTOMBOT_UNIT_NAME],
     ["--user", "start", PHANTOMBOT_UNIT_NAME],
+    ["--user", "enable", HEARTBEAT_TIMER_NAME],
+    ["--user", "start", HEARTBEAT_TIMER_NAME],
   ]) {
     const r = await opts.systemctl.run(args);
     if (r.exitCode !== 0) {
@@ -178,7 +227,9 @@ export async function installPhantombotUnit(
       return { installed: false };
     }
   }
-  opts.out.write("enabled and started phantombot.service\n");
+  opts.out.write(
+    "enabled and started phantombot.service + phantombot-heartbeat.timer\n",
+  );
   return { installed: true };
 }
 
@@ -194,6 +245,8 @@ export async function uninstallPhantombotUnit(
 ): Promise<{ removed: boolean }> {
   // stop + disable are best-effort: a half-installed unit is fine to remove.
   for (const args of [
+    ["--user", "stop", HEARTBEAT_TIMER_NAME],
+    ["--user", "disable", HEARTBEAT_TIMER_NAME],
     ["--user", "stop", PHANTOMBOT_UNIT_NAME],
     ["--user", "disable", PHANTOMBOT_UNIT_NAME],
   ]) {
@@ -205,11 +258,20 @@ export async function uninstallPhantombotUnit(
     }
   }
 
+  // Main unit gets a "(no unit file at …)" log if absent so the user can
+  // tell whether they ever installed. Heartbeat units are silent if absent
+  // (don't add noise for users on pre-phase-26 installs).
   if (existsSync(opts.unitPath)) {
     await unlink(opts.unitPath);
     opts.out.write(`removed ${opts.unitPath}\n`);
   } else {
     opts.out.write(`(no unit file at ${opts.unitPath})\n`);
+  }
+  for (const path of [heartbeatServicePath(), heartbeatTimerPath()]) {
+    if (existsSync(path)) {
+      await unlink(path);
+      opts.out.write(`removed ${path}\n`);
+    }
   }
 
   const r = await opts.systemctl.run(["--user", "daemon-reload"]);

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runHeartbeatCli } from "../src/cli/heartbeat.ts";
+import type { Config } from "../src/config.ts";
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+let workdir: string;
+let config: Config;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-hbcli-"));
+  await mkdir(join(workdir, "personas", "phantom", "memory"), {
+    recursive: true,
+  });
+  await mkdir(join(workdir, "personas", "phantom", "kb"), {
+    recursive: true,
+  });
+  process.env.XDG_DATA_HOME = workdir;
+  config = {
+    defaultPersona: "phantom",
+    turnTimeoutMs: 600_000,
+    personasDir: join(workdir, "personas"),
+    memoryDbPath: join(workdir, "memory.sqlite"),
+    configPath: join(workdir, "config.toml"),
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1_500_000 },
+    },
+    channels: {},
+    embeddings: { provider: "none" },
+  };
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("runHeartbeatCli", () => {
+  test("happy path returns 0 and prints summary", async () => {
+    await writeFile(
+      join(workdir, "personas", "phantom", "memory", `${new Date().toISOString().slice(0, 10)}.md`),
+      "[decision] something\n",
+    );
+    await writeFile(
+      join(workdir, "personas", "phantom", "memory", "decisions.md"),
+      "# Decisions\n",
+    );
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("heartbeat ok:");
+    expect(out.text).toContain("promoted 1");
+  });
+
+  test("missing persona → exit 2", async () => {
+    const err = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      persona: "doesnotexist",
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("not found");
+  });
+});

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -133,6 +133,8 @@ describe("runInstall", () => {
       "--user daemon-reload",
       "--user enable phantombot.service",
       "--user start phantombot.service",
+      "--user enable phantombot-heartbeat.timer",
+      "--user start phantombot-heartbeat.timer",
     ]);
     expect(out.text).toContain("journalctl --user -u phantombot");
     // No auto-set message when env was already set.
@@ -154,6 +156,8 @@ describe("runUninstall", () => {
     });
     expect(code).toBe(0);
     expect(sys.calls.map((a) => a.join(" "))).toEqual([
+      "--user stop phantombot-heartbeat.timer",
+      "--user disable phantombot-heartbeat.timer",
       "--user stop phantombot.service",
       "--user disable phantombot.service",
       "--user daemon-reload",

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -23,6 +23,7 @@ describe("phantombot CLI dispatcher", () => {
       "create-persona",
       "embedding",
       "harness",
+      "heartbeat",
       "import-persona",
       "install",
       "memory",

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the heartbeat job (no LLM, no network).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  checkStaleness,
+  extractRecentSection,
+  promoteTaggedLines,
+  runHeartbeat,
+} from "../src/lib/heartbeat.ts";
+import { MemoryIndex } from "../src/lib/memoryIndex.ts";
+
+let workdir: string;
+let personaDir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-hb-"));
+  personaDir = join(workdir, "persona");
+  await mkdir(join(personaDir, "memory"), { recursive: true });
+  await mkdir(join(personaDir, "kb"), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+async function file(rel: string, content: string) {
+  await writeFile(join(personaDir, rel), content);
+}
+
+describe("promoteTaggedLines", () => {
+  test("appends [decision] / [lesson] / [person] / [commitment] lines to the right drawers", async () => {
+    await file(
+      "memory/2026-05-02.md",
+      [
+        "# 2026-05-02",
+        "",
+        "## 14:00",
+        "[decision] Switched to deepseek for kai's heartbeat",
+        "[lesson] Bun.spawn doesn't see runtime process.env mutations",
+        "[person] Andrew prefers blunt > polished",
+        "[commitment] Ship phase 26 today",
+        "[unrelated] not a recognized tag — should be skipped",
+      ].join("\n"),
+    );
+    // Empty drawer files (the scaffold would normally make them with placeholders)
+    for (const d of ["decisions.md", "lessons.md", "people.md", "commitments.md"]) {
+      await file(`memory/${d}`, `# ${d}\n\n## (no entries yet)\n`);
+    }
+
+    const r = await promoteTaggedLines(personaDir, "2026-05-02");
+    const drawers = r.map((p) => p.drawer).sort();
+    expect(drawers).toEqual([
+      "memory/commitments.md",
+      "memory/decisions.md",
+      "memory/lessons.md",
+      "memory/people.md",
+    ]);
+
+    const decisions = await readFile(
+      join(personaDir, "memory/decisions.md"),
+      "utf8",
+    );
+    expect(decisions).toContain("[decision] Switched to deepseek");
+    expect(decisions).toContain("## 2026-05-02");
+  });
+
+  test("dedups against existing drawer content (no double-promotion)", async () => {
+    await file(
+      "memory/2026-05-02.md",
+      "[decision] Use SQLite WAL for memory store",
+    );
+    await file(
+      "memory/decisions.md",
+      "# Decisions\n\n## 2026-05-02\n\n- [decision] Use SQLite WAL for memory store\n",
+    );
+    const r = await promoteTaggedLines(personaDir, "2026-05-02");
+    expect(r).toEqual([]);
+    const after = await readFile(
+      join(personaDir, "memory/decisions.md"),
+      "utf8",
+    );
+    // Still only one occurrence
+    expect(
+      after.match(/Use SQLite WAL for memory store/g)?.length,
+    ).toBe(1);
+  });
+
+  test("returns [] when today's daily file is missing", async () => {
+    expect(await promoteTaggedLines(personaDir, "2026-05-02")).toEqual([]);
+  });
+
+  test("ignores non-tag lines + unknown tags", async () => {
+    await file(
+      "memory/2026-05-02.md",
+      "## morning\n\nplain text line\n[unknown] not a real tag\n",
+    );
+    expect(await promoteTaggedLines(personaDir, "2026-05-02")).toEqual([]);
+  });
+});
+
+describe("extractRecentSection", () => {
+  test("extracts the body between ## Recent and the next ## header", () => {
+    const md = `# Memory
+
+## Always
+
+- I am Phantom
+
+## Recent
+- 2026-05-01 deployed phantombot
+- 2026-05-02 fixed Pi parser
+
+## Notes
+
+- something else
+`;
+    const recent = extractRecentSection(md);
+    expect(recent).toContain("2026-05-01 deployed");
+    expect(recent).toContain("2026-05-02 fixed");
+    expect(recent).not.toContain("something else");
+    expect(recent).not.toContain("I am Phantom");
+  });
+
+  test("returns undefined if there's no ## Recent header", () => {
+    expect(extractRecentSection("# nope\n\njust text\n")).toBeUndefined();
+  });
+});
+
+describe("checkStaleness", () => {
+  test("flags lines whose date is older than the threshold", async () => {
+    await file(
+      "MEMORY.md",
+      `# memory
+
+## Recent
+- 2026-04-25 old item
+- 2026-04-29 still old
+- 2026-05-02 fresh
+`,
+    );
+    const now = new Date("2026-05-02T10:00:00Z");
+    const r = await checkStaleness(personaDir, now);
+    expect(r).toHaveLength(2);
+    expect(r[0]?.line).toContain("old item");
+    expect(r[0]?.ageHours).toBeGreaterThan(48);
+  });
+
+  test("returns [] when MEMORY.md is missing", async () => {
+    expect(await checkStaleness(personaDir, new Date())).toEqual([]);
+  });
+
+  test("returns [] when ## Recent is missing", async () => {
+    await file("MEMORY.md", "# memory\n\nsome content\n");
+    expect(await checkStaleness(personaDir, new Date())).toEqual([]);
+  });
+});
+
+describe("runHeartbeat (integration)", () => {
+  test("promotes + indexes + reports", async () => {
+    await file(
+      "memory/2026-05-02.md",
+      "[decision] Promote me",
+    );
+    await file("memory/decisions.md", "# Decisions\n");
+    await file(
+      "MEMORY.md",
+      `# memory
+
+## Recent
+- 2026-04-25 stale
+- 2026-05-02 fresh
+`,
+    );
+    await file("kb/Note.md", "indexable");
+    const ix = await MemoryIndex.open(":memory:");
+    const r = await runHeartbeat({
+      personaDir,
+      today: "2026-05-02",
+      now: new Date("2026-05-02T10:00:00Z"),
+      index: ix,
+    });
+    expect(r.promoted).toHaveLength(1);
+    expect(r.staleRecent).toHaveLength(1);
+    expect(r.indexedFiles).toBeGreaterThan(0);
+    ix.close();
+  });
+});

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -98,6 +98,8 @@ describe("installPhantombotUnit", () => {
       ["--user", "daemon-reload"],
       ["--user", "enable", "phantombot.service"],
       ["--user", "start", "phantombot.service"],
+      ["--user", "enable", "phantombot-heartbeat.timer"],
+      ["--user", "start", "phantombot-heartbeat.timer"],
     ]);
     expect(out.text).toContain("wrote unit file");
     expect(out.text).toContain("enabled and started");
@@ -281,6 +283,8 @@ describe("uninstallPhantombotUnit", () => {
     });
     expect(result.removed).toBe(true);
     expect(sys.calls).toEqual([
+      ["--user", "stop", "phantombot-heartbeat.timer"],
+      ["--user", "disable", "phantombot-heartbeat.timer"],
       ["--user", "stop", "phantombot.service"],
       ["--user", "disable", "phantombot.service"],
       ["--user", "daemon-reload"],


### PR DESCRIPTION
## Summary

\`phantombot heartbeat\` — mechanical short-lived oneshot, runs every 30 minutes via systemd timer (installed by \`phantombot install\`). Three things only:

1. **Promote tagged daily-file lines to the matching drawer**:
   - \`[decision]\` → \`memory/decisions.md\`
   - \`[lesson]\` → \`memory/lessons.md\`
   - \`[person]\` → \`memory/people.md\`
   - \`[commitment]\` → \`memory/commitments.md\`
   Deduped by literal text equality (re-runs no-op).

2. **Staleness scan** of \`MEMORY.md\`'s \`## Recent\` section — flags date-stamped lines >48h old via \`log.warn\`. Does not mutate.

3. **Refresh FTS5 index** so notes the harness wrote during the last 30 minutes are searchable. **No embedding pass** — that's nightly's job.

Per the OpenClaw spec: heartbeat is mechanical, nightly is cognitive.

## Install integration

\`phantombot install\` now writes BOTH \`phantombot.service\` AND \`phantombot-heartbeat.service\` + \`phantombot-heartbeat.timer\`, then enables/starts both. \`phantombot uninstall\` reverses both.

## Test plan

- [x] \`bun test\` — 260 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- 13 new tests: promoteTaggedLines (4), extractRecentSection (2), checkStaleness (3), runHeartbeat integration (1), cli-heartbeat (2). Updates 3 existing install/uninstall tests to expect the new 5-call systemctl sequence.