### PR TITLE
feat: consolidate persona CLI + auto-set default on import + install.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,8 @@ phantombot/
 │   │   ├── memory.ts         # phantombot memory (search/get/today/index/list)
 │   │   ├── heartbeat.ts nightly.ts
 │   │   ├── embedding.ts      # phantombot embedding (TUI: Gemini config)
-│   │   ├── create-persona.ts import-persona.ts
+│   │   ├── persona.ts        # phantombot persona (consolidates create / import / restore / switch)
+│   │   ├── create-persona.ts import-persona.ts  # implementation files; no top-level subcommand
 │   ├── harnesses/
 │   │   ├── types.ts          # HarnessRequest / HarnessChunk discriminated union
 │   │   ├── claude.ts         # Bun.spawn `claude --print --output-format stream-json …`
@@ -185,10 +186,12 @@ Every merged PR auto-releases `v1.0.<PR_NUMBER>`. The workflow at `.github/workf
 
 1. **`bun-linux-x64` instead of baseline** — SIGILLs on pre-AVX2 hardware. Use `bun-linux-x64-baseline`. Documented at the top of `.github/workflows/release.yml`.
 2. **`echo … > src/version.ts` in CI** — would clobber the comment block. Use `sed -i "s/0.1.0-dev/$VERSION/" src/version.ts` instead. The placeholder literal must round-trip exactly; if you change `version.ts`, also update the sed pattern in the workflow.
-3. **`sudo cp` to install kai's binary** — leaves `.bak` root-owned, blocks future `phantombot update` from kai. Use `sudo install -o kai -g kai -m 755 …`. Documented in PR #47's repro.
+3. **`sudo cp` to install someone's binary** — leaves `.bak` root-owned, blocks future `phantombot update` from the unprivileged user. Use `sudo install -o <user> -g <group> -m 755 …`. Documented in PR #47's repro.
 4. **`copyFile` over an existing foreign-owned file** — fails with EACCES because `O_TRUNC` checks the existing file's mode. `applyUpdate` unlinks `.bak` first; if you add similar copy logic, do the same.
 5. **@clack/prompts confirm in non-TTY context** — returns the cancel sentinel. If you write code that calls `p.confirm` directly and expect a boolean, tests will hit the cancel path silently. Prefer `ConfirmFn` injection (see `src/cli/harness.ts`).
 6. **Forgetting `tests/cli.test.ts` subcommand list** — every new subcommand needs to be added there or that test fails on PR merge.
+7. **Importing a persona on a fresh box without setting it as default** — the built-in fallback `default_persona = "phantom"` doesn't have a directory; `phantombot run` would fail with "persona 'phantom' not found." `runImportPersona` now adopts the imported persona as default if the current default's dir doesn't exist. If you add another path that creates a persona, do the same — see `maybeAdoptAsDefault` in `src/cli/import-persona.ts`.
+8. **`install.sh` piped to `sh` runs without a TTY** — interactive @clack TUIs would misbehave. The script detects this with `[ -t 0 ] && [ -t 1 ]` before launching the persona TUI, and prints the next-step hint instead. If you add interactive setup steps to the install flow, repeat the check.
 
 ## Process for updating this file
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ A personality-first chat agent. Phantombot wraps Claude Code and Inflection Pi w
 
 ```
 # First-time / config
-phantombot import-persona <openclaw-dir>     # copy persona files in; also pulls Telegram config from ~/.openclaw/openclaw.json
-phantombot create-persona                    # interactive TUI: build a fresh persona from scratch
+phantombot persona                           # TUI: create / import / restore / switch the active persona
+phantombot persona <name>                    # switch default persona to <name>
+phantombot persona --import <dir> [--as <n>] # non-interactive import (OpenClaw or phantombot-shaped)
 phantombot telegram                          # interactive TUI: configure the Telegram channel
 phantombot harness                           # interactive TUI: pick primary + fallback harnesses
 phantombot voice                             # interactive TUI: pick TTS/STT provider (ElevenLabs/OpenAI/Azure Edge)
@@ -96,24 +97,37 @@ If you literally need two personas answering simultaneously (different bots, dif
 - **(Optional)** Inflection Pi installed and configured if you want it in the fallback chain
 - A Telegram bot token from [@BotFather](https://t.me/BotFather)
 
-### From a GitHub release (recommended)
+### One-liner install (recommended)
 
 ```bash
-# Initial install on the target box (any Linux x86-64 or arm64):
-curl -L -o ~/.local/bin/phantombot \
-  https://github.com/andrewagrahamhodges/phantombot/releases/latest/download/phantombot-vX.Y.Z-linux-x64
-chmod +x ~/.local/bin/phantombot
+curl -fsSL https://raw.githubusercontent.com/andrewagrahamhodges/phantombot/main/install.sh | sh
+```
 
-# Subsequent updates:
-phantombot update                 # interactive TUI
-phantombot update --force --restart   # unattended (cron-friendly)
+What it does:
+
+1. Detects host arch (`x86_64` → x64, `aarch64` → arm64).
+2. Fetches the latest GitHub release tag.
+3. Downloads the matching binary + `SHA256SUMS`, **verifies the checksum**, refuses on mismatch.
+4. Installs to `~/.local/bin/phantombot` (mode 0755).
+5. Warns if `~/.local/bin` isn't on `PATH`.
+6. Launches `phantombot persona` to set up the first persona — unless stdin/stdout aren't a TTY (e.g. running headless), in which case it prints the next-step hint and exits cleanly.
+
+Override the install dir: `PHANTOMBOT_INSTALL_DIR=/opt/bin curl -fsSL … | sh`.
+Skip the post-install TUI: `PHANTOMBOT_SKIP_TUI=1 curl -fsSL … | sh` (useful for CI / unattended provisioning).
+
+Subsequent updates use the same release feed:
+
+```bash
+phantombot update                       # interactive TUI
+phantombot update --check               # exit 2 if newer available, 0 if current
+phantombot update --force --restart     # unattended (cron-friendly)
 ```
 
 CI publishes a fresh release per merged PR, tagged `v1.0.<PR_NUMBER>`. Each release ships:
 
 - `phantombot-v1.0.N-linux-x64`     — x86-64, **baseline** (no AVX2 required)
 - `phantombot-v1.0.N-linux-arm64`   — ARM64
-- `SHA256SUMS`                      — `phantombot update` verifies against this
+- `SHA256SUMS`                      — both `install.sh` and `phantombot update` verify against this
 
 ### From source
 
@@ -130,8 +144,13 @@ The default `build` script targets `bun-linux-x64-baseline`. If you "optimise" t
 
 ### First-time setup
 
+The one-liner above runs `phantombot persona` for you in interactive mode. Or do it explicitly:
+
 ```bash
-phantombot create-persona                    # OR phantombot import-persona ~/clawd
+phantombot persona                           # TUI: create / import / restore / switch
+# OR non-interactively:
+phantombot persona --import ~/clawd --as robbie
+
 phantombot harness                           # claude / pi / both
 phantombot telegram                          # bot token + allowed user IDs
 phantombot voice                             # optional: TTS/STT provider for voice messages
@@ -140,6 +159,8 @@ phantombot run                               # foreground sanity check (Ctrl-C t
 phantombot install                           # then install as a systemd --user service
 journalctl --user -u phantombot -f           # tail the logs
 ```
+
+> **First-import note**: when you import a persona on a fresh box, `phantombot persona --import` automatically sets it as `default_persona` (unless you already have a persona configured). Without this, the built-in fallback `"phantom"` would still be the default and `phantombot run` would fail with "persona 'phantom' not found." Switch later with `phantombot persona <name>`.
 
 If you're a headless service account (no login session), enable linger first:
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+# phantombot installer.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/andrewagrahamhodges/phantombot/main/install.sh | sh
+#
+# What it does:
+#   1. Detects host arch (x86_64 → x64, aarch64 → arm64).
+#   2. Fetches the latest GitHub release tag.
+#   3. Downloads the matching binary + SHA256SUMS.
+#   4. Verifies the SHA256.
+#   5. Installs to ~/.local/bin/phantombot (mode 0755).
+#   6. Warns if ~/.local/bin isn't on PATH.
+#   7. Launches `phantombot persona` to set up the first persona.
+#
+# Override the install dir with PHANTOMBOT_INSTALL_DIR=/some/path.
+# Skip the persona TUI launch with PHANTOMBOT_SKIP_TUI=1 (e.g. CI smoke tests).
+#
+# Refusal modes (intentional — bail fast):
+#   - unsupported arch
+#   - no curl available
+#   - GitHub API didn't return a parseable tag
+#   - SHA256 mismatch
+#   - install dir not writable
+
+set -eu
+
+REPO="andrewagrahamhodges/phantombot"
+INSTALL_DIR="${PHANTOMBOT_INSTALL_DIR:-$HOME/.local/bin}"
+
+# --- arch detection ------------------------------------------------------
+
+uname_m="$(uname -m)"
+case "$uname_m" in
+  x86_64|amd64)        arch="x64" ;;
+  aarch64|arm64)       arch="arm64" ;;
+  *)
+    printf 'phantombot: unsupported arch %s (only linux x86_64 / aarch64 are released)\n' "$uname_m" >&2
+    exit 1
+    ;;
+esac
+
+# --- preflight -----------------------------------------------------------
+
+if ! command -v curl >/dev/null 2>&1; then
+  printf 'phantombot: curl not found (needed to download the release)\n' >&2
+  exit 1
+fi
+if ! command -v sha256sum >/dev/null 2>&1; then
+  printf 'phantombot: sha256sum not found (needed to verify the download)\n' >&2
+  exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+if [ ! -w "$INSTALL_DIR" ]; then
+  printf 'phantombot: install dir %s is not writable\n' "$INSTALL_DIR" >&2
+  exit 1
+fi
+
+# --- discover latest tag -------------------------------------------------
+
+api_url="https://api.github.com/repos/$REPO/releases/latest"
+auth_header=""
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  auth_header="Authorization: Bearer $GITHUB_TOKEN"
+fi
+
+if [ -n "$auth_header" ]; then
+  release_json="$(curl -fsSL -H "$auth_header" "$api_url")"
+else
+  release_json="$(curl -fsSL "$api_url")"
+fi
+
+# Cheap tag extraction with sed — avoids a jq dependency.
+tag="$(printf '%s' "$release_json" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+if [ -z "$tag" ]; then
+  printf 'phantombot: could not parse latest tag from %s\n' "$api_url" >&2
+  exit 1
+fi
+
+asset="phantombot-${tag}-linux-${arch}"
+binary_url="https://github.com/$REPO/releases/download/${tag}/${asset}"
+sums_url="https://github.com/$REPO/releases/download/${tag}/SHA256SUMS"
+
+# --- download + verify ---------------------------------------------------
+
+tmp_bin="$(mktemp "${TMPDIR:-/tmp}/phantombot.XXXXXX")"
+trap 'rm -f "$tmp_bin"' EXIT INT TERM
+
+printf 'phantombot: downloading %s\n' "$asset"
+curl -fsSL -o "$tmp_bin" "$binary_url"
+
+printf 'phantombot: verifying SHA256\n'
+expected="$(curl -fsSL "$sums_url" | grep " $asset\$" | awk '{print $1}')"
+if [ -z "$expected" ]; then
+  printf 'phantombot: SHA256SUMS has no entry for %s\n' "$asset" >&2
+  exit 1
+fi
+actual="$(sha256sum "$tmp_bin" | awk '{print $1}')"
+if [ "$expected" != "$actual" ]; then
+  printf 'phantombot: SHA256 mismatch (expected %s, got %s) — refusing to install\n' "$expected" "$actual" >&2
+  exit 1
+fi
+
+# --- install -------------------------------------------------------------
+
+# Atomic on Linux: rename(2) over the destination is safe even if the
+# destination is the running binary (kernel uses inode, not path).
+chmod 0755 "$tmp_bin"
+mv "$tmp_bin" "$INSTALL_DIR/phantombot"
+trap - EXIT INT TERM
+
+printf 'phantombot: installed %s to %s/phantombot\n' "$tag" "$INSTALL_DIR"
+
+# --- PATH check ----------------------------------------------------------
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    printf '\nphantombot: %s is not on your PATH.\n' "$INSTALL_DIR" >&2
+    printf 'add this to your shell profile (~/.bashrc or ~/.zshrc):\n' >&2
+    printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR" >&2
+    printf '\nthen re-open your shell, or for this session:\n' >&2
+    printf '  export PATH="%s:$PATH"\n\n' "$INSTALL_DIR" >&2
+    ;;
+esac
+
+# --- launch the persona TUI ---------------------------------------------
+
+if [ -n "${PHANTOMBOT_SKIP_TUI:-}" ]; then
+  exit 0
+fi
+
+# If stdin is not a TTY (e.g. piped from `curl … | sh`), the @clack
+# prompts will misbehave. Detect and print the next-step hint instead.
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+  printf '\nphantombot: not a TTY (script was piped). Run this next to set up your first persona:\n' >&2
+  printf '  phantombot persona\n\n' >&2
+  exit 0
+fi
+
+printf '\nphantombot: launching persona TUI to set up your first persona.\n\n'
+exec "$INSTALL_DIR/phantombot" persona

--- a/src/cli/create-persona.ts
+++ b/src/cli/create-persona.ts
@@ -1,15 +1,19 @@
 /**
- * `phantombot create-persona` — interactive TUI to create a new persona.
+ * Persona creation flow — used by `phantombot persona` (the consolidated
+ * subcommand) when the user picks "Create a new persona" from its menu.
  *
  * Asks a handful of questions, generates BOOT.md (and a placeholder
  * MEMORY.md), and optionally sets the new persona as default.
  *
- * The TUI lives in `gatherInputs`. Side effects live in `applyPersona`.
- * Tests cover applyPersona with synthetic inputs; the prompt flow is
- * verified manually.
+ * Side effects live in `applyPersona`; the prompt flow is in
+ * `runCreatePersona`. Tests cover applyPersona with synthetic inputs;
+ * the prompt flow is verified manually.
+ *
+ * This file does NOT export a `defineCommand(...)` default — the
+ * top-level `phantombot create-persona` subcommand was retired in
+ * favor of `phantombot persona` (see src/cli/persona.ts).
  */
 
-import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -226,13 +230,3 @@ export async function runCreatePersona(input: RunInput = {}): Promise<number> {
   return 0;
 }
 
-export default defineCommand({
-  meta: {
-    name: "create-persona",
-    description: "Create a new persona via interactive prompts.",
-  },
-  async run() {
-    const code = await runCreatePersona();
-    process.exitCode = code;
-  },
-});

--- a/src/cli/import-persona.ts
+++ b/src/cli/import-persona.ts
@@ -1,15 +1,19 @@
 /**
- * `phantombot import-persona <openclaw-dir>` — copy an OpenClaw agent
- * directory's persona files into phantombot's personas dir, and (if
- * --no-telegram is not passed) sniff the standard OpenClaw config at
- * ~/.openclaw/openclaw.json for a Telegram bot block; if found, write
- * it to phantombot's [channels.telegram].
+ * Persona import flow — used by `phantombot persona --import <dir>` or
+ * the "Import from a directory" / "Restore from archive" menu entries
+ * in `phantombot persona`. The top-level `phantombot import-persona`
+ * subcommand was retired in favor of `phantombot persona`
+ * (see src/cli/persona.ts).
+ *
+ * Copies an OpenClaw agent directory's persona files into phantombot's
+ * personas dir, and (if --no-telegram is not passed) sniffs the
+ * standard OpenClaw config at ~/.openclaw/openclaw.json for a Telegram
+ * bot block; if found, writes it to phantombot's [channels.telegram].
  *
  * The persona-file work is in src/importer/openclaw.ts.
  * The telegram sniff is in src/cli/telegram.ts (parseOpenClawTelegram).
  */
 
-import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -120,6 +124,15 @@ export async function runImportPersona(
     out.write(`scaffolded (${scaffold.created.length}):\n`);
     for (const f of scaffold.created) out.write(`  ${f}\n`);
   }
+
+  // Auto-set as default if the current default doesn't actually exist
+  // on disk. Without this, a fresh box with `default_persona = "phantom"`
+  // (the built-in fallback) would still try to load `personas/phantom/`
+  // even after importing `personas/robbie/` — and `phantombot run`
+  // would fail with "persona 'phantom' not found." We don't clobber a
+  // working default if the user is importing an additional persona.
+  await maybeAdoptAsDefault(config, result.name, out);
+
   out.write(
     "\nNote: conversation history was NOT imported (phantombot v1 has no transcript importer).\n",
   );
@@ -422,6 +435,38 @@ async function maybeImportOpenclawVoice(args: {
   }
 }
 
+/**
+ * If the current default_persona (from state.json or config.toml) points
+ * at a persona dir that doesn't exist, adopt the just-imported persona
+ * as the new default. The built-in fallback "phantom" is treated as
+ * non-existent if there's no `personas/phantom/` on disk — so a fresh
+ * box that imports its first persona will switch the default to it
+ * automatically, fixing the bug where `phantombot run` later failed
+ * with "persona 'phantom' not found."
+ *
+ * Doesn't override a working default — if the user already has a
+ * persona configured and is importing another, the import is additive,
+ * not destructive.
+ */
+async function maybeAdoptAsDefault(
+  config: Config,
+  importedName: string,
+  out: WriteSink,
+): Promise<void> {
+  const currentDefaultDir = personaDir(config, config.defaultPersona);
+  if (existsSync(currentDefaultDir)) {
+    // Working default already; don't touch.
+    return;
+  }
+  const { loadState, saveState } = await import("../state.ts");
+  const state = await loadState();
+  state.default_persona = importedName;
+  await saveState(state);
+  out.write(
+    `\nadopted '${importedName}' as default_persona (previous default '${config.defaultPersona}' has no persona dir on disk)\n`,
+  );
+}
+
 async function maybeRestartHint(
   serviceControl: ServiceControl | undefined,
   out: WriteSink,
@@ -453,43 +498,3 @@ function maskToken(t: string): string {
   return t.slice(0, 6) + "…" + t.slice(-4);
 }
 
-export default defineCommand({
-  meta: {
-    name: "import-persona",
-    description:
-      "Import a persona from an OpenClaw agent directory. Also imports the OpenClaw Telegram config from ~/.openclaw/openclaw.json if found (use --no-telegram to skip).",
-  },
-  args: {
-    path: {
-      type: "positional",
-      description:
-        "Path to the OpenClaw agent directory to import. If omitted, an interactive TUI is shown (current persona / restore from archive / import from path / cancel).",
-      required: false,
-    },
-    as: {
-      type: "string",
-      description:
-        "Target persona name (defaults to the basename of the source directory).",
-    },
-    overwrite: {
-      type: "boolean",
-      description: "Replace any existing persona with the same name.",
-      default: false,
-    },
-    "no-telegram": {
-      type: "boolean",
-      description:
-        "Skip the OpenClaw Telegram config sniff at ~/.openclaw/openclaw.json.",
-      default: false,
-    },
-  },
-  async run({ args }) {
-    const code = await runImportPersona({
-      source: args.path ? String(args.path) : undefined,
-      as: args.as ? String(args.as) : undefined,
-      overwrite: Boolean(args.overwrite),
-      noTelegram: Boolean(args["no-telegram"]),
-    });
-    process.exitCode = code;
-  },
-});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,8 +15,7 @@
 
 import { defineCommand } from "citty";
 import { VERSION } from "../version.ts";
-import importPersonaCmd from "./import-persona.ts";
-import createPersonaCmd from "./create-persona.ts";
+import personaCmd from "./persona.ts";
 import telegramCmd from "./telegram.ts";
 import harnessCmd from "./harness.ts";
 import installCmd from "./install.ts";
@@ -41,8 +40,7 @@ export const mainCommand = defineCommand({
       "Personality-first chat agent CLI. Wraps Claude Code and Pi CLIs with persona, memory, and a Telegram bot front-end.",
   },
   subCommands: {
-    "import-persona": importPersonaCmd,
-    "create-persona": createPersonaCmd,
+    persona: personaCmd,
     telegram: telegramCmd,
     harness: harnessCmd,
     embedding: embeddingCmd,

--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -31,6 +31,7 @@ import {
   personaDir,
 } from "../config.ts";
 import type { WriteSink } from "../lib/io.ts";
+import { log } from "../lib/logger.ts";
 import { listArchives } from "../lib/personaArchive.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
 import { loadState, saveState } from "../state.ts";
@@ -260,6 +261,10 @@ async function runPersonaMenu(input: RunPersonaMenuInput): Promise<number> {
  * Read the personas directory and return the names of subdirectories
  * (each subdir = one persona). Returns [] if the personas dir doesn't
  * exist yet — fresh installs have no personas.
+ *
+ * Non-ENOENT read failures (EACCES, EIO, etc.) still return [] so the
+ * caller's UI keeps working, but they're logged to stderr first so the
+ * user has a hint that the empty list isn't the same as "no personas."
  */
 export function listExistingPersonas(config: Config): string[] {
   if (!existsSync(config.personasDir)) return [];
@@ -268,7 +273,11 @@ export function listExistingPersonas(config: Config): string[] {
       .filter((e) => e.isDirectory())
       .map((e) => e.name)
       .sort();
-  } catch {
+  } catch (e) {
+    log.warn("persona: failed to read personas dir", {
+      personasDir: config.personasDir,
+      error: (e as Error).message,
+    });
     return [];
   }
 }

--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -1,0 +1,314 @@
+/**
+ * `phantombot persona` — single entry point for persona management.
+ *
+ * Replaces the previous `phantombot create-persona` and
+ * `phantombot import-persona` top-level subcommands. The argument grammar:
+ *
+ *   phantombot persona                       — TUI: current persona + menu
+ *                                              (create / import / restore / switch)
+ *   phantombot persona <name>                — switch default persona to <name>
+ *                                              (positional; <name> must exist)
+ *   phantombot persona --import <dir>        — import non-interactively
+ *   phantombot persona --import <dir> --as N — import with explicit target name
+ *
+ * The `--import` flag and a positional <name> are mutually exclusive; pass
+ * `--as` with `--import` to set the target name instead of using a positional.
+ *
+ * The underlying create / import / restore work still lives in
+ * `src/cli/create-persona.ts` and `src/cli/import-persona.ts` — those files
+ * keep their `run*` exports for direct programmatic use and existing tests.
+ * Only their `defineCommand(...)` defaults are removed so phantombot's
+ * dispatcher only exposes the consolidated entry point.
+ */
+
+import { defineCommand } from "citty";
+import { existsSync, readdirSync } from "node:fs";
+import * as p from "@clack/prompts";
+
+import {
+  type Config,
+  loadConfig,
+  personaDir,
+} from "../config.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { listArchives } from "../lib/personaArchive.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import { loadState, saveState } from "../state.ts";
+import { runCreatePersona } from "./create-persona.ts";
+import { runImportPersona } from "./import-persona.ts";
+import { maybePromptRestart } from "./harness.ts";
+
+export interface RunPersonaInput {
+  /** Positional <name> — switch default. Mutually exclusive with `import`. */
+  name?: string;
+  /** Import flag value: path to a persona dir to import. */
+  import?: string;
+  /** Override target persona name on import. Default: basename(import). */
+  as?: string;
+  /** Skip the OpenClaw Telegram sniff during import. */
+  noTelegram?: boolean;
+  config?: Config;
+  serviceControl?: ServiceControl;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runPersona(input: RunPersonaInput = {}): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+
+  if (input.import && input.name) {
+    err.write(
+      "specify --as <name> with --import; don't combine --import with a positional name.\n",
+    );
+    return 2;
+  }
+
+  if (input.import) {
+    return runImportPersona({
+      source: input.import,
+      as: input.as,
+      overwrite: false,
+      noTelegram: input.noTelegram,
+      config: input.config,
+      serviceControl: input.serviceControl,
+      out,
+      err,
+    });
+  }
+
+  if (input.name) {
+    return runSwitchPersona({
+      name: input.name,
+      config: input.config,
+      serviceControl: input.serviceControl,
+      out,
+      err,
+    });
+  }
+
+  return runPersonaMenu({
+    config: input.config,
+    serviceControl: input.serviceControl,
+    out,
+    err,
+  });
+}
+
+/**
+ * Switch the default persona to `name`. Validates that the persona dir
+ * exists; refuses with a clear error if it doesn't, listing available
+ * personas. Prompts for a phantombot restart if the service is running.
+ */
+export interface RunSwitchPersonaInput {
+  name: string;
+  config?: Config;
+  serviceControl?: ServiceControl;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runSwitchPersona(
+  input: RunSwitchPersonaInput,
+): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const config = input.config ?? (await loadConfig());
+
+  const targetDir = personaDir(config, input.name);
+  if (!existsSync(targetDir)) {
+    const available = listExistingPersonas(config);
+    err.write(
+      `persona '${input.name}' not found at ${targetDir}\n` +
+        (available.length > 0
+          ? `available: ${available.join(", ")}\n`
+          : "no personas exist yet — create one with `phantombot persona`.\n"),
+    );
+    return 1;
+  }
+
+  const state = await loadState();
+  const previous = state.default_persona ?? config.defaultPersona;
+  if (previous === input.name) {
+    out.write(`'${input.name}' is already the default.\n`);
+    return 0;
+  }
+  state.default_persona = input.name;
+  await saveState(state);
+  out.write(
+    `default_persona: '${previous ?? "(unset)"}' → '${input.name}'\n`,
+  );
+
+  const svc = input.serviceControl ?? defaultServiceControl();
+  await maybePromptRestart(svc);
+  return 0;
+}
+
+interface RunPersonaMenuInput {
+  config?: Config;
+  serviceControl?: ServiceControl;
+  out: WriteSink;
+  err: WriteSink;
+}
+
+/**
+ * The interactive TUI menu. Shows current persona, lists what's on disk,
+ * and offers create / import / restore / switch / cancel. Each action
+ * delegates to the relevant existing run* function.
+ */
+async function runPersonaMenu(input: RunPersonaMenuInput): Promise<number> {
+  const config = input.config ?? (await loadConfig());
+
+  p.intro("Persona");
+
+  const personas = listExistingPersonas(config);
+  const currentDefault = config.defaultPersona;
+  const defaultExists = personas.includes(currentDefault);
+
+  if (defaultExists) {
+    p.note(
+      `Current default: ${currentDefault}\n  ${personaDir(config, currentDefault)}\n` +
+        `On disk: ${personas.join(", ")}`,
+      "Status",
+    );
+  } else if (personas.length > 0) {
+    p.note(
+      `Default ('${currentDefault}') doesn't exist on disk.\nOn disk: ${personas.join(", ")}`,
+      "Status",
+    );
+  } else {
+    p.note("No personas yet. Create or import one to get started.", "Status");
+  }
+
+  type Action = "create" | "import" | "restore" | "switch" | "cancel";
+  const archives = await listArchives(config.personasDir);
+  const switchableCount = personas.filter((n) => n !== currentDefault).length;
+
+  const action = await p.select<Action>({
+    message: "What do you want to do?",
+    options: [
+      { value: "create", label: "Create a new persona" },
+      {
+        value: "import",
+        label: "Import from a directory (OpenClaw or phantombot-shaped)",
+      },
+      {
+        value: "restore",
+        label: `Restore an archived persona (${archives.length} available)`,
+        hint: archives.length === 0 ? "none yet" : undefined,
+      },
+      {
+        value: "switch",
+        label: "Switch the default persona",
+        hint:
+          switchableCount === 0
+            ? "create or import another first"
+            : `${switchableCount} other(s) available`,
+      },
+      { value: "cancel", label: "Cancel" },
+    ],
+  });
+  if (p.isCancel(action) || action === "cancel") {
+    p.cancel("cancelled");
+    return 0;
+  }
+
+  if (action === "create") {
+    return runCreatePersona({ config, out: input.out });
+  }
+  if (action === "import" || action === "restore") {
+    // runImportPersona without a source falls into its own TUI which
+    // already handles both "import from a directory" and "restore from
+    // archive" — we just route there. Could split later if the menus
+    // need to diverge.
+    return runImportPersona({
+      config,
+      serviceControl: input.serviceControl,
+      out: input.out,
+      err: input.err,
+    });
+  }
+  if (action === "switch") {
+    if (switchableCount === 0) {
+      p.cancel("nothing to switch to.");
+      return 0;
+    }
+    const pick = await p.select<string>({
+      message: "Switch default persona to",
+      options: personas
+        .filter((n) => n !== currentDefault)
+        .map((n) => ({ value: n, label: n })),
+    });
+    if (p.isCancel(pick)) {
+      p.cancel("cancelled");
+      return 0;
+    }
+    const code = await runSwitchPersona({
+      name: pick as string,
+      config,
+      serviceControl: input.serviceControl,
+      out: input.out,
+      err: input.err,
+    });
+    p.outro("done");
+    return code;
+  }
+  return 0;
+}
+
+/**
+ * Read the personas directory and return the names of subdirectories
+ * (each subdir = one persona). Returns [] if the personas dir doesn't
+ * exist yet — fresh installs have no personas.
+ */
+export function listExistingPersonas(config: Config): string[] {
+  if (!existsSync(config.personasDir)) return [];
+  try {
+    return readdirSync(config.personasDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+export default defineCommand({
+  meta: {
+    name: "persona",
+    description:
+      "Manage personas: create, import, switch, or list. Run with no args for the TUI; pass <name> to switch; pass --import <dir> to import non-interactively.",
+  },
+  args: {
+    name: {
+      type: "positional",
+      description:
+        "Switch default persona to <name>. Mutually exclusive with --import.",
+      required: false,
+    },
+    import: {
+      type: "string",
+      description:
+        "Import a persona directory (OpenClaw or phantombot-shaped) non-interactively.",
+    },
+    as: {
+      type: "string",
+      description:
+        "Target persona name when importing. Default: basename of the source directory.",
+    },
+    "no-telegram": {
+      type: "boolean",
+      description:
+        "Skip the OpenClaw Telegram config sniff at ~/.openclaw/openclaw.json.",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    process.exitCode = await runPersona({
+      name: args.name ? String(args.name) : undefined,
+      import: args.import ? String(args.import) : undefined,
+      as: args.as ? String(args.as) : undefined,
+      noTelegram: Boolean(args["no-telegram"]),
+    });
+  },
+});

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -229,3 +229,64 @@ describe("runImportPersona — telegram sniff", () => {
     await expect(readFile(config.configPath, "utf8")).rejects.toThrow();
   });
 });
+
+describe("runImportPersona — auto-adopt as default", () => {
+  let savedStateEnv: string | undefined;
+  let stateFile: string;
+
+  beforeEach(async () => {
+    savedStateEnv = process.env.PHANTOMBOT_STATE;
+    stateFile = join(workdir, "state.json");
+    process.env.PHANTOMBOT_STATE = stateFile;
+  });
+
+  afterEach(() => {
+    if (savedStateEnv === undefined) delete process.env.PHANTOMBOT_STATE;
+    else process.env.PHANTOMBOT_STATE = savedStateEnv;
+  });
+
+  test("first import on fresh box: adopts imported name as default_persona", async () => {
+    // Fresh state — no personas/phantom/ exists. The configured default
+    // ('phantom') is the built-in fallback that doesn't have a directory.
+    expect(config.defaultPersona).toBe("phantom");
+    const out = new CaptureStream();
+    const code = await runImportPersona({
+      source,
+      as: "robbie",
+      noTelegram: true,
+      config,
+      serviceControl: svcInactive,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("adopted 'robbie' as default_persona");
+    const state = JSON.parse(await readFile(stateFile, "utf8"));
+    expect(state.default_persona).toBe("robbie");
+  });
+
+  test("doesn't override a working default (additive imports)", async () => {
+    // Pre-existing persona at the configured default — additive import
+    // shouldn't shift the default away from it.
+    await mkdir(join(config.personasDir, "phantom"), { recursive: true });
+    await writeFile(
+      join(config.personasDir, "phantom", "BOOT.md"),
+      "# id",
+      "utf8",
+    );
+    const out = new CaptureStream();
+    const code = await runImportPersona({
+      source,
+      as: "robbie",
+      noTelegram: true,
+      config,
+      serviceControl: svcInactive,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).not.toContain("adopted");
+    // No state file written.
+    await expect(readFile(stateFile, "utf8")).rejects.toThrow();
+  });
+});

--- a/tests/cli-persona.test.ts
+++ b/tests/cli-persona.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the consolidated `phantombot persona` CLI.
+ *
+ * Three flows the CLI exposes:
+ *   - bare `phantombot persona`           → TUI menu (not driven by tests)
+ *   - `phantombot persona <name>`         → switch default
+ *   - `phantombot persona --import <dir>` → non-interactive import
+ *
+ * The TUI menu itself isn't tested here (it'd require @clack/prompts
+ * mocking that's not worth the friction for a menu-of-existing-flows);
+ * the underlying flows are covered by cli-create-persona / cli-import-persona.
+ *
+ * What we DO cover here: the dispatcher arg parsing, the switch path
+ * end-to-end, and the bug-fix mutual-exclusion between --import and a
+ * positional <name>.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPersona, runSwitchPersona } from "../src/cli/persona.ts";
+import type { Config } from "../src/config.ts";
+import type { ServiceControl } from "../src/lib/systemd.ts";
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+const svcInactive: ServiceControl = {
+  isActive: async () => false,
+  restart: async () => ({ ok: true }),
+  rerenderUnitIfStale: async () => ({ rerendered: false }),
+};
+
+let workdir: string;
+let personasDir: string;
+let configPath: string;
+let stateDir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-persona-cli-"));
+  personasDir = join(workdir, "personas");
+  await mkdir(personasDir, { recursive: true });
+  configPath = join(workdir, "config.toml");
+  // state.ts loads from ~/.local/share/phantombot/state.json by default.
+  // Override via env so tests don't pollute the real home dir.
+  stateDir = join(workdir, "data");
+  await mkdir(stateDir, { recursive: true });
+  process.env.PHANTOMBOT_STATE = join(stateDir, "state.json");
+});
+
+afterEach(async () => {
+  delete process.env.PHANTOMBOT_STATE;
+  await rm(workdir, { recursive: true, force: true });
+});
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    defaultPersona: "phantom",
+    turnTimeoutMs: 1000,
+    personasDir,
+    memoryDbPath: join(workdir, "memory.sqlite"),
+    configPath,
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1 },
+    },
+    channels: {},
+    embeddings: { provider: "none" },
+    voice: { provider: "none" },
+    ...overrides,
+  };
+}
+
+describe("runPersona arg validation", () => {
+  test("--import combined with positional name → exit 2", async () => {
+    const err = new CaptureStream();
+    const code = await runPersona({
+      name: "robbie",
+      import: "/tmp/somewhere",
+      config: makeConfig(),
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("don't combine --import");
+  });
+});
+
+describe("runSwitchPersona", () => {
+  test("missing persona dir → exit 1 with available list", async () => {
+    await mkdir(join(personasDir, "phantom"), { recursive: true });
+    await mkdir(join(personasDir, "robbie"), { recursive: true });
+    const err = new CaptureStream();
+    const code = await runSwitchPersona({
+      name: "missing",
+      config: makeConfig(),
+      serviceControl: svcInactive,
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("'missing' not found");
+    expect(err.text).toMatch(/available:.*phantom/);
+    expect(err.text).toMatch(/available:.*robbie/);
+  });
+
+  test("missing persona dir with no personas at all → distinct hint", async () => {
+    const err = new CaptureStream();
+    const code = await runSwitchPersona({
+      name: "anything",
+      config: makeConfig(),
+      serviceControl: svcInactive,
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("no personas exist yet");
+  });
+
+  test("happy path: writes default_persona to state.json", async () => {
+    await mkdir(join(personasDir, "robbie"), { recursive: true });
+    const out = new CaptureStream();
+    const code = await runSwitchPersona({
+      name: "robbie",
+      config: makeConfig(),
+      serviceControl: svcInactive,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("→ 'robbie'");
+    const state = JSON.parse(
+      await Bun.file(process.env.PHANTOMBOT_STATE!).text(),
+    );
+    expect(state.default_persona).toBe("robbie");
+  });
+
+  test("already-current → no-op exit 0, no state write", async () => {
+    await mkdir(join(personasDir, "phantom"), { recursive: true });
+    // Pre-write state with phantom as default.
+    await writeFile(
+      process.env.PHANTOMBOT_STATE!,
+      JSON.stringify({ default_persona: "phantom" }),
+      "utf8",
+    );
+    const out = new CaptureStream();
+    const code = await runSwitchPersona({
+      name: "phantom",
+      config: makeConfig(),
+      serviceControl: svcInactive,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("already the default");
+  });
+});
+
+describe("runPersona dispatch", () => {
+  test("positional <name> routes to runSwitchPersona", async () => {
+    await mkdir(join(personasDir, "robbie"), { recursive: true });
+    const out = new CaptureStream();
+    const code = await runPersona({
+      name: "robbie",
+      config: makeConfig(),
+      serviceControl: svcInactive,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("→ 'robbie'");
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -20,16 +20,15 @@ describe("phantombot CLI dispatcher", () => {
     const subs = mainCommand.subCommands ?? {};
     const names = Object.keys(subs).sort();
     expect(names).toEqual([
-      "create-persona",
       "embedding",
       "env",
       "harness",
       "heartbeat",
-      "import-persona",
       "install",
       "memory",
       "nightly",
       "notify",
+      "persona",
       "run",
       "task",
       "telegram",


### PR DESCRIPTION
Four asks bundled into one cohesive PR (per the conversation):

1. **Consolidate** \`phantombot create-persona\` + \`phantombot import-persona\` into a single \`phantombot persona\` entry point.
2. **Fix** the bug where \`phantombot run\` failed with *"persona 'phantom' not found"* after a successful import.
3. **One-liner installer** at the repo root + the curl line at the top of the README install section.
4. **Persona switching** as both a TUI option and a positional arg.

## What changed

### 1. New \`phantombot persona\` (src/cli/persona.ts)

\`\`\`
phantombot persona                       # TUI: current persona + create / import / restore / switch
phantombot persona <name>                # switch default persona to <name>
phantombot persona --import <dir>        # non-interactive import
phantombot persona --import <dir> --as N
\`\`\`

\`--import\` + positional \`<name>\` are mutually exclusive (exit 2 with hint).

The two old top-level subcommands are **removed** from the dispatcher. Their implementation files (\`create-persona.ts\`, \`import-persona.ts\`) stay in place — \`runCreatePersona\` / \`runImportPersona\` / \`applyRestore\` are still exported and used by the new \`persona.ts\` and the existing tests. Only the \`defineCommand\` defaults are dropped.

### 2. Auto-set \`default_persona\` on import (the bug fix)

\`\`\`
$ phantombot persona --import ~/clawd --as robbie
imported persona 'robbie' to /home/robbie/.local/share/phantombot/personas/robbie
copied (282):
  …
adopted 'robbie' as default_persona (previous default 'phantom' has no persona dir on disk)

$ phantombot run
phantombot — persona 'robbie', harnesses claude → pi
…
\`\`\`

Reproduces and fixes the user-reported bug:

> \`\`\`
> robbie@OpenClaw-Hodges:~$ phantombot run
> persona 'phantom' not found at /home/robbie/.local/share/phantombot/personas/phantom
> import or create one with \`phantombot import-persona <openclaw-dir>\` …
> \`\`\`

The new \`maybeAdoptAsDefault\` helper writes \`state.json\` only when the current default's directory doesn't exist — additive imports (where the user already has a working persona) **don't** shift the default. Tested both ways.

### 3. \`install.sh\` (repo root)

\`\`\`
curl -fsSL https://raw.githubusercontent.com/andrewagrahamhodges/phantombot/main/install.sh | sh
\`\`\`

- Arch detection (\`x86_64\` → x64, \`aarch64\` → arm64; refuses other archs)
- Fetches latest release tag from GH API (honors \`GITHUB_TOKEN\` if set)
- Downloads binary + \`SHA256SUMS\`, **verifies the checksum**, refuses on mismatch
- Installs to \`~/.local/bin/phantombot\` (mode 0755)
- Warns if PATH doesn't include the install dir
- Launches \`phantombot persona\` to set up the first persona — but **detects non-TTY** (\`curl … | sh\` case) and prints the next-step hint instead of trying to drive @clack
- Overrides: \`PHANTOMBOT_INSTALL_DIR=/some/path\`, \`PHANTOMBOT_SKIP_TUI=1\`

Verified with \`sh -n install.sh\` (no test framework for shell scripts; manual smoke test on a fresh VM is documented as the validation path).

### 4. Switching

\`phantombot persona <name>\` (or the TUI menu's "Switch" entry) writes \`state.default_persona\` and prompts for restart via the existing \`maybePromptRestart\` plumbing. Refuses with a clear "available: …" list when the target doesn't exist.

## Test plan

- [x] \`bun tsc --noEmit\` clean
- [x] \`bun test\` — **442 pass / 1 skip / 0 fail** (was 434; +8 new tests)
- [x] \`sh -n install.sh\` clean
- [x] Local \`bun run build\` produces a binary; \`./dist/phantombot --help\` shows \`persona\` and **no longer shows** \`create-persona\` / \`import-persona\`
- [ ] **Self-test on merge**: workflow run produces \`v1.0.<this PR number>\` with both binaries
- [ ] **Real-world**: re-run the import on the OpenClaw-Hodges box (\`phantombot persona --import ~/clawd --as robbie\` → \`phantombot run\` should now Just Work)

## Files

**New**:
- \`src/cli/persona.ts\` — the consolidated entry
- \`install.sh\` — one-liner installer
- \`tests/cli-persona.test.ts\` — 5 new tests for switch + dispatch

**Modified**:
- \`src/cli/index.ts\` — drop create-persona / import-persona, add persona
- \`src/cli/create-persona.ts\` — drop \`defineCommand\` default, keep all functions
- \`src/cli/import-persona.ts\` — same; add \`maybeAdoptAsDefault\` for the bug fix
- \`tests/cli.test.ts\` — subcommand list updated
- \`tests/cli-import-persona.test.ts\` — +2 tests for adopt-on-fresh-box and additive-import-no-shift
- \`README.md\` — one-liner install becomes recommended; persona docs updated; first-import note added
- \`AGENTS.md\` — repo layout, two new pitfalls (auto-adopt semantics; install.sh TTY detection)

## Out of scope

- Hosting the install.sh on a custom domain (e.g. \`phantombot.dev\`) — the raw GH URL works for now; nothing prevents a domain redirect later
- Smoke-testing install.sh in CI — would need an isolated container with no Bun + a mock release; not worth the carry yet