### PR TITLE
fix: import-persona summary mislabels memory/ and kb/ files

### DIFF
--- a/src/importer/openclaw.ts
+++ b/src/importer/openclaw.ts
@@ -131,6 +131,7 @@ export async function importPersona(
           join(targetDir, e.name),
           copied,
           skipped,
+          targetDir,
         );
       } else {
         const reason = SKIP_DIRS.has(e.name)
@@ -221,13 +222,10 @@ async function copyMarkdownTree(
     }
     const target = join(dst, e.name);
     await copyFile(join(src, e.name), target);
-    // Use a slash-prefixed path relative to the persona dir so the
-    // summary is unambiguous about it being inside memory/ or kb/.
-    copied.push(
-      relative(baseDst, target) === e.name
-        ? e.name
-        : relative(baseDst, target),
-    );
+    // Path relative to the persona dir, so the summary is unambiguous
+    // about a file being inside memory/ or kb/ (e.g. "memory/decisions.md"
+    // rather than just "decisions.md", which collides with top-level files).
+    copied.push(relative(baseDst, target));
   }
 }
 

--- a/tests/importer.test.ts
+++ b/tests/importer.test.ts
@@ -161,11 +161,13 @@ describe("importPersona — recursive memory/ and kb/ subdirs", () => {
     await writeFile(join(source, "kb", "Home.md"), "# Home");
     const r = await importPersona({ source, personasDir, as: "x" });
     expect(r.copied).toContain("BOOT.md");
-    expect(r.copied).toContain("decisions.md");
-    expect(r.copied).toContain("2026-05-02.md");
-    expect(r.copied).toContain("Home.md");
-    // Nested entry — relative to its containing top-level subdir
-    expect(r.copied.some((c) => c.includes("DeyeInverter"))).toBe(true);
+    // Files under memory/ and kb/ keep their parent-dir prefix in the
+    // summary, so a top-level `decisions.md` (if it ever existed) would
+    // be distinguishable from `memory/decisions.md`.
+    expect(r.copied).toContain("memory/decisions.md");
+    expect(r.copied).toContain("memory/2026-05-02.md");
+    expect(r.copied).toContain("kb/Home.md");
+    expect(r.copied).toContain("kb/concepts/DeyeInverter.md");
     const { join: j } = await import("node:path");
     const { readFile } = await import("node:fs/promises");
     const dec = await readFile(
@@ -193,7 +195,7 @@ describe("importPersona — recursive memory/ and kb/ subdirs", () => {
     await writeFile(join(source, "kb", ".secret"), "shh");
     await writeFile(join(source, "kb", "Note.md"), "note");
     const r = await importPersona({ source, personasDir, as: "x" });
-    expect(r.copied).toContain("Note.md");
+    expect(r.copied).toContain("kb/Note.md");
     expect(r.copied).not.toContain("data.json");
     expect(r.copied).not.toContain(".secret");
     expect(r.skipped.some((s) => s.includes("data.json"))).toBe(true);


### PR DESCRIPTION
## Summary

- `phantombot import-persona` summary listed every file under `memory/` and `kb/` without its prefix, making memory drawers and KB notes indistinguishable from top-level identity files in the output.
- Files were always copied to the right place — only the printed listing was wrong.
- Reported by Andrew on a real import: 282-file `clawd-archive` listed flat (`decisions.md`, `2026-03-09.md`, `property-arnhem.md`, …) with one inconsistent survivor (`archive/2026-03.md`).

## Cause

`copyMarkdownTree` defaulted `baseDst` to `dst` (the subtree root) when called from `importPersona`, so `relative(baseDst, target)` stripped the leading `memory/` / `kb/`. The source comment already documented the intended behavior; the implementation didn't match.

## Fix

Pass `targetDir` as `baseDst` from the caller so listed paths are relative to the persona root. Drop the now-dead ternary that papered over `relative(...) === e.name`. Tests updated to assert the prefixed paths.

## Test plan

- [x] `bun test tests/importer.test.ts` (asserts `memory/decisions.md`, `kb/Home.md`, `kb/concepts/DeyeInverter.md` in `copied`)
- [ ] Re-import the same `clawd-archive` after merge — expect `memory/2026-03-09.md`, `kb/property-arnhem.md`, etc. in the summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)