### PR TITLE
fix: applyUpdate clears stale .bak before copyFile

### DIFF
--- a/src/lib/binaryUpdate.ts
+++ b/src/lib/binaryUpdate.ts
@@ -154,9 +154,22 @@ export type ApplyResult =
 
 /**
  * Atomic swap. Steps:
- *   1. Copy targetPath → ${targetPath}.bak (so a botched rename is recoverable).
- *   2. rename(tempPath, targetPath) — atomic on Linux even when targetPath
+ *   1. Remove a stale ${targetPath}.bak if one exists (best-effort) — see
+ *      below for why this isn't redundant with copyFile's overwrite.
+ *   2. Copy targetPath → ${targetPath}.bak (so a botched rename is
+ *      recoverable).
+ *   3. rename(tempPath, targetPath) — atomic on Linux even when targetPath
  *      is the running process's binary; the kernel uses inode, not path.
+ *
+ * Why we explicitly unlink the .bak first: copyFile opens the destination
+ * with O_TRUNC. Linux requires write permission on an existing file to
+ * truncate it, even if the parent dir is writable. So if a previous .bak
+ * was written by a different user (e.g. an earlier `sudo cp` during
+ * initial deploy left a root-owned .bak), running `phantombot update` as
+ * the unprivileged service user fails with EACCES — even though kai owns
+ * the dir and the live binary. unlink only needs write+execute on the
+ * parent dir, which we've already verified via checkWritable, so an old
+ * foreign-owned .bak can be cleared without elevated privileges.
  *
  * Returns the .bak path on success so the caller can tell the user where
  * to find the rollback if something downstream (e.g. service restart)
@@ -169,6 +182,11 @@ export async function applyUpdate(opts: ApplyUpdateOpts): Promise<ApplyResult> {
   const backupPath = `${opts.targetPath}.bak`;
   try {
     if (existsSync(opts.targetPath)) {
+      // Defensive unlink of any stale backup from a prior install (see
+      // doc above). Best-effort: rm errors are swallowed because the
+      // copyFile that follows surfaces the real one if the dir itself
+      // isn't writable.
+      await rm(backupPath, { force: true });
       // copyFile (not rename) so we keep targetPath intact in case the
       // rename in step 2 fails — we always have a working binary on disk.
       await copyFile(opts.targetPath, backupPath);

--- a/tests/lib-binaryUpdate.test.ts
+++ b/tests/lib-binaryUpdate.test.ts
@@ -179,6 +179,28 @@ describe("applyUpdate", () => {
     if (r.ok) return;
     expect(r.error).toContain("temp file missing");
   });
+
+  test("clears a stale, unwriteable .bak before backing up", async () => {
+    // Repro of the kw-openclaw failure: a .bak from a prior `sudo cp`
+    // initial deploy is mode 0o644 with no write bit for the current
+    // user. copyFile with O_TRUNC needs write permission on the
+    // existing file; if applyUpdate doesn't unlink first, this fails
+    // with EACCES even though the dir and live binary are kai-owned.
+    const target = join(workdir, "phantombot");
+    const backup = join(workdir, "phantombot.bak");
+    const tmp = join(workdir, "phantombot.update.tmp");
+    await writeFile(target, "OLD", { mode: 0o755 });
+    await writeFile(tmp, "NEW", { mode: 0o755 });
+    // Stale .bak with no write bit at all — simulates a foreign-owned
+    // file we don't have permission to overwrite, but CAN unlink (since
+    // unlink takes its perms from the parent dir).
+    await writeFile(backup, "STALE_BAK", { mode: 0o444 });
+    const r = await applyUpdate({ tempPath: tmp, targetPath: target });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(await readFile(target, "utf8")).toBe("NEW");
+    expect(await readFile(backup, "utf8")).toBe("OLD");
+  });
 });
 
 describe("checkWritable", () => {


### PR DESCRIPTION
## Bug repro (real, from kw-openclaw)

\`\`\`
$ phantombot update
…
downloading phantombot-v1.0.46-linux-x64…
verified 96.6 MB (sha256 ok).
install failed: failed to back up /home/kai/.local/bin/phantombot:
EACCES: permission denied, copyfile
'/home/kai/.local/bin/phantombot' -> '/home/kai/.local/bin/phantombot.bak'
\`\`\`

## Cause

The initial deploy script for kai used \`sudo cp /home/kai/.local/bin/phantombot /home/kai/.local/bin/phantombot.bak\`. \`sudo cp\` creates the destination owned by **root**, so kai's later \`phantombot update\` couldn't overwrite the existing \`.bak\`.

Why \`copyFile\` fails: it opens the destination with \`O_TRUNC\`, which requires write permission **on the existing file**. The parent dir being kai-writable isn't enough — Linux checks the file's own mode/ownership for truncation.

\`checkWritable\` only verifies the parent dir, so it doesn't catch this.

## Fix

\`applyUpdate\` now \`rm -f\`s the \`.bak\` before \`copyFile\`. Unlink takes its permission from the parent dir (write+exec), which we've already verified, so a foreign-owned stale \`.bak\` is cleared without elevated privileges.

## Test plan

- [x] Regression test pre-creates \`.bak\` at mode \`0o444\` (no write bit) and confirms \`applyUpdate\` still succeeds and the new \`.bak\` content is the previous live binary
- [x] \`bun tsc --noEmit\` clean
- [x] \`bun test\` — 370 pass / 1 skip / 0 fail (was 369; +1 regression test)
- [ ] **Real-world**: after merge → \`v1.0.<this PR number>\` → kai runs \`phantombot update --force --restart\` (this time it succeeds)

## Note for the kw-openclaw box

Already cleared the stale \`.bak\` (and a leftover \`.update.tmp\`) by hand so testing isn't blocked while this lands. Once it merges, the next install on a fresh box can't repeat the failure mode.