### PR TITLE
ci: pre-create ~/.config/systemd/user before tests (hotfix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,12 @@ jobs:
       # heartbeat/nightly unit files to a hardcoded ~/.config/systemd/user/
       # path even when tests pass an isolated tmpdir for the main unit. The
       # dir exists on a developer's box but not on a fresh runner, so writeFile
-      # fails with ENOENT. Pre-creating the dir unblocks the pipeline; the
-      # proper fix (parameterizing the helper paths) is tracked as a follow-up.
-      - name: Pre-create ~/.config/systemd/user (hotfix; see issue tracker)
-        run: mkdir -p "$HOME/.config/systemd/user"
+      # fails with ENOENT. The pollution side of the same bug (real files left
+      # behind in dev `~/.config/systemd/user/` after every `bun test` run) is
+      # tracked separately. When the proper fix lands, delete this step.
+      # Tracked: https://github.com/andrewagrahamhodges/phantombot/issues/44
+      - name: Pre-create ~/.config/systemd/user (hotfix; see #44)
+        run: mkdir -p "${HOME:?HOME unset}/.config/systemd/user"
 
       - name: Test
         run: bun test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,15 @@ jobs:
       - name: Typecheck
         run: bun tsc --noEmit
 
+      # Hotfix for a latent test-isolation bug: installPhantombotUnit writes
+      # heartbeat/nightly unit files to a hardcoded ~/.config/systemd/user/
+      # path even when tests pass an isolated tmpdir for the main unit. The
+      # dir exists on a developer's box but not on a fresh runner, so writeFile
+      # fails with ENOENT. Pre-creating the dir unblocks the pipeline; the
+      # proper fix (parameterizing the helper paths) is tracked as a follow-up.
+      - name: Pre-create ~/.config/systemd/user (hotfix; see issue tracker)
+        run: mkdir -p "$HOME/.config/systemd/user"
+
       - name: Test
         run: bun test
 


### PR DESCRIPTION
## What

Adds one workflow step before `bun test`:

```yaml
- name: Pre-create ~/.config/systemd/user (hotfix; see #44)
  run: mkdir -p "${HOME:?HOME unset}/.config/systemd/user"
```

## Why

PR #37 merged successfully but its self-test workflow run **failed** — 4 install tests blew up on the GH runner that pass cleanly locally:

- `installPhantombotUnit > writes the unit file and runs daemon-reload, enable, start`
- `installPhantombotUnit > aborts on systemctl failure`
- `runInstall > auto-set message printed when systemd env is auto-detected`
- `runInstall > happy path writes unit + runs reload/enable/start, returns 0`

Root cause (per review of `src/lib/systemd.ts`): `installPhantombotUnit` honors `opts.unitPath` for the main unit but unconditionally calls `heartbeatServicePath()` etc. — those four functions all hardcode `homedir() + .config/systemd/user/...`. Tests only set `unitPath` (in `mkdtemp`), so the heartbeat/nightly writes leak to the real home dir. That dir exists on dev boxes but not on a fresh GitHub runner.

Net effect today: **no `v1.0.37` release was produced**. PRs #38–#42 won't auto-release either if not fixed.

## Why a hotfix instead of the proper fix

The proper fix is to parameterize `heartbeatServicePath` etc. in `InstallOptions` so tests can pass tmpdir paths — and stop polluting dev machines too. Tracked as **#44**. Done as a separate PR so the release pipeline isn't blocked while we get the refactor right.

## Test plan

- [x] `bun tsc --noEmit` clean
- [x] `bun test` — 335 pass / 1 skip / 0 fail (the hotfix doesn't change runtime behavior, only the CI environment)
- [ ] **Self-test on merge**: workflow run produces `v1.0.<this PR number>` with both binaries + checksums

## Follow-up

- **#44** — installPhantombotUnit pollutes real ~/.config/systemd/user/ during tests (proper fix; deletes this hotfix step in the same PR)