### PR TITLE
Phase 30: Telegram TTS/STT — voice in → voice out, text in → text out

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -17,6 +17,12 @@
 
 import type { Config } from "../config.ts";
 import type { Harness } from "../harnesses/types.ts";
+import {
+  synthesize,
+  sttSupported,
+  transcribe,
+  ttsSupported,
+} from "../lib/audio.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import type { MemoryStore } from "../memory/store.ts";
@@ -27,7 +33,14 @@ export interface TelegramMessage {
   chatId: number;
   fromUserId: number;
   fromUsername?: string;
+  /** For text messages — the text. For voice messages — empty string until STT runs. */
   text: string;
+  /** Set when the incoming message was a voice note. */
+  voice?: {
+    fileId: string;
+    mimeType: string;
+    durationS: number;
+  };
 }
 
 export interface TelegramTransport {
@@ -44,6 +57,12 @@ export interface TelegramTransport {
   ): Promise<{ updates: TelegramMessage[]; nextOffset: number }>;
   sendMessage(chatId: number, text: string): Promise<void>;
   sendTyping(chatId: number): Promise<void>;
+  /** Send an OGG-Opus voice note. */
+  sendVoice(chatId: number, audio: Buffer, mime: string): Promise<void>;
+  /** Send the "recording voice" status indicator. */
+  sendRecording(chatId: number): Promise<void>;
+  /** Download a file by Telegram file_id; returns audio bytes + content-type. */
+  downloadFile(fileId: string): Promise<{ data: Buffer; mime: string }>;
 }
 
 /**
@@ -115,6 +134,69 @@ export class HttpTelegramTransport implements TelegramTransport {
       /* typing indicator is best-effort */
     });
   }
+
+  async sendRecording(chatId: number): Promise<void> {
+    const url = `https://api.telegram.org/bot${this.token}/sendChatAction`;
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, action: "record_voice" }),
+    }).catch(() => {});
+  }
+
+  async sendVoice(
+    chatId: number,
+    audio: Buffer,
+    mime: string,
+  ): Promise<void> {
+    const form = new FormData();
+    form.set("chat_id", String(chatId));
+    form.set(
+      "voice",
+      new Blob([audio], { type: mime || "audio/ogg" }),
+      "voice.ogg",
+    );
+    const res = await fetch(
+      `https://api.telegram.org/bot${this.token}/sendVoice`,
+      { method: "POST", body: form },
+    );
+    if (!res.ok) {
+      log.warn("telegram: sendVoice non-OK", {
+        chatId,
+        status: res.status,
+      });
+    }
+  }
+
+  async downloadFile(
+    fileId: string,
+  ): Promise<{ data: Buffer; mime: string }> {
+    // Two-step: getFile to get file_path, then GET the file URL.
+    const meta = await fetch(
+      `https://api.telegram.org/bot${this.token}/getFile?file_id=${encodeURIComponent(fileId)}`,
+    );
+    const metaBody = (await meta.json()) as {
+      ok?: boolean;
+      result?: { file_path?: string };
+    };
+    if (!metaBody.ok || !metaBody.result?.file_path) {
+      throw new Error(`getFile failed for ${fileId}`);
+    }
+    const file = await fetch(
+      `https://api.telegram.org/file/bot${this.token}/${metaBody.result.file_path}`,
+    );
+    const data = Buffer.from(await file.arrayBuffer());
+    const mime =
+      file.headers.get("content-type") ?? guessMimeFromPath(metaBody.result.file_path);
+    return { data, mime };
+  }
+}
+
+function guessMimeFromPath(path: string): string {
+  if (path.endsWith(".oga") || path.endsWith(".ogg")) return "audio/ogg";
+  if (path.endsWith(".mp3")) return "audio/mpeg";
+  if (path.endsWith(".m4a")) return "audio/mp4";
+  return "audio/ogg";
 }
 
 interface TelegramRawUpdate {
@@ -123,12 +205,17 @@ interface TelegramRawUpdate {
     chat?: { id?: number };
     from?: { id?: number; username?: string };
     text?: string;
+    voice?: {
+      duration?: number;
+      mime_type?: string;
+      file_id?: string;
+    };
   };
 }
 
 /**
  * Pure parser exposed for testing. Consumes Telegram getUpdates result
- * objects and returns only the message-with-text updates we care about.
+ * objects and returns the messages we care about — text or voice.
  */
 export function parseGetUpdatesResult(
   raw: TelegramRawUpdate[],
@@ -142,19 +229,36 @@ export function parseGetUpdatesResult(
     }
     const msg = u.message;
     if (
-      typeof u.update_id === "number" &&
-      msg &&
-      typeof msg.chat?.id === "number" &&
-      typeof msg.from?.id === "number" &&
-      typeof msg.text === "string" &&
-      msg.text.length > 0
+      typeof u.update_id !== "number" ||
+      !msg ||
+      typeof msg.chat?.id !== "number" ||
+      typeof msg.from?.id !== "number"
     ) {
+      continue;
+    }
+
+    if (typeof msg.text === "string" && msg.text.length > 0) {
       updates.push({
         updateId: u.update_id,
         chatId: msg.chat.id,
         fromUserId: msg.from.id,
         fromUsername: msg.from.username,
         text: msg.text,
+      });
+      continue;
+    }
+    if (msg.voice && typeof msg.voice.file_id === "string") {
+      updates.push({
+        updateId: u.update_id,
+        chatId: msg.chat.id,
+        fromUserId: msg.from.id,
+        fromUsername: msg.from.username,
+        text: "", // filled by STT before harness dispatch
+        voice: {
+          fileId: msg.voice.file_id,
+          mimeType: msg.voice.mime_type ?? "audio/ogg",
+          durationS: msg.voice.duration ?? 0,
+        },
       });
     }
   }
@@ -225,21 +329,66 @@ export async function runTelegramServer(
       }
 
       const startedAt = Date.now();
+      const isVoice = Boolean(msg.voice);
       log.info("telegram: incoming", {
         chatId: msg.chatId,
         fromUserId: msg.fromUserId,
         fromUsername: msg.fromUsername,
         textLength: msg.text.length,
         persona: input.persona,
+        voice: isVoice,
+        voiceDurationS: msg.voice?.durationS,
       });
 
-      // Send typing immediately, then refresh every typingRefreshMs while
-      // the harness works. Telegram's typing indicator lasts ~5s; without
-      // this the user sees "typing…" disappear and assumes the bot died.
-      void input.transport.sendTyping(msg.chatId);
+      // For voice messages: download → transcribe → use the transcript
+      // as the user message before invoking the harness.
+      if (isVoice && msg.voice) {
+        if (!sttSupported(input.config)) {
+          await input.transport.sendMessage(
+            msg.chatId,
+            `(voice messages need OpenAI or ElevenLabs configured — current provider is '${input.config.voice.provider}')`,
+          );
+          continue;
+        }
+        try {
+          const file = await input.transport.downloadFile(msg.voice.fileId);
+          const r = await transcribe(input.config, file.data, file.mime);
+          if (!r.ok) {
+            log.error("telegram: STT failed", { error: r.error });
+            await input.transport.sendMessage(
+              msg.chatId,
+              `(voice transcription failed: ${r.error})`,
+            );
+            continue;
+          }
+          msg.text = r.text;
+          log.info("telegram: STT ok", {
+            chatId: msg.chatId,
+            transcriptChars: r.text.length,
+          });
+        } catch (e) {
+          log.error("telegram: voice download failed", {
+            error: (e as Error).message,
+          });
+          await input.transport.sendMessage(
+            msg.chatId,
+            `(couldn't download your voice message: ${(e as Error).message})`,
+          );
+          continue;
+        }
+      }
+
+      // Send the right indicator depending on which way we'll reply.
+      // Refresh both kinds every typingRefreshMs while the harness works.
+      const willReplyWithVoice = isVoice && ttsSupported(input.config);
+      const sendStatus = () =>
+        willReplyWithVoice
+          ? input.transport.sendRecording(msg.chatId)
+          : input.transport.sendTyping(msg.chatId);
+      void sendStatus();
       const refreshMs = input.typingRefreshMs ?? 4000;
       const typingTimer = setInterval(() => {
-        void input.transport.sendTyping(msg.chatId);
+        void sendStatus();
       }, refreshMs);
 
       let reply = "";
@@ -287,10 +436,31 @@ export async function runTelegramServer(
         : reply.length > 0
           ? reply
           : "(no reply)";
+
+      // Voice in → voice out (when TTS is configured AND no error).
+      // Text in → text out, always.
+      let sentAsVoice = false;
       try {
-        await input.transport.sendMessage(msg.chatId, outText);
+        if (willReplyWithVoice && !errored && reply.length > 0) {
+          const r = await synthesize(input.config, reply);
+          if (r.ok) {
+            await input.transport.sendVoice(
+              msg.chatId,
+              r.audio.data,
+              r.audio.mime,
+            );
+            sentAsVoice = true;
+          } else {
+            log.warn("telegram: TTS failed; falling back to text", {
+              error: r.error,
+            });
+            await input.transport.sendMessage(msg.chatId, outText);
+          }
+        } else {
+          await input.transport.sendMessage(msg.chatId, outText);
+        }
       } catch (e) {
-        log.error("telegram: sendMessage failed", {
+        log.error("telegram: send failed", {
           error: (e as Error).message,
           chatId: msg.chatId,
         });
@@ -302,6 +472,8 @@ export async function runTelegramServer(
         replyChars: outText.length,
         progressEvents: progressCount,
         harness: chosenHarness ?? (errored ? "(error)" : "(unknown)"),
+        modality: sentAsVoice ? "voice" : "text",
+        inputModality: isVoice ? "voice" : "text",
         ok: !errored,
       });
     }

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,0 +1,259 @@
+/**
+ * Shared TTS / STT types + the dispatcher that picks the right
+ * provider based on Config.voice.provider.
+ *
+ * Telegram needs OGG-Opus for sendVoice, so every provider returns
+ * audio in that container (or a buffer Telegram can accept as-is).
+ */
+
+import type { Config } from "../config.ts";
+
+export interface SynthesizedAudio {
+  data: Buffer;
+  /** Telegram-compatible MIME for sendVoice. We aim for audio/ogg. */
+  mime: string;
+}
+
+export type SynthesizeResult =
+  | { ok: true; audio: SynthesizedAudio }
+  | { ok: false; error: string };
+
+export type TranscribeResult =
+  | { ok: true; text: string }
+  | { ok: false; error: string };
+
+/**
+ * True if the configured provider can do STT (i.e. transcribe Telegram
+ * voice messages). Azure Edge has no STT counterpart.
+ */
+export function sttSupported(config: Config): boolean {
+  const p = config.voice.provider;
+  if (p === "openai" || p === "elevenlabs") {
+    const envVar =
+      p === "openai"
+        ? "PHANTOMBOT_OPENAI_API_KEY"
+        : "PHANTOMBOT_ELEVENLABS_API_KEY";
+    return Boolean(process.env[envVar]);
+  }
+  return false;
+}
+
+/** True if the configured provider can synthesize TTS. */
+export function ttsSupported(config: Config): boolean {
+  const p = config.voice.provider;
+  if (p === "none") return false;
+  if (p === "azure_edge") return true; // free, no key
+  const envVar =
+    p === "openai"
+      ? "PHANTOMBOT_OPENAI_API_KEY"
+      : "PHANTOMBOT_ELEVENLABS_API_KEY";
+  return Boolean(process.env[envVar]);
+}
+
+export async function synthesize(
+  config: Config,
+  text: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SynthesizeResult> {
+  const p = config.voice.provider;
+  if (p === "elevenlabs") {
+    const key = process.env.PHANTOMBOT_ELEVENLABS_API_KEY;
+    if (!key) return { ok: false, error: "no ElevenLabs API key in env" };
+    return elevenlabsTts(key, text, config.voice.elevenlabs!, fetchImpl);
+  }
+  if (p === "openai") {
+    const key = process.env.PHANTOMBOT_OPENAI_API_KEY;
+    if (!key) return { ok: false, error: "no OpenAI API key in env" };
+    return openaiTts(key, text, config.voice.openai!, fetchImpl);
+  }
+  if (p === "azure_edge") {
+    return {
+      ok: false,
+      error:
+        "Azure Edge TTS not implemented yet — configure ElevenLabs or OpenAI for voice replies",
+    };
+  }
+  return { ok: false, error: "TTS provider is 'none'" };
+}
+
+export async function transcribe(
+  config: Config,
+  audio: Buffer,
+  mime: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TranscribeResult> {
+  const p = config.voice.provider;
+  if (p === "elevenlabs") {
+    const key = process.env.PHANTOMBOT_ELEVENLABS_API_KEY;
+    if (!key)
+      return { ok: false, error: "no ElevenLabs API key in env" };
+    return elevenlabsScribe(key, audio, mime, fetchImpl);
+  }
+  if (p === "openai") {
+    const key = process.env.PHANTOMBOT_OPENAI_API_KEY;
+    if (!key) return { ok: false, error: "no OpenAI API key in env" };
+    return openaiWhisper(key, audio, mime, fetchImpl);
+  }
+  return {
+    ok: false,
+    error: `STT not supported for provider '${p}' — configure ElevenLabs or OpenAI to accept voice messages`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Provider implementations (local — no SDK deps, raw HTTPS)
+// ---------------------------------------------------------------------------
+
+async function elevenlabsTts(
+  apiKey: string,
+  text: string,
+  cfg: NonNullable<Config["voice"]["elevenlabs"]>,
+  fetchImpl: typeof fetch,
+): Promise<SynthesizeResult> {
+  const url =
+    `https://api.elevenlabs.io/v1/text-to-speech/${encodeURIComponent(cfg.voiceId)}` +
+    `?output_format=opus_48000_128`;
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "xi-api-key": apiKey,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        text,
+        model_id: cfg.modelId,
+        voice_settings: {
+          stability: cfg.stability,
+          similarity_boost: cfg.similarityBoost,
+          style: cfg.style,
+        },
+      }),
+    });
+  } catch (e) {
+    return { ok: false, error: `network: ${(e as Error).message}` };
+  }
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    return {
+      ok: false,
+      error: `elevenlabs HTTP ${res.status}: ${errText.slice(0, 200)}`,
+    };
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  return { ok: true, audio: { data: buf, mime: "audio/ogg" } };
+}
+
+async function openaiTts(
+  apiKey: string,
+  text: string,
+  cfg: NonNullable<Config["voice"]["openai"]>,
+  fetchImpl: typeof fetch,
+): Promise<SynthesizeResult> {
+  let res: Response;
+  try {
+    res = await fetchImpl("https://api.openai.com/v1/audio/speech", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: cfg.model,
+        voice: cfg.voice,
+        input: text,
+        speed: cfg.speed,
+        response_format: "opus",
+      }),
+    });
+  } catch (e) {
+    return { ok: false, error: `network: ${(e as Error).message}` };
+  }
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    return {
+      ok: false,
+      error: `openai HTTP ${res.status}: ${errText.slice(0, 200)}`,
+    };
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  return { ok: true, audio: { data: buf, mime: "audio/ogg" } };
+}
+
+async function elevenlabsScribe(
+  apiKey: string,
+  audio: Buffer,
+  mime: string,
+  fetchImpl: typeof fetch,
+): Promise<TranscribeResult> {
+  const form = new FormData();
+  form.set(
+    "file",
+    new Blob([audio], { type: mime || "audio/ogg" }),
+    "voice.ogg",
+  );
+  form.set("model_id", "scribe_v1");
+  let res: Response;
+  try {
+    res = await fetchImpl("https://api.elevenlabs.io/v1/speech-to-text", {
+      method: "POST",
+      headers: { "xi-api-key": apiKey },
+      body: form,
+    });
+  } catch (e) {
+    return { ok: false, error: `network: ${(e as Error).message}` };
+  }
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    return {
+      ok: false,
+      error: `elevenlabs scribe HTTP ${res.status}: ${errText.slice(0, 200)}`,
+    };
+  }
+  const body = (await res.json()) as { text?: string };
+  if (typeof body.text !== "string") {
+    return { ok: false, error: "no transcript text in scribe response" };
+  }
+  return { ok: true, text: body.text };
+}
+
+async function openaiWhisper(
+  apiKey: string,
+  audio: Buffer,
+  mime: string,
+  fetchImpl: typeof fetch,
+): Promise<TranscribeResult> {
+  const form = new FormData();
+  form.set(
+    "file",
+    new Blob([audio], { type: mime || "audio/ogg" }),
+    "voice.ogg",
+  );
+  form.set("model", "whisper-1");
+  let res: Response;
+  try {
+    res = await fetchImpl(
+      "https://api.openai.com/v1/audio/transcriptions",
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${apiKey}` },
+        body: form,
+      },
+    );
+  } catch (e) {
+    return { ok: false, error: `network: ${(e as Error).message}` };
+  }
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    return {
+      ok: false,
+      error: `whisper HTTP ${res.status}: ${errText.slice(0, 200)}`,
+    };
+  }
+  const body = (await res.json()) as { text?: string };
+  if (typeof body.text !== "string") {
+    return { ok: false, error: "no transcript text in whisper response" };
+  }
+  return { ok: true, text: body.text };
+}

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -31,7 +31,11 @@ import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
 class FakeTransport implements TelegramTransport {
   pendingUpdates: TelegramMessage[] = [];
   sent: Array<{ chatId: number; text: string }> = [];
+  voiceSent: Array<{ chatId: number; mime: string; bytes: number }> = [];
   typing: number[] = [];
+  recording: number[] = [];
+  downloadedFileIds: string[] = [];
+  fakeFileBytes = Buffer.from([0x4f, 0x67, 0x67, 0x53]); // "OggS" magic
   receivedSignals: Array<AbortSignal | undefined> = [];
   async getUpdates(
     offset: number,
@@ -56,6 +60,22 @@ class FakeTransport implements TelegramTransport {
   }
   async sendTyping(chatId: number): Promise<void> {
     this.typing.push(chatId);
+  }
+  async sendRecording(chatId: number): Promise<void> {
+    this.recording.push(chatId);
+  }
+  async sendVoice(
+    chatId: number,
+    audio: Buffer,
+    mime: string,
+  ): Promise<void> {
+    this.voiceSent.push({ chatId, mime, bytes: audio.byteLength });
+  }
+  async downloadFile(
+    fileId: string,
+  ): Promise<{ data: Buffer; mime: string }> {
+    this.downloadedFileIds.push(fileId);
+    return { data: this.fakeFileBytes, mime: "audio/ogg" };
   }
 }
 
@@ -292,6 +312,157 @@ describe("runTelegramServer dispatch", () => {
     });
     expect(transport.sent).toEqual([{ chatId: 1001, text: "(error: boom)" }]);
     expect(await memory.recentTurns("phantom", "telegram:1001", 10)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Voice round-trip
+// ---------------------------------------------------------------------------
+
+describe("runTelegramServer voice round-trip", () => {
+  const SAVED_KEY = process.env.PHANTOMBOT_OPENAI_API_KEY;
+  beforeEach(() => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    if (SAVED_KEY === undefined) delete process.env.PHANTOMBOT_OPENAI_API_KEY;
+    else process.env.PHANTOMBOT_OPENAI_API_KEY = SAVED_KEY;
+  });
+
+  function withVoiceConfig(): Config {
+    const c = baseConfig();
+    return {
+      ...c,
+      voice: {
+        provider: "openai",
+        openai: { model: "tts-1", voice: "nova", speed: 1 },
+      },
+    };
+  }
+
+  test("voice in: STT runs, file is downloaded, transcript drives the harness, reply goes back as voice", async () => {
+    const originalFetch = globalThis.fetch;
+    let whisperCalled = 0;
+    let ttsCalled = 0;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (
+      url: string | URL | Request,
+    ) => {
+      const u = String(url);
+      if (u.includes("audio/transcriptions")) {
+        whisperCalled++;
+        return new Response(JSON.stringify({ text: "hello from voice" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (u.includes("audio/speech")) {
+        ttsCalled++;
+        return new Response(Buffer.from([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "audio/ogg" },
+        });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    }) as unknown as typeof fetch;
+
+    try {
+      const transport = new FakeTransport();
+      transport.pendingUpdates.push({
+        updateId: 1,
+        chatId: 1001,
+        fromUserId: 42,
+        text: "",
+        voice: { fileId: "abc-file", mimeType: "audio/ogg", durationS: 3 },
+      });
+      const harness = new ScriptedHarness("fake", [
+        { type: "done", finalText: "hi from kai" },
+      ]);
+      await runTelegramServer({
+        config: withVoiceConfig(),
+        memory,
+        harnesses: [harness],
+        agentDir,
+        persona: "phantom",
+        transport,
+        oneShot: true,
+      });
+      expect(transport.downloadedFileIds).toEqual(["abc-file"]);
+      expect(whisperCalled).toBe(1);
+      expect(harness.invocations).toBe(1);
+      expect(harness.lastRequest?.userMessage).toBe("hello from voice");
+      expect(transport.voiceSent).toHaveLength(1);
+      expect(transport.voiceSent[0]?.chatId).toBe(1001);
+      expect(transport.sent).toEqual([]);
+      expect(ttsCalled).toBe(1);
+      expect(transport.recording.length).toBeGreaterThan(0);
+      expect(transport.typing).toEqual([]);
+    } finally {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    }
+  });
+
+  test("text in: still sends as text even when voice provider is configured", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hi via text",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "hello back" },
+    ]);
+    await runTelegramServer({
+      config: withVoiceConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(transport.sent).toEqual([
+      { chatId: 1001, text: "hello back" },
+    ]);
+    expect(transport.voiceSent).toEqual([]);
+    expect(transport.downloadedFileIds).toEqual([]);
+    expect(transport.typing.length).toBeGreaterThan(0);
+    expect(transport.recording).toEqual([]);
+  });
+
+  test("voice in but azure_edge (no STT) → text reply explaining why, no harness call", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "",
+      voice: { fileId: "xyz", mimeType: "audio/ogg", durationS: 5 },
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const cfg = baseConfig();
+    cfg.voice = {
+      provider: "azure_edge",
+      azure_edge: {
+        voice: "en-US-JennyNeural",
+        rate: "+0%",
+        pitch: "+0Hz",
+      },
+    };
+    await runTelegramServer({
+      config: cfg,
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]?.text).toContain("voice messages need");
   });
 });
 

--- a/tests/lib-audio.test.ts
+++ b/tests/lib-audio.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the TTS / STT dispatcher and provider implementations.
+ * Uses mocked fetch — no network calls.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  sttSupported,
+  synthesize,
+  transcribe,
+  ttsSupported,
+} from "../src/lib/audio.ts";
+import type { Config } from "../src/config.ts";
+
+const SAVED_ENV = {
+  PHANTOMBOT_OPENAI_API_KEY: process.env.PHANTOMBOT_OPENAI_API_KEY,
+  PHANTOMBOT_ELEVENLABS_API_KEY: process.env.PHANTOMBOT_ELEVENLABS_API_KEY,
+};
+
+beforeEach(() => {
+  delete process.env.PHANTOMBOT_OPENAI_API_KEY;
+  delete process.env.PHANTOMBOT_ELEVENLABS_API_KEY;
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(SAVED_ENV)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+function makeConfig(provider: Config["voice"]["provider"]): Config {
+  const base: Omit<Config, "voice"> = {
+    defaultPersona: "x",
+    turnTimeoutMs: 1,
+    personasDir: "/tmp",
+    memoryDbPath: "/tmp/m.sqlite",
+    configPath: "/tmp/c.toml",
+    harnesses: {
+      chain: [],
+      claude: { bin: "x", model: "y", fallbackModel: "" },
+      pi: { bin: "x", maxPayloadBytes: 1 },
+    },
+    channels: {},
+    embeddings: { provider: "none" },
+  };
+  if (provider === "elevenlabs") {
+    return {
+      ...base,
+      voice: {
+        provider: "elevenlabs",
+        elevenlabs: {
+          voiceId: "v",
+          modelId: "m",
+          stability: 1,
+          similarityBoost: 0.7,
+          style: 0.8,
+        },
+      },
+    };
+  }
+  if (provider === "openai") {
+    return {
+      ...base,
+      voice: {
+        provider: "openai",
+        openai: { model: "tts-1", voice: "nova", speed: 1 },
+      },
+    };
+  }
+  if (provider === "azure_edge") {
+    return {
+      ...base,
+      voice: {
+        provider: "azure_edge",
+        azure_edge: { voice: "en-US-JennyNeural", rate: "+0%", pitch: "+0Hz" },
+      },
+    };
+  }
+  return { ...base, voice: { provider: "none" } };
+}
+
+function fakeBytesFetch(bytes: Buffer, status = 200): typeof fetch {
+  return (async () =>
+    new Response(bytes, {
+      status,
+      headers: { "content-type": "audio/ogg" },
+    })) as unknown as typeof fetch;
+}
+
+function fakeJsonFetch(body: unknown, status = 200): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+describe("ttsSupported / sttSupported", () => {
+  test("none → both false", () => {
+    expect(ttsSupported(makeConfig("none"))).toBe(false);
+    expect(sttSupported(makeConfig("none"))).toBe(false);
+  });
+  test("azure_edge → tts true, stt false", () => {
+    expect(ttsSupported(makeConfig("azure_edge"))).toBe(true);
+    expect(sttSupported(makeConfig("azure_edge"))).toBe(false);
+  });
+  test("openai with key → both true", () => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "k";
+    expect(ttsSupported(makeConfig("openai"))).toBe(true);
+    expect(sttSupported(makeConfig("openai"))).toBe(true);
+  });
+  test("openai without key → both false", () => {
+    expect(ttsSupported(makeConfig("openai"))).toBe(false);
+    expect(sttSupported(makeConfig("openai"))).toBe(false);
+  });
+  test("elevenlabs with key → both true", () => {
+    process.env.PHANTOMBOT_ELEVENLABS_API_KEY = "k";
+    expect(ttsSupported(makeConfig("elevenlabs"))).toBe(true);
+    expect(sttSupported(makeConfig("elevenlabs"))).toBe(true);
+  });
+});
+
+describe("synthesize", () => {
+  test("elevenlabs returns ogg buffer on success", async () => {
+    process.env.PHANTOMBOT_ELEVENLABS_API_KEY = "k";
+    const fakeAudio = Buffer.from([1, 2, 3, 4, 5]);
+    const r = await synthesize(
+      makeConfig("elevenlabs"),
+      "hello",
+      fakeBytesFetch(fakeAudio),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.audio.mime).toBe("audio/ogg");
+      expect(r.audio.data).toEqual(fakeAudio);
+    }
+  });
+
+  test("openai returns ogg buffer on success", async () => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "k";
+    const fakeAudio = Buffer.from([7, 8, 9]);
+    const r = await synthesize(
+      makeConfig("openai"),
+      "hello",
+      fakeBytesFetch(fakeAudio),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  test("azure_edge → not implemented error (clear message)", async () => {
+    const r = await synthesize(makeConfig("azure_edge"), "hello");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("not implemented");
+  });
+
+  test("none → error", async () => {
+    const r = await synthesize(makeConfig("none"), "hello");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("none");
+  });
+
+  test("missing key → clear error", async () => {
+    const r = await synthesize(makeConfig("elevenlabs"), "hello");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("ElevenLabs API key");
+  });
+
+  test("HTTP 401 → error with status", async () => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "bad";
+    const r = await synthesize(
+      makeConfig("openai"),
+      "hello",
+      fakeBytesFetch(Buffer.from(""), 401),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("HTTP 401");
+  });
+});
+
+describe("transcribe", () => {
+  test("openai whisper returns text", async () => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "k";
+    const r = await transcribe(
+      makeConfig("openai"),
+      Buffer.from("audio bytes"),
+      "audio/ogg",
+      fakeJsonFetch({ text: "hello world" }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.text).toBe("hello world");
+  });
+
+  test("elevenlabs scribe returns text", async () => {
+    process.env.PHANTOMBOT_ELEVENLABS_API_KEY = "k";
+    const r = await transcribe(
+      makeConfig("elevenlabs"),
+      Buffer.from("audio"),
+      "audio/ogg",
+      fakeJsonFetch({ text: "transcript here" }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.text).toBe("transcript here");
+  });
+
+  test("azure_edge → STT not supported", async () => {
+    const r = await transcribe(
+      makeConfig("azure_edge"),
+      Buffer.from(""),
+      "audio/ogg",
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("not supported");
+  });
+
+  test("HTTP error returns clear message", async () => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "bad";
+    const r = await transcribe(
+      makeConfig("openai"),
+      Buffer.from(""),
+      "audio/ogg",
+      fakeJsonFetch({ error: { message: "bad" } }, 401),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("401");
+  });
+
+  test("response without text → error", async () => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "k";
+    const r = await transcribe(
+      makeConfig("openai"),
+      Buffer.from(""),
+      "audio/ogg",
+      fakeJsonFetch({}),
+    );
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

phantombot now actually speaks and listens through Telegram.

**Routing rule** (per spec):
- text in → harness → text out (unchanged)
- **voice in → STT → harness → TTS → voice out**
- voice in but no STT provider → friendly text reply, no harness call

**Provider locking** (per spec — same provider both directions):
| Voice config | STT | TTS |
|---|---|---|
| **elevenlabs** | Scribe (scribe_v1) | TTS (opus_48000_128 → OGG) |
| **openai** | Whisper-1 | TTS opus → OGG |
| **azure_edge** | not supported (text reply explaining) | not implemented yet (clear error) |
| **none** | not supported | not supported |

## What's new

- **\`src/lib/audio.ts\`** — \`synthesize()\` / \`transcribe()\` dispatchers + four provider implementations (raw HTTPS, no SDK). \`ttsSupported\` / \`sttSupported\` capability checks.
- **\`src/channels/telegram.ts\`** — \`TelegramMessage.voice\`, \`parseGetUpdatesResult\` extracts voice updates, \`HttpTelegramTransport\` adds \`sendVoice\` / \`sendRecording\` / \`downloadFile\`. \`runTelegramServer\` does the voice round-trip: download → STT → harness → TTS → sendVoice. The "typing…"/"recording…" indicator is refreshed every 4s based on which direction we'll reply.

## Test plan

- [x] \`bun test\` — 318 pass / 1 skip / 0 fail
- [x] \`bun tsc --noEmit\` — clean
- 19 new tests across \`tests/lib-audio.test.ts\` (provider gating, success, HTTP errors, network errors, missing key, missing text in response) and \`tests/channels-telegram.test.ts\` (voice-in/voice-out round-trip with mocked Whisper + OpenAI TTS; text-in-stays-text; voice-in-with-azure_edge → friendly refusal).

## Notes

- Azure Edge TTS deferred — the Microsoft Edge Read Aloud websocket protocol is well-known but ~150 lines of new code that nobody currently needs. ElevenLabs and OpenAI cover the user's actual use case. Stub error message is clear if anyone hits it.
- All audio formats normalized to \`audio/ogg\` with Opus codec for Telegram \`sendVoice\` compatibility.