### PR TITLE
fix: .env round-trip + chmod race in voice config

### DIFF
--- a/src/lib/envFile.ts
+++ b/src/lib/envFile.ts
@@ -13,7 +13,13 @@
  */
 
 import { existsSync } from "node:fs";
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { xdgConfigHome } from "../config.ts";
 
@@ -42,12 +48,23 @@ export async function saveEnvFile(
     if (!/^[A-Z_][A-Z0-9_]*$/i.test(k)) continue; // skip invalid keys silently
     lines.push(`${k}=${quote(v)}`);
   }
-  await writeFile(path, lines.join("\n") + "\n", "utf8");
-  // Best-effort permission lock — secrets file should not be world-readable.
+  // Write to a tempfile at mode 0o600 then atomically rename over the target.
+  // Avoids the chmod race where a fresh file is briefly world-readable at
+  // umask-default 0o644 between writeFile() and a follow-up chmod().
+  const tmp = `${path}.tmp`;
   try {
-    await chmod(path, 0o600);
-  } catch {
-    /* fine on filesystems that don't support chmod (e.g. some FUSE) */
+    await writeFile(tmp, lines.join("\n") + "\n", {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(tmp, path);
+  } catch (e) {
+    try {
+      await unlink(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw e;
   }
 }
 
@@ -77,10 +94,15 @@ export function parseEnv(text: string): EnvVars {
     if (eq <= 0) continue;
     const key = line.slice(0, eq).trim();
     let val = line.slice(eq + 1).trim();
-    if (
-      (val.startsWith('"') && val.endsWith('"')) ||
-      (val.startsWith("'") && val.endsWith("'"))
-    ) {
+    if (val.startsWith('"') && val.endsWith('"') && val.length >= 2) {
+      // Double-quoted: undo the escapes that quote() applies. Order matters:
+      // unescape \\ → \ first, then \" → ", so a literal `\"` two-char value
+      // (written as "\\\"") round-trips correctly without double-processing.
+      val = val
+        .slice(1, -1)
+        .replace(/\\\\/g, "\\")
+        .replace(/\\"/g, '"');
+    } else if (val.startsWith("'") && val.endsWith("'") && val.length >= 2) {
       val = val.slice(1, -1);
     }
     out[key] = val;

--- a/tests/lib-envFile.test.ts
+++ b/tests/lib-envFile.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -64,6 +71,46 @@ describe("saveEnvFile / loadEnvFile round-trip", () => {
 
   test("loadEnvFile returns {} when file is missing", async () => {
     expect(await loadEnvFile(envPath)).toEqual({});
+  });
+
+  test("round-trips a value containing a double-quote", async () => {
+    const value = 'has " quote';
+    await saveEnvFile(envPath, { X: value });
+    expect((await loadEnvFile(envPath)).X).toBe(value);
+  });
+
+  test("round-trips a value containing a backslash", async () => {
+    const value = "has \\ backslash";
+    await saveEnvFile(envPath, { X: value });
+    expect((await loadEnvFile(envPath)).X).toBe(value);
+  });
+
+  test("round-trips a value containing both \\ and \"", async () => {
+    const value = 'mix \\ and " here';
+    await saveEnvFile(envPath, { X: value });
+    expect((await loadEnvFile(envPath)).X).toBe(value);
+  });
+
+  test('round-trips the literal two-char sequence \\"', async () => {
+    const value = '\\"'; // backslash + double-quote (2 chars)
+    expect(value.length).toBe(2);
+    await saveEnvFile(envPath, { X: value });
+    expect((await loadEnvFile(envPath)).X).toBe(value);
+  });
+
+  test("updateEnvFile replaces a 0644 file with mode 0600 (no chmod race)", async () => {
+    // Pre-create the file at a world-readable mode to simulate the case
+    // where the previous saveEnvFile lost the race or an outside process
+    // wrote it. After updateEnvFile the final mode must be 0o600.
+    await writeFile(envPath, "OLD=1\n", { encoding: "utf8", mode: 0o644 });
+    await chmod(envPath, 0o644); // belt-and-braces in case umask masked it
+    expect((await stat(envPath)).mode & 0o077).not.toBe(0);
+
+    await updateEnvFile(envPath, { OLD: "2", NEW: "3" });
+
+    const s = await stat(envPath);
+    expect((s.mode & 0o777).toString(8)).toBe("600");
+    expect(await loadEnvFile(envPath)).toEqual({ OLD: "2", NEW: "3" });
   });
 });
 


### PR DESCRIPTION
## Summary

Two follow-ups from the Phase 29 review on PR #29 — both in `src/lib/envFile.ts`.

### 1. `.env` round-trip bug for values containing `"` or `\`

`quote()` escapes `"` → `\"` and `\` → `\\` when wrapping a value in double
quotes, but `parseEnv()` stripped the wrapping quotes **without** unescaping.
A value containing `"` could not survive a `saveEnvFile()` / `loadEnvFile()`
cycle.

Fix: in `parseEnv()`, after detecting a double-quoted value and slicing the
wrapping quotes, unescape `\\` → `\` then `\"` → `"`. Order matters so the
literal `\"` two-char value (written as `"\\\""`) isn't double-processed.
Single-quoted values are left as-is (no escape convention).

### 2. chmod race in `.env` write

`saveEnvFile()` previously did `writeFile(path, contents)` (creates at
umask-default `0o644`) then `chmod(path, 0o600)`. Tiny window where the
secrets file is world-readable.

Fix: write to `${path}.tmp` with `mode: 0o600` directly, then `rename` over
the target — atomic, no race. The follow-up `chmod` is gone.

## Test plan

- [x] `bun test tests/lib-envFile.test.ts` — 16 pass (5 new)
- [x] `bun tsc --noEmit` — clean
- [x] `bun test` — 323 pass / 1 skip / 0 fail

New tests:
- round-trip a value containing `"`
- round-trip a value containing `\`
- round-trip a value containing both `\` and `"`
- round-trip the literal two-char sequence `\"`
- `updateEnvFile` over a pre-existing 0o644 file ends with mode 0o600

## Out of scope (separate PRs)

- Hardcoded default voice ID
- OpenAI key validator hitting `/v1/models` instead of `/v1/audio/speech`