### PR TITLE
Phase 29: phantombot voice TUI + .env secrets file + import-persona voice sniff

### DIFF
--- a/src/cli/import-persona.ts
+++ b/src/cli/import-persona.ts
@@ -30,6 +30,9 @@ import {
 } from "../lib/personaArchive.ts";
 import { ensurePersonaScaffold } from "../lib/personaScaffold.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import { defaultEnvFilePath, updateEnvFile } from "../lib/envFile.ts";
+import { parseOpenClawVoice } from "../lib/voice.ts";
+import { applyVoiceConfig } from "./voice.ts";
 import { parseOpenClawTelegram } from "./telegram.ts";
 
 export interface RunImportPersonaInput {
@@ -128,6 +131,12 @@ export async function runImportPersona(
       out,
     });
   }
+
+  await maybeImportOpenclawVoice({
+    config,
+    openclawConfigPath: input.openclawConfigPath,
+    out,
+  });
 
   await maybeRestartHint(input.serviceControl, out);
   return 0;
@@ -355,6 +364,60 @@ async function maybeImportOpenclawTelegram(args: {
   } else {
     args.out.write(
       `\n(no openclaw telegram config at ${openclawJsonPath}; skipping)\n`,
+    );
+  }
+}
+
+async function maybeImportOpenclawVoice(args: {
+  config: Config;
+  openclawConfigPath?: string;
+  out: WriteSink;
+}): Promise<void> {
+  const openclawJsonPath =
+    args.openclawConfigPath ?? join(homedir(), ".openclaw", "openclaw.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(openclawJsonPath, "utf8"));
+  } catch {
+    return;
+  }
+  const v = parseOpenClawVoice(parsed);
+  if (!v) return;
+  await applyVoiceConfig({
+    configPath: args.config.configPath,
+    envPath: defaultEnvFilePath(),
+    voice: v.config,
+    // Don't overwrite an existing key in the .env from openclaw.json.
+    // If the user wants to import the key too, they can re-run
+    // `phantombot voice` and paste it.
+  });
+  if (v.importedKey) {
+    // Conservatively SET if missing; never overwrite a key the user's
+    // already configured.
+    const envPath = defaultEnvFilePath();
+    const { loadEnvFile } = await import("../lib/envFile.ts");
+    const cur = await loadEnvFile(envPath);
+    if (!cur[v.importedKey.var]) {
+      await updateEnvFile(envPath, {
+        [v.importedKey.var]: v.importedKey.value,
+      });
+      args.out.write(
+        `\nimported voice config from ${openclawJsonPath}:\n` +
+          `  provider: ${v.config.provider}\n` +
+          `  api key:  ${v.importedKey.var} (saved to .env — was empty before)\n`,
+      );
+    } else {
+      args.out.write(
+        `\nimported voice metadata from ${openclawJsonPath}:\n` +
+          `  provider: ${v.config.provider}\n` +
+          `  api key:  ${v.importedKey.var} already set in .env (left unchanged)\n`,
+      );
+    }
+  } else {
+    args.out.write(
+      `\nimported voice metadata from ${openclawJsonPath}:\n` +
+        `  provider: ${v.config.provider}\n` +
+        `  (no API key in source; run \`phantombot voice\` to set one)\n`,
     );
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import memoryCmd from "./memory.ts";
 import embeddingCmd from "./embedding.ts";
 import heartbeatCmd from "./heartbeat.ts";
 import nightlyCmd from "./nightly.ts";
+import voiceCmd from "./voice.ts";
 
 export const mainCommand = defineCommand({
   meta: {
@@ -45,5 +46,6 @@ export const mainCommand = defineCommand({
     memory: memoryCmd,
     heartbeat: heartbeatCmd,
     nightly: nightlyCmd,
+    voice: voiceCmd,
   },
 });

--- a/src/cli/voice.ts
+++ b/src/cli/voice.ts
@@ -1,0 +1,340 @@
+/**
+ * `phantombot voice` — interactive TUI for TTS/STT provider configuration.
+ *
+ * Provider + voice metadata land in config.toml under [voice]. API keys
+ * land in the .env file alongside config.toml.
+ */
+
+import { defineCommand } from "citty";
+import * as p from "@clack/prompts";
+
+import { type Config, loadConfig } from "../config.ts";
+import { setIn, updateConfigToml } from "../lib/configWriter.ts";
+import { defaultEnvFilePath, updateEnvFile } from "../lib/envFile.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import {
+  AZURE_EDGE_DEFAULTS,
+  AZURE_EDGE_VOICE_OPTIONS,
+  ELEVENLABS_DEFAULTS,
+  ENV_KEY_FOR_PROVIDER,
+  OPENAI_DEFAULTS,
+  OPENAI_VOICE_OPTIONS,
+  type VoiceConfig,
+  type VoiceProvider,
+  validateElevenLabsKey,
+  validateOpenAIKey,
+} from "../lib/voice.ts";
+import { maybePromptRestart } from "./harness.ts";
+
+export interface ApplyVoiceInput {
+  configPath: string;
+  envPath: string;
+  voice: VoiceConfig;
+  /** If set, write to env. If "" (empty string), CLEAR the env var. If undefined, leave env untouched. */
+  apiKey?: string;
+}
+
+export async function applyVoiceConfig(input: ApplyVoiceInput): Promise<void> {
+  await updateConfigToml(input.configPath, (toml) => {
+    setIn(toml, ["voice", "provider"], input.voice.provider);
+    if (input.voice.provider === "elevenlabs" && input.voice.elevenlabs) {
+      const e = input.voice.elevenlabs;
+      setIn(toml, ["voice", "elevenlabs", "voice_id"], e.voiceId);
+      setIn(toml, ["voice", "elevenlabs", "model_id"], e.modelId);
+      setIn(toml, ["voice", "elevenlabs", "stability"], e.stability);
+      setIn(toml, ["voice", "elevenlabs", "similarity_boost"], e.similarityBoost);
+      setIn(toml, ["voice", "elevenlabs", "style"], e.style);
+    }
+    if (input.voice.provider === "openai" && input.voice.openai) {
+      const o = input.voice.openai;
+      setIn(toml, ["voice", "openai", "model"], o.model);
+      setIn(toml, ["voice", "openai", "voice"], o.voice);
+      setIn(toml, ["voice", "openai", "speed"], o.speed);
+    }
+    if (input.voice.provider === "azure_edge" && input.voice.azure_edge) {
+      const a = input.voice.azure_edge;
+      setIn(toml, ["voice", "azure_edge", "voice"], a.voice);
+      setIn(toml, ["voice", "azure_edge", "rate"], a.rate);
+      setIn(toml, ["voice", "azure_edge", "pitch"], a.pitch);
+    }
+  });
+
+  if (input.apiKey !== undefined) {
+    const provider = input.voice.provider;
+    if (provider === "elevenlabs" || provider === "openai") {
+      const envVar = ENV_KEY_FOR_PROVIDER[provider];
+      await updateEnvFile(input.envPath, { [envVar]: input.apiKey });
+    }
+  }
+}
+
+interface RunInput {
+  config?: Config;
+  serviceControl?: ServiceControl;
+}
+
+export async function runVoice(input: RunInput = {}): Promise<number> {
+  const config = input.config ?? (await loadConfig());
+  const svc = input.serviceControl ?? defaultServiceControl();
+
+  p.intro("Configure TTS / STT");
+
+  const existing = config.voice;
+  if (existing.provider !== "none") {
+    p.note(
+      `provider:  ${existing.provider}\n` +
+        formatExistingDetails(existing),
+      "Existing config",
+    );
+  }
+
+  const provider = await p.select<VoiceProvider | "cancel">({
+    message: "Provider",
+    options: [
+      {
+        value: "elevenlabs",
+        label: "ElevenLabs",
+        hint: "premium, custom voices, paid (API key required)",
+      },
+      {
+        value: "openai",
+        label: "OpenAI",
+        hint: "6 built-in voices, cheap, paid (API key required)",
+      },
+      {
+        value: "azure_edge",
+        label: "Azure Edge TTS",
+        hint: "Microsoft's free Edge endpoint (no key needed)",
+      },
+      { value: "none", label: "None — disable TTS/STT" },
+      { value: "cancel", label: "Cancel" },
+    ],
+    initialValue: existing.provider === "none" ? "elevenlabs" : existing.provider,
+  });
+  if (p.isCancel(provider) || provider === "cancel") {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  if (provider === "none") {
+    await applyVoiceConfig({
+      configPath: config.configPath,
+      envPath: defaultEnvFilePath(),
+      voice: { provider: "none" },
+    });
+    p.note(`provider set to "none"`, "Saved");
+    await maybePromptRestart(svc);
+    p.outro("done");
+    return 0;
+  }
+
+  if (provider === "elevenlabs") return runElevenLabsFlow(config, svc, existing);
+  if (provider === "openai") return runOpenAIFlow(config, svc, existing);
+  if (provider === "azure_edge") return runAzureEdgeFlow(config, svc, existing);
+  return 0;
+}
+
+async function runElevenLabsFlow(
+  config: Config,
+  svc: ServiceControl,
+  existing: VoiceConfig,
+): Promise<number> {
+  const cur = existing.elevenlabs ?? ELEVENLABS_DEFAULTS;
+  const key = await p.password({
+    message: "ElevenLabs API key (https://elevenlabs.io/app/settings/api-keys)",
+    validate: (v) => (!v || v.length === 0 ? "key is required" : undefined),
+  });
+  if (p.isCancel(key)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+  const spinner = p.spinner();
+  spinner.start("validating key against /v1/voices…");
+  const r = await validateElevenLabsKey(key as string);
+  if (!r.ok) {
+    spinner.stop(`key rejected: ${r.error}`);
+    p.cancel("aborting — key did not validate");
+    return 1;
+  }
+  spinner.stop(`key validated (${r.voiceCount} voices on this account)`);
+
+  const voiceId = await p.text({
+    message: "Voice ID (default = your previous one or Daniel)",
+    placeholder: cur.voiceId,
+    defaultValue: cur.voiceId,
+  });
+  if (p.isCancel(voiceId)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+  const modelId = await p.text({
+    message: "Model ID",
+    placeholder: cur.modelId,
+    defaultValue: cur.modelId,
+  });
+  if (p.isCancel(modelId)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  await applyVoiceConfig({
+    configPath: config.configPath,
+    envPath: defaultEnvFilePath(),
+    apiKey: key as string,
+    voice: {
+      provider: "elevenlabs",
+      elevenlabs: {
+        voiceId: (voiceId as string) || cur.voiceId,
+        modelId: (modelId as string) || cur.modelId,
+        stability: cur.stability,
+        similarityBoost: cur.similarityBoost,
+        style: cur.style,
+      },
+    },
+  });
+
+  p.note(
+    `provider:  elevenlabs\n` +
+      `voice id:  ${(voiceId as string) || cur.voiceId}\n` +
+      `model:     ${(modelId as string) || cur.modelId}\n` +
+      `key saved to ${defaultEnvFilePath()} as ${ENV_KEY_FOR_PROVIDER.elevenlabs}`,
+    "Saved",
+  );
+  await maybePromptRestart(svc);
+  p.outro("done");
+  return 0;
+}
+
+async function runOpenAIFlow(
+  config: Config,
+  svc: ServiceControl,
+  existing: VoiceConfig,
+): Promise<number> {
+  const cur = existing.openai ?? OPENAI_DEFAULTS;
+  const key = await p.password({
+    message: "OpenAI API key (https://platform.openai.com/api-keys)",
+    validate: (v) => (!v || v.length === 0 ? "key is required" : undefined),
+  });
+  if (p.isCancel(key)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+  const spinner = p.spinner();
+  spinner.start("validating key against /v1/models…");
+  const r = await validateOpenAIKey(key as string);
+  if (!r.ok) {
+    spinner.stop(`key rejected: ${r.error}`);
+    p.cancel("aborting — key did not validate");
+    return 1;
+  }
+  spinner.stop(`key validated (${r.modelCount} models visible)`);
+
+  const voice = await p.select<string>({
+    message: "Voice",
+    options: OPENAI_VOICE_OPTIONS.map((v) => ({ value: v, label: v })),
+    initialValue: cur.voice,
+  });
+  if (p.isCancel(voice)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+  const model = await p.select<string>({
+    message: "Model",
+    options: [
+      { value: "tts-1", label: "tts-1 (fast, lower quality)" },
+      { value: "tts-1-hd", label: "tts-1-hd (slower, higher quality)" },
+    ],
+    initialValue: cur.model,
+  });
+  if (p.isCancel(model)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  await applyVoiceConfig({
+    configPath: config.configPath,
+    envPath: defaultEnvFilePath(),
+    apiKey: key as string,
+    voice: {
+      provider: "openai",
+      openai: {
+        model: model as string,
+        voice: voice as string,
+        speed: cur.speed,
+      },
+    },
+  });
+  p.note(
+    `provider:  openai\n` +
+      `voice:     ${voice}\n` +
+      `model:     ${model}\n` +
+      `key saved to ${defaultEnvFilePath()} as ${ENV_KEY_FOR_PROVIDER.openai}`,
+    "Saved",
+  );
+  await maybePromptRestart(svc);
+  p.outro("done");
+  return 0;
+}
+
+async function runAzureEdgeFlow(
+  config: Config,
+  svc: ServiceControl,
+  existing: VoiceConfig,
+): Promise<number> {
+  const cur = existing.azure_edge ?? AZURE_EDGE_DEFAULTS;
+  const voice = await p.select<string>({
+    message: "Voice (Azure Edge — free, no key)",
+    options: AZURE_EDGE_VOICE_OPTIONS.map((v) => ({ value: v, label: v })),
+    initialValue: cur.voice,
+  });
+  if (p.isCancel(voice)) {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  await applyVoiceConfig({
+    configPath: config.configPath,
+    envPath: defaultEnvFilePath(),
+    voice: {
+      provider: "azure_edge",
+      azure_edge: {
+        voice: voice as string,
+        rate: cur.rate,
+        pitch: cur.pitch,
+      },
+    },
+  });
+  p.note(
+    `provider:  azure_edge\n` +
+      `voice:     ${voice}\n` +
+      `(no API key required)`,
+    "Saved",
+  );
+  await maybePromptRestart(svc);
+  p.outro("done");
+  return 0;
+}
+
+function formatExistingDetails(v: VoiceConfig): string {
+  if (v.provider === "elevenlabs" && v.elevenlabs) {
+    return `voice id:  ${v.elevenlabs.voiceId}\nmodel:     ${v.elevenlabs.modelId}`;
+  }
+  if (v.provider === "openai" && v.openai) {
+    return `voice:     ${v.openai.voice}\nmodel:     ${v.openai.model}`;
+  }
+  if (v.provider === "azure_edge" && v.azure_edge) {
+    return `voice:     ${v.azure_edge.voice}`;
+  }
+  return "";
+}
+
+export default defineCommand({
+  meta: {
+    name: "voice",
+    description:
+      "Configure TTS / STT provider (ElevenLabs / OpenAI / Azure Edge). Validates the API key before saving.",
+  },
+  async run() {
+    process.exitCode = await runVoice();
+  },
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,8 @@ export interface Config {
       dims: number;
     };
   };
+
+  voice: import("./lib/voice.ts").VoiceConfig;
 }
 
 export function xdgConfigHome(): string {
@@ -84,6 +86,7 @@ export async function loadConfig(): Promise<Config> {
   const tomlTelegram = (tomlChannels.telegram ?? {}) as Record<string, unknown>;
   const tomlEmbeddings = (toml.embeddings ?? {}) as Record<string, unknown>;
   const tomlGemini = (tomlEmbeddings.gemini ?? {}) as Record<string, unknown>;
+  const tomlVoice = (toml.voice ?? {}) as Record<string, unknown>;
 
   return {
     defaultPersona:
@@ -152,7 +155,67 @@ export async function loadConfig(): Promise<Config> {
     },
 
     embeddings: buildEmbeddingsConfig(tomlEmbeddings, tomlGemini),
+
+    voice: buildVoiceConfig(tomlVoice),
   };
+}
+
+function buildVoiceConfig(
+  tomlVoice: Record<string, unknown>,
+): import("./lib/voice.ts").VoiceConfig {
+  const provider =
+    (asString(tomlVoice.provider) as
+      | "elevenlabs"
+      | "openai"
+      | "azure_edge"
+      | "none"
+      | undefined) ?? "none";
+
+  if (provider === "elevenlabs") {
+    const e = (tomlVoice.elevenlabs ?? {}) as Record<string, unknown>;
+    return {
+      provider: "elevenlabs",
+      elevenlabs: {
+        voiceId: asString(e.voice_id) ?? "",
+        modelId: asString(e.model_id) ?? "eleven_turbo_v2_5",
+        stability: asNumber(e.stability) ?? 1,
+        similarityBoost: asNumber(e.similarity_boost) ?? 0.7,
+        style: asNumber(e.style) ?? 0.8,
+      },
+    };
+  }
+  if (provider === "openai") {
+    const o = (tomlVoice.openai ?? {}) as Record<string, unknown>;
+    return {
+      provider: "openai",
+      openai: {
+        model: asString(o.model) ?? "tts-1",
+        voice: asString(o.voice) ?? "nova",
+        speed: asNumber(o.speed) ?? 1.0,
+      },
+    };
+  }
+  if (provider === "azure_edge") {
+    const a = (tomlVoice.azure_edge ?? {}) as Record<string, unknown>;
+    return {
+      provider: "azure_edge",
+      azure_edge: {
+        voice: asString(a.voice) ?? "en-US-JennyNeural",
+        rate: asString(a.rate) ?? "+0%",
+        pitch: asString(a.pitch) ?? "+0Hz",
+      },
+    };
+  }
+  return { provider: "none" };
+}
+
+function asNumber(v: unknown): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
 }
 
 function buildEmbeddingsConfig(

--- a/src/lib/envFile.ts
+++ b/src/lib/envFile.ts
@@ -1,0 +1,97 @@
+/**
+ * Tiny .env reader/writer for phantombot's secrets file.
+ *
+ * Lives at $XDG_CONFIG_HOME/phantombot/.env. Distinct from config.toml
+ * (user-managed, may have comments) — secrets here are phantombot-managed
+ * (set/cleared by `phantombot voice` and similar). Mode 600 on write.
+ *
+ * Format: standard shell-style `KEY=value`, one per line, no quoting
+ * unless the value contains whitespace or `#` (then we wrap in double
+ * quotes). Comments (`#`) and blank lines are preserved on read but not
+ * surfaced in the parsed map; round-trip will lose them. Acceptable
+ * because this file is phantombot-owned.
+ */
+
+import { existsSync } from "node:fs";
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { xdgConfigHome } from "../config.ts";
+
+export type EnvVars = Record<string, string>;
+
+export function defaultEnvFilePath(): string {
+  return (
+    process.env.PHANTOMBOT_ENV_FILE ??
+    join(xdgConfigHome(), "phantombot", ".env")
+  );
+}
+
+export async function loadEnvFile(path: string): Promise<EnvVars> {
+  if (!existsSync(path)) return {};
+  const text = await readFile(path, "utf8");
+  return parseEnv(text);
+}
+
+export async function saveEnvFile(
+  path: string,
+  vars: EnvVars,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const lines: string[] = [];
+  for (const [k, v] of Object.entries(vars)) {
+    if (!/^[A-Z_][A-Z0-9_]*$/i.test(k)) continue; // skip invalid keys silently
+    lines.push(`${k}=${quote(v)}`);
+  }
+  await writeFile(path, lines.join("\n") + "\n", "utf8");
+  // Best-effort permission lock — secrets file should not be world-readable.
+  try {
+    await chmod(path, 0o600);
+  } catch {
+    /* fine on filesystems that don't support chmod (e.g. some FUSE) */
+  }
+}
+
+/**
+ * Update a subset of variables in-place, preserving the rest. Useful when
+ * `phantombot voice` only knows about the TTS keys but the env file may
+ * contain unrelated user-set values.
+ */
+export async function updateEnvFile(
+  path: string,
+  patch: EnvVars,
+): Promise<void> {
+  const cur = await loadEnvFile(path);
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === "") delete cur[k];
+    else cur[k] = v;
+  }
+  await saveEnvFile(path, cur);
+}
+
+export function parseEnv(text: string): EnvVars {
+  const out: EnvVars = {};
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let val = line.slice(eq + 1).trim();
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+function quote(v: string): string {
+  if (v === "") return "";
+  if (/[\s#"'\\]/.test(v)) {
+    return `"${v.replace(/(["\\])/g, "\\$1")}"`;
+  }
+  return v;
+}

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -49,10 +49,12 @@ export interface SystemdUnitParams {
  * Generate the [Unit]/[Service]/[Install] body for the phantombot
  * systemd --user unit. Pure function.
  *
- * The Environment=PATH line ensures the harness's Bash tool can find
- * `phantombot` (installed at ~/.local/bin/phantombot) when it tries to
- * call `phantombot memory search ...`. Default systemd-user PATH does
- * NOT include ~/.local/bin.
+ * - Environment=PATH ensures the harness's Bash tool can find
+ *   `phantombot` (installed at ~/.local/bin/phantombot) when it tries
+ *   to call `phantombot memory search ...`.
+ * - EnvironmentFile=-%h/.config/phantombot/.env sources the secrets
+ *   file (TTS keys, etc.). The leading `-` makes it OK if the file
+ *   doesn't exist — phantombot voice writes it when first configured.
  */
 export function generateSystemdUnit(params: SystemdUnitParams): string {
   const exec = [params.binPath, ...params.args].map(quoteArg).join(" ");
@@ -69,6 +71,7 @@ ExecStart=${exec}
 Restart=on-failure
 RestartSec=5
 Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+EnvironmentFile=-%h/.config/phantombot/.env
 StandardOutput=journal
 StandardError=journal
 
@@ -92,6 +95,7 @@ Description=Phantombot heartbeat — mechanical 30-minute maintenance pass
 Type=oneshot
 ExecStart=${exec}
 Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+EnvironmentFile=-%h/.config/phantombot/.env
 StandardOutput=journal
 StandardError=journal
 `;
@@ -126,6 +130,7 @@ Type=oneshot
 ExecStart=${exec}
 TimeoutStartSec=2700
 Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+EnvironmentFile=-%h/.config/phantombot/.env
 StandardOutput=journal
 StandardError=journal
 `;

--- a/src/lib/voice.ts
+++ b/src/lib/voice.ts
@@ -1,0 +1,227 @@
+/**
+ * Voice — TTS/STT provider configuration.
+ *
+ * Three providers in v1:
+ *   - elevenlabs:  premium, custom voices, paid (key required)
+ *   - openai:      6 built-in voices, cheap, paid (key required)
+ *   - azure_edge:  Microsoft's free Edge TTS endpoint (no key)
+ *   - none:        TTS/STT disabled
+ *
+ * API keys live in $XDG_CONFIG_HOME/phantombot/.env; voice metadata
+ * (provider, voice ID, model, modulation params) lives in config.toml
+ * under [voice]. The systemd unit reads the .env file via
+ * EnvironmentFile= so the keys are available at runtime.
+ */
+
+export type VoiceProvider = "elevenlabs" | "openai" | "azure_edge" | "none";
+
+export interface ElevenLabsVoice {
+  voiceId: string;
+  modelId: string;
+  /** 0..1; higher = more consistent / less expressive */
+  stability: number;
+  /** 0..1; higher = closer match to the original voice */
+  similarityBoost: number;
+  /** 0..1; >0 leans into stylistic emphasis */
+  style: number;
+}
+
+export interface OpenAIVoice {
+  /** "tts-1" | "tts-1-hd" */
+  model: string;
+  /** "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer" */
+  voice: string;
+  /** 0.25..4.0 */
+  speed: number;
+}
+
+export interface AzureEdgeVoice {
+  /** e.g. "en-US-JennyNeural", "en-US-AriaNeural" */
+  voice: string;
+  /** "+0%" | "+10%" | "-20%" etc. */
+  rate: string;
+  /** "+0Hz" | "+50Hz" etc. */
+  pitch: string;
+}
+
+export interface VoiceConfig {
+  provider: VoiceProvider;
+  elevenlabs?: ElevenLabsVoice;
+  openai?: OpenAIVoice;
+  azure_edge?: AzureEdgeVoice;
+}
+
+export const ENV_KEY_FOR_PROVIDER: Record<
+  Exclude<VoiceProvider, "azure_edge" | "none">,
+  string
+> = {
+  elevenlabs: "PHANTOMBOT_ELEVENLABS_API_KEY",
+  openai: "PHANTOMBOT_OPENAI_API_KEY",
+};
+
+/** A small curated default voice list per provider for the TUI. */
+export const ELEVENLABS_DEFAULTS = {
+  voiceId: "onwK4e9ZLuTAKqWW03F9", // "Daniel" — what kai's openclaw used
+  modelId: "eleven_turbo_v2_5",
+  stability: 1,
+  similarityBoost: 0.7,
+  style: 0.8,
+};
+
+export const OPENAI_VOICE_OPTIONS = [
+  "alloy",
+  "echo",
+  "fable",
+  "onyx",
+  "nova",
+  "shimmer",
+] as const;
+
+export const OPENAI_DEFAULTS: OpenAIVoice = {
+  model: "tts-1",
+  voice: "nova",
+  speed: 1.0,
+};
+
+export const AZURE_EDGE_VOICE_OPTIONS = [
+  "en-US-JennyNeural",
+  "en-US-AriaNeural",
+  "en-US-GuyNeural",
+  "en-US-ChristopherNeural",
+  "en-GB-LibbyNeural",
+  "en-GB-RyanNeural",
+] as const;
+
+export const AZURE_EDGE_DEFAULTS: AzureEdgeVoice = {
+  voice: "en-US-JennyNeural",
+  rate: "+0%",
+  pitch: "+0Hz",
+};
+
+/**
+ * Validate an ElevenLabs key by hitting GET /v1/voices.
+ */
+export async function validateElevenLabsKey(
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true; voiceCount: number } | { ok: false; error: string }> {
+  try {
+    const res = await fetchImpl(
+      "https://api.elevenlabs.io/v1/voices?show_legacy=false",
+      { headers: { "xi-api-key": apiKey } },
+    );
+    if (res.status === 401) return { ok: false, error: "401 Unauthorized — wrong key" };
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    const body = (await res.json()) as { voices?: unknown[] };
+    return { ok: true, voiceCount: body.voices?.length ?? 0 };
+  } catch (e) {
+    return { ok: false, error: `network: ${(e as Error).message}` };
+  }
+}
+
+/**
+ * Validate an OpenAI key by hitting GET /v1/models (cheap, no quota cost).
+ */
+export async function validateOpenAIKey(
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true; modelCount: number } | { ok: false; error: string }> {
+  try {
+    const res = await fetchImpl("https://api.openai.com/v1/models", {
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
+    if (res.status === 401) return { ok: false, error: "401 Unauthorized — wrong key" };
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    const body = (await res.json()) as { data?: unknown[] };
+    return { ok: true, modelCount: body.data?.length ?? 0 };
+  } catch (e) {
+    return { ok: false, error: `network: ${(e as Error).message}` };
+  }
+}
+
+/**
+ * Extract voice config from an OpenClaw config object. Returns undefined
+ * when no voice block is present. Looks at both `tts` (modern openclaw)
+ * and `talk` (older variant kai's machine had).
+ */
+export function parseOpenClawVoice(
+  openclawJson: unknown,
+): { config: VoiceConfig; importedKey?: { var: string; value: string } } | undefined {
+  const json = openclawJson as Record<string, unknown> | undefined;
+  if (!json) return undefined;
+
+  const tts = json.tts as
+    | { provider?: string; elevenlabs?: Record<string, unknown> }
+    | undefined;
+  const talk = json.talk as
+    | { voiceId?: unknown; apiKey?: unknown; modelId?: unknown }
+    | undefined;
+
+  // Modern: `tts.elevenlabs.{voiceId, modelId, voiceSettings}`
+  if (tts?.provider === "elevenlabs" && tts.elevenlabs) {
+    const el = tts.elevenlabs;
+    const settings = (el.voiceSettings ?? {}) as Record<string, unknown>;
+    const voiceId =
+      typeof el.voiceId === "string"
+        ? el.voiceId
+        : ELEVENLABS_DEFAULTS.voiceId;
+    const modelId =
+      typeof el.modelId === "string"
+        ? el.modelId
+        : ELEVENLABS_DEFAULTS.modelId;
+    return {
+      config: {
+        provider: "elevenlabs",
+        elevenlabs: {
+          voiceId,
+          modelId,
+          stability:
+            typeof settings.stability === "number"
+              ? settings.stability
+              : ELEVENLABS_DEFAULTS.stability,
+          similarityBoost:
+            typeof settings.similarityBoost === "number"
+              ? settings.similarityBoost
+              : ELEVENLABS_DEFAULTS.similarityBoost,
+          style:
+            typeof settings.style === "number"
+              ? settings.style
+              : ELEVENLABS_DEFAULTS.style,
+        },
+      },
+    };
+  }
+
+  // Older `talk` block (kai): {voiceId, apiKey, modelId?}
+  if (talk && (typeof talk.voiceId === "string" || typeof talk.apiKey === "string")) {
+    const voiceId =
+      typeof talk.voiceId === "string"
+        ? talk.voiceId
+        : ELEVENLABS_DEFAULTS.voiceId;
+    const modelId =
+      typeof talk.modelId === "string"
+        ? talk.modelId
+        : ELEVENLABS_DEFAULTS.modelId;
+    const out: ReturnType<typeof parseOpenClawVoice> = {
+      config: {
+        provider: "elevenlabs",
+        elevenlabs: {
+          voiceId,
+          modelId,
+          stability: ELEVENLABS_DEFAULTS.stability,
+          similarityBoost: ELEVENLABS_DEFAULTS.similarityBoost,
+          style: ELEVENLABS_DEFAULTS.style,
+        },
+      },
+    };
+    if (typeof talk.apiKey === "string" && talk.apiKey.length > 0) {
+      out.importedKey = {
+        var: ENV_KEY_FOR_PROVIDER.elevenlabs,
+        value: talk.apiKey,
+      };
+    }
+    return out;
+  }
+
+  return undefined;
+}

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -186,6 +186,7 @@ const baseConfig = (
     },
   },
   embeddings: { provider: "none" },
+  voice: { provider: "none" },
 });
 
 describe("runTelegramServer dispatch", () => {

--- a/tests/cli-create-persona.test.ts
+++ b/tests/cli-create-persona.test.ts
@@ -33,6 +33,7 @@ beforeEach(async () => {
     },
     channels: {},
     embeddings: { provider: "none" },
+    voice: { provider: "none" },
   };
 });
 

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -41,6 +41,7 @@ beforeEach(async () => {
     },
     channels: {},
     embeddings: { provider: "none" },
+    voice: { provider: "none" },
   };
 });
 

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -58,6 +58,7 @@ beforeEach(async () => {
     },
     channels: {},
     embeddings: { provider: "none" },
+    voice: { provider: "none" },
   };
 });
 

--- a/tests/cli-memory.test.ts
+++ b/tests/cli-memory.test.ts
@@ -54,6 +54,7 @@ beforeEach(async () => {
     },
     channels: {},
     embeddings: { provider: "none" },
+    voice: { provider: "none" },
   };
 });
 

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -35,6 +35,7 @@ beforeEach(async () => {
     },
     channels: {},
     embeddings: { provider: "none" },
+    voice: { provider: "none" },
   };
 });
 

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -45,6 +45,7 @@ beforeEach(async () => {
     },
     channels: {},
     embeddings: { provider: "none" },
+    voice: { provider: "none" },
   };
 });
 

--- a/tests/cli-voice.test.ts
+++ b/tests/cli-voice.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyVoiceConfig } from "../src/cli/voice.ts";
+import { loadEnvFile } from "../src/lib/envFile.ts";
+
+let workdir: string;
+let configPath: string;
+let envPath: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-voice-"));
+  configPath = join(workdir, "config.toml");
+  envPath = join(workdir, ".env");
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("applyVoiceConfig — elevenlabs", () => {
+  test("writes [voice] + [voice.elevenlabs] to config.toml + key to env", async () => {
+    await applyVoiceConfig({
+      configPath,
+      envPath,
+      apiKey: "sk_live_TEST",
+      voice: {
+        provider: "elevenlabs",
+        elevenlabs: {
+          voiceId: "voice_123",
+          modelId: "eleven_turbo_v2_5",
+          stability: 1,
+          similarityBoost: 0.7,
+          style: 0.8,
+        },
+      },
+    });
+    const cfg = await readFile(configPath, "utf8");
+    expect(cfg).toContain("[voice]");
+    expect(cfg).toContain('provider = "elevenlabs"');
+    expect(cfg).toContain("[voice.elevenlabs]");
+    expect(cfg).toContain('voice_id = "voice_123"');
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_ELEVENLABS_API_KEY).toBe("sk_live_TEST");
+  });
+});
+
+describe("applyVoiceConfig — openai", () => {
+  test("writes [voice.openai] block", async () => {
+    await applyVoiceConfig({
+      configPath,
+      envPath,
+      apiKey: "sk-OAITEST",
+      voice: {
+        provider: "openai",
+        openai: { model: "tts-1", voice: "nova", speed: 1.0 },
+      },
+    });
+    const cfg = await readFile(configPath, "utf8");
+    expect(cfg).toContain('voice = "nova"');
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_OPENAI_API_KEY).toBe("sk-OAITEST");
+  });
+});
+
+describe("applyVoiceConfig — azure_edge", () => {
+  test("writes [voice.azure_edge] block; does NOT write any key (free)", async () => {
+    await applyVoiceConfig({
+      configPath,
+      envPath,
+      voice: {
+        provider: "azure_edge",
+        azure_edge: {
+          voice: "en-US-JennyNeural",
+          rate: "+0%",
+          pitch: "+0Hz",
+        },
+      },
+    });
+    const cfg = await readFile(configPath, "utf8");
+    expect(cfg).toContain('voice = "en-US-JennyNeural"');
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_ELEVENLABS_API_KEY).toBeUndefined();
+    expect(env.PHANTOMBOT_OPENAI_API_KEY).toBeUndefined();
+  });
+});
+
+describe("applyVoiceConfig — none", () => {
+  test('flips provider to "none"', async () => {
+    await applyVoiceConfig({
+      configPath,
+      envPath,
+      voice: { provider: "none" },
+    });
+    const cfg = await readFile(configPath, "utf8");
+    expect(cfg).toContain('provider = "none"');
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -31,6 +31,7 @@ describe("phantombot CLI dispatcher", () => {
       "run",
       "telegram",
       "uninstall",
+      "voice",
     ]);
   });
 });

--- a/tests/lib-embedJob.test.ts
+++ b/tests/lib-embedJob.test.ts
@@ -263,6 +263,7 @@ describe("defaultEmbedder", () => {
       },
       channels: {},
       embeddings: { provider: "none" },
+      voice: { provider: "none" },
     });
     expect(e).toBeUndefined();
   });
@@ -280,6 +281,7 @@ describe("defaultEmbedder", () => {
         pi: { bin: "x", maxPayloadBytes: 1 },
       },
       channels: {},
+      voice: { provider: "none" },
       embeddings: {
         provider: "gemini",
         gemini: { apiKey: "", model: "g", dims: 1536 },

--- a/tests/lib-envFile.test.ts
+++ b/tests/lib-envFile.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadEnvFile,
+  parseEnv,
+  saveEnvFile,
+  updateEnvFile,
+} from "../src/lib/envFile.ts";
+
+let workdir: string;
+let envPath: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-env-"));
+  envPath = join(workdir, ".env");
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("parseEnv", () => {
+  test("parses KEY=value lines, skips comments and blanks", () => {
+    expect(
+      parseEnv(`# comment\nFOO=bar\n\n  BAZ=qux  \n# another\nQUOTED="with space"\n`),
+    ).toEqual({
+      FOO: "bar",
+      BAZ: "qux",
+      QUOTED: "with space",
+    });
+  });
+
+  test("handles single-quoted values", () => {
+    expect(parseEnv("X='quoted'\n")).toEqual({ X: "quoted" });
+  });
+});
+
+describe("saveEnvFile / loadEnvFile round-trip", () => {
+  test("writes the file and reads it back", async () => {
+    await saveEnvFile(envPath, { FOO: "bar", PHANTOMBOT_X: "abc-123" });
+    expect(existsSync(envPath)).toBe(true);
+    expect(await loadEnvFile(envPath)).toEqual({
+      FOO: "bar",
+      PHANTOMBOT_X: "abc-123",
+    });
+  });
+
+  test("write quotes values with spaces or special chars", async () => {
+    await saveEnvFile(envPath, { X: "has space", Y: "no-special" });
+    const text = await readFile(envPath, "utf8");
+    expect(text).toContain('X="has space"');
+    expect(text).toContain("Y=no-special");
+  });
+
+  test("file mode is 600 after save (owner-only)", async () => {
+    await saveEnvFile(envPath, { FOO: "bar" });
+    const s = await stat(envPath);
+    // Mode bits we care about: rwx for owner, none for group/world.
+    expect((s.mode & 0o077).toString(8)).toBe("0");
+  });
+
+  test("loadEnvFile returns {} when file is missing", async () => {
+    expect(await loadEnvFile(envPath)).toEqual({});
+  });
+});
+
+describe("updateEnvFile", () => {
+  test("merges patch into existing keys", async () => {
+    await saveEnvFile(envPath, { A: "1", B: "2" });
+    await updateEnvFile(envPath, { B: "two", C: "3" });
+    expect(await loadEnvFile(envPath)).toEqual({
+      A: "1",
+      B: "two",
+      C: "3",
+    });
+  });
+
+  test("empty value DELETES the key", async () => {
+    await saveEnvFile(envPath, { A: "1", B: "2" });
+    await updateEnvFile(envPath, { B: "" });
+    expect(await loadEnvFile(envPath)).toEqual({ A: "1" });
+  });
+
+  test("creates the file if it doesn't exist", async () => {
+    await updateEnvFile(envPath, { NEW: "1" });
+    expect(await loadEnvFile(envPath)).toEqual({ NEW: "1" });
+  });
+
+  test("ignores keys that aren't valid env-var names", async () => {
+    await saveEnvFile(envPath, {
+      VALID: "1",
+      "with-dash": "skipped",
+      "1starts-digit": "skipped",
+    });
+    expect(await loadEnvFile(envPath)).toEqual({ VALID: "1" });
+  });
+});
+
+describe("preserves keys it doesn't know about", () => {
+  test("hand-edited additional vars survive an updateEnvFile call", async () => {
+    await writeFile(
+      envPath,
+      "USER_VAR=keep_me\nPHANTOMBOT_X=managed\n",
+      "utf8",
+    );
+    await updateEnvFile(envPath, { PHANTOMBOT_X: "managed_v2" });
+    expect(await loadEnvFile(envPath)).toEqual({
+      USER_VAR: "keep_me",
+      PHANTOMBOT_X: "managed_v2",
+    });
+  });
+});

--- a/tests/lib-voice.test.ts
+++ b/tests/lib-voice.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseOpenClawVoice,
+  validateElevenLabsKey,
+  validateOpenAIKey,
+} from "../src/lib/voice.ts";
+
+function fakeFetch(body: unknown, status = 200): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+describe("validateElevenLabsKey", () => {
+  test("ok=true returns voice count", async () => {
+    const r = await validateElevenLabsKey(
+      "k",
+      fakeFetch({ voices: [{}, {}, {}] }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.voiceCount).toBe(3);
+  });
+
+  test("ok=false on 401", async () => {
+    const r = await validateElevenLabsKey("badkey", fakeFetch({}, 401));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("401");
+  });
+
+  test("ok=false on network error", async () => {
+    const failing = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const r = await validateElevenLabsKey("k", failing);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("network");
+  });
+});
+
+describe("validateOpenAIKey", () => {
+  test("ok=true returns model count", async () => {
+    const r = await validateOpenAIKey(
+      "k",
+      fakeFetch({ data: [{}, {}] }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.modelCount).toBe(2);
+  });
+
+  test("ok=false on 401", async () => {
+    const r = await validateOpenAIKey("k", fakeFetch({}, 401));
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("parseOpenClawVoice", () => {
+  test("modern tts.elevenlabs layout", () => {
+    const r = parseOpenClawVoice({
+      tts: {
+        provider: "elevenlabs",
+        elevenlabs: {
+          voiceId: "voice_123",
+          modelId: "eleven_v3",
+          voiceSettings: {
+            stability: 0.5,
+            similarityBoost: 0.6,
+            style: 0.7,
+          },
+        },
+      },
+    });
+    expect(r).toBeDefined();
+    expect(r?.config.provider).toBe("elevenlabs");
+    expect(r?.config.elevenlabs?.voiceId).toBe("voice_123");
+    expect(r?.config.elevenlabs?.modelId).toBe("eleven_v3");
+    expect(r?.config.elevenlabs?.stability).toBe(0.5);
+    expect(r?.importedKey).toBeUndefined();
+  });
+
+  test("older talk block — extracts voiceId + apiKey", () => {
+    const r = parseOpenClawVoice({
+      talk: {
+        voiceId: "onwK4e9ZLuTAKqWW03F9",
+        apiKey: "sk_secret",
+      },
+    });
+    expect(r?.config.provider).toBe("elevenlabs");
+    expect(r?.config.elevenlabs?.voiceId).toBe("onwK4e9ZLuTAKqWW03F9");
+    expect(r?.importedKey?.var).toBe("PHANTOMBOT_ELEVENLABS_API_KEY");
+    expect(r?.importedKey?.value).toBe("sk_secret");
+  });
+
+  test("returns undefined when no voice block is present", () => {
+    expect(parseOpenClawVoice({})).toBeUndefined();
+    expect(parseOpenClawVoice({ tts: {} })).toBeUndefined();
+    expect(parseOpenClawVoice({ talk: {} })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

New \`phantombot voice\` TUI for TTS/STT provider configuration, plus a \`.env\` secrets file alongside \`config.toml\`, plus an OpenClaw voice-config sniff in \`import-persona\`. **Configuration only — no actual TTS/STT integration yet.** That's phase 30; this PR makes sure the config plumbing is right first.

## Three providers

| Provider | Key needed | Voice picker |
|---|---|---|
| **elevenlabs** | yes (validated against /v1/voices) | voice ID + model ID + stability/similarity/style |
| **openai** | yes (validated against /v1/models) | alloy / echo / fable / onyx / nova / shimmer; tts-1 / tts-1-hd |
| **azure_edge** | no (free endpoint) | curated list of Edge voices |
| **none** | — | disables TTS/STT |

## File layout

- **\`config.toml\`** — \`[voice]\` block with provider + voice metadata (voice IDs, model, modulation params).
- **\`~/.config/phantombot/.env\`** — secrets only (\`PHANTOMBOT_ELEVENLABS_API_KEY\`, \`PHANTOMBOT_OPENAI_API_KEY\`). Mode 600. Other env vars (e.g. user-set \`PATH\` overrides) are preserved across phantombot writes.
- **systemd units** — main + heartbeat + nightly all get \`EnvironmentFile=-%h/.config/phantombot/.env\` so runtime processes see the keys. The leading \`-\` makes it OK if the file doesn't exist yet.

## Import behavior

\`phantombot import-persona\` now sniffs the OpenClaw config (\`~/.openclaw/openclaw.json\` by default) for both modern (\`tts.elevenlabs\`) and older (\`talk\`) voice block layouts. **kai's box has the older layout** — the import will pull the voice ID, modelId, and (if present) the API key. Never overwrites an existing key in \`.env\`; logs whether it imported or left a key alone.

## Test plan

- [x] \`bun test\` — 299 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- 22 new tests across \`tests/lib-envFile.test.ts\` (parse, round-trip, mode-600, merge/delete, preserve non-managed), \`tests/lib-voice.test.ts\` (validate happy/401/network for both providers; OpenClaw parse — modern/older/missing), \`tests/cli-voice.test.ts\` (apply for each provider).

## What lands in phase 30

- ElevenLabs/OpenAI/Edge TTS clients (synthesize text → audio buffer)
- Telegram \`sendVoice\` integration in \`runTelegramServer\` after assistant reply
- Per-chat or per-persona toggle (do users always want voice?)
- OpenAI Whisper STT for incoming Telegram voice messages → text → harness