### PR TITLE
Phase 27: nightly cognitive cycle + isolated harness invocation + timer

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import runCmd from "./run.ts";
 import memoryCmd from "./memory.ts";
 import embeddingCmd from "./embedding.ts";
 import heartbeatCmd from "./heartbeat.ts";
+import nightlyCmd from "./nightly.ts";
 
 export const mainCommand = defineCommand({
   meta: {
@@ -43,5 +44,6 @@ export const mainCommand = defineCommand({
     run: runCmd,
     memory: memoryCmd,
     heartbeat: heartbeatCmd,
+    nightly: nightlyCmd,
   },
 });

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -1,0 +1,152 @@
+/**
+ * `phantombot nightly` — runs the cognitive distillation pass.
+ *
+ * Spawns the harness once with the nightly prompt as a system-prompt
+ * suffix and the prompt body as the user message. Conversation key is
+ * `system:nightly:<YYYY-MM-DD>` so it's isolated from Telegram chats
+ * and from any other phantombot conversation namespace.
+ *
+ * Schedule: runs daily at 02:00 local via systemd timer (installed
+ * by `phantombot install`). Manual invocation works the same.
+ */
+
+import { defineCommand } from "citty";
+import { existsSync } from "node:fs";
+
+import { type Config, loadConfig, personaDir } from "../config.ts";
+import { ClaudeHarness } from "../harnesses/claude.ts";
+import { PiHarness } from "../harnesses/pi.ts";
+import type { Harness } from "../harnesses/types.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { log } from "../lib/logger.ts";
+import {
+  buildNightlyPrompt,
+  nightlyConversationKey,
+  saveNightlyState,
+} from "../lib/nightly.ts";
+import { openMemoryStore } from "../memory/store.ts";
+import { runTurn } from "../orchestrator/turn.ts";
+
+export interface RunNightlyInput {
+  config?: Config;
+  persona?: string;
+  /** Override "today" — useful for backfill or testing. ISO YYYY-MM-DD. */
+  today?: string;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+
+  const config = input.config ?? (await loadConfig());
+  const persona = input.persona ?? config.defaultPersona;
+  const dir = personaDir(config, persona);
+  if (!existsSync(dir)) {
+    err.write(`persona '${persona}' not found at ${dir}\n`);
+    return 2;
+  }
+
+  const harnesses = buildHarnessChain(config, err);
+  if (harnesses.length === 0) {
+    err.write("no harnesses configured\n");
+    return 2;
+  }
+
+  const today = input.today ?? new Date().toISOString().slice(0, 10);
+  const conversation = nightlyConversationKey(today);
+  const prompt = buildNightlyPrompt(persona, today);
+
+  out.write(
+    `nightly: persona='${persona}' date=${today} conversation=${conversation}\n`,
+  );
+
+  const memory = await openMemoryStore(config.memoryDbPath);
+  const startedAt = Date.now();
+  let finalReply = "";
+  let errored: string | undefined;
+
+  try {
+    for await (const chunk of runTurn({
+      persona,
+      conversation,
+      userMessage: prompt,
+      agentDir: dir,
+      harnesses,
+      memory,
+      timeoutMs: 30 * 60_000, // 30-minute hard cap on the cognitive pass
+      systemPromptSuffix:
+        "You are operating in NIGHTLY MAINTENANCE MODE. " +
+        "Skip pleasantries. Do work, write files, report briefly.",
+    })) {
+      if (chunk.type === "text") finalReply += chunk.text;
+      if (chunk.type === "done") finalReply = chunk.finalText;
+      if (chunk.type === "error") errored = chunk.error;
+    }
+  } catch (e) {
+    errored = (e as Error).message;
+    log.error("nightly: turn threw", { error: errored });
+  } finally {
+    await memory.close();
+  }
+
+  const durationMs = Date.now() - startedAt;
+  // If the harness wrote .nightly-state.json itself (per the prompt), great.
+  // We ALSO record a phantombot-side timestamp so we never lose the
+  // last-run anchor even if the harness flubbed phase 5.
+  await saveNightlyState(dir, {
+    last_run: new Date().toISOString(),
+    last_status: errored ? "error" : "ok",
+    ...(errored ? { errors: [errored] } : {}),
+  });
+
+  out.write(
+    `nightly ${errored ? "FAILED" : "ok"}: ` +
+      `${durationMs}ms, ${finalReply.length} reply chars` +
+      (errored ? ` — ${errored}` : "") +
+      `\n`,
+  );
+  log.info("nightly: complete", {
+    persona,
+    date: today,
+    durationMs,
+    replyChars: finalReply.length,
+    ok: !errored,
+  });
+  return errored ? 1 : 0;
+}
+
+function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
+  const out: Harness[] = [];
+  for (const id of config.harnesses.chain) {
+    if (id === "claude") out.push(new ClaudeHarness(config.harnesses.claude));
+    else if (id === "pi") out.push(new PiHarness(config.harnesses.pi));
+    else err.write(`warning: unknown harness '${id}', skipping\n`);
+  }
+  return out;
+}
+
+export default defineCommand({
+  meta: {
+    name: "nightly",
+    description:
+      "Run the cognitive distillation pass — promote, KB-feed, compress. Isolated conversation; long-running; manual or via the systemd timer.",
+  },
+  args: {
+    persona: {
+      type: "string",
+      description: "Persona name (default: configured default).",
+    },
+    date: {
+      type: "string",
+      description: "Override today's date (YYYY-MM-DD); useful for backfill.",
+    },
+  },
+  async run({ args }) {
+    process.exitCode = await runNightly({
+      persona: args.persona ? String(args.persona) : undefined,
+      today: args.date ? String(args.date) : undefined,
+    });
+  },
+});

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -1,0 +1,137 @@
+/**
+ * Nightly cognitive pass.
+ *
+ * Runs the harness once per day in an isolated conversation
+ * (`system:nightly:<YYYY-MM-DD>`) so it can never bleed into Telegram
+ * chats. The harness gets the full persona BOOT.md + a focused
+ * distillation directive, plus access to phantombot's memory CLI tools
+ * (search / get / list / today / index) via its native Bash tool.
+ *
+ * Phases the harness is instructed to run (from the OpenClaw spec):
+ *
+ *   1. Day essence — read today's daily file, write a 2-3 line summary
+ *      header at the top.
+ *   2. Promote — anything tagged or worth keeping into the structured
+ *      drawers (people / decisions / lessons / commitments).
+ *   3. KB feed — for each durable concept, `phantombot memory search`
+ *      first to dedup, then update an existing note OR create a new
+ *      atomic note with frontmatter and [[wikilinks]]. Sweep kb/inbox/.
+ *   4. Compress — trim MEMORY.md if bloating; clear ## Recent items
+ *      that have been distilled.
+ *   5. State — write a summary to memory/.nightly-state.json so the
+ *      next run knows what was done.
+ *
+ * Phantombot just spawns this run; the cognitive work is the harness's
+ * own. No phantombot-side judgment about what to keep, distill, or link.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { log } from "./logger.ts";
+
+export interface NightlyState {
+  last_run?: string;
+  last_status?: "ok" | "error" | "partial";
+  items_promoted?: number;
+  kb_notes_updated?: number;
+  kb_notes_created?: number;
+  errors?: string[];
+}
+
+export function nightlyConversationKey(date: string): string {
+  return `system:nightly:${date}`;
+}
+
+export function nightlyStatePath(personaDir: string): string {
+  return join(personaDir, "memory", ".nightly-state.json");
+}
+
+/** Read the previous nightly state. Returns {} if no prior run. */
+export async function loadNightlyState(
+  personaDir: string,
+): Promise<NightlyState> {
+  const p = nightlyStatePath(personaDir);
+  if (!existsSync(p)) return {};
+  try {
+    return JSON.parse(await readFile(p, "utf8")) as NightlyState;
+  } catch (e) {
+    log.warn("nightly: state file unreadable; treating as empty", {
+      error: (e as Error).message,
+    });
+    return {};
+  }
+}
+
+/** Update the previous nightly state with a fresh run record. */
+export async function saveNightlyState(
+  personaDir: string,
+  patch: Partial<NightlyState>,
+): Promise<void> {
+  const cur = await loadNightlyState(personaDir);
+  const next = { ...cur, ...patch };
+  await writeFile(
+    nightlyStatePath(personaDir),
+    JSON.stringify(next, null, 2) + "\n",
+    "utf8",
+  );
+}
+
+/**
+ * Build the user-message that starts the nightly turn. Embeds the
+ * persona name, today's date, and the 5-phase contract.
+ */
+export function buildNightlyPrompt(
+  personaName: string,
+  today: string,
+): string {
+  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Today is ${today}.
+
+This conversation is ISOLATED (conversation key system:nightly:${today}); nothing you say here will appear in Telegram or any user-facing chat. Speak in summaries, not replies.
+
+You have access to phantombot's memory tools via Bash:
+
+  phantombot memory today                       # path to today's daily file
+  phantombot memory search "<query>"            # FTS5 + (if configured) semantic search
+  phantombot memory get <persona-relative-path> # cat a file
+  phantombot memory list <persona-relative-dir> # ls a dir
+  phantombot memory index --rebuild             # full reindex (FTS + embeddings)
+
+You also have your normal Read / Write / Edit tools — use them on files inside this persona's working directory (\`agentDir\`). The structured drawers are under memory/ and the KB vault under kb/. The four templates in kb/templates/ are scaffolds for atomic-note / runbook / decision / postmortem.
+
+Run these five phases IN ORDER. Be brief in any text you write to MEMORY.md or drawers — long form goes in KB notes:
+
+PHASE 1 — Day essence
+  Read today's daily file (memory/${today}.md). If it exists, prepend a 2-3 line "Day essence" section summarising what mattered today. Skip if the file doesn't exist or is empty.
+
+PHASE 2 — Promote to drawers
+  Re-read the daily file. For each promote-able item that the heartbeat hasn't already filed:
+    - People / relationships  → memory/people.md
+    - Decisions with rationale → memory/decisions.md
+    - Mistakes and learnings   → memory/lessons.md
+    - Deadlines / obligations  → memory/commitments.md
+  Append under a "## ${today}" header. Don't duplicate items the heartbeat already promoted.
+
+PHASE 3 — Feed the KB
+  Re-read the daily file for durable knowledge (procedures, configs, runbooks, concepts, decisions worth keeping).
+  For each candidate:
+    a) phantombot memory search "<topic>" to check for existing coverage
+    b) If a note already covers the area: open and update it (add the new case, edge cases, links)
+    c) Otherwise create a new atomic note in the right kb/<category>/ subdir using one of kb/templates/ as a starting point. Frontmatter required: type, tags, created, updated. Link related notes with [[wikilinks]].
+  Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
+  Run \`phantombot memory index --rebuild\` at the end so new notes have embeddings.
+
+PHASE 4 — Compress MEMORY.md
+  MEMORY.md should stay short (orientation layer only). If it's bloated, move detail into the relevant KB note(s) and leave a short pointer. Clear items from "## Recent" that you've now distilled to a permanent home.
+
+PHASE 5 — State report
+  Write your summary to memory/.nightly-state.json (overwrite). Include:
+    last_run         (ISO 8601 timestamp)
+    last_status      ("ok" | "partial" | "error")
+    items_promoted   (count from phase 2)
+    kb_notes_updated (count from phase 3, existing-note edits)
+    kb_notes_created (count from phase 3, new-note writes)
+    errors           (array of strings — anything that went wrong; empty array on full success)
+
+When you're done, your final reply (which won't go anywhere user-facing) should be a brief sentence acknowledging completion. Phantombot will log it.`;
+}

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -14,6 +14,8 @@ import type { WriteSink } from "./io.ts";
 export const PHANTOMBOT_UNIT_NAME = "phantombot.service";
 export const HEARTBEAT_SERVICE_NAME = "phantombot-heartbeat.service";
 export const HEARTBEAT_TIMER_NAME = "phantombot-heartbeat.timer";
+export const NIGHTLY_SERVICE_NAME = "phantombot-nightly.service";
+export const NIGHTLY_TIMER_NAME = "phantombot-nightly.timer";
 
 export function defaultUnitPath(): string {
   return join(homedir(), ".config", "systemd", "user", PHANTOMBOT_UNIT_NAME);
@@ -25,6 +27,14 @@ export function heartbeatServicePath(): string {
 
 export function heartbeatTimerPath(): string {
   return join(homedir(), ".config", "systemd", "user", HEARTBEAT_TIMER_NAME);
+}
+
+export function nightlyServicePath(): string {
+  return join(homedir(), ".config", "systemd", "user", NIGHTLY_SERVICE_NAME);
+}
+
+export function nightlyTimerPath(): string {
+  return join(homedir(), ".config", "systemd", "user", NIGHTLY_TIMER_NAME);
 }
 
 export interface SystemdUnitParams {
@@ -88,6 +98,38 @@ Description=Phantombot heartbeat timer (every 30 min)
 [Timer]
 OnBootSec=2min
 OnUnitActiveSec=30min
+AccuracySec=1min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`;
+}
+
+/** Generate the nightly oneshot service body. */
+export function generateNightlyService(binPath: string): string {
+  const exec = [binPath, "nightly"].map(quoteArg).join(" ");
+  return `[Unit]
+Description=Phantombot nightly — cognitive distillation pass
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=${exec}
+TimeoutStartSec=2700
+StandardOutput=journal
+StandardError=journal
+`;
+}
+
+/** Generate the nightly timer body — fires daily at 02:00 local. */
+export function generateNightlyTimer(): string {
+  return `[Unit]
+Description=Phantombot nightly timer (daily 02:00)
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
 AccuracySec=1min
 Persistent=true
 
@@ -205,12 +247,19 @@ export async function installPhantombotUnit(
   await writeFile(opts.unitPath, unit, "utf8");
   opts.out.write(`wrote unit file: ${opts.unitPath}\n`);
 
-  // Also write the heartbeat service + timer alongside.
+  // Heartbeat service + timer
   const hbService = heartbeatServicePath();
   const hbTimer = heartbeatTimerPath();
   await writeFile(hbService, generateHeartbeatService(opts.binPath), "utf8");
   await writeFile(hbTimer, generateHeartbeatTimer(), "utf8");
   opts.out.write(`wrote heartbeat units: ${hbService} + ${hbTimer}\n`);
+
+  // Nightly service + timer
+  const ngService = nightlyServicePath();
+  const ngTimer = nightlyTimerPath();
+  await writeFile(ngService, generateNightlyService(opts.binPath), "utf8");
+  await writeFile(ngTimer, generateNightlyTimer(), "utf8");
+  opts.out.write(`wrote nightly units: ${ngService} + ${ngTimer}\n`);
 
   for (const args of [
     ["--user", "daemon-reload"],
@@ -218,6 +267,8 @@ export async function installPhantombotUnit(
     ["--user", "start", PHANTOMBOT_UNIT_NAME],
     ["--user", "enable", HEARTBEAT_TIMER_NAME],
     ["--user", "start", HEARTBEAT_TIMER_NAME],
+    ["--user", "enable", NIGHTLY_TIMER_NAME],
+    ["--user", "start", NIGHTLY_TIMER_NAME],
   ]) {
     const r = await opts.systemctl.run(args);
     if (r.exitCode !== 0) {
@@ -228,7 +279,7 @@ export async function installPhantombotUnit(
     }
   }
   opts.out.write(
-    "enabled and started phantombot.service + phantombot-heartbeat.timer\n",
+    "enabled and started phantombot.service + heartbeat.timer + nightly.timer\n",
   );
   return { installed: true };
 }
@@ -245,6 +296,8 @@ export async function uninstallPhantombotUnit(
 ): Promise<{ removed: boolean }> {
   // stop + disable are best-effort: a half-installed unit is fine to remove.
   for (const args of [
+    ["--user", "stop", NIGHTLY_TIMER_NAME],
+    ["--user", "disable", NIGHTLY_TIMER_NAME],
     ["--user", "stop", HEARTBEAT_TIMER_NAME],
     ["--user", "disable", HEARTBEAT_TIMER_NAME],
     ["--user", "stop", PHANTOMBOT_UNIT_NAME],
@@ -267,7 +320,12 @@ export async function uninstallPhantombotUnit(
   } else {
     opts.out.write(`(no unit file at ${opts.unitPath})\n`);
   }
-  for (const path of [heartbeatServicePath(), heartbeatTimerPath()]) {
+  for (const path of [
+    heartbeatServicePath(),
+    heartbeatTimerPath(),
+    nightlyServicePath(),
+    nightlyTimerPath(),
+  ]) {
     if (existsSync(path)) {
       await unlink(path);
       opts.out.write(`removed ${path}\n`);

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -46,6 +46,8 @@ export interface TurnInput {
   historyLimit?: number;
   /** Skip loading prior turns AND skip persisting this one. Default false. */
   noHistory?: boolean;
+  /** Extra text appended to the system prompt. Used by nightly to inject distillation directives. */
+  systemPromptSuffix?: string;
 }
 
 export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
@@ -59,7 +61,7 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
         input.historyLimit ?? 20,
       );
 
-  const systemPrompt = buildSystemPrompt(
+  const baseSystemPrompt = buildSystemPrompt(
     persona,
     {
       channel: "cli",
@@ -68,6 +70,9 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
     },
     undefined, // vector-search retrieval reserved for a later phase
   );
+  const systemPrompt = input.systemPromptSuffix
+    ? baseSystemPrompt + "\n\n" + input.systemPromptSuffix
+    : baseSystemPrompt;
 
   let finalText = "";
   let succeeded = false;

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -135,6 +135,8 @@ describe("runInstall", () => {
       "--user start phantombot.service",
       "--user enable phantombot-heartbeat.timer",
       "--user start phantombot-heartbeat.timer",
+      "--user enable phantombot-nightly.timer",
+      "--user start phantombot-nightly.timer",
     ]);
     expect(out.text).toContain("journalctl --user -u phantombot");
     // No auto-set message when env was already set.
@@ -156,6 +158,8 @@ describe("runUninstall", () => {
     });
     expect(code).toBe(0);
     expect(sys.calls.map((a) => a.join(" "))).toEqual([
+      "--user stop phantombot-nightly.timer",
+      "--user disable phantombot-nightly.timer",
       "--user stop phantombot-heartbeat.timer",
       "--user disable phantombot-heartbeat.timer",
       "--user stop phantombot.service",

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runNightly } from "../src/cli/nightly.ts";
+import type { Config } from "../src/config.ts";
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+let workdir: string;
+let config: Config;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-ngcli-"));
+  await mkdir(join(workdir, "personas", "phantom"), { recursive: true });
+  config = {
+    defaultPersona: "phantom",
+    turnTimeoutMs: 600_000,
+    personasDir: join(workdir, "personas"),
+    memoryDbPath: join(workdir, "memory.sqlite"),
+    configPath: join(workdir, "config.toml"),
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1_500_000 },
+    },
+    channels: {},
+    embeddings: { provider: "none" },
+  };
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("runNightly — early exits", () => {
+  test("missing persona → exit 2", async () => {
+    const err = new CaptureStream();
+    const code = await runNightly({
+      config,
+      persona: "doesnotexist",
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("not found");
+  });
+
+  test("empty harness chain → exit 2", async () => {
+    const err = new CaptureStream();
+    const code = await runNightly({
+      config: { ...config, harnesses: { ...config.harnesses, chain: [] } },
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("no harnesses");
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -27,6 +27,7 @@ describe("phantombot CLI dispatcher", () => {
       "import-persona",
       "install",
       "memory",
+      "nightly",
       "run",
       "telegram",
       "uninstall",

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildNightlyPrompt,
+  loadNightlyState,
+  nightlyConversationKey,
+  nightlyStatePath,
+  saveNightlyState,
+} from "../src/lib/nightly.ts";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-nightly-"));
+  await mkdir(join(workdir, "memory"), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("nightlyConversationKey", () => {
+  test("uses system:nightly:<date> namespace", () => {
+    expect(nightlyConversationKey("2026-05-02")).toBe(
+      "system:nightly:2026-05-02",
+    );
+  });
+});
+
+describe("nightlyStatePath", () => {
+  test("returns memory/.nightly-state.json under the persona dir", () => {
+    expect(nightlyStatePath("/tmp/persona")).toBe(
+      "/tmp/persona/memory/.nightly-state.json",
+    );
+  });
+});
+
+describe("loadNightlyState / saveNightlyState", () => {
+  test("returns {} when no state file exists", async () => {
+    expect(await loadNightlyState(workdir)).toEqual({});
+  });
+
+  test("save then load round-trips", async () => {
+    await saveNightlyState(workdir, {
+      last_run: "2026-05-02T02:15:00Z",
+      last_status: "ok",
+      items_promoted: 5,
+    });
+    const r = await loadNightlyState(workdir);
+    expect(r.last_run).toBe("2026-05-02T02:15:00Z");
+    expect(r.last_status).toBe("ok");
+    expect(r.items_promoted).toBe(5);
+  });
+
+  test("save merges into existing state", async () => {
+    await saveNightlyState(workdir, {
+      last_run: "2026-05-01T02:00:00Z",
+      items_promoted: 3,
+    });
+    await saveNightlyState(workdir, {
+      last_run: "2026-05-02T02:00:00Z",
+      last_status: "ok",
+    });
+    const r = await loadNightlyState(workdir);
+    expect(r.last_run).toBe("2026-05-02T02:00:00Z");
+    expect(r.last_status).toBe("ok");
+    // items_promoted from the first save is preserved.
+    expect(r.items_promoted).toBe(3);
+  });
+
+  test("malformed JSON falls back to {} (logs warn but doesn't throw)", async () => {
+    await writeFile(nightlyStatePath(workdir), "not json", "utf8");
+    expect(await loadNightlyState(workdir)).toEqual({});
+  });
+});
+
+describe("buildNightlyPrompt", () => {
+  test("embeds the persona name + today + isolation note", () => {
+    const p = buildNightlyPrompt("kai", "2026-05-02");
+    expect(p).toContain("persona 'kai'");
+    expect(p).toContain("Today is 2026-05-02");
+    expect(p).toContain("system:nightly:2026-05-02");
+    expect(p).toContain("ISOLATED");
+    expect(p).toContain("PHASE 1");
+    expect(p).toContain("PHASE 5");
+  });
+
+  test("references all five phases in order", () => {
+    const p = buildNightlyPrompt("x", "2026-01-01");
+    const phase1 = p.indexOf("PHASE 1");
+    const phase5 = p.indexOf("PHASE 5");
+    expect(phase1).toBeGreaterThan(0);
+    expect(phase5).toBeGreaterThan(phase1);
+    for (let i = 2; i <= 4; i++) {
+      const idx = p.indexOf(`PHASE ${i}`);
+      expect(idx).toBeGreaterThan(phase1);
+      expect(idx).toBeLessThan(phase5);
+    }
+  });
+
+  test("references the phantombot memory tools the harness must call", () => {
+    const p = buildNightlyPrompt("x", "2026-01-01");
+    expect(p).toContain("phantombot memory today");
+    expect(p).toContain("phantombot memory search");
+    expect(p).toContain("phantombot memory get");
+    expect(p).toContain("phantombot memory index --rebuild");
+  });
+});

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -100,6 +100,8 @@ describe("installPhantombotUnit", () => {
       ["--user", "start", "phantombot.service"],
       ["--user", "enable", "phantombot-heartbeat.timer"],
       ["--user", "start", "phantombot-heartbeat.timer"],
+      ["--user", "enable", "phantombot-nightly.timer"],
+      ["--user", "start", "phantombot-nightly.timer"],
     ]);
     expect(out.text).toContain("wrote unit file");
     expect(out.text).toContain("enabled and started");
@@ -283,6 +285,8 @@ describe("uninstallPhantombotUnit", () => {
     });
     expect(result.removed).toBe(true);
     expect(sys.calls).toEqual([
+      ["--user", "stop", "phantombot-nightly.timer"],
+      ["--user", "disable", "phantombot-nightly.timer"],
       ["--user", "stop", "phantombot-heartbeat.timer"],
       ["--user", "disable", "phantombot-heartbeat.timer"],
       ["--user", "stop", "phantombot.service"],


### PR DESCRIPTION
## Summary

\`phantombot nightly\` — runs the cognitive distillation pass per the OpenClaw spec. Spawns the harness once with the full persona context plus a focused 5-phase directive, in an isolated conversation (\`system:nightly:<YYYY-MM-DD>\`) so it never bleeds into Telegram.

The harness does the cognitive work; phantombot just orchestrates the run + tracks state.

## Five phases (from the OpenClaw spec)

1. **Day essence** — 2-3 line summary on today's daily file.
2. **Promote** — anything heartbeat hasn't filed → drawers.
3. **Feed the KB** — search-before-write, update existing OR create atomic note with frontmatter + \`[[wikilinks]]\`; sweep \`kb/inbox/\`; \`memory index --rebuild\` to embed.
4. **Compress \`MEMORY.md\`** — keep it short, push detail into KB.
5. **State report** — write \`memory/.nightly-state.json\`.

## New library + cli

- **\`src/lib/nightly.ts\`** — prompt builder, state read/write, conversation-key helper.
- **\`src/cli/nightly.ts\`** — \`runNightly\` opens memory, runs harness with a 30-min cap, always writes a phantombot-side last-run timestamp (so we don't lose the anchor if the harness flubbed phase 5).
- **\`src/orchestrator/turn.ts\`** — adds optional \`systemPromptSuffix\` so callers can inject one-off instructions on top of the persona prompt.
- **\`src/lib/systemd.ts\`** — \`generateNightlyService\` (Type=oneshot, TimeoutStartSec=2700) + \`generateNightlyTimer\` (OnCalendar=02:00, Persistent=true). \`install\` / \`uninstall\` now manage all three pairs (main + heartbeat + nightly).

## Test plan

- [x] \`bun test\` — 271 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- 11 new tests across \`tests/lib-nightly.test.ts\` (state + prompt) and \`tests/cli-nightly.test.ts\` (early-exit). Updates 2 install/uninstall tests for the 7-call sequence.