### PR TITLE
ci: GitHub Releases pipeline + baseline x64 build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release on PR merge
+
+# Fires for every PR merged into main. Cuts a GitHub Release tagged
+# v1.0.<PR_NUMBER> with two cross-compiled binaries (x64-baseline + arm64)
+# and a SHA256SUMS file. `phantombot update` reads this feed.
+#
+# Why every PR (not manual tags): the user runs `phantombot update --force
+# --restart` from cron and wants always-fresh binaries. If a PR shouldn't
+# release, we'll add a `release:skip` label gate later.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write   # create release + upload assets
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun tsc --noEmit
+
+      - name: Test
+        run: bun test
+
+      - name: Compute version + bake into src/version.ts
+        id: version
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          VERSION="1.0.${PR_NUMBER}"
+          TAG="v${VERSION}"
+          printf 'export const VERSION = "%s";\n' "$VERSION" > src/version.ts
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build x64 (baseline — no AVX2 required)
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          mkdir -p dist
+          bun build --compile --target=bun-linux-x64-baseline \
+            ./src/index.ts \
+            --outfile "dist/phantombot-${TAG}-linux-x64"
+
+      - name: Build arm64
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          bun build --compile --target=bun-linux-arm64 \
+            ./src/index.ts \
+            --outfile "dist/phantombot-${TAG}-linux-arm64"
+
+      - name: Compute SHA256SUMS
+        working-directory: dist
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          sha256sum "phantombot-${TAG}-linux-x64" "phantombot-${TAG}-linux-arm64" > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Create GitHub Release with binary assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "Automated release for PR #${PR_NUMBER}: ${PR_TITLE}
+
+            Binaries:
+            - phantombot-${TAG}-linux-x64 — x86-64, baseline (no AVX2 required)
+            - phantombot-${TAG}-linux-arm64 — ARM64
+
+            Verify with: sha256sum -c SHA256SUMS
+
+            Install with: phantombot update" \
+            "dist/phantombot-${TAG}-linux-x64" \
+            "dist/phantombot-${TAG}-linux-arm64" \
+            "dist/SHA256SUMS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,24 +77,37 @@ jobs:
           sha256sum "phantombot-${TAG}-linux-x64" "phantombot-${TAG}-linux-arm64" > SHA256SUMS
           cat SHA256SUMS
 
-      - name: Create GitHub Release with binary assets
+      - name: Write release notes to file
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          cat > release-notes.md <<EOF
+          Automated release for PR #${PR_NUMBER}: ${PR_TITLE}
+
+          Binaries:
+          - phantombot-${TAG}-linux-x64 — x86-64, baseline (no AVX2 required)
+          - phantombot-${TAG}-linux-arm64 — ARM64
+
+          Verify with: sha256sum -c SHA256SUMS
+
+          Install with: phantombot update
+          EOF
+
+      - name: Create GitHub Release with binary assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # --target pins the git tag to the merge commit we built from.
+          # Without it, a second PR landing mid-workflow would shift the
+          # tag onto the wrong sha (binaries would still be correct, but
+          # `git checkout v1.0.N` would lie about what code is in there).
           gh release create "$TAG" \
+            --target "${{ github.event.pull_request.merge_commit_sha }}" \
             --title "$TAG" \
-            --notes "Automated release for PR #${PR_NUMBER}: ${PR_TITLE}
-
-            Binaries:
-            - phantombot-${TAG}-linux-x64 — x86-64, baseline (no AVX2 required)
-            - phantombot-${TAG}-linux-arm64 — ARM64
-
-            Verify with: sha256sum -c SHA256SUMS
-
-            Install with: phantombot update" \
+            --notes-file release-notes.md \
             "dist/phantombot-${TAG}-linux-x64" \
             "dist/phantombot-${TAG}-linux-arm64" \
             "dist/SHA256SUMS"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "dev": "bun --watch src/index.ts",
     "test": "bun test",
     "typecheck": "bun tsc --noEmit",
-    "build": "mkdir -p dist && bun build --compile --target=bun-linux-x64 ./src/index.ts --outfile dist/phantombot"
+    "build": "bun run build:x64",
+    "build:x64": "mkdir -p dist && bun build --compile --target=bun-linux-x64-baseline ./src/index.ts --outfile dist/phantombot",
+    "build:arm64": "mkdir -p dist && bun build --compile --target=bun-linux-arm64 ./src/index.ts --outfile dist/phantombot-arm64"
   },
   "dependencies": {
     "@clack/prompts": "^1.3.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@
  */
 
 import { defineCommand } from "citty";
+import { VERSION } from "../version.ts";
 import importPersonaCmd from "./import-persona.ts";
 import createPersonaCmd from "./create-persona.ts";
 import telegramCmd from "./telegram.ts";
@@ -30,7 +31,7 @@ import voiceCmd from "./voice.ts";
 export const mainCommand = defineCommand({
   meta: {
     name: "phantombot",
-    version: "0.1.0",
+    version: VERSION,
     description:
       "Personality-first chat agent CLI. Wraps Claude Code and Pi CLIs with persona, memory, and a Telegram bot front-end.",
   },

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,14 @@
+/**
+ * The single source of truth for phantombot's version string.
+ *
+ * Local development always reports the `-dev` suffix. CI overwrites this
+ * file before `bun build --compile` with `1.0.<PR_NUMBER>` so the binary
+ * baked into a GitHub Release prints its real version. See
+ * .github/workflows/release.yml.
+ *
+ * `phantombot update` reads VERSION from this constant to decide whether
+ * a newer release is available, so anything that bakes a wrong value
+ * here will produce wrong update prompts.
+ */
+
+export const VERSION = "0.1.0-dev";


### PR DESCRIPTION
## Summary

Sets up the release feed `phantombot update` (PR B) will consume, and fixes the build-target bug that broke this morning's deploy to kai.

### What changes

- **`package.json`**: build script now targets `bun-linux-x64-baseline` (was plain `bun-linux-x64`). The supervisor box that runs kai is pre-AVX2 silicon — the non-baseline binary SIGILL'd on launch. Splits into `build:x64`, `build:arm64`, and `build` alias for `build:x64`.
- **`.github/workflows/release.yml`**: fires on every PR merge to `main`. Typecheck + test gate, then cross-compiles `bun-linux-x64-baseline` and `bun-linux-arm64` from a single `ubuntu-latest` runner (Bun cross-targets natively — no ARM runner needed). Publishes both binaries + `SHA256SUMS` to a GitHub Release tagged `v1.0.<PR_NUMBER>`.
- **`src/version.ts`**: single source of truth for the version string. `0.1.0-dev` in tree; CI overwrites with `1.0.<PR_NUMBER>` before build. Citty meta reads it.

### Versioning

Per request: `1.0.<PR_NUMBER>`. So when this PR merges as PR #N, the first release is `v1.0.N` — and the workflow's own self-test.

### Asset naming

- `phantombot-v1.0.N-linux-x64`
- `phantombot-v1.0.N-linux-arm64`
- `SHA256SUMS`

### Why every PR

Cron-friendly philosophy: `phantombot update --force --restart` (coming in PR B) wants always-fresh artifacts. If trivial PRs become noise we'll add a `release:skip` label gate later.

## Test plan

- [x] `bun tsc --noEmit` clean
- [x] `bun test` — 335 pass / 1 skip / 0 fail (no tests added; pipeline is exercised by its own merge)
- [x] Local `bun run build` produces `dist/phantombot` reporting `0.1.0-dev`
- [ ] **Self-test on merge**: workflow run produces `v1.0.<this PR number>` with both binaries + checksums

## Out of scope (PR B)

- `phantombot update` command + TUI + `--check` / `--force` / `--restart` flags
- Cron-friendly arch auto-detect (`process.arch` → asset suffix)
- SHA256 verification of downloaded binary before atomic swap