### PR TITLE
chore: clear seven open follow-ups (#34, #36, #38, #39, #40, #41, #44)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ name: Release on PR merge
 # Why every PR (not manual tags): the user runs `phantombot update --force
 # --restart` from cron and wants always-fresh binaries. If a PR shouldn't
 # release, we'll add a `release:skip` label gate later.
+#
+# Why bun-linux-x64-baseline (and not plain bun-linux-x64): one of the
+# deploy targets (the `kw-openclaw` supervisor box that runs kai) is older
+# silicon without AVX2. The non-baseline target SIGILLs on launch there.
+# Don't 'optimise' to plain x64 without verifying every deploy target has
+# AVX2 — see the SIGILL post-mortem from the May 2026 first deploy.
 
 on:
   pull_request:
@@ -30,24 +36,17 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned to a major to keep releases reproducible. A point-release
+          # regression in `bun --compile` would otherwise silently break
+          # every PR merge until upstream ships a fix, and historical
+          # binaries wouldn't carry a recoverable build-toolchain version.
+          bun-version: 1.x
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Typecheck
         run: bun tsc --noEmit
-
-      # Hotfix for a latent test-isolation bug: installPhantombotUnit writes
-      # heartbeat/nightly unit files to a hardcoded ~/.config/systemd/user/
-      # path even when tests pass an isolated tmpdir for the main unit. The
-      # dir exists on a developer's box but not on a fresh runner, so writeFile
-      # fails with ENOENT. The pollution side of the same bug (real files left
-      # behind in dev `~/.config/systemd/user/` after every `bun test` run) is
-      # tracked separately. When the proper fix lands, delete this step.
-      # Tracked: https://github.com/andrewagrahamhodges/phantombot/issues/44
-      - name: Pre-create ~/.config/systemd/user (hotfix; see #44)
-        run: mkdir -p "${HOME:?HOME unset}/.config/systemd/user"
 
       - name: Test
         run: bun test
@@ -59,7 +58,15 @@ jobs:
         run: |
           VERSION="1.0.${PR_NUMBER}"
           TAG="v${VERSION}"
-          printf 'export const VERSION = "%s";\n' "$VERSION" > src/version.ts
+          # Replace only the literal placeholder so the doc comment in
+          # src/version.ts (and any future sibling const) survives. The
+          # placeholder must round-trip exactly; see the file's comment.
+          sed -i "s/0.1.0-dev/${VERSION}/" src/version.ts
+          # Sanity check: the constant must now match VERSION exactly,
+          # otherwise the binary would lie about its own version and
+          # phantombot update would loop.
+          grep -q "VERSION = \"${VERSION}\"" src/version.ts \
+            || { echo "version injection failed"; cat src/version.ts; exit 1; }
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -162,15 +162,19 @@ export async function maybePromptRestart(
 
 /**
  * Re-render the installed systemd unit if it's stale; print a one-line
- * notice when it happened. Exposed so tests can verify the rewrite path
- * without going through the @clack confirm prompt in maybePromptRestart.
+ * notice when it happened (and surface the backup path so a hand-edit is
+ * recoverable). Exposed so tests can verify the rewrite path without
+ * going through the @clack confirm prompt in maybePromptRestart.
  */
 export async function maybeUpgradeUnit(
   svc: ServiceControl,
-): Promise<{ rerendered: boolean }> {
+): Promise<{ rerendered: boolean; backupPath?: string }> {
   const r = await svc.rerenderUnitIfStale();
   if (r.rerendered) {
-    p.note("systemd unit upgraded to current template", "Unit");
+    const note = r.backupPath
+      ? `systemd unit upgraded to current template\nprevious contents saved to ${r.backupPath}`
+      : "systemd unit upgraded to current template";
+    p.note(note, "Unit");
   }
   return r;
 }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -26,6 +26,16 @@ import type { WriteSink } from "../lib/io.ts";
 export interface RunInstallInput {
   binPath?: string;
   unitPath?: string;
+  /**
+   * Optional path overrides for the heartbeat/nightly companion units —
+   * pass-through to installPhantombotUnit. Tests use these to keep all
+   * unit writes inside a tmpdir; production leaves them undefined and
+   * the helper picks the per-user XDG locations.
+   */
+  heartbeatServicePath?: string;
+  heartbeatTimerPath?: string;
+  nightlyServicePath?: string;
+  nightlyTimerPath?: string;
   out?: WriteSink;
   err?: WriteSink;
   /** Override systemctl runner for testing. */
@@ -67,6 +77,10 @@ export async function runInstall(input: RunInstallInput = {}): Promise<number> {
   const result = await installPhantombotUnit({
     binPath,
     unitPath,
+    heartbeatServicePath: input.heartbeatServicePath,
+    heartbeatTimerPath: input.heartbeatTimerPath,
+    nightlyServicePath: input.nightlyServicePath,
+    nightlyTimerPath: input.nightlyTimerPath,
     systemctl,
     out,
     err,

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -24,19 +24,17 @@ export type TranscribeResult =
   | { ok: false; error: string };
 
 /**
- * Tri-state diagnostic for TTS/STT support. The reason+provider+envVar
- * fields let UIs render an honest, actionable message instead of a single
- * catch-all "voice unavailable" string. Used by the Telegram channel to
- * tell the user *why* a voice message can't be processed.
+ * Tri-state diagnostic for TTS/STT support. Each `{ ok: false }` variant
+ * carries exactly the fields its reason needs — `envVar` is required on
+ * `key_missing` and absent on the other two — so consumers can render an
+ * honest, actionable message without `??` defenses against malformed
+ * payloads.
  */
 export type AudioSupport =
   | { ok: true }
-  | {
-      ok: false;
-      reason: "provider_none" | "provider_no_stt" | "key_missing";
-      provider: VoiceProvider;
-      envVar?: string;
-    };
+  | { ok: false; reason: "provider_none"; provider: VoiceProvider }
+  | { ok: false; reason: "provider_no_stt"; provider: VoiceProvider }
+  | { ok: false; reason: "key_missing"; provider: VoiceProvider; envVar: string };
 
 /** Diagnose whether the configured provider can perform STT. */
 export function sttSupport(config: Config): AudioSupport {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -219,23 +219,31 @@ export interface ServiceControl {
    * reach the running service even after restart. The voice/telegram/harness
    * TUIs call this before restart so the saved config actually takes effect.
    */
-  rerenderUnitIfStale(): Promise<{ rerendered: boolean }>;
+  rerenderUnitIfStale(): Promise<{ rerendered: boolean; backupPath?: string }>;
 }
 
 /**
  * Compare the on-disk unit at unitPath against the canonical template for
  * binPath. If absent or different, write the canonical template and run
- * `systemctl --user daemon-reload`. Returns whether a rerender happened.
+ * `systemctl --user daemon-reload`. Returns whether a rerender happened
+ * and, if it did, the path of any backup written.
  *
  * Pure on the inputs — caller picks the unit path, the bin path, and the
  * systemctl runner. Tests inject a fake runner; callers in production use
  * BunSystemctlRunner with an env that has XDG_RUNTIME_DIR set.
+ *
+ * Backup behaviour: when an existing unit differs from the template,
+ * its old contents are saved to `${unitPath}.bak` *before* we overwrite,
+ * so a hand-edit (which the user really shouldn't be doing — phantombot
+ * owns this file) is recoverable instead of silently lost. The .bak path
+ * is returned so callers can surface it. A fresh install (current === undefined)
+ * has nothing to back up; in that case backupPath is undefined.
  */
 export async function ensureUnitCurrent(opts: {
   unitPath: string;
   binPath: string;
   systemctl: SystemctlRunner;
-}): Promise<{ rerendered: boolean }> {
+}): Promise<{ rerendered: boolean; backupPath?: string }> {
   const expected = generateSystemdUnit({
     binPath: opts.binPath,
     args: ["run"],
@@ -246,9 +254,14 @@ export async function ensureUnitCurrent(opts: {
   }
   if (current === expected) return { rerendered: false };
   await mkdir(dirname(opts.unitPath), { recursive: true });
+  let backupPath: string | undefined;
+  if (current !== undefined) {
+    backupPath = `${opts.unitPath}.bak`;
+    await writeFile(backupPath, current, "utf8");
+  }
   await writeFile(opts.unitPath, expected, "utf8");
   await opts.systemctl.run(["--user", "daemon-reload"]);
-  return { rerendered: true };
+  return { rerendered: true, backupPath };
 }
 
 /**
@@ -258,7 +271,10 @@ export async function ensureUnitCurrent(opts: {
  * the user-systemd bus is reachable (no linger → nothing we can daemon-
  * reload anyway).
  */
-async function defaultRerenderUnitIfStale(): Promise<{ rerendered: boolean }> {
+async function defaultRerenderUnitIfStale(): Promise<{
+  rerendered: boolean;
+  backupPath?: string;
+}> {
   const binPath = process.execPath;
   if (basename(binPath) !== "phantombot") return { rerendered: false };
   const unitPath = defaultUnitPath();
@@ -306,6 +322,17 @@ export function defaultServiceControl(): ServiceControl {
 export interface InstallOptions {
   binPath: string;
   unitPath: string;
+  /**
+   * Optional path overrides for the heartbeat/nightly companion units.
+   * Default to the per-user XDG locations (~/.config/systemd/user/...).
+   * Tests override these to keep writes inside a tmpdir; without that,
+   * `bun test` would create real files in the developer's actual
+   * ~/.config/systemd/user/ that the test cleanup never removes.
+   */
+  heartbeatServicePath?: string;
+  heartbeatTimerPath?: string;
+  nightlyServicePath?: string;
+  nightlyTimerPath?: string;
   systemctl: SystemctlRunner;
   out: WriteSink;
   err: WriteSink;
@@ -320,15 +347,19 @@ export async function installPhantombotUnit(
   opts.out.write(`wrote unit file: ${opts.unitPath}\n`);
 
   // Heartbeat service + timer
-  const hbService = heartbeatServicePath();
-  const hbTimer = heartbeatTimerPath();
+  const hbService = opts.heartbeatServicePath ?? heartbeatServicePath();
+  const hbTimer = opts.heartbeatTimerPath ?? heartbeatTimerPath();
+  await mkdir(dirname(hbService), { recursive: true });
+  await mkdir(dirname(hbTimer), { recursive: true });
   await writeFile(hbService, generateHeartbeatService(opts.binPath), "utf8");
   await writeFile(hbTimer, generateHeartbeatTimer(), "utf8");
   opts.out.write(`wrote heartbeat units: ${hbService} + ${hbTimer}\n`);
 
   // Nightly service + timer
-  const ngService = nightlyServicePath();
-  const ngTimer = nightlyTimerPath();
+  const ngService = opts.nightlyServicePath ?? nightlyServicePath();
+  const ngTimer = opts.nightlyTimerPath ?? nightlyTimerPath();
+  await mkdir(dirname(ngService), { recursive: true });
+  await mkdir(dirname(ngTimer), { recursive: true });
   await writeFile(ngService, generateNightlyService(opts.binPath), "utf8");
   await writeFile(ngTimer, generateNightlyTimer(), "utf8");
   opts.out.write(`wrote nightly units: ${ngService} + ${ngTimer}\n`);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,10 +1,23 @@
 /**
  * The single source of truth for phantombot's version string.
  *
- * Local development always reports the `-dev` suffix. CI overwrites this
- * file before `bun build --compile` with `1.0.<PR_NUMBER>` so the binary
- * baked into a GitHub Release prints its real version. See
- * .github/workflows/release.yml.
+ * Local development always reports the `-dev` suffix. CI replaces the
+ * literal `0.1.0-dev` below with `1.0.<PR_NUMBER>` (sed, not full-file
+ * overwrite — see .github/workflows/release.yml) before
+ * `bun build --compile`, so the released binary prints its real version.
+ *
+ * **Versioning scheme is intentionally NOT semver.** `1.0.<PR_NUMBER>`
+ * uses the GitHub PR number as the patch component because every merged
+ * PR auto-releases. There is no path to bumping major or minor without
+ * breaking the scheme, and PR-numbered patches are not ordered by
+ * semantic impact (1.0.42 is a "patch" of 1.0.41 only by coincidence).
+ * Don't bolt semver-aware logic onto `phantombot update` (e.g. "this
+ * is a major upgrade, read the release notes first") — the version
+ * string can't carry that information here.
+ *
+ * **Contract for the placeholder**: the literal `"0.1.0-dev"` below
+ * must round-trip exactly. The CI sed substitution targets that string;
+ * if you change the literal, also change the sed pattern.
  *
  * `phantombot update` reads VERSION from this constant to decide whether
  * a newer release is available, so anything that bakes a wrong value

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -37,10 +37,24 @@ class CaptureStream {
 
 let workdir: string;
 let unitPath: string;
+let installPaths: {
+  heartbeatServicePath: string;
+  heartbeatTimerPath: string;
+  nightlyServicePath: string;
+  nightlyTimerPath: string;
+};
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-install-"));
   unitPath = join(workdir, "phantombot.service");
+  // Without these, runInstall would write the heartbeat/nightly units
+  // into the real ~/.config/systemd/user/ on the test runner — see #44.
+  installPaths = {
+    heartbeatServicePath: join(workdir, "phantombot-heartbeat.service"),
+    heartbeatTimerPath: join(workdir, "phantombot-heartbeat.timer"),
+    nightlyServicePath: join(workdir, "phantombot-nightly.service"),
+    nightlyTimerPath: join(workdir, "phantombot-nightly.timer"),
+  };
 });
 
 afterEach(async () => {
@@ -105,6 +119,7 @@ describe("runInstall", () => {
     const code = await runInstall({
       binPath: "/usr/local/bin/phantombot",
       unitPath,
+      ...installPaths,
       systemctl: sys,
       out,
       err,
@@ -123,6 +138,7 @@ describe("runInstall", () => {
     const code = await runInstall({
       binPath: "/usr/local/bin/phantombot",
       unitPath,
+      ...installPaths,
       systemctl: sys,
       out,
       err,

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -45,10 +45,32 @@ class CaptureStream {
 
 let workdir: string;
 let unitPath: string;
+let hbServicePath: string;
+let hbTimerPath: string;
+let ngServicePath: string;
+let ngTimerPath: string;
+
+/**
+ * Build the four heartbeat/nightly path overrides every install test
+ * needs. Without these, installPhantombotUnit would write to the real
+ * ~/.config/systemd/user/ on the test runner — the bug fixed in #44.
+ */
+function tmpInstallPaths() {
+  return {
+    heartbeatServicePath: hbServicePath,
+    heartbeatTimerPath: hbTimerPath,
+    nightlyServicePath: ngServicePath,
+    nightlyTimerPath: ngTimerPath,
+  };
+}
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-systemd-"));
   unitPath = join(workdir, "phantombot.service");
+  hbServicePath = join(workdir, "phantombot-heartbeat.service");
+  hbTimerPath = join(workdir, "phantombot-heartbeat.timer");
+  ngServicePath = join(workdir, "phantombot-nightly.service");
+  ngTimerPath = join(workdir, "phantombot-nightly.timer");
 });
 
 afterEach(async () => {
@@ -86,6 +108,7 @@ describe("installPhantombotUnit", () => {
     const result = await installPhantombotUnit({
       binPath: "/usr/local/bin/phantombot",
       unitPath,
+      ...tmpInstallPaths(),
       systemctl: sys,
       out,
       err,
@@ -118,6 +141,7 @@ describe("installPhantombotUnit", () => {
     const result = await installPhantombotUnit({
       binPath: "/usr/local/bin/phantombot",
       unitPath,
+      ...tmpInstallPaths(),
       systemctl: sys,
       out,
       err,


### PR DESCRIPTION
Bundles every open follow-up issue from PR #29 / #33 / #37 reviews into one PR. Each fix is small and uncontroversial; bundling avoids spamming the release queue with seven trivial single-issue merges.

## Closes

- **#34** — \`ensureUnitCurrent\` stashes \`.bak\` before overwriting + surfaces the path
- **#36** — \`AudioSupport\` narrowed to a per-reason discriminated union
- **#38** — release.yml pins \`bun-version: 1.x\`
- **#39** — release.yml uses \`sed -i\` instead of full-file \`printf >\`; preserves the comment block
- **#40** — \`src/version.ts\` doc explicitly says the scheme isn't semver
- **#41** — release.yml top comment explains *why* baseline-x64 is mandatory
- **#44** — \`InstallOptions\` accepts optional heartbeat/nightly path overrides; tests use tmpdir paths; the \`mkdir -p ~/.config/systemd/user\` hotfix step is removed

## Test plan

- [x] \`bun tsc --noEmit\` clean
- [x] \`bun test\` — 335 pass / 1 skip / 0 fail (no regressions; existing diagnostic tests still cover the narrowed \`AudioSupport\` shape)
- [x] Verified my real \`~/.config/systemd/user/\` is no longer polluted by \`bun test\` runs (the bug from #44)
- [ ] Self-test: workflow run produces \`v1.0.<this PR number>\`

## Notes

- Each issue has its own paragraph in the commit message body (squash-merge will collapse, but the issue refs survive).
- The hotfix removal in release.yml is in the same change as the underlying fix — no window where the pipeline depends on the hotfix while the bug is "fixed elsewhere."