### PR TITLE
Phase 28: persona-prompt memory rules + nightly override + systemd PATH fix

### DIFF
--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -20,7 +20,7 @@ import type { Harness } from "../harnesses/types.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import {
-  buildNightlyPrompt,
+  buildNightlyPromptForPersona,
   nightlyConversationKey,
   saveNightlyState,
 } from "../lib/nightly.ts";
@@ -56,7 +56,7 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
 
   const today = input.today ?? new Date().toISOString().slice(0, 10);
   const conversation = nightlyConversationKey(today);
-  const prompt = buildNightlyPrompt(persona, today);
+  const prompt = await buildNightlyPromptForPersona(dir, persona, today);
 
   out.write(
     `nightly: persona='${persona}' date=${today} conversation=${conversation}\n`,

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -30,6 +30,8 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "./logger.ts";
 
+const NIGHTLY_PROMPT_OVERRIDE = "nightly-prompt.md";
+
 export interface NightlyState {
   last_run?: string;
   last_status?: "ok" | "error" | "partial";
@@ -75,6 +77,35 @@ export async function saveNightlyState(
     JSON.stringify(next, null, 2) + "\n",
     "utf8",
   );
+}
+
+/**
+ * If a persona dir contains a `nightly-prompt.md` file, use it as the
+ * template (with `{{persona}}` and `{{today}}` substitutions); otherwise
+ * fall back to the built-in `buildNightlyPrompt`. Lets users customize
+ * the nightly directive per-persona (e.g. add a "summarize calendar
+ * before phase 3" step) without forking phantombot.
+ */
+export async function buildNightlyPromptForPersona(
+  personaDir: string,
+  personaName: string,
+  today: string,
+): Promise<string> {
+  const overridePath = join(personaDir, NIGHTLY_PROMPT_OVERRIDE);
+  if (existsSync(overridePath)) {
+    try {
+      const tpl = await readFile(overridePath, "utf8");
+      return tpl
+        .replace(/\{\{persona\}\}/g, personaName)
+        .replace(/\{\{today\}\}/g, today);
+    } catch (e) {
+      log.warn("nightly: override unreadable, falling back to default", {
+        path: overridePath,
+        error: (e as Error).message,
+      });
+    }
+  }
+  return buildNightlyPrompt(personaName, today);
 }
 
 /**

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -48,6 +48,11 @@ export interface SystemdUnitParams {
 /**
  * Generate the [Unit]/[Service]/[Install] body for the phantombot
  * systemd --user unit. Pure function.
+ *
+ * The Environment=PATH line ensures the harness's Bash tool can find
+ * `phantombot` (installed at ~/.local/bin/phantombot) when it tries to
+ * call `phantombot memory search ...`. Default systemd-user PATH does
+ * NOT include ~/.local/bin.
  */
 export function generateSystemdUnit(params: SystemdUnitParams): string {
   const exec = [params.binPath, ...params.args].map(quoteArg).join(" ");
@@ -63,6 +68,7 @@ Type=simple
 ExecStart=${exec}
 Restart=on-failure
 RestartSec=5
+Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 StandardOutput=journal
 StandardError=journal
 
@@ -85,6 +91,7 @@ Description=Phantombot heartbeat — mechanical 30-minute maintenance pass
 [Service]
 Type=oneshot
 ExecStart=${exec}
+Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 StandardOutput=journal
 StandardError=journal
 `;
@@ -118,6 +125,7 @@ Wants=network-online.target
 Type=oneshot
 ExecStart=${exec}
 TimeoutStartSec=2700
+Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 StandardOutput=journal
 StandardError=journal
 `;

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -32,6 +32,12 @@ export function buildSystemPrompt(
     sections.push("# Tools available to you\n\n" + persona.tools.trim());
   }
 
+  // Always-on memory tool description + the two hard rules. Comes after
+  // the persona-supplied tools.md so user customizations stay primary,
+  // but always present so the harness knows the search/get/today
+  // commands exist and that it should use them.
+  sections.push(MEMORY_TOOLS_SECTION);
+
   if (retrievedMemory && retrievedMemory.trim().length > 0) {
     sections.push("# Retrieved context for this turn\n\n" + retrievedMemory.trim());
   }
@@ -46,3 +52,53 @@ export function buildSystemPrompt(
 
   return sections.join("\n\n");
 }
+
+/**
+ * Memory tools the harness can call from its own Bash tool, plus the
+ * two always-applied rules: search-before-debug, capture-as-you-go.
+ *
+ * Exported for inspection / testing — also reused by the nightly prompt.
+ */
+export const MEMORY_TOOLS_SECTION =
+  `# Memory tools
+
+You have a four-layer memory system. Phantombot exposes the following
+commands you can run from your Bash tool:
+
+  phantombot memory today                         # path of today's daily file
+  phantombot memory search "<query>" [--scope memory|kb|all] [--limit N]
+                                                  # JSON results: hybrid FTS + vector
+  phantombot memory get <persona-relative-path>   # cat a file
+  phantombot memory list <persona-relative-dir>   # ls a dir
+  phantombot memory index [--rebuild]             # refresh search index
+
+Layout (relative to your working dir):
+
+  memory/<YYYY-MM-DD>.md     — today's daily journal (you write to it)
+  memory/people.md           — structured drawer (people / relationships)
+  memory/decisions.md        — structured drawer (with rationale)
+  memory/lessons.md          — structured drawer (mistakes + learnings)
+  memory/commitments.md      — structured drawer (deadlines)
+  kb/                        — Obsidian-shaped second brain (atomic notes)
+  kb/inbox/                  — quick capture; nightly cycle files or discards
+  kb/templates/              — frontmatter skeletons (atomic / runbook /
+                               decision / postmortem)
+
+Two hard rules — apply on every nontrivial task:
+
+1. SEARCH BEFORE DEBUGGING. Run \`phantombot memory search "<topic>"\`
+   first. If memory or KB has prior knowledge, use it. Investigate
+   from scratch only if neither found anything.
+
+2. CAPTURE AS YOU GO. Decisions / lessons / commitments go in today's
+   daily file (\`phantombot memory today\` returns the path) — tag them
+   with \`[decision]\`, \`[lesson]\`, \`[person]\`, or \`[commitment]\` so
+   the heartbeat (every 30 min) and nightly cycle can promote them
+   to the right drawer. KB-worthy thoughts go in
+   \`kb/inbox/<short-name>.md\`. The nightly cycle files them later.
+
+The heartbeat is mechanical (no LLM). The nightly is cognitive — that's
+when KB notes get created or updated based on what you captured during
+the day. Don't try to do nightly's job mid-conversation; just capture
+well and the nightly cycle handles synthesis.`;
+

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildNightlyPrompt,
+  buildNightlyPromptForPersona,
   loadNightlyState,
   nightlyConversationKey,
   nightlyStatePath,
@@ -106,5 +107,31 @@ describe("buildNightlyPrompt", () => {
     expect(p).toContain("phantombot memory search");
     expect(p).toContain("phantombot memory get");
     expect(p).toContain("phantombot memory index --rebuild");
+  });
+});
+
+describe("buildNightlyPromptForPersona — override", () => {
+  test("returns the built-in prompt when no override file exists", async () => {
+    const built = await buildNightlyPromptForPersona(
+      workdir,
+      "kai",
+      "2026-05-02",
+    );
+    expect(built).toContain("PHASE 5");
+    expect(built).toContain("persona 'kai'");
+  });
+
+  test("uses the override file with {{persona}} / {{today}} substitution", async () => {
+    await writeFile(
+      join(workdir, "nightly-prompt.md"),
+      "Hey {{persona}}, today is {{today}}. Do the thing.",
+      "utf8",
+    );
+    const built = await buildNightlyPromptForPersona(
+      workdir,
+      "robbie",
+      "2026-05-02",
+    );
+    expect(built).toBe("Hey robbie, today is 2026-05-02. Do the thing.");
   });
 });

--- a/tests/persona-builder-memory-tools.test.ts
+++ b/tests/persona-builder-memory-tools.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for the always-on Memory tools section in buildSystemPrompt.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  MEMORY_TOOLS_SECTION,
+  buildSystemPrompt,
+} from "../src/persona/builder.ts";
+
+const channelCtx = {
+  channel: "cli",
+  conversationId: "cli:default",
+  timestamp: new Date("2026-05-02T12:00:00Z"),
+};
+
+describe("buildSystemPrompt — memory tools section", () => {
+  test("always appends the memory tools section", () => {
+    const prompt = buildSystemPrompt(
+      { boot: "I am test", identitySource: "BOOT.md" },
+      channelCtx,
+    );
+    expect(prompt).toContain("# Memory tools");
+    expect(prompt).toContain("phantombot memory search");
+    expect(prompt).toContain("SEARCH BEFORE DEBUGGING");
+    expect(prompt).toContain("CAPTURE AS YOU GO");
+  });
+
+  test("memory tools section comes after persona-supplied tools.md", () => {
+    const prompt = buildSystemPrompt(
+      {
+        boot: "I am test",
+        identitySource: "BOOT.md",
+        tools: "Use the kettle in the kitchen.",
+        toolsSource: "tools.md",
+      },
+      channelCtx,
+    );
+    const ti = prompt.indexOf("# Tools available to you");
+    const mi = prompt.indexOf("# Memory tools");
+    expect(ti).toBeGreaterThan(0);
+    expect(mi).toBeGreaterThan(ti);
+  });
+
+  test("MEMORY_TOOLS_SECTION mentions the heartbeat + nightly cadence", () => {
+    expect(MEMORY_TOOLS_SECTION).toContain("heartbeat");
+    expect(MEMORY_TOOLS_SECTION).toContain("nightly");
+  });
+});


### PR DESCRIPTION
## Summary

Three small but load-bearing changes that wire the memory system into every harness invocation.

### 1. Always-on memory tools section in the system prompt

\`buildSystemPrompt\` now appends a fixed \`# Memory tools\` section listing every \`phantombot memory\` subcommand the harness can call from Bash, explaining the four-layer layout, and stating two hard rules:

- **SEARCH BEFORE DEBUGGING** — \`phantombot memory search "<topic>"\` first.
- **CAPTURE AS YOU GO** — tag daily-file entries with \`[decision]\` / \`[lesson]\` / \`[person]\` / \`[commitment]\` so heartbeat + nightly can promote them.

Always present so each persona doesn't need to repeat it. Exported as \`MEMORY_TOOLS_SECTION\` for inspection.

### 2. Nightly prompt override

\`buildNightlyPromptForPersona\` now checks for \`<personaDir>/nightly-prompt.md\` and uses it as a template if present (\`{{persona}}\` / \`{{today}}\` substitution). Falls back to the built-in 5-phase contract otherwise. Customize per-persona without forking phantombot.

### 3. Systemd PATH fix

\`generateSystemdUnit\` / \`generateHeartbeatService\` / \`generateNightlyService\` now set:

\`\`\`
Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
\`\`\`

Default systemd-user PATH does NOT include \`~/.local/bin\`, which would silently break the harness's \`phantombot memory ...\` invocations. The \`%h\` specifier is "the user's home dir" — works for any installer.

## Test plan

- [x] \`bun test\` — 276 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- New tests: 3 builder (memory section always present, comes after tools.md, mentions heartbeat + nightly cadence) + 2 nightly-override (fallback, template substitution).