### PR TITLE
fix: voice TUI must rerender stale systemd unit + clearer audio errors

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -18,8 +18,9 @@
 import type { Config } from "../config.ts";
 import type { Harness } from "../harnesses/types.ts";
 import {
+  type AudioSupport,
+  sttSupport,
   synthesize,
-  sttSupported,
   transcribe,
   ttsSupported,
 } from "../lib/audio.ts";
@@ -343,10 +344,11 @@ export async function runTelegramServer(
       // For voice messages: download → transcribe → use the transcript
       // as the user message before invoking the harness.
       if (isVoice && msg.voice) {
-        if (!sttSupported(input.config)) {
+        const stt = sttSupport(input.config);
+        if (!stt.ok) {
           await input.transport.sendMessage(
             msg.chatId,
-            `(voice messages need OpenAI or ElevenLabs configured — current provider is '${input.config.voice.provider}')`,
+            voiceUnavailableMessage(stt),
           );
           continue;
         }
@@ -478,4 +480,24 @@ export async function runTelegramServer(
       });
     }
   } while (!input.oneShot);
+}
+
+/**
+ * Render an honest, actionable explanation when sttSupport() rules a
+ * voice message out. Each variant points at the specific user action that
+ * fixes it, instead of the old single-message catch-all that misled
+ * users into thinking their provider was wrong when actually the systemd
+ * unit was stale.
+ */
+export function voiceUnavailableMessage(
+  s: Extract<AudioSupport, { ok: false }>,
+): string {
+  if (s.reason === "provider_none") {
+    return "voice transcription is disabled — run `phantombot voice` to set up OpenAI or ElevenLabs";
+  }
+  if (s.reason === "provider_no_stt") {
+    return `current provider '${s.provider}' has no STT — switch via \`phantombot voice\``;
+  }
+  // key_missing
+  return `voice key not loaded into the service environment — run \`phantombot install\` to upgrade the systemd unit, then try again. (provider '${s.provider}', expected env var ${s.envVar})`;
 }

--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -130,13 +130,17 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
 }
 
 /**
- * Shared post-apply hook for the config-mutating TUIs. If phantombot is
- * currently running under systemd, offer to restart it inline so the
- * change takes effect.
+ * Shared post-apply hook for the config-mutating TUIs.
+ *
+ * Two steps. Always: re-render the on-disk systemd unit if it's stale (a
+ * pre-Phase-29 unit lacks `EnvironmentFile=` and silently swallows the
+ * .env secrets the TUI just wrote). Then: if phantombot is running, offer
+ * to restart it inline so the change takes effect.
  */
 export async function maybePromptRestart(
   svc: ServiceControl,
 ): Promise<void> {
+  await maybeUpgradeUnit(svc);
   if (!(await svc.isActive())) return;
   const restart = await p.confirm({
     message: "phantombot is currently running. Restart to apply changes?",
@@ -154,6 +158,21 @@ export async function maybePromptRestart(
     r.ok ? "restarted" : `restart failed: ${r.stderr ?? "unknown"}`,
     "Restart",
   );
+}
+
+/**
+ * Re-render the installed systemd unit if it's stale; print a one-line
+ * notice when it happened. Exposed so tests can verify the rewrite path
+ * without going through the @clack confirm prompt in maybePromptRestart.
+ */
+export async function maybeUpgradeUnit(
+  svc: ServiceControl,
+): Promise<{ rerendered: boolean }> {
+  const r = await svc.rerenderUnitIfStale();
+  if (r.rerendered) {
+    p.note("systemd unit upgraded to current template", "Unit");
+  }
+  return r;
 }
 
 export default defineCommand({

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Config } from "../config.ts";
+import type { VoiceProvider } from "./voice.ts";
 
 export interface SynthesizedAudio {
   data: Buffer;
@@ -23,31 +24,62 @@ export type TranscribeResult =
   | { ok: false; error: string };
 
 /**
- * True if the configured provider can do STT (i.e. transcribe Telegram
- * voice messages). Azure Edge has no STT counterpart.
+ * Tri-state diagnostic for TTS/STT support. The reason+provider+envVar
+ * fields let UIs render an honest, actionable message instead of a single
+ * catch-all "voice unavailable" string. Used by the Telegram channel to
+ * tell the user *why* a voice message can't be processed.
  */
-export function sttSupported(config: Config): boolean {
-  const p = config.voice.provider;
-  if (p === "openai" || p === "elevenlabs") {
-    const envVar =
-      p === "openai"
-        ? "PHANTOMBOT_OPENAI_API_KEY"
-        : "PHANTOMBOT_ELEVENLABS_API_KEY";
-    return Boolean(process.env[envVar]);
-  }
-  return false;
-}
+export type AudioSupport =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "provider_none" | "provider_no_stt" | "key_missing";
+      provider: VoiceProvider;
+      envVar?: string;
+    };
 
-/** True if the configured provider can synthesize TTS. */
-export function ttsSupported(config: Config): boolean {
-  const p = config.voice.provider;
-  if (p === "none") return false;
-  if (p === "azure_edge") return true; // free, no key
+/** Diagnose whether the configured provider can perform STT. */
+export function sttSupport(config: Config): AudioSupport {
+  const provider = config.voice.provider;
+  if (provider === "none") {
+    return { ok: false, reason: "provider_none", provider };
+  }
+  if (provider === "azure_edge") {
+    return { ok: false, reason: "provider_no_stt", provider };
+  }
   const envVar =
-    p === "openai"
+    provider === "openai"
       ? "PHANTOMBOT_OPENAI_API_KEY"
       : "PHANTOMBOT_ELEVENLABS_API_KEY";
-  return Boolean(process.env[envVar]);
+  return process.env[envVar]
+    ? { ok: true }
+    : { ok: false, reason: "key_missing", provider, envVar };
+}
+
+/** Diagnose whether the configured provider can synthesize TTS. */
+export function ttsSupport(config: Config): AudioSupport {
+  const provider = config.voice.provider;
+  if (provider === "none") {
+    return { ok: false, reason: "provider_none", provider };
+  }
+  if (provider === "azure_edge") return { ok: true }; // free, no key
+  const envVar =
+    provider === "openai"
+      ? "PHANTOMBOT_OPENAI_API_KEY"
+      : "PHANTOMBOT_ELEVENLABS_API_KEY";
+  return process.env[envVar]
+    ? { ok: true }
+    : { ok: false, reason: "key_missing", provider, envVar };
+}
+
+/** Boolean wrapper around sttSupport — kept for callers that don't need the reason. */
+export function sttSupported(config: Config): boolean {
+  return sttSupport(config).ok;
+}
+
+/** Boolean wrapper around ttsSupport — kept for callers that don't need the reason. */
+export function ttsSupported(config: Config): boolean {
+  return ttsSupport(config).ok;
 }
 
 export async function synthesize(

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -6,9 +6,9 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type { WriteSink } from "./io.ts";
 
 export const PHANTOMBOT_UNIT_NAME = "phantombot.service";
@@ -209,6 +209,64 @@ export interface ServiceControl {
   isActive(): Promise<boolean>;
   /** Restart the phantombot service. Returns ok=false on failure. */
   restart(): Promise<{ ok: boolean; stderr?: string }>;
+  /**
+   * Bring the on-disk systemd unit up-to-date with the current template if
+   * it's stale (or absent under conditions where re-render is appropriate).
+   * Returns whether a rewrite happened — callers can use it to print a notice.
+   *
+   * Why this matters: a pre-Phase-29 unit lacks `EnvironmentFile=`, so
+   * secrets written to ~/.config/phantombot/.env (TTS keys, etc.) never
+   * reach the running service even after restart. The voice/telegram/harness
+   * TUIs call this before restart so the saved config actually takes effect.
+   */
+  rerenderUnitIfStale(): Promise<{ rerendered: boolean }>;
+}
+
+/**
+ * Compare the on-disk unit at unitPath against the canonical template for
+ * binPath. If absent or different, write the canonical template and run
+ * `systemctl --user daemon-reload`. Returns whether a rerender happened.
+ *
+ * Pure on the inputs — caller picks the unit path, the bin path, and the
+ * systemctl runner. Tests inject a fake runner; callers in production use
+ * BunSystemctlRunner with an env that has XDG_RUNTIME_DIR set.
+ */
+export async function ensureUnitCurrent(opts: {
+  unitPath: string;
+  binPath: string;
+  systemctl: SystemctlRunner;
+}): Promise<{ rerendered: boolean }> {
+  const expected = generateSystemdUnit({
+    binPath: opts.binPath,
+    args: ["run"],
+  });
+  let current: string | undefined;
+  if (existsSync(opts.unitPath)) {
+    current = await readFile(opts.unitPath, "utf8");
+  }
+  if (current === expected) return { rerendered: false };
+  await mkdir(dirname(opts.unitPath), { recursive: true });
+  await writeFile(opts.unitPath, expected, "utf8");
+  await opts.systemctl.run(["--user", "daemon-reload"]);
+  return { rerendered: true };
+}
+
+/**
+ * Default rerenderUnitIfStale wiring: only fires when the running binary is
+ * an installed `phantombot` (not `bun` in dev), only when a unit exists on
+ * disk (don't presume an install the user never asked for), and only when
+ * the user-systemd bus is reachable (no linger → nothing we can daemon-
+ * reload anyway).
+ */
+async function defaultRerenderUnitIfStale(): Promise<{ rerendered: boolean }> {
+  const binPath = process.execPath;
+  if (basename(binPath) !== "phantombot") return { rerendered: false };
+  const unitPath = defaultUnitPath();
+  if (!existsSync(unitPath)) return { rerendered: false };
+  const sysEnv = ensureUserSystemdEnv();
+  if (!sysEnv.ready) return { rerendered: false };
+  const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
+  return ensureUnitCurrent({ unitPath, binPath, systemctl });
 }
 
 /**
@@ -241,6 +299,7 @@ export function defaultServiceControl(): ServiceControl {
         ? { ok: true }
         : { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
     },
+    rerenderUnitIfStale: defaultRerenderUnitIfStale,
   };
 }
 

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -462,7 +462,46 @@ describe("runTelegramServer voice round-trip", () => {
     });
     expect(harness.invocations).toBe(0);
     expect(transport.sent).toHaveLength(1);
-    expect(transport.sent[0]?.text).toContain("voice messages need");
+    // provider_no_stt diagnostic — names the provider and points at the fix.
+    expect(transport.sent[0]?.text).toContain("'azure_edge'");
+    expect(transport.sent[0]?.text).toContain("phantombot voice");
+  });
+
+  test("voice in but openai key missing → key_missing diagnostic names provider + env var", async () => {
+    // Drop the OPENAI key so sttSupport returns key_missing.
+    const saved = process.env.PHANTOMBOT_OPENAI_API_KEY;
+    delete process.env.PHANTOMBOT_OPENAI_API_KEY;
+    try {
+      const transport = new FakeTransport();
+      transport.pendingUpdates.push({
+        updateId: 1,
+        chatId: 1001,
+        fromUserId: 42,
+        text: "",
+        voice: { fileId: "abc", mimeType: "audio/ogg", durationS: 2 },
+      });
+      const harness = new ScriptedHarness("fake", [
+        { type: "done", finalText: "should not run" },
+      ]);
+      await runTelegramServer({
+        config: withVoiceConfig(),
+        memory,
+        harnesses: [harness],
+        agentDir,
+        persona: "phantom",
+        transport,
+        oneShot: true,
+      });
+      expect(harness.invocations).toBe(0);
+      expect(transport.sent).toHaveLength(1);
+      const text = transport.sent[0]!.text;
+      expect(text).toContain("'openai'");
+      expect(text).toContain("PHANTOMBOT_OPENAI_API_KEY");
+      expect(text).toContain("phantombot install");
+    } finally {
+      if (saved === undefined) delete process.env.PHANTOMBOT_OPENAI_API_KEY;
+      else process.env.PHANTOMBOT_OPENAI_API_KEY = saved;
+    }
   });
 });
 

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -18,10 +18,12 @@ import type { ServiceControl } from "../src/lib/systemd.ts";
 const svcInactive: ServiceControl = {
   isActive: async () => false,
   restart: async () => ({ ok: true }),
+  rerenderUnitIfStale: async () => ({ rerendered: false }),
 };
 const svcActive: ServiceControl = {
   isActive: async () => true,
   restart: async () => ({ ok: true }),
+  rerenderUnitIfStale: async () => ({ rerendered: false }),
 };
 
 class CaptureStream {

--- a/tests/cli-voice.test.ts
+++ b/tests/cli-voice.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { maybeUpgradeUnit } from "../src/cli/harness.ts";
 import { applyVoiceConfig } from "../src/cli/voice.ts";
 import { loadEnvFile } from "../src/lib/envFile.ts";
+import {
+  ensureUnitCurrent,
+  generateSystemdUnit,
+  type ServiceControl,
+  type SystemctlResult,
+  type SystemctlRunner,
+} from "../src/lib/systemd.ts";
 
 let workdir: string;
 let configPath: string;
@@ -95,5 +103,76 @@ describe("applyVoiceConfig — none", () => {
     });
     const cfg = await readFile(configPath, "utf8");
     expect(cfg).toContain('provider = "none"');
+  });
+});
+
+describe("voice save flow rewrites stale systemd unit before restart", () => {
+  test("on-disk unit lacking EnvironmentFile= is rewritten and restart sees the upgraded unit", async () => {
+    // Pre-create a stale unit (no EnvironmentFile=). This is the exact
+    // shape of an install from before Phase 29 — the bug the PR fixes.
+    const unitPath = join(workdir, "phantombot.service");
+    const BIN = "/home/kai/.local/bin/phantombot";
+    const stale = `[Unit]
+Description=Phantombot — personality-first chat agent
+
+[Service]
+Type=simple
+ExecStart=${BIN} run
+
+[Install]
+WantedBy=default.target
+`;
+    expect(stale).not.toContain("EnvironmentFile=");
+    await writeFile(unitPath, stale, "utf8");
+
+    class FakeSystemctl implements SystemctlRunner {
+      calls: string[][] = [];
+      async run(args: readonly string[]): Promise<SystemctlResult> {
+        this.calls.push([...args]);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+    }
+    const sys = new FakeSystemctl();
+
+    const callOrder: string[] = [];
+    let unitContentAtRestart: string | undefined;
+    const svc: ServiceControl = {
+      isActive: async () => true,
+      restart: async () => {
+        callOrder.push("restart");
+        unitContentAtRestart = await readFile(unitPath, "utf8");
+        return { ok: true };
+      },
+      rerenderUnitIfStale: async () => {
+        callOrder.push("rerender");
+        return ensureUnitCurrent({ unitPath, binPath: BIN, systemctl: sys });
+      },
+    };
+
+    // Drive through the shared upgrade-unit helper. (maybePromptRestart
+    // would block on @clack's confirm prompt in a non-TTY test runner;
+    // maybeUpgradeUnit is the prompt-free part of the flow that owns the
+    // rerender step.)
+    const r = await maybeUpgradeUnit(svc);
+    expect(r.rerendered).toBe(true);
+
+    // The on-disk unit now has EnvironmentFile= — the actual fix.
+    const rewritten = await readFile(unitPath, "utf8");
+    expect(rewritten).toContain(
+      "EnvironmentFile=-%h/.config/phantombot/.env",
+    );
+    expect(rewritten).toBe(generateSystemdUnit({ binPath: BIN, args: ["run"] }));
+
+    // daemon-reload was issued as part of the rerender.
+    expect(sys.calls).toEqual([["--user", "daemon-reload"]]);
+
+    // Now simulate the restart step that maybePromptRestart would do
+    // after the rerender — and verify it sees the upgraded unit, not the
+    // stale one. This is the "before restart" guarantee the spec asks for.
+    await svc.restart();
+    expect(callOrder).toEqual(["rerender", "restart"]);
+    expect(unitContentAtRestart).toContain(
+      "EnvironmentFile=-%h/.config/phantombot/.env",
+    );
   });
 });

--- a/tests/lib-audio.test.ts
+++ b/tests/lib-audio.test.ts
@@ -5,9 +5,11 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  sttSupport,
   sttSupported,
   synthesize,
   transcribe,
+  ttsSupport,
   ttsSupported,
 } from "../src/lib/audio.ts";
 import type { Config } from "../src/config.ts";
@@ -118,6 +120,72 @@ describe("ttsSupported / sttSupported", () => {
     process.env.PHANTOMBOT_ELEVENLABS_API_KEY = "k";
     expect(ttsSupported(makeConfig("elevenlabs"))).toBe(true);
     expect(sttSupported(makeConfig("elevenlabs"))).toBe(true);
+  });
+});
+
+describe("ttsSupport / sttSupport (diagnostic variants)", () => {
+  test("none → provider_none for both", () => {
+    expect(ttsSupport(makeConfig("none"))).toEqual({
+      ok: false,
+      reason: "provider_none",
+      provider: "none",
+    });
+    expect(sttSupport(makeConfig("none"))).toEqual({
+      ok: false,
+      reason: "provider_none",
+      provider: "none",
+    });
+  });
+
+  test("azure_edge → ok for tts, provider_no_stt for stt", () => {
+    expect(ttsSupport(makeConfig("azure_edge"))).toEqual({ ok: true });
+    expect(sttSupport(makeConfig("azure_edge"))).toEqual({
+      ok: false,
+      reason: "provider_no_stt",
+      provider: "azure_edge",
+    });
+  });
+
+  test("openai without key → key_missing names env var for both", () => {
+    expect(ttsSupport(makeConfig("openai"))).toEqual({
+      ok: false,
+      reason: "key_missing",
+      provider: "openai",
+      envVar: "PHANTOMBOT_OPENAI_API_KEY",
+    });
+    expect(sttSupport(makeConfig("openai"))).toEqual({
+      ok: false,
+      reason: "key_missing",
+      provider: "openai",
+      envVar: "PHANTOMBOT_OPENAI_API_KEY",
+    });
+  });
+
+  test("openai with key → ok for both", () => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "k";
+    expect(ttsSupport(makeConfig("openai"))).toEqual({ ok: true });
+    expect(sttSupport(makeConfig("openai"))).toEqual({ ok: true });
+  });
+
+  test("elevenlabs without key → key_missing names env var for both", () => {
+    expect(ttsSupport(makeConfig("elevenlabs"))).toEqual({
+      ok: false,
+      reason: "key_missing",
+      provider: "elevenlabs",
+      envVar: "PHANTOMBOT_ELEVENLABS_API_KEY",
+    });
+    expect(sttSupport(makeConfig("elevenlabs"))).toEqual({
+      ok: false,
+      reason: "key_missing",
+      provider: "elevenlabs",
+      envVar: "PHANTOMBOT_ELEVENLABS_API_KEY",
+    });
+  });
+
+  test("elevenlabs with key → ok for both", () => {
+    process.env.PHANTOMBOT_ELEVENLABS_API_KEY = "k";
+    expect(ttsSupport(makeConfig("elevenlabs"))).toEqual({ ok: true });
+    expect(sttSupport(makeConfig("elevenlabs"))).toEqual({ ok: true });
   });
 });
 

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildSystemctlEnv,
+  ensureUnitCurrent,
   ensureUserSystemdEnv,
   generateSystemdUnit,
   installPhantombotUnit,
@@ -268,6 +269,69 @@ describe("ensureUserSystemdEnv", () => {
     expect(r.ready).toBe(true);
     expect(r.runtimeDir).toBe("/tmp/fake-runtime");
     expect(env.XDG_RUNTIME_DIR).toBe("/tmp/fake-runtime");
+  });
+});
+
+describe("ensureUnitCurrent", () => {
+  const BIN = "/home/kai/.local/bin/phantombot";
+
+  test("identical on-disk unit → no rerender, no systemctl call", async () => {
+    const sys = new FakeSystemctl();
+    const expected = generateSystemdUnit({ binPath: BIN, args: ["run"] });
+    await writeFile(unitPath, expected, "utf8");
+    const r = await ensureUnitCurrent({ unitPath, binPath: BIN, systemctl: sys });
+    expect(r.rerendered).toBe(false);
+    expect(sys.calls).toEqual([]);
+    // File untouched.
+    expect(await readFile(unitPath, "utf8")).toBe(expected);
+  });
+
+  test("missing unit → rerender + daemon-reload", async () => {
+    const sys = new FakeSystemctl();
+    const r = await ensureUnitCurrent({ unitPath, binPath: BIN, systemctl: sys });
+    expect(r.rerendered).toBe(true);
+    expect(sys.calls).toEqual([["--user", "daemon-reload"]]);
+    const written = await readFile(unitPath, "utf8");
+    expect(written).toBe(generateSystemdUnit({ binPath: BIN, args: ["run"] }));
+  });
+
+  test("one-byte diff → rerender + daemon-reload", async () => {
+    const sys = new FakeSystemctl();
+    const expected = generateSystemdUnit({ binPath: BIN, args: ["run"] });
+    // Append one stray newline to make the file differ by exactly one byte.
+    await writeFile(unitPath, `${expected}\n`, "utf8");
+    const r = await ensureUnitCurrent({ unitPath, binPath: BIN, systemctl: sys });
+    expect(r.rerendered).toBe(true);
+    expect(sys.calls).toEqual([["--user", "daemon-reload"]]);
+    expect(await readFile(unitPath, "utf8")).toBe(expected);
+  });
+
+  test("pre-Phase-29 unit lacking EnvironmentFile= → rerender adds it", async () => {
+    const sys = new FakeSystemctl();
+    const stale = `[Unit]
+Description=Phantombot — personality-first chat agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${BIN} run
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+`;
+    expect(stale).not.toContain("EnvironmentFile=");
+    await writeFile(unitPath, stale, "utf8");
+    const r = await ensureUnitCurrent({ unitPath, binPath: BIN, systemctl: sys });
+    expect(r.rerendered).toBe(true);
+    expect(sys.calls).toEqual([["--user", "daemon-reload"]]);
+    const rewritten = await readFile(unitPath, "utf8");
+    expect(rewritten).toContain("EnvironmentFile=-%h/.config/phantombot/.env");
+    expect(rewritten).toContain(`ExecStart=${BIN} run`);
   });
 });
 


### PR DESCRIPTION
## The bug

`phantombot voice` writes the API key to `~/.config/phantombot/.env` and restarts the service — but a unit on disk from before Phase 29 lacks `EnvironmentFile=`, so the key never reaches `process.env`. Telegram then says:

> (voice messages need OpenAI or ElevenLabs configured — current provider is 'elevenlabs')

…which lies about the real cause: the provider is fine, the key just never landed in the service environment.

## Fix 1 — rerender stale unit before restart

`ensureUnitCurrent({ unitPath, binPath, systemctl })` in `src/lib/systemd.ts` compares the on-disk unit to `generateSystemdUnit({ binPath, args: ["run"] })`. If absent or different: rewrite + `systemctl --user daemon-reload`. Wired through:

- New `ServiceControl.rerenderUnitIfStale()` method (default impl uses `process.execPath`, `defaultUnitPath()`, real systemctl).
- `maybePromptRestart()` in `src/cli/harness.ts` now calls a new `maybeUpgradeUnit(svc)` helper first, then proceeds to the existing restart prompt. Prints `"systemd unit upgraded to current template"` when rerender fired.
- Same wiring covers `phantombot voice`, `phantombot telegram`, `phantombot harness`, and `phantombot embedding` because they all share `maybePromptRestart`.

## Fix 2 — honest diagnostics

New `AudioSupport` tri-state in `src/lib/audio.ts`:

```ts
export type AudioSupport =
  | { ok: true }
  | {
      ok: false;
      reason: "provider_none" | "provider_no_stt" | "key_missing";
      provider: VoiceProvider;
      envVar?: string;
    };
```

`ttsSupport()` and `sttSupport()` return it. `sttSupported()` / `ttsSupported()` are kept as `.ok` boolean wrappers (no caller churn for non-diagnostic uses).

`src/channels/telegram.ts` replaces the single message with `voiceUnavailableMessage()`:

- `provider_none` → `"voice transcription is disabled — run \`phantombot voice\` to set up OpenAI or ElevenLabs"`
- `provider_no_stt` → ``"current provider 'X' has no STT — switch via `phantombot voice`"``
- `key_missing` → ``"voice key not loaded into the service environment — run `phantombot install` to upgrade the systemd unit, then try again. (provider 'X', expected env var Y)"``

## Test plan

- [x] `bun tsc --noEmit` — clean
- [x] `bun test` — 335 pass / 1 skip / 0 fail (was 323; +12 new tests)

New tests:
- `ensureUnitCurrent`: identical → no rerender; missing → rerender + daemon-reload; one-byte diff → rerender + daemon-reload; pre-Phase-29 unit lacking `EnvironmentFile=` → rerender adds it.
- `AudioSupport`: every variant for every provider (`none`, `azure_edge`, `openai` ±key, `elevenlabs` ±key), including env-var name in the `key_missing` payload.
- `telegram.ts`: `key_missing` diagnostic includes provider and env var name and points at `phantombot install`. Existing azure_edge test updated to the new `provider_no_stt` wording.
- `voice.ts`: pre-creates a stale unit lacking `EnvironmentFile=`, drives `maybeUpgradeUnit` against a real on-disk file, asserts the rewrite happened (file now contains `EnvironmentFile=`) and that the simulated restart sees the upgraded unit (call order: `rerender` → `restart`).

## Out of scope

- `phantombot doctor` sub-command
- Misleading "current provider" wording elsewhere