### PR TITLE
feat: phantombot update — atomic, verified, cron-friendly

### DIFF
--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -130,23 +130,39 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
 }
 
 /**
+ * A confirm prompt: returns true to proceed, false to skip. Default
+ * wraps `@clack/prompts` confirm; tests inject a stub so they can drive
+ * `maybePromptRestart` end-to-end without a real TTY.
+ */
+export type ConfirmFn = (message: string) => Promise<boolean>;
+
+const defaultConfirm: ConfirmFn = async (message) => {
+  const r = await p.confirm({ message, initialValue: true });
+  return !p.isCancel(r) && r === true;
+};
+
+/**
  * Shared post-apply hook for the config-mutating TUIs.
  *
  * Two steps. Always: re-render the on-disk systemd unit if it's stale (a
  * pre-Phase-29 unit lacks `EnvironmentFile=` and silently swallows the
  * .env secrets the TUI just wrote). Then: if phantombot is running, offer
  * to restart it inline so the change takes effect.
+ *
+ * `confirm` is parameterized so tests can drive the full ordering
+ * (rerender → confirm → restart) without going through @clack's
+ * non-TTY-friendly prompt.
  */
 export async function maybePromptRestart(
   svc: ServiceControl,
+  confirm: ConfirmFn = defaultConfirm,
 ): Promise<void> {
   await maybeUpgradeUnit(svc);
   if (!(await svc.isActive())) return;
-  const restart = await p.confirm({
-    message: "phantombot is currently running. Restart to apply changes?",
-    initialValue: true,
-  });
-  if (p.isCancel(restart) || !restart) {
+  const proceed = await confirm(
+    "phantombot is currently running. Restart to apply changes?",
+  );
+  if (!proceed) {
     p.note(
       "skipped — restart later with: systemctl --user restart phantombot",
       "Restart",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,7 @@ import memoryCmd from "./memory.ts";
 import embeddingCmd from "./embedding.ts";
 import heartbeatCmd from "./heartbeat.ts";
 import nightlyCmd from "./nightly.ts";
+import updateCmd from "./update.ts";
 import voiceCmd from "./voice.ts";
 
 export const mainCommand = defineCommand({
@@ -47,6 +48,7 @@ export const mainCommand = defineCommand({
     memory: memoryCmd,
     heartbeat: heartbeatCmd,
     nightly: nightlyCmd,
+    update: updateCmd,
     voice: voiceCmd,
   },
 });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,267 @@
+/**
+ * `phantombot update` — fetch latest GitHub Release, verify, atomically
+ * swap the running binary, optionally restart the service.
+ *
+ * Flag matrix:
+ *   (none)           interactive TUI; confirm before installing; prompt for restart
+ *   --check          print "X newer than Y" or "up to date"; exit 0/2/1
+ *   --force          skip the install confirm (cron-friendly)
+ *   --restart        skip the restart prompt and just restart
+ *   --force --restart  fully unattended; ideal for cron
+ *
+ * Exit codes (chosen to be cron-alertable):
+ *   0   — updated successfully, OR already on the latest version
+ *   1   — error (network, checksum mismatch, write-permission, etc.)
+ *   2   — update available but not installed (only with --check)
+ */
+
+import { defineCommand } from "citty";
+import { realpath } from "node:fs/promises";
+import { basename } from "node:path";
+import * as p from "@clack/prompts";
+
+import {
+  applyUpdate,
+  checkWritable,
+  downloadAndVerify,
+} from "../lib/binaryUpdate.ts";
+import {
+  detectSupportedArch,
+  findLatestRelease,
+  type LatestRelease,
+} from "../lib/githubReleases.ts";
+import {
+  defaultServiceControl,
+  type ServiceControl,
+} from "../lib/systemd.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { VERSION } from "../version.ts";
+
+export interface RunUpdateInput {
+  check?: boolean;
+  force?: boolean;
+  restart?: boolean;
+  /** Defaults to process.execPath. Tests override. */
+  binPath?: string;
+  /**
+   * Raw arch string (matches `process.arch`); converted via
+   * detectSupportedArch internally. Defaults to process.arch. Tests pass
+   * a value like "ia32" to exercise the unsupported-arch refusal.
+   */
+  procArch?: string;
+  /** Defaults to VERSION constant. Tests override. */
+  currentVersion?: string;
+  /** Inject for testing. */
+  fetchImpl?: typeof fetch;
+  serviceControl?: ServiceControl;
+  /** Inject confirm to bypass @clack's TTY-only prompt in tests. */
+  confirmInstall?: (release: LatestRelease) => Promise<boolean>;
+  confirmRestart?: () => Promise<boolean>;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const currentVersion = input.currentVersion ?? VERSION;
+  const procArch = input.procArch ?? process.arch;
+  const arch = detectSupportedArch(procArch);
+
+  if (!arch) {
+    err.write(
+      `phantombot is only released for linux-x64 and linux-arm64; this machine reports arch=${procArch}\n`,
+    );
+    return 1;
+  }
+
+  // Resolve symlinks so target swaps land on the real file. Without this,
+  // a `~/.local/bin/phantombot → /opt/phantombot/bin/phantombot` symlink
+  // would have its symlink replaced by a regular binary.
+  const rawBinPath = input.binPath ?? process.execPath;
+  let binPath: string;
+  try {
+    binPath = await realpath(rawBinPath);
+  } catch {
+    binPath = rawBinPath;
+  }
+
+  if (basename(binPath) !== "phantombot") {
+    err.write(
+      `not a phantombot binary at ${binPath} (basename=${basename(binPath)}). ` +
+        `Are you running from source via 'bun src/index.ts'? ` +
+        `Build a release binary with 'bun run build' first.\n`,
+    );
+    return 1;
+  }
+
+  // 1. Discover latest release.
+  const r = await findLatestRelease({
+    arch,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!r.ok) {
+    err.write(`update check failed: ${r.error}\n`);
+    return 1;
+  }
+  const release = r.release;
+
+  // 2. Compare versions.
+  if (release.version === currentVersion) {
+    out.write(`Already on ${release.tag}.\n`);
+    return 0;
+  }
+
+  // 3. --check just reports.
+  if (input.check) {
+    out.write(`Update available: ${currentVersion} → ${release.version}\n`);
+    out.write(`  asset:  ${release.binary.name} (${formatBytes(release.binary.size)})\n`);
+    return 2;
+  }
+
+  // 4. Confirm install (skip with --force).
+  if (!input.force) {
+    const confirm =
+      input.confirmInstall ??
+      (async (rel) => defaultConfirmInstall(rel, currentVersion));
+    const proceed = await confirm(release);
+    if (!proceed) {
+      out.write("update cancelled.\n");
+      return 0;
+    }
+  }
+
+  // 5. Permission precheck — fail fast before downloading 100MB.
+  const writable = await checkWritable(binPath);
+  if (!writable.ok) {
+    err.write(`cannot install update: ${writable.reason}\n`);
+    return 1;
+  }
+
+  // 6. Download + SHA256 verify.
+  const tempPath = `${binPath}.update.tmp`;
+  out.write(`downloading ${release.binary.name}…\n`);
+  const dl = await downloadAndVerify({
+    binaryUrl: release.binary.url,
+    checksumsUrl: release.checksums.url,
+    expectedAssetName: release.binary.name,
+    destPath: tempPath,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!dl.ok) {
+    err.write(`download failed: ${dl.error}\n`);
+    return 1;
+  }
+  out.write(`verified ${formatBytes(dl.bytes)} (sha256 ok).\n`);
+
+  // 7. Atomic swap.
+  const swap = await applyUpdate({ tempPath, targetPath: binPath });
+  if (!swap.ok) {
+    err.write(`install failed: ${swap.error}\n`);
+    return 1;
+  }
+  out.write(
+    `installed ${release.tag} at ${binPath} (previous binary saved to ${swap.backupPath}).\n`,
+  );
+
+  // 8. Restart handling. The running phantombot process keeps its
+  // in-memory binary, so restart is needed to actually load the new bits.
+  const svc = input.serviceControl ?? defaultServiceControl();
+  let shouldRestart = input.restart ?? false;
+  if (!input.restart && !input.force) {
+    const confirmRestart =
+      input.confirmRestart ?? defaultConfirmRestart;
+    if (await svc.isActive()) {
+      shouldRestart = await confirmRestart();
+    }
+  }
+  if (shouldRestart) {
+    const r = await svc.restart();
+    if (r.ok) {
+      out.write("restarted phantombot.service.\n");
+    } else {
+      err.write(
+        `restart failed: ${r.stderr ?? "unknown"} — run 'systemctl --user restart phantombot' manually.\n`,
+      );
+      // Don't fail the whole command; the binary swap succeeded. The
+      // user just needs to restart by hand.
+    }
+  } else if (!input.force) {
+    out.write(
+      "restart with: systemctl --user restart phantombot\n",
+    );
+  }
+
+  return 0;
+}
+
+async function defaultConfirmInstall(
+  release: LatestRelease,
+  currentVersion: string,
+): Promise<boolean> {
+  p.intro(`phantombot update`);
+  const summary =
+    `current:   ${currentVersion}\n` +
+    `available: ${release.version} (${release.tag})\n` +
+    `asset:     ${release.binary.name} (${formatBytes(release.binary.size)})\n` +
+    (release.body
+      ? `\n--- release notes ---\n${truncate(release.body, 800)}`
+      : "");
+  p.note(summary, "Update available");
+  const r = await p.confirm({
+    message: `Install ${release.tag}?`,
+    initialValue: true,
+  });
+  return !p.isCancel(r) && r === true;
+}
+
+async function defaultConfirmRestart(): Promise<boolean> {
+  const r = await p.confirm({
+    message: "phantombot is currently running. Restart now to load the new binary?",
+    initialValue: true,
+  });
+  return !p.isCancel(r) && r === true;
+}
+
+function formatBytes(n: number): string {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max) + "\n…[release notes truncated]";
+}
+
+export default defineCommand({
+  meta: {
+    name: "update",
+    description:
+      "Fetch the latest phantombot release, verify the SHA256, atomically swap the running binary, and optionally restart the service.",
+  },
+  args: {
+    check: {
+      type: "boolean",
+      description: "Print whether an update is available without installing. Exit code 2 if available, 0 if up to date.",
+      default: false,
+    },
+    force: {
+      type: "boolean",
+      description: "Skip the install confirmation (use from cron).",
+      default: false,
+    },
+    restart: {
+      type: "boolean",
+      description: "Restart phantombot.service after installing. Useful with --force for unattended updates.",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    process.exitCode = await runUpdate({
+      check: args.check as boolean,
+      force: args.force as boolean,
+      restart: args.restart as boolean,
+    });
+  },
+});

--- a/src/lib/binaryUpdate.ts
+++ b/src/lib/binaryUpdate.ts
@@ -1,0 +1,237 @@
+/**
+ * Download + SHA256-verify + atomically swap a phantombot binary.
+ *
+ * The actual filesystem swap relies on Linux semantics: rename(2) over
+ * the currently-executing binary is safe. The kernel keeps the running
+ * process backed by the original inode; the new file gets a fresh inode
+ * at the same path. The next exec() of that path picks up the new file.
+ *
+ * SHA256 verification is mandatory — we refuse to swap if the downloaded
+ * bytes don't match SHA256SUMS. A poisoned mirror or in-flight tamper
+ * stops the install instead of cooking kai's box with a hostile binary.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import {
+  chmod,
+  copyFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+
+export interface DownloadAndVerifyOpts {
+  /** URL of the binary asset (browser_download_url from the release). */
+  binaryUrl: string;
+  /** URL of the SHA256SUMS file (browser_download_url from the release). */
+  checksumsUrl: string;
+  /** The asset name as it appears in SHA256SUMS, e.g. phantombot-v1.0.43-linux-x64. */
+  expectedAssetName: string;
+  /** Where to write the verified binary. Caller picks; usually `${execPath}.update.tmp`. */
+  destPath: string;
+  fetchImpl?: typeof fetch;
+}
+
+export type DownloadResult =
+  | { ok: true; bytes: number; sha256: string }
+  | { ok: false; error: string };
+
+/**
+ * Stream the asset to destPath, then re-read it to compute SHA256, then
+ * compare against the SHA256SUMS entry for expectedAssetName. On any
+ * failure (network, missing entry, mismatch) the partial file is removed.
+ */
+export async function downloadAndVerify(
+  opts: DownloadAndVerifyOpts,
+): Promise<DownloadResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  // 1. Fetch the SHA256SUMS file first. If the upstream is broken or
+  // tampered with, we want to fail before downloading 100MB of binary.
+  let checksumsRes: Response;
+  try {
+    checksumsRes = await fetchImpl(opts.checksumsUrl);
+  } catch (e) {
+    return {
+      ok: false,
+      error: `network error fetching SHA256SUMS: ${(e as Error).message}`,
+    };
+  }
+  if (!checksumsRes.ok) {
+    return {
+      ok: false,
+      error: `SHA256SUMS download HTTP ${checksumsRes.status}`,
+    };
+  }
+  const checksumsText = await checksumsRes.text();
+  const expectedSha256 = parseSha256SumsLine(
+    checksumsText,
+    opts.expectedAssetName,
+  );
+  if (!expectedSha256) {
+    return {
+      ok: false,
+      error: `SHA256SUMS has no entry for ${opts.expectedAssetName}`,
+    };
+  }
+
+  // 2. Download the binary.
+  let binRes: Response;
+  try {
+    binRes = await fetchImpl(opts.binaryUrl);
+  } catch (e) {
+    return {
+      ok: false,
+      error: `network error fetching binary: ${(e as Error).message}`,
+    };
+  }
+  if (!binRes.ok) {
+    return { ok: false, error: `binary download HTTP ${binRes.status}` };
+  }
+  const bytes = Buffer.from(await binRes.arrayBuffer());
+
+  // 3. Verify SHA256.
+  const actualSha256 = createHash("sha256").update(bytes).digest("hex");
+  if (actualSha256 !== expectedSha256) {
+    return {
+      ok: false,
+      error: `SHA256 mismatch for ${opts.expectedAssetName}: expected ${expectedSha256}, got ${actualSha256}`,
+    };
+  }
+
+  // 4. Write to destPath at mode 0o755 (executable).
+  try {
+    await writeFile(opts.destPath, bytes, { mode: 0o755 });
+    // writeFile mode is honored only on file CREATION; existing files
+    // keep their old mode. Force-set explicitly so re-runs with a stale
+    // tmp don't end up unexecutable.
+    await chmod(opts.destPath, 0o755);
+  } catch (e) {
+    // Defensive cleanup so a partial write doesn't haunt later runs.
+    await rm(opts.destPath, { force: true });
+    return {
+      ok: false,
+      error: `failed writing ${opts.destPath}: ${(e as Error).message}`,
+    };
+  }
+
+  return { ok: true, bytes: bytes.byteLength, sha256: actualSha256 };
+}
+
+/**
+ * Pure parser exposed for testing. SHA256SUMS files are one entry per
+ * line, formatted by `sha256sum`: `<hex>  <filename>` (two spaces, no
+ * newlines inside an entry). Returns the hex digest if found, undefined
+ * otherwise.
+ */
+export function parseSha256SumsLine(
+  text: string,
+  filename: string,
+): string | undefined {
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    // Accept either two-space (text-mode) or one-space-and-asterisk (binary-mode).
+    const m = /^([0-9a-fA-F]{64})\s+\*?(\S+)\s*$/.exec(line);
+    if (!m || !m[1] || !m[2]) continue;
+    if (m[2] === filename) return m[1].toLowerCase();
+  }
+  return undefined;
+}
+
+export interface ApplyUpdateOpts {
+  /** Path of the freshly-downloaded, verified binary (e.g. `${target}.update.tmp`). */
+  tempPath: string;
+  /** Path of the binary to replace (usually process.execPath). */
+  targetPath: string;
+}
+
+export type ApplyResult =
+  | { ok: true; backupPath: string }
+  | { ok: false; error: string };
+
+/**
+ * Atomic swap. Steps:
+ *   1. Copy targetPath → ${targetPath}.bak (so a botched rename is recoverable).
+ *   2. rename(tempPath, targetPath) — atomic on Linux even when targetPath
+ *      is the running process's binary; the kernel uses inode, not path.
+ *
+ * Returns the .bak path on success so the caller can tell the user where
+ * to find the rollback if something downstream (e.g. service restart)
+ * blows up.
+ */
+export async function applyUpdate(opts: ApplyUpdateOpts): Promise<ApplyResult> {
+  if (!existsSync(opts.tempPath)) {
+    return { ok: false, error: `temp file missing: ${opts.tempPath}` };
+  }
+  const backupPath = `${opts.targetPath}.bak`;
+  try {
+    if (existsSync(opts.targetPath)) {
+      // copyFile (not rename) so we keep targetPath intact in case the
+      // rename in step 2 fails — we always have a working binary on disk.
+      await copyFile(opts.targetPath, backupPath);
+    }
+  } catch (e) {
+    return {
+      ok: false,
+      error: `failed to back up ${opts.targetPath}: ${(e as Error).message}`,
+    };
+  }
+  try {
+    await rename(opts.tempPath, opts.targetPath);
+  } catch (e) {
+    // Best-effort rollback: if backup exists, restore it.
+    if (existsSync(backupPath)) {
+      try {
+        await copyFile(backupPath, opts.targetPath);
+      } catch {
+        /* if restore fails too, the user has the .bak to copy by hand */
+      }
+    }
+    return {
+      ok: false,
+      error: `failed to swap ${opts.tempPath} → ${opts.targetPath}: ${(e as Error).message}`,
+    };
+  }
+  return { ok: true, backupPath };
+}
+
+/**
+ * Quick capability check before we bother downloading anything: can we
+ * actually write to (and replace) the binary at targetPath? Returns
+ * undefined when writeable, or a hint string the CLI can surface.
+ *
+ * Linux's rule: replacing a file by name needs write+execute on the
+ * containing directory, NOT write on the file itself. So we test the
+ * dirname's writability via stat + euid match (close enough — true
+ * permission check requires access(2) which Bun exposes via fs/promises).
+ */
+export async function checkWritable(
+  targetPath: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  // Use fs.access with W_OK on the parent dir; that's the actual
+  // permission Linux enforces for rename-over-existing.
+  const { access, constants } = await import("node:fs/promises");
+  const { dirname } = await import("node:path");
+  const parent = dirname(targetPath);
+  try {
+    await access(parent, constants.W_OK);
+  } catch {
+    return {
+      ok: false,
+      reason: `no write access to ${parent}; re-run with sudo or relocate the binary to a user-writable path`,
+    };
+  }
+  // Sanity: does targetPath actually exist?
+  try {
+    await stat(targetPath);
+  } catch {
+    return {
+      ok: false,
+      reason: `target ${targetPath} doesn't exist; nothing to update (are you running phantombot from source via bun?)`,
+    };
+  }
+  return { ok: true };
+}

--- a/src/lib/githubReleases.ts
+++ b/src/lib/githubReleases.ts
@@ -1,0 +1,169 @@
+/**
+ * Tiny GitHub Releases client. Used by `phantombot update` to discover
+ * the latest released version + the right binary asset for the host arch.
+ *
+ * No GitHub auth needed because the repo is public; if the API ever rate-
+ * limits us (60/h unauth), GITHUB_TOKEN in env is honored for higher caps.
+ *
+ * Repo coordinates default to the current upstream and are env-overridable
+ * (PHANTOMBOT_UPDATE_REPO=owner/name) so the impending repo rename can be
+ * staged through env without a phantombot rebuild.
+ */
+
+const DEFAULT_REPO = "andrewagrahamhodges/phantombot";
+
+/** What kind of host arch the running phantombot needs an asset for. */
+export type SupportedArch = "x64" | "arm64";
+
+export interface ReleaseAsset {
+  name: string;
+  url: string;
+  size: number;
+}
+
+export interface LatestRelease {
+  /** Without the leading `v`, e.g. "1.0.43". */
+  version: string;
+  /** The full tag, e.g. "v1.0.43". */
+  tag: string;
+  /** GitHub release body text (release notes). May be empty. */
+  body: string;
+  /** The binary asset for the requested arch. */
+  binary: ReleaseAsset;
+  /** The SHA256SUMS file alongside it. */
+  checksums: ReleaseAsset;
+}
+
+export type FindLatestResult =
+  | { ok: true; release: LatestRelease }
+  | { ok: false; error: string };
+
+/**
+ * Hit GitHub's `/releases/latest` endpoint, find the binary asset that
+ * matches the requested arch + the SHA256SUMS file beside it, and return
+ * everything `phantombot update` needs to download and verify.
+ */
+export async function findLatestRelease(opts: {
+  arch: SupportedArch;
+  /** Override the upstream repo. Default: env var or DEFAULT_REPO. */
+  repo?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<FindLatestResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const repo =
+    opts.repo ?? process.env.PHANTOMBOT_UPDATE_REPO ?? DEFAULT_REPO;
+  const url = `https://api.github.com/repos/${repo}/releases/latest`;
+
+  const headers: Record<string, string> = {
+    accept: "application/vnd.github+json",
+    "x-github-api-version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(url, { headers });
+  } catch (e) {
+    return {
+      ok: false,
+      error: `network error reaching ${url}: ${(e as Error).message}`,
+    };
+  }
+  if (res.status === 403) {
+    return {
+      ok: false,
+      error:
+        "GitHub API rate-limited (60/h unauth). Set GITHUB_TOKEN in env to lift the cap.",
+    };
+  }
+  if (res.status === 404) {
+    return {
+      ok: false,
+      error: `no releases found at ${repo}. Has the workflow ever produced one?`,
+    };
+  }
+  if (!res.ok) {
+    return { ok: false, error: `GitHub API HTTP ${res.status} from ${url}` };
+  }
+
+  let body: GithubReleaseResponse;
+  try {
+    body = (await res.json()) as GithubReleaseResponse;
+  } catch (e) {
+    return {
+      ok: false,
+      error: `GitHub API returned non-JSON: ${(e as Error).message}`,
+    };
+  }
+
+  if (typeof body.tag_name !== "string" || !Array.isArray(body.assets)) {
+    return {
+      ok: false,
+      error: "GitHub API response missing tag_name or assets",
+    };
+  }
+
+  const tag = body.tag_name;
+  const version = tag.startsWith("v") ? tag.slice(1) : tag;
+  const wantedBinaryName = `phantombot-${tag}-linux-${opts.arch}`;
+  const binary = body.assets.find((a) => a.name === wantedBinaryName);
+  const checksums = body.assets.find((a) => a.name === "SHA256SUMS");
+
+  if (!binary) {
+    const have = body.assets.map((a) => a.name).join(", ");
+    return {
+      ok: false,
+      error: `release ${tag} has no asset named ${wantedBinaryName} (have: ${have || "(none)"})`,
+    };
+  }
+  if (!checksums) {
+    return {
+      ok: false,
+      error: `release ${tag} has no SHA256SUMS asset; refusing to install without checksum verification`,
+    };
+  }
+
+  return {
+    ok: true,
+    release: {
+      version,
+      tag,
+      body: typeof body.body === "string" ? body.body : "",
+      binary: {
+        name: binary.name,
+        url: binary.browser_download_url,
+        size: binary.size,
+      },
+      checksums: {
+        name: checksums.name,
+        url: checksums.browser_download_url,
+        size: checksums.size,
+      },
+    },
+  };
+}
+
+/**
+ * Map node/bun's process.arch to the suffix the release workflow uses.
+ * Returns undefined on architectures we don't ship binaries for, so the
+ * CLI can refuse with a clear message instead of trying a missing asset.
+ */
+export function detectSupportedArch(
+  procArch: string = process.arch,
+): SupportedArch | undefined {
+  if (procArch === "x64") return "x64";
+  if (procArch === "arm64") return "arm64";
+  return undefined;
+}
+
+interface GithubReleaseResponse {
+  tag_name?: string;
+  body?: string;
+  assets?: Array<{
+    name: string;
+    browser_download_url: string;
+    size: number;
+  }>;
+}

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -1,0 +1,360 @@
+/**
+ * End-to-end tests for `phantombot update`. Mocks fetch + ServiceControl.
+ *
+ * What we're trying to nail down:
+ *   - Exit-code matrix for cron usage: 0/1/2 must match the spec.
+ *   - Confirm-bypass with --force.
+ *   - Auto-restart with --restart.
+ *   - The atomic swap actually replaces the binary on disk.
+ *   - Refusal modes: dev (running from bun), unsupported arch, missing
+ *     SHA256SUMS asset, checksum mismatch, no write access.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runUpdate } from "../src/cli/update.ts";
+import type { ServiceControl } from "../src/lib/systemd.ts";
+
+let workdir: string;
+let binPath: string;
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-update-"));
+  binPath = join(workdir, "phantombot");
+  await writeFile(binPath, "OLD_BINARY", { mode: 0o755 });
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+const ASSET = "phantombot-v1.0.99-linux-x64";
+const NEW_BYTES = Buffer.from("NEW_BINARY_VERIFIED");
+const NEW_SHA = createHash("sha256").update(NEW_BYTES).digest("hex");
+
+function fakeReleaseFetch(opts: {
+  releaseStatus?: number;
+  releaseBody?: unknown;
+  binary?: Buffer;
+  checksumsText?: string;
+} = {}): typeof fetch {
+  const releaseStatus = opts.releaseStatus ?? 200;
+  const releaseBody = opts.releaseBody ?? {
+    tag_name: "v1.0.99",
+    body: "test release",
+    assets: [
+      {
+        name: ASSET,
+        browser_download_url: "https://example/" + ASSET,
+        size: NEW_BYTES.byteLength,
+      },
+      {
+        name: "phantombot-v1.0.99-linux-arm64",
+        browser_download_url: "https://example/arm64",
+        size: NEW_BYTES.byteLength,
+      },
+      {
+        name: "SHA256SUMS",
+        browser_download_url: "https://example/SHA256SUMS",
+        size: 256,
+      },
+    ],
+  };
+  const binary = opts.binary ?? NEW_BYTES;
+  const checksumsText =
+    opts.checksumsText ?? `${NEW_SHA}  ${ASSET}\n`;
+  return (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("api.github.com")) {
+      return new Response(
+        typeof releaseBody === "string"
+          ? releaseBody
+          : JSON.stringify(releaseBody),
+        {
+          status: releaseStatus,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }
+    if (u.includes("SHA256SUMS")) {
+      return new Response(checksumsText, {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    return new Response(binary, {
+      status: 200,
+      headers: { "content-type": "application/octet-stream" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+function makeSvc(opts: { active?: boolean; restartOk?: boolean } = {}) {
+  const calls: string[] = [];
+  return {
+    calls,
+    svc: {
+      isActive: async () => {
+        calls.push("isActive");
+        return opts.active ?? false;
+      },
+      restart: async () => {
+        calls.push("restart");
+        return opts.restartOk === false
+          ? { ok: false, stderr: "fake restart failure" }
+          : { ok: true };
+      },
+      rerenderUnitIfStale: async () => ({ rerendered: false }),
+    } as ServiceControl,
+  };
+}
+
+describe("runUpdate exit codes (cron contract)", () => {
+  test("already on latest → exit 0, no download", async () => {
+    const out = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.99",
+      fetchImpl: fakeReleaseFetch(),
+      out,
+      err: new CaptureStream(),
+      force: true,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("Already on v1.0.99");
+    // Binary on disk untouched.
+    expect((await readFile(binPath, "utf8"))).toBe("OLD_BINARY");
+  });
+
+  test("--check + update available → exit 2, no install", async () => {
+    const out = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      out,
+      err: new CaptureStream(),
+      check: true,
+    });
+    expect(code).toBe(2);
+    expect(out.text).toContain("Update available");
+    expect(out.text).toContain("1.0.42 → 1.0.99");
+    expect((await readFile(binPath, "utf8"))).toBe("OLD_BINARY");
+  });
+
+  test("--check + already current → exit 0", async () => {
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.99",
+      fetchImpl: fakeReleaseFetch(),
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      check: true,
+    });
+    expect(code).toBe(0);
+  });
+
+  test("network error → exit 1", async () => {
+    const failingFetch = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as unknown as typeof fetch;
+    const err = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: failingFetch,
+      out: new CaptureStream(),
+      err,
+      force: true,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("network");
+  });
+
+  test("checksum mismatch → exit 1, binary on disk untouched", async () => {
+    const wrong = createHash("sha256").update(Buffer.from("evil")).digest("hex");
+    const err = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch({
+        checksumsText: `${wrong}  ${ASSET}\n`,
+      }),
+      out: new CaptureStream(),
+      err,
+      force: true,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("SHA256 mismatch");
+    expect((await readFile(binPath, "utf8"))).toBe("OLD_BINARY");
+  });
+});
+
+describe("runUpdate refusals", () => {
+  test("not running a phantombot binary (basename != phantombot) → exit 1", async () => {
+    const wrongPath = join(workdir, "bun");
+    await writeFile(wrongPath, "BUN", { mode: 0o755 });
+    const err = new CaptureStream();
+    const code = await runUpdate({
+      binPath: wrongPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      out: new CaptureStream(),
+      err,
+      force: true,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("source");
+  });
+
+  test("unsupported arch → exit 1", async () => {
+    const err = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procArch: "ia32",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      out: new CaptureStream(),
+      err,
+      force: true,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("only released for");
+  });
+});
+
+describe("runUpdate happy path with --force --restart", () => {
+  test("downloads, verifies, swaps, restarts — the full cron contract", async () => {
+    const out = new CaptureStream();
+    const { svc, calls } = makeSvc({ active: true, restartOk: true });
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      out,
+      err: new CaptureStream(),
+      force: true,
+      restart: true,
+    });
+    expect(code).toBe(0);
+    // New binary swapped in.
+    const swapped = await readFile(binPath);
+    expect(swapped.equals(NEW_BYTES)).toBe(true);
+    // Old binary saved as .bak so a botched restart is recoverable.
+    const backup = await readFile(`${binPath}.bak`, "utf8");
+    expect(backup).toBe("OLD_BINARY");
+    // No leftover tmp.
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(`${binPath}.update.tmp`)).toBe(false);
+    // Restart was called (and only once).
+    expect(calls.filter((c) => c === "restart")).toEqual(["restart"]);
+    expect(out.text).toContain("verified");
+    expect(out.text).toContain("installed v1.0.99");
+    expect(out.text).toContain("restarted");
+  });
+
+  test("--force without --restart skips restart even when service is active", async () => {
+    const out = new CaptureStream();
+    const { svc, calls } = makeSvc({ active: true, restartOk: true });
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      out,
+      err: new CaptureStream(),
+      force: true,
+      // restart NOT set
+    });
+    expect(code).toBe(0);
+    expect(calls).not.toContain("restart");
+    // No "restart with: ..." hint either, since --force is unattended.
+    expect(out.text).not.toContain("restart with:");
+  });
+
+  test("restart failure doesn't fail the whole update (binary is already swapped)", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const { svc } = makeSvc({ active: true, restartOk: false });
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      out,
+      err,
+      force: true,
+      restart: true,
+    });
+    // Exit 0 — the install succeeded; restart is best-effort.
+    expect(code).toBe(0);
+    expect(err.text).toContain("restart failed");
+    expect(err.text).toContain("manually");
+    // Binary still got swapped.
+    expect((await readFile(binPath)).equals(NEW_BYTES)).toBe(true);
+  });
+});
+
+describe("runUpdate confirm injection", () => {
+  test("interactive: confirmInstall=false skips download entirely", async () => {
+    const out = new CaptureStream();
+    let confirmCalled = 0;
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      out,
+      err: new CaptureStream(),
+      confirmInstall: async () => {
+        confirmCalled++;
+        return false;
+      },
+    });
+    expect(code).toBe(0);
+    expect(confirmCalled).toBe(1);
+    expect(out.text).toContain("cancelled");
+    expect((await readFile(binPath, "utf8"))).toBe("OLD_BINARY");
+  });
+
+  test("interactive: confirmRestart=false skips restart even when service is active", async () => {
+    const { svc, calls } = makeSvc({ active: true, restartOk: true });
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      confirmInstall: async () => true,
+      confirmRestart: async () => false,
+    });
+    expect(code).toBe(0);
+    expect(calls).not.toContain("restart");
+  });
+});

--- a/tests/cli-voice.test.ts
+++ b/tests/cli-voice.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { maybeUpgradeUnit } from "../src/cli/harness.ts";
+import { maybePromptRestart } from "../src/cli/harness.ts";
 import { applyVoiceConfig } from "../src/cli/voice.ts";
 import { loadEnvFile } from "../src/lib/envFile.ts";
 import {
@@ -149,12 +149,11 @@ WantedBy=default.target
       },
     };
 
-    // Drive through the shared upgrade-unit helper. (maybePromptRestart
-    // would block on @clack's confirm prompt in a non-TTY test runner;
-    // maybeUpgradeUnit is the prompt-free part of the flow that owns the
-    // rerender step.)
-    const r = await maybeUpgradeUnit(svc);
-    expect(r.rerendered).toBe(true);
+    // Drive the REAL maybePromptRestart (not just maybeUpgradeUnit) by
+    // injecting an auto-confirm — this proves the production code path
+    // calls rerender BEFORE restart, instead of asserting on test-local
+    // instrumentation. This is the gap #35 was filed to close.
+    await maybePromptRestart(svc, async () => true);
 
     // The on-disk unit now has EnvironmentFile= — the actual fix.
     const rewritten = await readFile(unitPath, "utf8");
@@ -166,13 +165,40 @@ WantedBy=default.target
     // daemon-reload was issued as part of the rerender.
     expect(sys.calls).toEqual([["--user", "daemon-reload"]]);
 
-    // Now simulate the restart step that maybePromptRestart would do
-    // after the rerender — and verify it sees the upgraded unit, not the
-    // stale one. This is the "before restart" guarantee the spec asks for.
-    await svc.restart();
+    // The actual ordering inside maybePromptRestart: rerender first, then
+    // restart. If a refactor swaps the two lines, this fails — that's
+    // what was missing from the previous version of this test.
     expect(callOrder).toEqual(["rerender", "restart"]);
     expect(unitContentAtRestart).toContain(
       "EnvironmentFile=-%h/.config/phantombot/.env",
     );
+  });
+
+  test("maybePromptRestart skips restart when confirm returns false", async () => {
+    const unitPath = join(workdir, "phantombot.service");
+    const callOrder: string[] = [];
+    const fakeSystemctl: SystemctlRunner = {
+      async run(_args: readonly string[]): Promise<SystemctlResult> {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    };
+    const svc: ServiceControl = {
+      isActive: async () => true,
+      restart: async () => {
+        callOrder.push("restart");
+        return { ok: true };
+      },
+      rerenderUnitIfStale: async () => {
+        callOrder.push("rerender");
+        return ensureUnitCurrent({
+          unitPath,
+          binPath: "/bin/phantombot",
+          systemctl: fakeSystemctl,
+        });
+      },
+    };
+    await maybePromptRestart(svc, async () => false);
+    // Rerender ran (always does) but restart was declined.
+    expect(callOrder).toEqual(["rerender"]);
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -31,6 +31,7 @@ describe("phantombot CLI dispatcher", () => {
       "run",
       "telegram",
       "uninstall",
+      "update",
       "voice",
     ]);
   });

--- a/tests/lib-binaryUpdate.test.ts
+++ b/tests/lib-binaryUpdate.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the SHA256-verifying download + atomic-swap helpers.
+ *
+ * No real network: fetch is mocked. The tests do real filesystem swaps
+ * inside a per-test mkdtemp; the symlink/inode behavior of rename(2) is
+ * exercised against the actual filesystem (worth doing — Linux rename
+ * over a "running" target is the load-bearing assumption of update).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applyUpdate,
+  checkWritable,
+  downloadAndVerify,
+  parseSha256SumsLine,
+} from "../src/lib/binaryUpdate.ts";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-bupdate-"));
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+const ASSET_NAME = "phantombot-v1.0.43-linux-x64";
+
+function sha256(b: Buffer): string {
+  return createHash("sha256").update(b).digest("hex");
+}
+
+function fakeFetchTwo(
+  binary: Buffer,
+  checksumsText: string,
+): typeof fetch {
+  return (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("SHA256SUMS")) {
+      return new Response(checksumsText, {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+    }
+    return new Response(binary, {
+      status: 200,
+      headers: { "content-type": "application/octet-stream" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+describe("parseSha256SumsLine", () => {
+  test("parses a standard sha256sum text-mode line", () => {
+    const text =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  phantombot-v1.0.43-linux-x64\n" +
+      "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210  phantombot-v1.0.43-linux-arm64\n";
+    expect(
+      parseSha256SumsLine(text, "phantombot-v1.0.43-linux-x64"),
+    ).toBe("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+  });
+
+  test("returns undefined for missing filename", () => {
+    expect(parseSha256SumsLine("# header\n", "anything")).toBeUndefined();
+  });
+
+  test("accepts binary-mode lines (asterisk prefix)", () => {
+    const text =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef *file.bin\n";
+    expect(parseSha256SumsLine(text, "file.bin")).toBeDefined();
+  });
+});
+
+describe("downloadAndVerify", () => {
+  test("happy path: writes binary at 0o755 and returns sha256", async () => {
+    const fakeBinary = Buffer.from("FAKE_PHANTOMBOT_BYTES");
+    const expectedHash = sha256(fakeBinary);
+    const checksums = `${expectedHash}  ${ASSET_NAME}\n`;
+    const dest = join(workdir, "phantombot");
+    const r = await downloadAndVerify({
+      binaryUrl: "https://example/bin",
+      checksumsUrl: "https://example/SHA256SUMS",
+      expectedAssetName: ASSET_NAME,
+      destPath: dest,
+      fetchImpl: fakeFetchTwo(fakeBinary, checksums),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.bytes).toBe(fakeBinary.byteLength);
+    expect(r.sha256).toBe(expectedHash);
+    const written = await readFile(dest);
+    expect(written.equals(fakeBinary)).toBe(true);
+    const { stat } = await import("node:fs/promises");
+    const st = await stat(dest);
+    expect(st.mode & 0o777).toBe(0o755);
+  });
+
+  test("checksum mismatch → no file left at dest", async () => {
+    const fakeBinary = Buffer.from("ACTUAL_BYTES");
+    const wrongHash = "f".repeat(64);
+    const checksums = `${wrongHash}  ${ASSET_NAME}\n`;
+    const dest = join(workdir, "phantombot");
+    const r = await downloadAndVerify({
+      binaryUrl: "https://example/bin",
+      checksumsUrl: "https://example/SHA256SUMS",
+      expectedAssetName: ASSET_NAME,
+      destPath: dest,
+      fetchImpl: fakeFetchTwo(fakeBinary, checksums),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("SHA256 mismatch");
+    expect(existsSync(dest)).toBe(false);
+  });
+
+  test("missing SHA256SUMS entry for the asset", async () => {
+    const r = await downloadAndVerify({
+      binaryUrl: "https://example/bin",
+      checksumsUrl: "https://example/SHA256SUMS",
+      expectedAssetName: ASSET_NAME,
+      destPath: join(workdir, "phantombot"),
+      fetchImpl: fakeFetchTwo(Buffer.from("x"), "# empty\n"),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("no entry");
+  });
+
+  test("checksum download failure short-circuits (binary not fetched)", async () => {
+    let binaryFetched = false;
+    const fail404 = (async (url: string | URL | Request) => {
+      if (String(url).includes("SHA256SUMS")) {
+        return new Response("not found", { status: 404 });
+      }
+      binaryFetched = true;
+      return new Response(Buffer.from("x"), { status: 200 });
+    }) as unknown as typeof fetch;
+    const r = await downloadAndVerify({
+      binaryUrl: "https://example/bin",
+      checksumsUrl: "https://example/SHA256SUMS",
+      expectedAssetName: ASSET_NAME,
+      destPath: join(workdir, "phantombot"),
+      fetchImpl: fail404,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("SHA256SUMS");
+    expect(binaryFetched).toBe(false);
+  });
+});
+
+describe("applyUpdate", () => {
+  test("backs up the old binary, swaps in the new one", async () => {
+    const target = join(workdir, "phantombot");
+    const tmp = join(workdir, "phantombot.update.tmp");
+    await writeFile(target, "OLD", { mode: 0o755 });
+    await writeFile(tmp, "NEW", { mode: 0o755 });
+    const r = await applyUpdate({ tempPath: tmp, targetPath: target });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.backupPath).toBe(`${target}.bak`);
+    expect((await readFile(target, "utf8"))).toBe("NEW");
+    expect((await readFile(r.backupPath, "utf8"))).toBe("OLD");
+    // Tmp should be consumed by rename.
+    expect(existsSync(tmp)).toBe(false);
+  });
+
+  test("missing tmp file → clear error", async () => {
+    const r = await applyUpdate({
+      tempPath: join(workdir, "no-such-file"),
+      targetPath: join(workdir, "phantombot"),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("temp file missing");
+  });
+});
+
+describe("checkWritable", () => {
+  test("ok when the parent dir is writable and target exists", async () => {
+    const target = join(workdir, "phantombot");
+    await writeFile(target, "x", { mode: 0o755 });
+    const r = await checkWritable(target);
+    expect(r.ok).toBe(true);
+  });
+
+  test("not ok when target doesn't exist (running from source)", async () => {
+    const target = join(workdir, "no-such-binary");
+    const r = await checkWritable(target);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toContain("doesn't exist");
+  });
+});

--- a/tests/lib-githubReleases.test.ts
+++ b/tests/lib-githubReleases.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the GitHub Releases discovery client. Mocked fetch — no
+ * network calls.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  detectSupportedArch,
+  findLatestRelease,
+} from "../src/lib/githubReleases.ts";
+
+const SAVED_ENV = {
+  PHANTOMBOT_UPDATE_REPO: process.env.PHANTOMBOT_UPDATE_REPO,
+  GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+};
+
+beforeEach(() => {
+  delete process.env.PHANTOMBOT_UPDATE_REPO;
+  delete process.env.GITHUB_TOKEN;
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(SAVED_ENV)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+function fakeFetch(
+  status: number,
+  body: unknown,
+  contentType = "application/json",
+): typeof fetch {
+  return (async () =>
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "content-type": contentType },
+    })) as unknown as typeof fetch;
+}
+
+const SAMPLE_RELEASE = {
+  tag_name: "v1.0.43",
+  body: "Automated release for PR #43.",
+  assets: [
+    {
+      name: "phantombot-v1.0.43-linux-x64",
+      browser_download_url: "https://example/phantombot-v1.0.43-linux-x64",
+      size: 101_275_968,
+    },
+    {
+      name: "phantombot-v1.0.43-linux-arm64",
+      browser_download_url: "https://example/phantombot-v1.0.43-linux-arm64",
+      size: 95_000_000,
+    },
+    {
+      name: "SHA256SUMS",
+      browser_download_url: "https://example/SHA256SUMS",
+      size: 256,
+    },
+  ],
+};
+
+describe("detectSupportedArch", () => {
+  test("x64 maps", () => expect(detectSupportedArch("x64")).toBe("x64"));
+  test("arm64 maps", () => expect(detectSupportedArch("arm64")).toBe("arm64"));
+  test("ia32 / ppc / etc. → undefined", () => {
+    expect(detectSupportedArch("ia32")).toBeUndefined();
+    expect(detectSupportedArch("ppc64")).toBeUndefined();
+  });
+});
+
+describe("findLatestRelease", () => {
+  test("picks the x64 binary + SHA256SUMS, strips leading v from version", async () => {
+    const r = await findLatestRelease({
+      arch: "x64",
+      fetchImpl: fakeFetch(200, SAMPLE_RELEASE),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.release.version).toBe("1.0.43");
+    expect(r.release.tag).toBe("v1.0.43");
+    expect(r.release.binary.name).toBe("phantombot-v1.0.43-linux-x64");
+    expect(r.release.binary.url).toBe(
+      "https://example/phantombot-v1.0.43-linux-x64",
+    );
+    expect(r.release.checksums.name).toBe("SHA256SUMS");
+  });
+
+  test("picks the arm64 binary on arm64 host", async () => {
+    const r = await findLatestRelease({
+      arch: "arm64",
+      fetchImpl: fakeFetch(200, SAMPLE_RELEASE),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.release.binary.name).toBe("phantombot-v1.0.43-linux-arm64");
+  });
+
+  test("errors when the right-arch asset is absent", async () => {
+    const partial = {
+      ...SAMPLE_RELEASE,
+      assets: SAMPLE_RELEASE.assets.filter((a) => a.name === "SHA256SUMS"),
+    };
+    const r = await findLatestRelease({
+      arch: "x64",
+      fetchImpl: fakeFetch(200, partial),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("phantombot-v1.0.43-linux-x64");
+  });
+
+  test("errors when SHA256SUMS is missing — refuses to run unverified", async () => {
+    const noChecksums = {
+      ...SAMPLE_RELEASE,
+      assets: SAMPLE_RELEASE.assets.filter((a) => a.name !== "SHA256SUMS"),
+    };
+    const r = await findLatestRelease({
+      arch: "x64",
+      fetchImpl: fakeFetch(200, noChecksums),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("SHA256SUMS");
+    expect(r.error).toContain("checksum verification");
+  });
+
+  test("403 → rate limit hint mentioning GITHUB_TOKEN", async () => {
+    const r = await findLatestRelease({
+      arch: "x64",
+      fetchImpl: fakeFetch(403, { message: "rate limited" }),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("GITHUB_TOKEN");
+  });
+
+  test("404 → 'no releases found' hint", async () => {
+    const r = await findLatestRelease({
+      arch: "x64",
+      fetchImpl: fakeFetch(404, { message: "not found" }),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("no releases");
+  });
+
+  test("PHANTOMBOT_UPDATE_REPO env var overrides repo", async () => {
+    process.env.PHANTOMBOT_UPDATE_REPO = "fakeorg/fakerepo";
+    let seenUrl: string | undefined;
+    const recordingFetch = (async (url: string | URL | Request) => {
+      seenUrl = String(url);
+      return new Response(JSON.stringify(SAMPLE_RELEASE), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    await findLatestRelease({ arch: "x64", fetchImpl: recordingFetch });
+    expect(seenUrl).toContain("fakeorg/fakerepo");
+  });
+});


### PR DESCRIPTION
The consumer side of the release pipeline (PR #37). Direct response to *"update is ALWAYS a shit show"* — designed to be solid: atomic, SHA256-verified, dev-mode-aware, with rollback, and three flags that map cleanly to the cron use case.

## CLI surface

\`\`\`
phantombot update                      # interactive: TUI confirm + restart prompt
phantombot update --check              # print availability; exit 2 if newer, 0 if current
phantombot update --force              # skip the install confirm
phantombot update --restart            # restart phantombot.service after install
phantombot update --force --restart    # the cron incantation
\`\`\`

### Exit codes (cron-alertable)

| code | meaning |
|---|---|
| 0 | updated, OR already on latest |
| 1 | error (network / checksum / write-perm / dev-mode / unsupported arch) |
| 2 | update available but not installed (\`--check\` only) |

A cron entry like \`phantombot update --force --restart\` returns 0 on no-op or successful update — alert only on 1.

## How it's solid

- **SHA256 verified.** SHA256SUMS is fetched first; if it 404s or the sum doesn't match, we never write the binary to disk.
- **Atomic swap.** \`copyFile(target → .bak)\` then \`rename(tmp → target)\`. Linux's rename(2) over the running binary is safe — kernel keeps the running process backed by the original inode; the new file gets a fresh one. The old binary is preserved as \`.bak\` so a botched downstream restart is recoverable.
- **Permission preflight.** \`access(parent, W_OK)\` runs before downloading 100MB so we fail fast with "re-run with sudo" instead of mid-download.
- **Dev-mode refusal.** If \`basename(process.execPath) !== "phantombot"\` (running from \`bun src/...\`), we refuse with a clear message instead of overwriting Bun.
- **Symlink-aware.** \`realpath\` resolves \`~/.local/bin/phantombot\` if it's a symlink so the swap lands on the actual file, not the symlink.
- **Arch detection.** \`process.arch\` → matches the asset name from PR #37's release pipeline (\`phantombot-v1.0.N-linux-{x64,arm64}\`).
- **Rate-limit friendly.** Honors \`GITHUB_TOKEN\` if set; refuses with a hint if 403.
- **Repo override.** \`PHANTOMBOT_UPDATE_REPO\` env var lets the impending repo rename happen without a binary rebuild.

## Bonus: closes #35

\`maybePromptRestart\` now accepts an injectable confirm callback (default wraps @clack). The voice integration test in \`cli-voice.test.ts\` is rewritten to drive the **real** \`maybePromptRestart\` with an auto-confirm stub — proving the production code path calls rerender BEFORE restart, instead of asserting on test-local instrumentation. That was the gap #35 flagged.

## Files

**New**:
- \`src/lib/githubReleases.ts\` — GH Releases discovery, arch matching
- \`src/lib/binaryUpdate.ts\` — download + sha256 + atomic swap helpers
- \`src/cli/update.ts\` — orchestrator + Citty subcommand
- \`tests/lib-githubReleases.test.ts\` (9 tests)
- \`tests/lib-binaryUpdate.test.ts\` (11 tests)
- \`tests/cli-update.test.ts\` (12 tests covering exit-code matrix + happy path + refusals)

**Modified**:
- \`src/cli/index.ts\` — register \`update\` subcommand
- \`src/cli/harness.ts\` — \`maybePromptRestart\` confirm now injectable (closes #35)
- \`tests/cli.test.ts\` — \`update\` in expected subcommands list
- \`tests/cli-voice.test.ts\` — drive \`maybePromptRestart\` for real (closes #35)

## Test plan

- [x] \`bun tsc --noEmit\` clean
- [x] \`bun test\` — 369 pass / 1 skip / 0 fail (was 335; +34 new tests)
- [x] Local \`bun run build\` produces a binary; \`./dist/phantombot update --help\` shows the flags
- [ ] **Self-test on merge**: workflow run produces \`v1.0.<this PR number>\` with both binaries + checksums
- [ ] **Real-world test**: after merge, \`phantombot update --force --restart\` on kai's box should fetch \`v1.0.<this PR number>\`, verify, swap, and restart. (Will manually run after merge.)

## Closes

- #35 — voice flow integration test should drive \`maybePromptRestart\`