### PR TITLE
feat: slash commands + abort + grandchild kill + idle timeout + long-turn placeholder

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -1,0 +1,245 @@
+/**
+ * Slash command dispatcher for chat channels.
+ *
+ * Sits BEFORE the LLM in the message loop. Catches in-band control commands
+ * (`/stop`, `/reset`, `/status`, `/harness`, `/help`) and handles them in the
+ * channel layer so they keep working even when the LLM is hung on a
+ * subprocess tool call — that was the failure mode that motivated this
+ * module: PhantomBot's old design routed every message through the harness,
+ * so a stuck `gemini usage` subprocess would block `/stop` along with
+ * everything else.
+ *
+ * The handler is intentionally pure-ish: it returns a result object and
+ * mutates only what was passed in (memory store, harness chain, the active
+ * turn's AbortController). The channel adapter is responsible for sending
+ * the reply text back to the user.
+ *
+ * Recognized vs unknown:
+ *   - `/stop`, `/reset`, `/status`, `/harness`, `/help` → handled here.
+ *   - Any other `/foo` → returned as null, channel falls through to runTurn
+ *     so the LLM can interpret it (some personas use `/remember`, etc.).
+ */
+
+import type { Harness } from "../harnesses/types.ts";
+import { log } from "../lib/logger.ts";
+import type { MemoryStore } from "../memory/store.ts";
+
+export interface ActiveTurnHandle {
+  controller: AbortController;
+  startTime: number;
+}
+
+export interface SlashCommandContext {
+  /** For logging / disambiguation only. */
+  chatId: number;
+  persona: string;
+  /** Conversation key, e.g. "telegram:42". Used by /reset. */
+  conversation: string;
+  /** Memory store for /reset's deleteConversation call. */
+  memory: MemoryStore;
+  /**
+   * The harness chain — mutable. /harness reorders this in place so the
+   * channel adapter (which holds the same array reference) sees the new
+   * primary on the next turn.
+   */
+  harnesses: Harness[];
+  /** Wall-clock when the channel server started, for /status uptime. */
+  startedAt: number;
+  /** Currently running turn for this chat, if any. /stop aborts it. */
+  activeTurn?: ActiveTurnHandle;
+}
+
+export interface SlashCommandResult {
+  /** Reply text to send back to the user. Always non-empty for handled commands. */
+  reply: string;
+}
+
+const HELP =
+  `available commands:\n` +
+  `/stop     — abort the current turn\n` +
+  `/reset    — clear this chat's history\n` +
+  `/status   — show harness, uptime, context usage\n` +
+  `/harness  — list or switch the active harness (e.g. /harness pi)\n` +
+  `/help     — this list`;
+
+/**
+ * Parse + dispatch a slash command.
+ *
+ * Returns null if `text` is not a slash command we own — caller falls
+ * through to the LLM for that message. Returns a SlashCommandResult when
+ * the command is handled (recognized or refused).
+ */
+export async function handleSlashCommand(
+  text: string,
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult | null> {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/")) return null;
+
+  // Telegram convention in groups: `/cmd@BotName arg1 arg2`. Strip the
+  // @suffix so the command matches whether the bot was @-mentioned or not.
+  const parts = trimmed.split(/\s+/);
+  const head = parts[0]!;
+  const cmd = head.split("@")[0]!.toLowerCase();
+  const arg = parts.slice(1).join(" ").trim();
+
+  switch (cmd) {
+    case "/stop":
+      return handleStop(ctx);
+    case "/reset":
+      return handleReset(ctx);
+    case "/status":
+      return await handleStatus(ctx);
+    case "/harness":
+      return await handleHarness(arg, ctx);
+    case "/help":
+      return { reply: HELP };
+    default:
+      return null;
+  }
+}
+
+function handleStop(ctx: SlashCommandContext): SlashCommandResult {
+  if (!ctx.activeTurn) {
+    return { reply: "no active turn to stop" };
+  }
+  const elapsedS = ((Date.now() - ctx.activeTurn.startTime) / 1000).toFixed(1);
+  ctx.activeTurn.controller.abort();
+  log.info("commands: /stop fired", { chatId: ctx.chatId, elapsedS });
+  return { reply: `stopped (was running ${elapsedS}s)` };
+}
+
+async function handleReset(
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  const removed = await ctx.memory.deleteConversation(
+    ctx.persona,
+    ctx.conversation,
+  );
+  log.info("commands: /reset", {
+    chatId: ctx.chatId,
+    persona: ctx.persona,
+    conversation: ctx.conversation,
+    deletedTurns: removed,
+  });
+  const noun = removed === 1 ? "turn" : "turns";
+  return { reply: `reset: cleared ${removed} ${noun} from this chat` };
+}
+
+async function handleStatus(
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  const uptimeS = Math.floor((Date.now() - ctx.startedAt) / 1000);
+  const primary = ctx.harnesses[0]?.id ?? "(none)";
+  const chain = ctx.harnesses.map((h) => h.id).join(" → ") || "(none)";
+
+  // Rough context estimate: total chars across the last 20 turns, divided
+  // by 4 (the standard chars-per-token heuristic). Doesn't include the
+  // system prompt, which is ~stable across turns. Off by ~10-30% from a
+  // real tokenizer reading — fine for "is the context filling up" UX.
+  const recent = await ctx.memory.recentTurns(
+    ctx.persona,
+    ctx.conversation,
+    20,
+  );
+  const historyChars = recent.reduce((a, t) => a + t.text.length, 0);
+  const approxTokens = Math.round(historyChars / 4);
+  const windowTokens = nominalContextWindow(primary);
+  const pct = Math.min(
+    100,
+    Math.max(0, Math.round((approxTokens / windowTokens) * 100)),
+  );
+
+  const active = ctx.activeTurn
+    ? `yes (${((Date.now() - ctx.activeTurn.startTime) / 1000).toFixed(1)}s)`
+    : "no";
+
+  return {
+    reply:
+      `harness: ${primary}\n` +
+      `chain:   ${chain}\n` +
+      `uptime:  ${formatUptime(uptimeS)}\n` +
+      `context: ~${pct}% (≈${approxTokens.toLocaleString()} / ${windowTokens.toLocaleString()} tokens, last 20 turns)\n` +
+      `active:  ${active}`,
+  };
+}
+
+async function handleHarness(
+  arg: string,
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  if (ctx.harnesses.length === 0) {
+    return { reply: "no harnesses configured" };
+  }
+
+  if (!arg) {
+    // No arg → list current chain with availability.
+    const lines: string[] = [];
+    for (let i = 0; i < ctx.harnesses.length; i++) {
+      const h = ctx.harnesses[i]!;
+      const ok = await h.available();
+      const marker = i === 0 ? "→" : " ";
+      const suffix = ok ? "" : " (unavailable)";
+      lines.push(`${marker} ${h.id}${suffix}`);
+    }
+    return {
+      reply:
+        `current chain (→ = primary):\n${lines.join("\n")}\n\n` +
+        `use /harness <id> to switch primary`,
+    };
+  }
+
+  const wanted = arg.toLowerCase();
+  const idx = ctx.harnesses.findIndex((h) => h.id === wanted);
+  if (idx < 0) {
+    const ids = ctx.harnesses.map((h) => h.id).join(", ");
+    return { reply: `unknown harness '${wanted}' — available: ${ids}` };
+  }
+  if (idx === 0) {
+    return { reply: `${wanted} is already primary` };
+  }
+  const ok = await ctx.harnesses[idx]!.available();
+  if (!ok) {
+    return {
+      reply: `${wanted} is configured but its binary isn't available — refusing to switch`,
+    };
+  }
+  // Splice → unshift mutates in place so the channel adapter's reference to
+  // this same array sees the new ordering on the next turn.
+  const [picked] = ctx.harnesses.splice(idx, 1);
+  ctx.harnesses.unshift(picked!);
+  log.info("commands: /harness switched", {
+    chatId: ctx.chatId,
+    primary: wanted,
+  });
+  return { reply: `switched to ${wanted}` };
+}
+
+/**
+ * Rough context-window sizes per harness CLI for /status. Off by
+ * ±50% is fine for a percentage display — the user only needs to know
+ * "is context filling up." Wired here rather than on the Harness type
+ * because it's a UX number, not a behaviour-affecting one.
+ */
+export function nominalContextWindow(harnessId: string): number {
+  switch (harnessId) {
+    case "claude":
+      return 200_000;
+    case "gemini":
+      return 1_000_000;
+    case "pi":
+      return 64_000;
+    default:
+      return 128_000;
+  }
+}
+
+function formatUptime(s: number): string {
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -21,6 +21,7 @@
  */
 
 import type { Harness } from "../harnesses/types.ts";
+import { formatElapsedSeconds, truncateLine } from "../lib/format.ts";
 import { log } from "../lib/logger.ts";
 import type { MemoryStore } from "../memory/store.ts";
 
@@ -119,6 +120,20 @@ function handleStop(ctx: SlashCommandContext): SlashCommandResult {
 async function handleReset(
   ctx: SlashCommandContext,
 ): Promise<SlashCommandResult> {
+  // If a turn is in flight, abort it FIRST. Otherwise the user types
+  // /reset expecting a clean slate, the in-flight turn finishes a few
+  // seconds later, and `runTurn`'s on-success persist quietly appends
+  // the now-irrelevant user/assistant pair to the just-cleared
+  // conversation — defeating the reset.
+  let stoppedNote = "";
+  if (ctx.activeTurn) {
+    const elapsedS = (
+      (Date.now() - ctx.activeTurn.startTime) / 1000
+    ).toFixed(1);
+    ctx.activeTurn.controller.abort();
+    stoppedNote = ` (and stopped an in-flight turn that was ${elapsedS}s in)`;
+  }
+
   const removed = await ctx.memory.deleteConversation(
     ctx.persona,
     ctx.conversation,
@@ -128,9 +143,12 @@ async function handleReset(
     persona: ctx.persona,
     conversation: ctx.conversation,
     deletedTurns: removed,
+    abortedActiveTurn: Boolean(ctx.activeTurn),
   });
   const noun = removed === 1 ? "turn" : "turns";
-  return { reply: `reset: cleared ${removed} ${noun} from this chat` };
+  return {
+    reply: `reset: cleared ${removed} ${noun} from this chat${stoppedNote}`,
+  };
 }
 
 async function handleStatus(
@@ -174,16 +192,11 @@ async function handleStatus(
     reply:
       `harness: ${primary}\n` +
       `chain:   ${chain}\n` +
-      `uptime:  ${formatUptime(uptimeS)}\n` +
+      `uptime:  ${formatElapsedSeconds(uptimeS)}\n` +
       `context: ~${pct}% (≈${approxTokens.toLocaleString()} / ${windowTokens.toLocaleString()} tokens, last 20 turns)\n` +
       `active:  ${active}` +
       runningLine,
   };
-}
-
-function truncateLine(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return s.slice(0, max - 1) + "…";
 }
 
 async function handleHarness(
@@ -256,12 +269,3 @@ export function nominalContextWindow(harnessId: string): number {
   }
 }
 
-function formatUptime(s: number): string {
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ${s % 60}s`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ${m % 60}m`;
-  const d = Math.floor(h / 24);
-  return `${d}d ${h % 24}h`;
-}

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -27,6 +27,13 @@ import type { MemoryStore } from "../memory/store.ts";
 export interface ActiveTurnHandle {
   controller: AbortController;
   startTime: number;
+  /**
+   * Most recent progress note from the active harness — typically a tool
+   * name like "tool_execution_start: BashTool" or a stderr line. Surfaced
+   * by /status so the user can tell whether a long turn is genuinely
+   * working or stuck. The channel adapter updates this as chunks arrive.
+   */
+  lastProgressNote?: string;
 }
 
 export interface SlashCommandContext {
@@ -154,14 +161,29 @@ async function handleStatus(
     ? `yes (${((Date.now() - ctx.activeTurn.startTime) / 1000).toFixed(1)}s)`
     : "no";
 
+  // If a turn is in flight AND we've captured a progress note, append a
+  // "running:" line so the user can see what the harness is currently
+  // doing — important for the "is it stuck or just busy?" question that
+  // long Telegram-from-Claude turns provoke.
+  const runningLine =
+    ctx.activeTurn?.lastProgressNote
+      ? `\nrunning: ${truncateLine(ctx.activeTurn.lastProgressNote, 120)}`
+      : "";
+
   return {
     reply:
       `harness: ${primary}\n` +
       `chain:   ${chain}\n` +
       `uptime:  ${formatUptime(uptimeS)}\n` +
       `context: ~${pct}% (≈${approxTokens.toLocaleString()} / ${windowTokens.toLocaleString()} tokens, last 20 turns)\n` +
-      `active:  ${active}`,
+      `active:  ${active}` +
+      runningLine,
   };
+}
+
+function truncateLine(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
 }
 
 async function handleHarness(

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -28,6 +28,10 @@ import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import type { MemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
+import {
+  type ActiveTurnHandle,
+  handleSlashCommand,
+} from "./commands.ts";
 
 export interface TelegramMessage {
   updateId: number;
@@ -291,14 +295,49 @@ export interface RunTelegramServerInput {
 /**
  * The long-poll loop. Returns when signal is aborted, or after one
  * iteration if oneShot is set. Otherwise runs forever.
+ *
+ * Concurrency model:
+ *
+ *   - The polling loop never `await`s a turn directly. That was the
+ *     bug that broke /stop in the old design — a hung tool call inside
+ *     the harness blocked the polling loop, so even the next slash
+ *     command from the same user couldn't be picked up off the wire.
+ *
+ *   - Slash commands are handled INLINE in the polling loop, so they
+ *     respond immediately even when an LLM turn is running.
+ *
+ *   - Regular messages are queued onto a per-chat promise chain. Same
+ *     chat → still serial (the LLM's history would get scrambled
+ *     otherwise). Different chats → parallel.
+ *
+ *   - Each in-flight turn registers an AbortController under
+ *     `activeTurns[chatId]` so /stop can abort it.
+ *
+ *   - On `oneShot`, we drain in-flight workers before returning so tests
+ *     can assert on `transport.sent` without racing the workers.
  */
 export async function runTelegramServer(
   input: RunTelegramServerInput,
 ): Promise<void> {
+  const serverStartedAt = Date.now();
   const tg = input.config.channels.telegram!;
   const allowedSet = new Set(tg.allowedUserIds);
   const checkAllowed = (userId: number): boolean =>
     allowedSet.size === 0 || allowedSet.has(userId);
+
+  // /harness reorders this in place — keep a local mutable copy so we
+  // don't mutate the caller's array.
+  const harnesses: Harness[] = [...input.harnesses];
+
+  // Active turns per chat — keyed by chatId. Read by /stop and /status.
+  const activeTurns = new Map<number, ActiveTurnHandle>();
+
+  // Per-chat promise chain so messages within one chat stay ordered.
+  // We chain `next = prev.then(work)` and store `next` here. When the
+  // next message arrives, it chains off the latest entry.
+  const chatChains = new Map<number, Promise<void>>();
+  // Set of every in-flight worker promise — drained at shutdown / oneShot.
+  const inFlight = new Set<Promise<void>>();
 
   if (allowedSet.size === 0) {
     log.warn(
@@ -308,185 +347,281 @@ export async function runTelegramServer(
 
   let offset = 0;
 
-  do {
-    if (input.signal?.aborted) return;
-
-    const { updates, nextOffset } = await input.transport.getUpdates(
-      offset,
-      tg.pollTimeoutS,
-      input.signal,
-    );
-    offset = nextOffset;
-
-    for (const msg of updates) {
+  try {
+    do {
       if (input.signal?.aborted) return;
 
-      if (!checkAllowed(msg.fromUserId)) {
-        log.info("telegram: rejecting unauthorized user", {
+      const { updates, nextOffset } = await input.transport.getUpdates(
+        offset,
+        tg.pollTimeoutS,
+        input.signal,
+      );
+      offset = nextOffset;
+
+      for (const msg of updates) {
+        if (input.signal?.aborted) return;
+
+        if (!checkAllowed(msg.fromUserId)) {
+          log.info("telegram: rejecting unauthorized user", {
+            fromUserId: msg.fromUserId,
+            fromUsername: msg.fromUsername,
+          });
+          continue;
+        }
+
+        const isVoice = Boolean(msg.voice);
+        log.info("telegram: incoming", {
+          chatId: msg.chatId,
           fromUserId: msg.fromUserId,
           fromUsername: msg.fromUsername,
+          textLength: msg.text.length,
+          persona: input.persona,
+          voice: isVoice,
+          voiceDurationS: msg.voice?.durationS,
         });
-        continue;
-      }
 
-      const startedAt = Date.now();
-      const isVoice = Boolean(msg.voice);
-      log.info("telegram: incoming", {
-        chatId: msg.chatId,
-        fromUserId: msg.fromUserId,
-        fromUsername: msg.fromUsername,
-        textLength: msg.text.length,
-        persona: input.persona,
-        voice: isVoice,
-        voiceDurationS: msg.voice?.durationS,
-      });
-
-      // For voice messages: download → transcribe → use the transcript
-      // as the user message before invoking the harness.
-      if (isVoice && msg.voice) {
-        const stt = sttSupport(input.config);
-        if (!stt.ok) {
-          await input.transport.sendMessage(
-            msg.chatId,
-            voiceUnavailableMessage(stt),
-          );
-          continue;
-        }
-        try {
-          const file = await input.transport.downloadFile(msg.voice.fileId);
-          const r = await transcribe(input.config, file.data, file.mime);
-          if (!r.ok) {
-            log.error("telegram: STT failed", { error: r.error });
-            await input.transport.sendMessage(
-              msg.chatId,
-              `(voice transcription failed: ${r.error})`,
-            );
+        // Slash commands: handled INLINE so they bypass the per-chat queue
+        // and any in-flight turn. Voice messages are never slash commands
+        // (the body is empty until STT runs, by which point we've already
+        // committed to the LLM path).
+        if (!isVoice && msg.text.startsWith("/")) {
+          const result = await handleSlashCommand(msg.text, {
+            chatId: msg.chatId,
+            persona: input.persona,
+            conversation: `telegram:${msg.chatId}`,
+            memory: input.memory,
+            harnesses,
+            startedAt: serverStartedAt,
+            activeTurn: activeTurns.get(msg.chatId),
+          });
+          if (result) {
+            try {
+              await input.transport.sendMessage(msg.chatId, result.reply);
+            } catch (e) {
+              log.error("telegram: slash reply send failed", {
+                error: (e as Error).message,
+                chatId: msg.chatId,
+              });
+            }
             continue;
           }
-          msg.text = r.text;
-          log.info("telegram: STT ok", {
-            chatId: msg.chatId,
-            transcriptChars: r.text.length,
-          });
-        } catch (e) {
-          log.error("telegram: voice download failed", {
-            error: (e as Error).message,
-          });
-          await input.transport.sendMessage(
-            msg.chatId,
-            `(couldn't download your voice message: ${(e as Error).message})`,
-          );
-          continue;
+          // Unrecognized /command — fall through to the LLM.
         }
+
+        // Regular message: enqueue onto this chat's serial chain.
+        const prev = chatChains.get(msg.chatId) ?? Promise.resolve();
+        const next = prev.then(() =>
+          processChatMessage(msg, {
+            input,
+            harnesses,
+            activeTurns,
+          }),
+        );
+        // Detach completed entries so the maps don't leak.
+        const tracked = next.finally(() => {
+          if (chatChains.get(msg.chatId) === tracked) {
+            chatChains.delete(msg.chatId);
+          }
+          inFlight.delete(tracked);
+        });
+        chatChains.set(msg.chatId, tracked);
+        inFlight.add(tracked);
       }
+    } while (!input.oneShot);
+  } finally {
+    // Drain pending workers so tests can assert on transport state, and
+    // production shutdowns don't leave zombie subprocesses behind.
+    if (inFlight.size > 0) {
+      await Promise.allSettled([...inFlight]);
+    }
+  }
+}
 
-      // Send the right indicator depending on which way we'll reply.
-      // Refresh both kinds every typingRefreshMs while the harness works.
-      const willReplyWithVoice = isVoice && ttsSupported(input.config);
-      const sendStatus = () =>
-        willReplyWithVoice
-          ? input.transport.sendRecording(msg.chatId)
-          : input.transport.sendTyping(msg.chatId);
-      void sendStatus();
-      const refreshMs = input.typingRefreshMs ?? 4000;
-      const typingTimer = setInterval(() => {
-        void sendStatus();
-      }, refreshMs);
+/**
+ * Process one (non-slash) message: STT if voice, run the harness chain,
+ * send the reply. Stays self-contained so the polling loop can fire-and-
+ * track via Promise.allSettled at shutdown.
+ */
+async function processChatMessage(
+  msg: TelegramMessage,
+  ctx: {
+    input: RunTelegramServerInput;
+    harnesses: Harness[];
+    activeTurns: Map<number, ActiveTurnHandle>;
+  },
+): Promise<void> {
+  const { input, harnesses, activeTurns } = ctx;
+  const startedAt = Date.now();
+  const isVoice = Boolean(msg.voice);
 
-      let reply = "";
-      let errored: string | undefined;
-      let progressCount = 0;
-      let chosenHarness: string | undefined;
-      try {
-        for await (const chunk of runTurn({
-          persona: input.persona,
-          conversation: `telegram:${msg.chatId}`,
-          userMessage: msg.text,
-          agentDir: input.agentDir,
-          harnesses: input.harnesses,
-          memory: input.memory,
-          timeoutMs: input.config.turnTimeoutMs,
-          // Voice-in + voice-out: append a brevity directive for this turn
-          // only. Keeps voice notes short + spoken-friendly without putting
-          // brevity rules in persona files (which would also throttle text
-          // replies, where verbosity is fine).
-          systemPromptSuffix: willReplyWithVoice
-            ? VOICE_REPLY_INSTRUCTION
-            : undefined,
-        })) {
-          if (chunk.type === "text") reply += chunk.text;
-          if (chunk.type === "progress") {
-            progressCount++;
-            log.debug("telegram: progress", {
-              chatId: msg.chatId,
-              note: chunk.note.slice(0, 200),
-            });
-          }
-          if (chunk.type === "done") {
-            reply = chunk.finalText;
-            const meta = chunk.meta as
-              | { harnessId?: unknown }
-              | undefined;
-            if (typeof meta?.harnessId === "string") {
-              chosenHarness = meta.harnessId;
-            }
-          }
-          if (chunk.type === "error") errored = chunk.error;
-        }
-      } catch (e) {
-        errored = (e as Error).message;
-        log.error("telegram: turn threw", { error: errored });
-      } finally {
-        clearInterval(typingTimer);
+  // For voice messages: download → transcribe → use the transcript as
+  // the user message before invoking the harness.
+  if (isVoice && msg.voice) {
+    const stt = sttSupport(input.config);
+    if (!stt.ok) {
+      await input.transport.sendMessage(
+        msg.chatId,
+        voiceUnavailableMessage(stt),
+      );
+      return;
+    }
+    try {
+      const file = await input.transport.downloadFile(msg.voice.fileId);
+      const r = await transcribe(input.config, file.data, file.mime);
+      if (!r.ok) {
+        log.error("telegram: STT failed", { error: r.error });
+        await input.transport.sendMessage(
+          msg.chatId,
+          `(voice transcription failed: ${r.error})`,
+        );
+        return;
       }
+      msg.text = r.text;
+      log.info("telegram: STT ok", {
+        chatId: msg.chatId,
+        transcriptChars: r.text.length,
+      });
+    } catch (e) {
+      log.error("telegram: voice download failed", {
+        error: (e as Error).message,
+      });
+      await input.transport.sendMessage(
+        msg.chatId,
+        `(couldn't download your voice message: ${(e as Error).message})`,
+      );
+      return;
+    }
+  }
 
-      const outText = errored
-        ? `(error: ${errored})`
-        : reply.length > 0
-          ? reply
-          : "(no reply)";
+  // Send the right indicator depending on which way we'll reply.
+  // Refresh both kinds every typingRefreshMs while the harness works.
+  const willReplyWithVoice = isVoice && ttsSupported(input.config);
+  const sendStatus = () =>
+    willReplyWithVoice
+      ? input.transport.sendRecording(msg.chatId)
+      : input.transport.sendTyping(msg.chatId);
+  void sendStatus();
+  const refreshMs = input.typingRefreshMs ?? 4000;
+  const typingTimer = setInterval(() => {
+    void sendStatus();
+  }, refreshMs);
 
-      // Voice in → voice out (when TTS is configured AND no error).
-      // Text in → text out, always.
-      let sentAsVoice = false;
-      try {
-        if (willReplyWithVoice && !errored && reply.length > 0) {
-          const r = await synthesize(input.config, reply);
-          if (r.ok) {
-            await input.transport.sendVoice(
-              msg.chatId,
-              r.audio.data,
-              r.audio.mime,
-            );
-            sentAsVoice = true;
-          } else {
-            log.warn("telegram: TTS failed; falling back to text", {
-              error: r.error,
-            });
-            await input.transport.sendMessage(msg.chatId, outText);
-          }
-        } else {
-          await input.transport.sendMessage(msg.chatId, outText);
-        }
-      } catch (e) {
-        log.error("telegram: send failed", {
-          error: (e as Error).message,
+  // Register the AbortController so /stop can find us.
+  const controller = new AbortController();
+  const turnHandle: ActiveTurnHandle = {
+    controller,
+    startTime: startedAt,
+  };
+  activeTurns.set(msg.chatId, turnHandle);
+
+  let reply = "";
+  let errored: string | undefined;
+  let progressCount = 0;
+  let chosenHarness: string | undefined;
+  try {
+    for await (const chunk of runTurn({
+      persona: input.persona,
+      conversation: `telegram:${msg.chatId}`,
+      userMessage: msg.text,
+      agentDir: input.agentDir,
+      harnesses,
+      memory: input.memory,
+      timeoutMs: input.config.turnTimeoutMs,
+      signal: controller.signal,
+      // Voice-in + voice-out: append a brevity directive for this turn
+      // only. Keeps voice notes short + spoken-friendly without putting
+      // brevity rules in persona files (which would also throttle text
+      // replies, where verbosity is fine).
+      systemPromptSuffix: willReplyWithVoice
+        ? VOICE_REPLY_INSTRUCTION
+        : undefined,
+    })) {
+      if (chunk.type === "text") reply += chunk.text;
+      if (chunk.type === "progress") {
+        progressCount++;
+        log.debug("telegram: progress", {
           chatId: msg.chatId,
+          note: chunk.note.slice(0, 200),
         });
       }
-
-      log.info("telegram: complete", {
-        chatId: msg.chatId,
-        durationMs: Date.now() - startedAt,
-        replyChars: outText.length,
-        progressEvents: progressCount,
-        harness: chosenHarness ?? (errored ? "(error)" : "(unknown)"),
-        modality: sentAsVoice ? "voice" : "text",
-        inputModality: isVoice ? "voice" : "text",
-        ok: !errored,
-      });
+      if (chunk.type === "done") {
+        reply = chunk.finalText;
+        const meta = chunk.meta as { harnessId?: unknown } | undefined;
+        if (typeof meta?.harnessId === "string") {
+          chosenHarness = meta.harnessId;
+        }
+      }
+      if (chunk.type === "error") errored = chunk.error;
     }
-  } while (!input.oneShot);
+  } catch (e) {
+    errored = (e as Error).message;
+    log.error("telegram: turn threw", { error: errored });
+  } finally {
+    clearInterval(typingTimer);
+    // Only deregister if we're still the active turn for this chat.
+    // (Defensive: a /reset or /stop could have replaced us.)
+    if (activeTurns.get(msg.chatId) === turnHandle) {
+      activeTurns.delete(msg.chatId);
+    }
+  }
+
+  // /stop: the controller was aborted from outside. The reply text
+  // already came through from the slash command handler — don't send
+  // a second "(error: stopped)" message.
+  const wasStopped = controller.signal.aborted;
+  if (wasStopped) {
+    log.info("telegram: turn stopped by /stop", {
+      chatId: msg.chatId,
+      durationMs: Date.now() - startedAt,
+    });
+    return;
+  }
+
+  const outText = errored
+    ? `(error: ${errored})`
+    : reply.length > 0
+      ? reply
+      : "(no reply)";
+
+  // Voice in → voice out (when TTS is configured AND no error).
+  // Text in → text out, always.
+  let sentAsVoice = false;
+  try {
+    if (willReplyWithVoice && !errored && reply.length > 0) {
+      const r = await synthesize(input.config, reply);
+      if (r.ok) {
+        await input.transport.sendVoice(
+          msg.chatId,
+          r.audio.data,
+          r.audio.mime,
+        );
+        sentAsVoice = true;
+      } else {
+        log.warn("telegram: TTS failed; falling back to text", {
+          error: r.error,
+        });
+        await input.transport.sendMessage(msg.chatId, outText);
+      }
+    } else {
+      await input.transport.sendMessage(msg.chatId, outText);
+    }
+  } catch (e) {
+    log.error("telegram: send failed", {
+      error: (e as Error).message,
+      chatId: msg.chatId,
+    });
+  }
+
+  log.info("telegram: complete", {
+    chatId: msg.chatId,
+    durationMs: Date.now() - startedAt,
+    replyChars: outText.length,
+    progressEvents: progressCount,
+    harness: chosenHarness ?? (errored ? "(error)" : "(unknown)"),
+    modality: sentAsVoice ? "voice" : "text",
+    inputModality: isVoice ? "voice" : "text",
+    ok: !errored,
+  });
 }
 
 /**

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -24,6 +24,7 @@ import {
   transcribe,
   ttsSupported,
 } from "../lib/audio.ts";
+import { formatElapsedMs, truncateLine } from "../lib/format.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import type { MemoryStore } from "../memory/store.ts";
@@ -595,36 +596,55 @@ async function processChatMessage(
   const placeholderEditMs = input.placeholderEditMs ?? 60_000;
   let placeholderMsgId: number | undefined;
   let placeholderEditTimer: ReturnType<typeof setInterval> | undefined;
+  // `disposed` plus `placeholderPostPromise` together close the post-IIFE
+  // race: if the turn finishes between when the post timer fires and when
+  // sendMessage resolves, the IIFE bails before storing the messageId or
+  // arming the edit interval (otherwise we'd leak a setInterval forever
+  // and leave an orphan ⏳ message in the chat).
+  let disposed = false;
+  let placeholderPostPromise: Promise<void> | undefined;
   const renderPlaceholder = (): string => {
     const elapsedMs = Date.now() - startedAt;
     const note = turnHandle.lastProgressNote;
     return note
-      ? `⏳ working… ${formatElapsed(elapsedMs)} — currently: ${truncate(note, 120)}`
-      : `⏳ working… ${formatElapsed(elapsedMs)} elapsed`;
+      ? `⏳ working… ${formatElapsedMs(elapsedMs)} — currently: ${truncateLine(note, 120)}`
+      : `⏳ working… ${formatElapsedMs(elapsedMs)} elapsed`;
   };
   const placeholderPostTimer = setTimeout(() => {
-    void (async () => {
+    placeholderPostPromise = (async () => {
+      let id = 0;
       try {
-        const id = await input.transport.sendMessage(
+        id = await input.transport.sendMessage(
           msg.chatId,
           renderPlaceholder(),
         );
-        if (id > 0) {
-          placeholderMsgId = id;
-          placeholderEditTimer = setInterval(() => {
-            if (placeholderMsgId === undefined) return;
-            void input.transport.editMessage(
-              msg.chatId,
-              placeholderMsgId,
-              renderPlaceholder(),
-            );
-          }, placeholderEditMs);
-        }
       } catch (e) {
         log.warn("telegram: placeholder post failed", {
           error: (e as Error).message,
           chatId: msg.chatId,
         });
+        return;
+      }
+      // The turn may have finished while sendMessage was in flight. If so,
+      // delete the message we just posted (the cleanup phase already ran
+      // with placeholderMsgId still undefined, so it was skipped) and do
+      // NOT arm the edit interval.
+      if (disposed) {
+        if (id > 0) {
+          await input.transport.deleteMessage(msg.chatId, id).catch(() => {});
+        }
+        return;
+      }
+      if (id > 0) {
+        placeholderMsgId = id;
+        placeholderEditTimer = setInterval(() => {
+          if (disposed || placeholderMsgId === undefined) return;
+          void input.transport.editMessage(
+            msg.chatId,
+            placeholderMsgId,
+            renderPlaceholder(),
+          );
+        }, placeholderEditMs);
       }
     })();
   }, placeholderThresholdMs);
@@ -676,6 +696,9 @@ async function processChatMessage(
     errored = (e as Error).message;
     log.error("telegram: turn threw", { error: errored });
   } finally {
+    // Mark disposed BEFORE awaiting in-flight placeholder work so the
+    // post IIFE (if still running) sees the flag and bails.
+    disposed = true;
     clearInterval(typingTimer);
     clearTimeout(placeholderPostTimer);
     if (placeholderEditTimer) clearInterval(placeholderEditTimer);
@@ -688,8 +711,13 @@ async function processChatMessage(
 
   // Always clean up the placeholder if one was posted, so the chat
   // doesn't end up with an orphan "⏳ working…" message regardless of
-  // outcome (success / error / stop).
+  // outcome (success / error / stop). Awaits any in-flight post first
+  // so a placeholder that races with completion is still observed and
+  // deleted.
   const cleanupPlaceholder = async (): Promise<void> => {
+    if (placeholderPostPromise) {
+      await placeholderPostPromise;
+    }
     if (placeholderMsgId !== undefined) {
       await input.transport.deleteMessage(msg.chatId, placeholderMsgId);
       placeholderMsgId = undefined;
@@ -780,26 +808,6 @@ async function processChatMessage(
  * triggered ONLY when the input arrived as voice AND the reply will be
  * synthesized — text replies stay as detailed as the persona wants.
  */
-/**
- * Render an elapsed-ms duration as a short human string for the
- * placeholder line. Matches the /status format intentionally.
- *
- * Exported for testing.
- */
-export function formatElapsed(ms: number): string {
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ${s % 60}s`;
-  const h = Math.floor(m / 60);
-  return `${h}h ${m % 60}m`;
-}
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return s.slice(0, max - 1) + "…";
-}
-
 export const VOICE_REPLY_INSTRUCTION =
   `# Reply length (this turn only)
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -60,7 +60,8 @@ export interface TelegramTransport {
     timeoutS: number,
     signal?: AbortSignal,
   ): Promise<{ updates: TelegramMessage[]; nextOffset: number }>;
-  sendMessage(chatId: number, text: string): Promise<void>;
+  /** Send a text message; returns the new message_id (used for later edit/delete). */
+  sendMessage(chatId: number, text: string): Promise<number>;
   sendTyping(chatId: number): Promise<void>;
   /** Send an OGG-Opus voice note. */
   sendVoice(chatId: number, audio: Buffer, mime: string): Promise<void>;
@@ -68,6 +69,10 @@ export interface TelegramTransport {
   sendRecording(chatId: number): Promise<void>;
   /** Download a file by Telegram file_id; returns audio bytes + content-type. */
   downloadFile(fileId: string): Promise<{ data: Buffer; mime: string }>;
+  /** Edit an existing text message in place. Best-effort; failures are swallowed. */
+  editMessage(chatId: number, messageId: number, text: string): Promise<void>;
+  /** Delete a message by id. Best-effort; failures are swallowed. */
+  deleteMessage(chatId: number, messageId: number): Promise<void>;
 }
 
 /**
@@ -112,7 +117,7 @@ export class HttpTelegramTransport implements TelegramTransport {
     return parseGetUpdatesResult(body.result ?? [], offset);
   }
 
-  async sendMessage(chatId: number, text: string): Promise<void> {
+  async sendMessage(chatId: number, text: string): Promise<number> {
     const url = `https://api.telegram.org/bot${this.token}/sendMessage`;
     // Telegram caps message length at 4096 chars. Truncate gracefully.
     const safe = text.length > 4000 ? text.slice(0, 4000) + "\n…[truncated]" : text;
@@ -126,7 +131,55 @@ export class HttpTelegramTransport implements TelegramTransport {
         chatId,
         status: res.status,
       });
+      return 0;
     }
+    // Telegram returns the sent message in `result.message_id`. Callers
+    // that don't care can ignore it; the placeholder pipeline uses it
+    // for later editMessage/deleteMessage.
+    try {
+      const body = (await res.json()) as {
+        ok?: boolean;
+        result?: { message_id?: number };
+      };
+      return body.ok && typeof body.result?.message_id === "number"
+        ? body.result.message_id
+        : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  async editMessage(
+    chatId: number,
+    messageId: number,
+    text: string,
+  ): Promise<void> {
+    if (messageId === 0) return;
+    const url = `https://api.telegram.org/bot${this.token}/editMessageText`;
+    const safe = text.length > 4000 ? text.slice(0, 4000) + "\n…[truncated]" : text;
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        message_id: messageId,
+        text: safe,
+      }),
+    }).catch(() => {
+      /* edits are best-effort — placeholder editMessage failing isn't fatal */
+    });
+  }
+
+  async deleteMessage(chatId: number, messageId: number): Promise<void> {
+    if (messageId === 0) return;
+    const url = `https://api.telegram.org/bot${this.token}/deleteMessage`;
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, message_id: messageId }),
+    }).catch(() => {
+      /* deletes are best-effort — leaving an orphan placeholder isn't fatal */
+    });
   }
 
   async sendTyping(chatId: number): Promise<void> {
@@ -288,6 +341,20 @@ export interface RunTelegramServerInput {
    * stopped responding. Default 4000 ms. Tests use a smaller value.
    */
   typingRefreshMs?: number;
+  /**
+   * How long a turn can run silently before we post a "⏳ working…"
+   * placeholder message. Below this, short turns finish without any
+   * extra noise in the chat. Default 30_000 ms. Tests use smaller.
+   */
+  placeholderThresholdMs?: number;
+  /**
+   * How often we edit the placeholder with new elapsed time + last
+   * progress note while the turn is still running. Telegram allows
+   * ~1 edit/sec; we default to a generous 60_000 ms because the
+   * placeholder exists to reassure the user, not to render a real-time
+   * console. Tests override.
+   */
+  placeholderEditMs?: number;
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -514,6 +581,54 @@ async function processChatMessage(
   };
   activeTurns.set(msg.chatId, turnHandle);
 
+  // Long-turn placeholder lifecycle. Three states:
+  //   1. Silent  — turn is fast, no placeholder needed.
+  //   2. Posted  — turn went past placeholderThresholdMs (default 30s);
+  //                we sent a "⏳ working… 30s elapsed" message and have
+  //                its message_id. Periodically edit it with elapsed
+  //                time + last progress note.
+  //   3. Cleanup — turn finished. Delete the placeholder, then send the
+  //                final reply as a NEW message (Option B in the design
+  //                discussion: a fresh message triggers a Telegram push
+  //                notification; an edit does not).
+  const placeholderThresholdMs = input.placeholderThresholdMs ?? 30_000;
+  const placeholderEditMs = input.placeholderEditMs ?? 60_000;
+  let placeholderMsgId: number | undefined;
+  let placeholderEditTimer: ReturnType<typeof setInterval> | undefined;
+  const renderPlaceholder = (): string => {
+    const elapsedMs = Date.now() - startedAt;
+    const note = turnHandle.lastProgressNote;
+    return note
+      ? `⏳ working… ${formatElapsed(elapsedMs)} — currently: ${truncate(note, 120)}`
+      : `⏳ working… ${formatElapsed(elapsedMs)} elapsed`;
+  };
+  const placeholderPostTimer = setTimeout(() => {
+    void (async () => {
+      try {
+        const id = await input.transport.sendMessage(
+          msg.chatId,
+          renderPlaceholder(),
+        );
+        if (id > 0) {
+          placeholderMsgId = id;
+          placeholderEditTimer = setInterval(() => {
+            if (placeholderMsgId === undefined) return;
+            void input.transport.editMessage(
+              msg.chatId,
+              placeholderMsgId,
+              renderPlaceholder(),
+            );
+          }, placeholderEditMs);
+        }
+      } catch (e) {
+        log.warn("telegram: placeholder post failed", {
+          error: (e as Error).message,
+          chatId: msg.chatId,
+        });
+      }
+    })();
+  }, placeholderThresholdMs);
+
   let reply = "";
   let errored: string | undefined;
   let progressCount = 0;
@@ -526,7 +641,8 @@ async function processChatMessage(
       agentDir: input.agentDir,
       harnesses,
       memory: input.memory,
-      timeoutMs: input.config.turnTimeoutMs,
+      idleTimeoutMs: input.config.harnessIdleTimeoutMs,
+      hardTimeoutMs: input.config.harnessHardTimeoutMs,
       signal: controller.signal,
       // Voice-in + voice-out: append a brevity directive for this turn
       // only. Keeps voice notes short + spoken-friendly without putting
@@ -539,6 +655,9 @@ async function processChatMessage(
       if (chunk.type === "text") reply += chunk.text;
       if (chunk.type === "progress") {
         progressCount++;
+        // Stash the latest progress note on the active-turn handle so
+        // /status can show "currently: <tool>" in real time.
+        turnHandle.lastProgressNote = chunk.note.slice(0, 500);
         log.debug("telegram: progress", {
           chatId: msg.chatId,
           note: chunk.note.slice(0, 200),
@@ -558,6 +677,8 @@ async function processChatMessage(
     log.error("telegram: turn threw", { error: errored });
   } finally {
     clearInterval(typingTimer);
+    clearTimeout(placeholderPostTimer);
+    if (placeholderEditTimer) clearInterval(placeholderEditTimer);
     // Only deregister if we're still the active turn for this chat.
     // (Defensive: a /reset or /stop could have replaced us.)
     if (activeTurns.get(msg.chatId) === turnHandle) {
@@ -565,11 +686,23 @@ async function processChatMessage(
     }
   }
 
+  // Always clean up the placeholder if one was posted, so the chat
+  // doesn't end up with an orphan "⏳ working…" message regardless of
+  // outcome (success / error / stop).
+  const cleanupPlaceholder = async (): Promise<void> => {
+    if (placeholderMsgId !== undefined) {
+      await input.transport.deleteMessage(msg.chatId, placeholderMsgId);
+      placeholderMsgId = undefined;
+    }
+  };
+
   // /stop: the controller was aborted from outside. The reply text
   // already came through from the slash command handler — don't send
-  // a second "(error: stopped)" message.
+  // a second "(error: stopped)" message. We DO still delete the
+  // placeholder so the user isn't left with a stale "working…" line.
   const wasStopped = controller.signal.aborted;
   if (wasStopped) {
+    await cleanupPlaceholder();
     log.info("telegram: turn stopped by /stop", {
       chatId: msg.chatId,
       durationMs: Date.now() - startedAt,
@@ -584,9 +717,14 @@ async function processChatMessage(
       : "(no reply)";
 
   // Voice in → voice out (when TTS is configured AND no error).
-  // Text in → text out, always.
+  // Text in → text out, always. Order: delete placeholder FIRST, then
+  // send the real reply. Telegram pushes a notification on a new
+  // message but not on an edit, so this delete-then-new sequence is
+  // what guarantees the user's phone buzzes when a long turn finishes
+  // ("Option B" from the design discussion).
   let sentAsVoice = false;
   try {
+    await cleanupPlaceholder();
     if (willReplyWithVoice && !errored && reply.length > 0) {
       const r = await synthesize(input.config, reply);
       if (r.ok) {
@@ -642,6 +780,26 @@ async function processChatMessage(
  * triggered ONLY when the input arrived as voice AND the reply will be
  * synthesized — text replies stay as detailed as the persona wants.
  */
+/**
+ * Render an elapsed-ms duration as a short human string for the
+ * placeholder line. Matches the /status format intentionally.
+ *
+ * Exported for testing.
+ */
+export function formatElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}
+
 export const VOICE_REPLY_INSTRUCTION =
   `# Reply length (this turn only)
 

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -75,7 +75,11 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
       agentDir: dir,
       harnesses,
       memory,
-      timeoutMs: 30 * 60_000, // 30-minute hard cap on the cognitive pass
+      // Nightly tasks chew on long thinking — accept up to 5 minutes of
+      // silence between tool calls before assuming wedged. Hard cap stays
+      // at 30 minutes (matches the original behavior).
+      idleTimeoutMs: 5 * 60_000,
+      hardTimeoutMs: 30 * 60_000,
       systemPromptSuffix:
         "You are operating in NIGHTLY MAINTENANCE MODE. " +
         "Skip pleasantries. Do work, write files, report briefly.",

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -123,7 +123,8 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
           agentDir,
           harnesses,
           memory,
-          timeoutMs: config.turnTimeoutMs,
+          idleTimeoutMs: config.harnessIdleTimeoutMs,
+          hardTimeoutMs: config.harnessHardTimeoutMs,
         })) {
           if (chunk.type === "text") finalText += chunk.text;
           if (chunk.type === "done") finalText = chunk.finalText;

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,44 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { parse as parseToml } from "smol-toml";
+import { log } from "./lib/logger.ts";
 import { loadState } from "./state.ts";
+
+/**
+ * Read the legacy `turn_timeout_s` (TOML) or `PHANTOMBOT_TURN_TIMEOUT_MS`
+ * (env) and convert to ms. Returns undefined if neither is set.
+ *
+ * A side effect of being called: logs a one-shot warn naming the new
+ * pair so legacy users see the migration hint at startup. The warn is
+ * gated by a module-scoped flag so loadConfig can be called multiple
+ * times in tests without spamming.
+ */
+let legacyWarnLogged = false;
+function legacyTurnTimeoutMs(
+  toml: Record<string, unknown>,
+): number | undefined {
+  const envMs = asInt(process.env.PHANTOMBOT_TURN_TIMEOUT_MS);
+  if (envMs !== undefined) {
+    if (!legacyWarnLogged) {
+      log.warn(
+        "config: PHANTOMBOT_TURN_TIMEOUT_MS is deprecated; set PHANTOMBOT_HARNESS_IDLE_TIMEOUT_MS and PHANTOMBOT_HARNESS_HARD_TIMEOUT_MS instead",
+      );
+      legacyWarnLogged = true;
+    }
+    return envMs;
+  }
+  const tomlS = asInt(toml.turn_timeout_s);
+  if (tomlS !== undefined) {
+    if (!legacyWarnLogged) {
+      log.warn(
+        "config: turn_timeout_s is deprecated; replace with harness_idle_timeout_s and harness_hard_timeout_s in config.toml (currently aliased to both for back-compat)",
+      );
+      legacyWarnLogged = true;
+    }
+    return tomlS * 1000;
+  }
+  return undefined;
+}
 
 export interface Config {
   /** Persona used by `ask`/`chat` when --persona is omitted. */
@@ -110,11 +147,20 @@ export async function loadConfig(): Promise<Config> {
       asString(toml.default_persona) ??
       "phantom",
 
+    // Legacy alias: pre-PR-#56 configs only had `turn_timeout_s`, which
+    // meant "kill at this wall-clock with no other constraints." The new
+    // model splits that into idle (silence) + hard (total). To preserve
+    // the OLD semantics for an unmodified legacy config we map
+    // turn_timeout_s to BOTH ceilings: idle == hard == legacy value.
+    // That way a `turn_timeout_s = 600` config still tolerates 10
+    // minutes of silence, the way it used to. New configs that want the
+    // safer 120s-idle behavior set harness_idle_timeout_s explicitly.
     harnessIdleTimeoutMs:
       asInt(process.env.PHANTOMBOT_HARNESS_IDLE_TIMEOUT_MS) ??
       (asInt(toml.harness_idle_timeout_s) !== undefined
         ? asInt(toml.harness_idle_timeout_s)! * 1000
         : undefined) ??
+      legacyTurnTimeoutMs(toml) ??
       120_000,
 
     harnessHardTimeoutMs:
@@ -122,15 +168,7 @@ export async function loadConfig(): Promise<Config> {
       (asInt(toml.harness_hard_timeout_s) !== undefined
         ? asInt(toml.harness_hard_timeout_s)! * 1000
         : undefined) ??
-      // Legacy alias — keep accepting `turn_timeout_s` so older config
-      // files keep working. New configs should use the *_idle / *_hard
-      // pair above.
-      (asInt(process.env.PHANTOMBOT_TURN_TIMEOUT_MS) !== undefined
-        ? asInt(process.env.PHANTOMBOT_TURN_TIMEOUT_MS)!
-        : undefined) ??
-      (asInt(toml.turn_timeout_s) !== undefined
-        ? asInt(toml.turn_timeout_s)! * 1000
-        : undefined) ??
+      legacyTurnTimeoutMs(toml) ??
       3_600_000,
 
     personasDir:

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,7 +105,7 @@ export async function loadConfig(): Promise<Config> {
       (asInt(toml.turn_timeout_s) !== undefined
         ? asInt(toml.turn_timeout_s)! * 1000
         : undefined) ??
-      600_000,
+      120_000,
 
     personasDir:
       process.env.PHANTOMBOT_PERSONAS_DIR ??

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,8 +21,18 @@ import { loadState } from "./state.ts";
 export interface Config {
   /** Persona used by `ask`/`chat` when --persona is omitted. */
   defaultPersona: string;
-  /** Per-harness wall-clock timeout in milliseconds. */
-  turnTimeoutMs: number;
+  /**
+   * Kill the harness subprocess if no output lands on stdout for this
+   * long. Resets every time the harness emits a chunk. Right knob for
+   * "subprocess wedged on a hung tool call" — productive work that's
+   * spitting out tool events keeps the timer fed.
+   */
+  harnessIdleTimeoutMs: number;
+  /**
+   * Hard wall-clock cap on a single harness turn. Independent of activity.
+   * Caps runaway agents that legitimately keep emitting but never finish.
+   */
+  harnessHardTimeoutMs: number;
   /** Directory holding `<persona>/` subdirs. */
   personasDir: string;
   /** Path to the SQLite memory store file. */
@@ -100,12 +110,28 @@ export async function loadConfig(): Promise<Config> {
       asString(toml.default_persona) ??
       "phantom",
 
-    turnTimeoutMs:
-      asInt(process.env.PHANTOMBOT_TURN_TIMEOUT_MS) ??
+    harnessIdleTimeoutMs:
+      asInt(process.env.PHANTOMBOT_HARNESS_IDLE_TIMEOUT_MS) ??
+      (asInt(toml.harness_idle_timeout_s) !== undefined
+        ? asInt(toml.harness_idle_timeout_s)! * 1000
+        : undefined) ??
+      120_000,
+
+    harnessHardTimeoutMs:
+      asInt(process.env.PHANTOMBOT_HARNESS_HARD_TIMEOUT_MS) ??
+      (asInt(toml.harness_hard_timeout_s) !== undefined
+        ? asInt(toml.harness_hard_timeout_s)! * 1000
+        : undefined) ??
+      // Legacy alias — keep accepting `turn_timeout_s` so older config
+      // files keep working. New configs should use the *_idle / *_hard
+      // pair above.
+      (asInt(process.env.PHANTOMBOT_TURN_TIMEOUT_MS) !== undefined
+        ? asInt(process.env.PHANTOMBOT_TURN_TIMEOUT_MS)!
+        : undefined) ??
       (asInt(toml.turn_timeout_s) !== undefined
         ? asInt(toml.turn_timeout_s)! * 1000
         : undefined) ??
-      120_000,
+      3_600_000,
 
     personasDir:
       process.env.PHANTOMBOT_PERSONAS_DIR ??

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -101,8 +101,18 @@ export class ClaudeHarness implements Harness {
       stderr: "pipe",
     });
 
-    proc.stdin.write(renderStdinPayload(req));
-    proc.stdin.end();
+    // Same EPIPE-tolerant pattern as gemini.ts: a kernel-killed proc
+    // (e.g. signal already aborted between spawn and write) makes stdin
+    // unwritable; we don't want that to escape the generator before the
+    // for-await loop yields the proper "aborted" error chunk.
+    try {
+      proc.stdin.write(renderStdinPayload(req));
+      await proc.stdin.end();
+    } catch (e) {
+      log.warn("claude.invoke stdin write failed", {
+        error: (e as Error).message,
+      });
+    }
 
     // Kill coordinator: idle timer (resets on every chunk), hard timer
     // (never resets), abort listener (user typed /stop). On any of those

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -48,7 +48,12 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import {
+  createKillCoordinator,
+  killCauseToErrorChunk,
+} from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
+import { spawnInNewSession } from "../lib/processGroup.ts";
 
 export interface ClaudeHarnessConfig {
   /** Path to the `claude` CLI binary. Default: "claude" (looked up in PATH). */
@@ -88,7 +93,7 @@ export class ClaudeHarness implements Harness {
     // so claude resolves credentials from ~/.claude/.credentials.json.
     const env = filterAuthEnv(process.env);
 
-    const proc = Bun.spawn([this.config.bin, ...args], {
+    const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,
       env,
       stdin: "pipe",
@@ -99,36 +104,18 @@ export class ClaudeHarness implements Harness {
     proc.stdin.write(renderStdinPayload(req));
     proc.stdin.end();
 
-    // STATE-MACHINE FIX (was the timeout-vs-close bug in the Node skeleton):
-    // a SIGTERM-by-timeout kill must be distinguishable from a normal exit.
-    // The pre-Bun version emitted `done` with whatever partial text it had
-    // collected, which masked timeouts as successful short replies. We track
-    // the kill cause so the post-loop branch surfaces the right error:
-    //   - "timeout"  → recoverable, orchestrator tries the next harness
-    //   - "aborted"  → non-recoverable, user said /stop and meant it
-    let killCause: "timeout" | "aborted" | undefined;
-    const timeout = setTimeout(() => {
-      if (!killCause) {
-        killCause = "timeout";
-        log.warn("claude.invoke timeout", { timeoutMs: req.timeoutMs });
-        proc.kill("SIGTERM");
-      }
-    }, req.timeoutMs);
-
-    const onAbort = () => {
-      if (!killCause) {
-        killCause = "aborted";
-        log.info("claude.invoke aborted via signal");
-        proc.kill("SIGTERM");
-      }
-    };
-    if (req.signal) {
-      if (req.signal.aborted) {
-        onAbort();
-      } else {
-        req.signal.addEventListener("abort", onAbort, { once: true });
-      }
-    }
+    // Kill coordinator: idle timer (resets on every chunk), hard timer
+    // (never resets), abort listener (user typed /stop). On any of those
+    // firing, SIGTERM the whole process group → 5s grace → SIGKILL the
+    // group. The "kill cause" determines whether we yield a recoverable
+    // or non-recoverable error after the stdout pipe closes.
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: req.idleTimeoutMs,
+      hardTimeoutMs: req.hardTimeoutMs,
+      signal: req.signal,
+      harnessId: this.id,
+    });
 
     // Drain stderr in the background; surface as debug logs only.
     void consumeStderr(proc.stderr);
@@ -139,6 +126,7 @@ export class ClaudeHarness implements Harness {
 
     try {
       for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+        killer.touch();
         buffer += decoder.decode(chunk, { stream: true });
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
@@ -161,26 +149,17 @@ export class ClaudeHarness implements Harness {
         }
       }
     } finally {
-      clearTimeout(timeout);
-      if (req.signal && !req.signal.aborted) {
-        req.signal.removeEventListener("abort", onAbort);
-      }
+      await killer.dispose();
     }
 
-    if (killCause === "timeout") {
-      yield {
-        type: "error",
-        error: `claude timed out after ${req.timeoutMs}ms`,
-        recoverable: true,
-      };
-      return;
-    }
-    if (killCause === "aborted") {
-      yield {
-        type: "error",
-        error: "stopped",
-        recoverable: false,
-      };
+    const errChunk = killCauseToErrorChunk(
+      killer.killCause(),
+      this.id,
+      req.hardTimeoutMs,
+      req.idleTimeoutMs,
+    );
+    if (errChunk) {
+      yield errChunk;
       return;
     }
 

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -103,16 +103,32 @@ export class ClaudeHarness implements Harness {
     // a SIGTERM-by-timeout kill must be distinguishable from a normal exit.
     // The pre-Bun version emitted `done` with whatever partial text it had
     // collected, which masked timeouts as successful short replies. We track
-    // the timeout via a closure-captured boolean so the post-loop branch
-    // surfaces the timeout as a recoverable error instead.
-    let timedOut = false;
+    // the kill cause so the post-loop branch surfaces the right error:
+    //   - "timeout"  → recoverable, orchestrator tries the next harness
+    //   - "aborted"  → non-recoverable, user said /stop and meant it
+    let killCause: "timeout" | "aborted" | undefined;
     const timeout = setTimeout(() => {
-      if (!timedOut) {
-        timedOut = true;
+      if (!killCause) {
+        killCause = "timeout";
         log.warn("claude.invoke timeout", { timeoutMs: req.timeoutMs });
         proc.kill("SIGTERM");
       }
     }, req.timeoutMs);
+
+    const onAbort = () => {
+      if (!killCause) {
+        killCause = "aborted";
+        log.info("claude.invoke aborted via signal");
+        proc.kill("SIGTERM");
+      }
+    };
+    if (req.signal) {
+      if (req.signal.aborted) {
+        onAbort();
+      } else {
+        req.signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
 
     // Drain stderr in the background; surface as debug logs only.
     void consumeStderr(proc.stderr);
@@ -146,13 +162,24 @@ export class ClaudeHarness implements Harness {
       }
     } finally {
       clearTimeout(timeout);
+      if (req.signal && !req.signal.aborted) {
+        req.signal.removeEventListener("abort", onAbort);
+      }
     }
 
-    if (timedOut) {
+    if (killCause === "timeout") {
       yield {
         type: "error",
         error: `claude timed out after ${req.timeoutMs}ms`,
         recoverable: true,
+      };
+      return;
+    }
+    if (killCause === "aborted") {
+      yield {
+        type: "error",
+        error: "stopped",
+        recoverable: false,
       };
       return;
     }

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -119,16 +119,33 @@ export class GeminiHarness implements Harness {
       stderr: "pipe",
     });
 
-    // Same boolean-state-machine pattern as the Claude / Pi harnesses:
-    // a 3-state enum fights TS narrowing inside the for-await loop.
-    let timedOut = false;
+    // Same kill-cause state machine as the Claude / Pi harnesses. We track
+    // why we killed the subprocess so the post-loop branch can yield a
+    // recoverable error (timeout — try next harness) vs non-recoverable
+    // (abort — user said /stop).
+    let killCause: "timeout" | "aborted" | undefined;
     const timeout = setTimeout(() => {
-      if (!timedOut) {
-        timedOut = true;
+      if (!killCause) {
+        killCause = "timeout";
         log.warn("gemini.invoke timeout", { timeoutMs: req.timeoutMs });
         proc.kill("SIGTERM");
       }
     }, req.timeoutMs);
+
+    const onAbort = () => {
+      if (!killCause) {
+        killCause = "aborted";
+        log.info("gemini.invoke aborted via signal");
+        proc.kill("SIGTERM");
+      }
+    };
+    if (req.signal) {
+      if (req.signal.aborted) {
+        onAbort();
+      } else {
+        req.signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
 
     // Write the system prompt + history to stdin and close it. gemini
     // appends the -p value (the new user message) to whatever stdin
@@ -155,13 +172,24 @@ export class GeminiHarness implements Harness {
       finalText += decoder.decode();
     } finally {
       clearTimeout(timeout);
+      if (req.signal && !req.signal.aborted) {
+        req.signal.removeEventListener("abort", onAbort);
+      }
     }
 
-    if (timedOut) {
+    if (killCause === "timeout") {
       yield {
         type: "error",
         error: `gemini timed out after ${req.timeoutMs}ms`,
         recoverable: true,
+      };
+      return;
+    }
+    if (killCause === "aborted") {
+      yield {
+        type: "error",
+        error: "stopped",
+        recoverable: false,
       };
       return;
     }

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -34,7 +34,12 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import {
+  createKillCoordinator,
+  killCauseToErrorChunk,
+} from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
+import { spawnInNewSession } from "../lib/processGroup.ts";
 
 /**
  * Conservative ceiling on the bytes we'll put on argv via the `-p`
@@ -111,7 +116,7 @@ export class GeminiHarness implements Harness {
       userMessageBytes: Buffer.byteLength(req.userMessage, "utf8"),
     });
 
-    const proc = Bun.spawn([this.config.bin, ...args], {
+    const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,
       env: process.env,
       stdin: "pipe",
@@ -119,33 +124,19 @@ export class GeminiHarness implements Harness {
       stderr: "pipe",
     });
 
-    // Same kill-cause state machine as the Claude / Pi harnesses. We track
-    // why we killed the subprocess so the post-loop branch can yield a
-    // recoverable error (timeout — try next harness) vs non-recoverable
-    // (abort — user said /stop).
-    let killCause: "timeout" | "aborted" | undefined;
-    const timeout = setTimeout(() => {
-      if (!killCause) {
-        killCause = "timeout";
-        log.warn("gemini.invoke timeout", { timeoutMs: req.timeoutMs });
-        proc.kill("SIGTERM");
-      }
-    }, req.timeoutMs);
-
-    const onAbort = () => {
-      if (!killCause) {
-        killCause = "aborted";
-        log.info("gemini.invoke aborted via signal");
-        proc.kill("SIGTERM");
-      }
-    };
-    if (req.signal) {
-      if (req.signal.aborted) {
-        onAbort();
-      } else {
-        req.signal.addEventListener("abort", onAbort, { once: true });
-      }
-    }
+    // Idle + hard timer + abort listener. SIGTERM the whole process group
+    // on any of those firing, escalate to SIGKILL after 5s grace. The
+    // grandchild kill is the whole point: gemini-cli routinely spawns
+    // tool subprocesses (the kw-openclaw bug was `gemini usage` wedged
+    // on a TCP read; without process-group kill, that orphan survived
+    // its parent dying and held the socket open).
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: req.idleTimeoutMs,
+      hardTimeoutMs: req.hardTimeoutMs,
+      signal: req.signal,
+      harnessId: this.id,
+    });
 
     // Write the system prompt + history to stdin and close it. gemini
     // appends the -p value (the new user message) to whatever stdin
@@ -166,31 +157,23 @@ export class GeminiHarness implements Harness {
 
     try {
       for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+        killer.touch();
         finalText += decoder.decode(chunk, { stream: true });
       }
       // Flush any pending bytes in the decoder.
       finalText += decoder.decode();
     } finally {
-      clearTimeout(timeout);
-      if (req.signal && !req.signal.aborted) {
-        req.signal.removeEventListener("abort", onAbort);
-      }
+      await killer.dispose();
     }
 
-    if (killCause === "timeout") {
-      yield {
-        type: "error",
-        error: `gemini timed out after ${req.timeoutMs}ms`,
-        recoverable: true,
-      };
-      return;
-    }
-    if (killCause === "aborted") {
-      yield {
-        type: "error",
-        error: "stopped",
-        recoverable: false,
-      };
+    const errChunk = killCauseToErrorChunk(
+      killer.killCause(),
+      this.id,
+      req.hardTimeoutMs,
+      req.idleTimeoutMs,
+    );
+    if (errChunk) {
+      yield errChunk;
       return;
     }
 

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -24,7 +24,12 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import {
+  createKillCoordinator,
+  killCauseToErrorChunk,
+} from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
+import { spawnInNewSession } from "../lib/processGroup.ts";
 
 export interface PiHarnessConfig {
   /** Path to the `pi` CLI binary. Default: "pi" (looked up in PATH). */
@@ -78,7 +83,7 @@ export class PiHarness implements Harness {
       payloadBytes: totalBytes,
     });
 
-    const proc = Bun.spawn([this.config.bin, ...args], {
+    const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,
       env: process.env,
       stdin: "ignore",
@@ -86,32 +91,16 @@ export class PiHarness implements Harness {
       stderr: "pipe",
     });
 
-    // Same kill-cause state machine as the Claude / Gemini harnesses.
-    // Tracks why we killed the subprocess so the post-loop branch yields
-    // a recoverable error (timeout) vs non-recoverable (abort by /stop).
-    let killCause: "timeout" | "aborted" | undefined;
-    const timeout = setTimeout(() => {
-      if (!killCause) {
-        killCause = "timeout";
-        log.warn("pi.invoke timeout", { timeoutMs: req.timeoutMs });
-        proc.kill("SIGTERM");
-      }
-    }, req.timeoutMs);
-
-    const onAbort = () => {
-      if (!killCause) {
-        killCause = "aborted";
-        log.info("pi.invoke aborted via signal");
-        proc.kill("SIGTERM");
-      }
-    };
-    if (req.signal) {
-      if (req.signal.aborted) {
-        onAbort();
-      } else {
-        req.signal.addEventListener("abort", onAbort, { once: true });
-      }
-    }
+    // Idle + hard timer + abort listener; SIGTERM-then-SIGKILL the whole
+    // process group on any of those firing. See harnessRunner.ts for the
+    // state machine.
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: req.idleTimeoutMs,
+      hardTimeoutMs: req.hardTimeoutMs,
+      signal: req.signal,
+      harnessId: this.id,
+    });
 
     void consumeStderr(proc.stderr);
 
@@ -121,6 +110,7 @@ export class PiHarness implements Harness {
 
     try {
       for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+        killer.touch();
         buffer += decoder.decode(chunk, { stream: true });
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
@@ -142,26 +132,17 @@ export class PiHarness implements Harness {
         }
       }
     } finally {
-      clearTimeout(timeout);
-      if (req.signal && !req.signal.aborted) {
-        req.signal.removeEventListener("abort", onAbort);
-      }
+      await killer.dispose();
     }
 
-    if (killCause === "timeout") {
-      yield {
-        type: "error",
-        error: `pi timed out after ${req.timeoutMs}ms`,
-        recoverable: true,
-      };
-      return;
-    }
-    if (killCause === "aborted") {
-      yield {
-        type: "error",
-        error: "stopped",
-        recoverable: false,
-      };
+    const errChunk = killCauseToErrorChunk(
+      killer.killCause(),
+      this.id,
+      req.hardTimeoutMs,
+      req.idleTimeoutMs,
+    );
+    if (errChunk) {
+      yield errChunk;
       return;
     }
 

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -86,16 +86,32 @@ export class PiHarness implements Harness {
       stderr: "pipe",
     });
 
-    // Same state-machine fix as the Claude harness — boolean instead of
-    // a 3-state enum so TS narrowing doesn't fight us.
-    let timedOut = false;
+    // Same kill-cause state machine as the Claude / Gemini harnesses.
+    // Tracks why we killed the subprocess so the post-loop branch yields
+    // a recoverable error (timeout) vs non-recoverable (abort by /stop).
+    let killCause: "timeout" | "aborted" | undefined;
     const timeout = setTimeout(() => {
-      if (!timedOut) {
-        timedOut = true;
+      if (!killCause) {
+        killCause = "timeout";
         log.warn("pi.invoke timeout", { timeoutMs: req.timeoutMs });
         proc.kill("SIGTERM");
       }
     }, req.timeoutMs);
+
+    const onAbort = () => {
+      if (!killCause) {
+        killCause = "aborted";
+        log.info("pi.invoke aborted via signal");
+        proc.kill("SIGTERM");
+      }
+    };
+    if (req.signal) {
+      if (req.signal.aborted) {
+        onAbort();
+      } else {
+        req.signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
 
     void consumeStderr(proc.stderr);
 
@@ -127,13 +143,24 @@ export class PiHarness implements Harness {
       }
     } finally {
       clearTimeout(timeout);
+      if (req.signal && !req.signal.aborted) {
+        req.signal.removeEventListener("abort", onAbort);
+      }
     }
 
-    if (timedOut) {
+    if (killCause === "timeout") {
       yield {
         type: "error",
         error: `pi timed out after ${req.timeoutMs}ms`,
         recoverable: true,
+      };
+      return;
+    }
+    if (killCause === "aborted") {
+      yield {
+        type: "error",
+        error: "stopped",
+        recoverable: false,
       };
       return;
     }

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -26,6 +26,8 @@ export interface HarnessRequest {
   workingDir?: string;
   /** Per-turn wall-clock cap. After this, the harness should kill the subprocess and yield a recoverable error. */
   timeoutMs: number;
+  /** External abort signal (e.g. /stop command). When fired, the harness should kill the subprocess and yield a recoverable error — same outcome as timeout, different trigger. */
+  signal?: AbortSignal;
 }
 
 export type HarnessChunk =

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -24,9 +24,20 @@ export interface HarnessRequest {
   history: HistoryTurn[];
   /** Subprocess working directory. Defaults to the agent dir. */
   workingDir?: string;
-  /** Per-turn wall-clock cap. After this, the harness should kill the subprocess and yield a recoverable error. */
-  timeoutMs: number;
-  /** External abort signal (e.g. /stop command). When fired, the harness should kill the subprocess and yield a recoverable error — same outcome as timeout, different trigger. */
+  /**
+   * Idle timeout: kill the subprocess if no chunk lands on stdout for this
+   * long. Resets on every emitted chunk. This is the right knob for
+   * "subprocess is wedged" (e.g. a tool call hanging on a TCP read) —
+   * a productive turn that's emitting tool events constantly is not stuck.
+   */
+  idleTimeoutMs: number;
+  /**
+   * Hard wall-clock ceiling. Kills the subprocess regardless of activity.
+   * Guards against runaway agents that legitimately keep the idle timer
+   * fed but never converge on a final reply.
+   */
+  hardTimeoutMs: number;
+  /** External abort signal (e.g. /stop command). When fired, the harness should kill the subprocess and yield a non-recoverable "stopped" error. */
   signal?: AbortSignal;
 }
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,48 @@
+/**
+ * Tiny shared formatters for the chat-channel layer.
+ *
+ * Lives here so the truncation rule and the elapsed/uptime formats stay
+ * consistent across `/status`, the long-turn placeholder, and any future
+ * UX surface — instead of being copy-pasted into each.
+ *
+ * Keep this module dependency-free; it's pulled into the channel/CLI
+ * layers that should remain trivially importable from tests.
+ */
+
+/**
+ * Truncate a string to at most `max` characters, replacing the tail
+ * with a single ellipsis when truncation is needed. Empty strings and
+ * strings already within the budget are returned unchanged.
+ */
+export function truncateLine(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}
+
+/**
+ * Format a wall-clock duration (in MILLISECONDS) for the long-turn
+ * placeholder line. Always shows the largest two units, dropping
+ * subseconds entirely.
+ *
+ *   45_000   → "45s"
+ *   65_000   → "1m 5s"
+ *   8_000_000 → "2h 13m"
+ */
+export function formatElapsedMs(ms: number): string {
+  return formatElapsedSeconds(Math.floor(ms / 1000));
+}
+
+/**
+ * Same shape as formatElapsedMs but takes seconds. Used by /status,
+ * which already speaks in seconds. Adds a `Nd Nh` form for uptimes
+ * that exceed a day — placeholders never run that long.
+ */
+export function formatElapsedSeconds(s: number): string {
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}

--- a/src/lib/harnessRunner.ts
+++ b/src/lib/harnessRunner.ts
@@ -1,0 +1,161 @@
+/**
+ * Shared kill/timeout coordination for harness subprocesses.
+ *
+ * Every harness (claude/gemini/pi) needs the same machinery:
+ *
+ *   - spawn the binary in a fresh process group (so grandchildren die too)
+ *   - run an idle timer that resets on every chunk from stdout
+ *   - run a hard wall-clock timer that never resets
+ *   - listen for an external AbortSignal (the user typed /stop)
+ *   - on any of those firing, SIGTERM → 5s grace → SIGKILL the whole group
+ *
+ * Factoring this into one place keeps the three harness files focused on
+ * their per-CLI parsing and prevents the kill semantics from drifting
+ * between them (which is exactly what bit us before — claude knew about
+ * /stop but gemini didn't).
+ *
+ * Usage shape:
+ *
+ *   const runner = createKillCoordinator({
+ *     proc, idleTimeoutMs, hardTimeoutMs, signal, harnessId,
+ *   });
+ *   try {
+ *     for await (const chunk of proc.stdout) {
+ *       runner.touch();   // resets idle timer
+ *       // ...emit chunks...
+ *     }
+ *   } finally {
+ *     await runner.dispose();
+ *   }
+ *   const cause = runner.killCause();   // 'timeout' | 'idle' | 'aborted' | undefined
+ */
+
+import type { Subprocess, SpawnOptions } from "bun";
+import { killProcessGroup } from "./processGroup.ts";
+import { log } from "./logger.ts";
+
+export type KillCause = "timeout" | "idle" | "aborted" | undefined;
+
+export interface KillCoordinatorOpts {
+  proc: Subprocess<
+    SpawnOptions.Writable,
+    SpawnOptions.Readable,
+    SpawnOptions.Readable
+  >;
+  /** Kill if no chunk seen for this long. Resets via touch(). */
+  idleTimeoutMs: number;
+  /** Hard wall-clock cap. Never resets. */
+  hardTimeoutMs: number;
+  /** External abort, e.g. user typed /stop. */
+  signal?: AbortSignal;
+  /** For log lines only. */
+  harnessId: string;
+  /** Grace period between SIGTERM and SIGKILL. Default 5000ms. */
+  graceMs?: number;
+}
+
+export interface KillCoordinator {
+  /** Reset the idle timer. Call after every emitted chunk. */
+  touch(): void;
+  /** Stop all timers and detach signal listener. Idempotent. */
+  dispose(): Promise<void>;
+  /** Why the process was killed, if it was. undefined = exited normally. */
+  killCause(): KillCause;
+}
+
+export function createKillCoordinator(
+  opts: KillCoordinatorOpts,
+): KillCoordinator {
+  const graceMs = opts.graceMs ?? 5000;
+  let cause: KillCause;
+  let disposed = false;
+
+  const triggerKill = (newCause: Exclude<KillCause, undefined>): void => {
+    if (cause || disposed) return;
+    cause = newCause;
+    log.warn(`${opts.harnessId}.invoke killed: ${newCause}`, {
+      idleTimeoutMs: opts.idleTimeoutMs,
+      hardTimeoutMs: opts.hardTimeoutMs,
+    });
+    // Fire-and-forget; the for-await over stdout will end naturally as
+    // the kernel closes the pipe after SIGKILL.
+    void killProcessGroup(opts.proc, graceMs);
+  };
+
+  let idleTimer: ReturnType<typeof setTimeout> = setTimeout(
+    () => triggerKill("idle"),
+    opts.idleTimeoutMs,
+  );
+  const hardTimer: ReturnType<typeof setTimeout> = setTimeout(
+    () => triggerKill("timeout"),
+    opts.hardTimeoutMs,
+  );
+
+  const onAbort = (): void => triggerKill("aborted");
+  if (opts.signal) {
+    if (opts.signal.aborted) {
+      onAbort();
+    } else {
+      opts.signal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  return {
+    touch(): void {
+      if (cause || disposed) return;
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(
+        () => triggerKill("idle"),
+        opts.idleTimeoutMs,
+      );
+    },
+    async dispose(): Promise<void> {
+      if (disposed) return;
+      disposed = true;
+      clearTimeout(idleTimer);
+      clearTimeout(hardTimer);
+      if (opts.signal && !opts.signal.aborted) {
+        opts.signal.removeEventListener("abort", onAbort);
+      }
+    },
+    killCause(): KillCause {
+      return cause;
+    },
+  };
+}
+
+/**
+ * Render the standard "killed by X" HarnessChunk for a kill cause.
+ * Returns undefined if the process exited naturally (no kill).
+ *
+ *   - "timeout"  → recoverable (orchestrator advances to next harness)
+ *   - "idle"     → recoverable (same — wedged subprocess, try a different one)
+ *   - "aborted"  → non-recoverable (user said /stop and meant it)
+ */
+export function killCauseToErrorChunk(
+  cause: KillCause,
+  harnessId: string,
+  hardTimeoutMs: number,
+  idleTimeoutMs: number,
+):
+  | { type: "error"; error: string; recoverable: boolean }
+  | undefined {
+  if (cause === "timeout") {
+    return {
+      type: "error",
+      error: `${harnessId} timed out after ${hardTimeoutMs}ms (hard wall-clock cap)`,
+      recoverable: true,
+    };
+  }
+  if (cause === "idle") {
+    return {
+      type: "error",
+      error: `${harnessId} timed out after ${idleTimeoutMs}ms with no output (likely wedged on a tool call)`,
+      recoverable: true,
+    };
+  }
+  if (cause === "aborted") {
+    return { type: "error", error: "stopped", recoverable: false };
+  }
+  return undefined;
+}

--- a/src/lib/processGroup.ts
+++ b/src/lib/processGroup.ts
@@ -1,0 +1,140 @@
+/**
+ * Process-group spawn + kill helpers.
+ *
+ * Why this exists: a phantombot harness (claude/gemini/pi) commonly
+ * spawns its own subprocesses to execute tool calls — `Bash`, `WebFetch`,
+ * `gemini usage`, etc. When phantombot kills the harness on timeout or
+ * /stop, `Bun.spawn`'s `proc.kill(SIGTERM)` only signals the direct
+ * subprocess. The grandchildren are reparented to PID 1 and keep
+ * running.
+ *
+ * The motivating bug (kw-openclaw, 2026-05-02): a `gemini usage` tool
+ * call wedged on a TCP read inside the gemini subprocess. After the
+ * 600s wall-clock timeout fired, gemini died — but `gemini usage`
+ * survived as an orphan with the open socket, eating fds and
+ * confusing later runs.
+ *
+ * Fix: spawn the binary with Bun's `detached: true` option. This puts
+ * the spawned process in its own session and process group BEFORE
+ * exec, so `pid == pgid == sid` from the moment Bun.spawn returns.
+ * We can then signal the entire descendant tree in one syscall via
+ * `process.kill(-pid, sig)` — the kernel routes a negative pid to
+ * every member of the matching pgid.
+ *
+ * Why this option vs a `setsid <cmd>` wrapper: a setsid prefix would
+ * also work, but it has a brief race — the setsid() syscall doesn't
+ * happen until after Bun.spawn returns and the child actually exec's
+ * setsid. If you try to kill the group within ~50ms of spawn (rare
+ * in production but real in tests), the new pgroup doesn't exist
+ * yet and you get ESRCH. Bun's `detached` does the setsid before
+ * exec, so the pgroup is live by the time `proc.pid` is observable
+ * in the caller.
+ *
+ * `detached` is undocumented in Bun's public API as of 1.3.x but
+ * works reliably (it maps to posix_spawn's POSIX_SPAWN_SETSID flag).
+ * If a future Bun release changes this, the fallback is to wrap the
+ * cmd in `setsid` and accept the spawn-time race.
+ */
+
+import type { Subprocess, SpawnOptions } from "bun";
+import { log } from "./logger.ts";
+
+/**
+ * Spawn a subprocess as the leader of a fresh process group/session.
+ *
+ * Identical to `Bun.spawn` except the resulting process's `pid` doubles
+ * as a `pgid` you can pass to `killProcessGroup` to bring the whole
+ * descendant tree down with one signal.
+ */
+export function spawnInNewSession<
+  Stdin extends SpawnOptions.Writable,
+  Stdout extends SpawnOptions.Readable,
+  Stderr extends SpawnOptions.Readable,
+>(
+  cmd: string[],
+  opts: SpawnOptions.OptionsObject<Stdin, Stdout, Stderr>,
+): Subprocess<Stdin, Stdout, Stderr> {
+  if (cmd.length === 0) {
+    throw new Error("spawnInNewSession: cmd cannot be empty");
+  }
+  return Bun.spawn(cmd, {
+    ...opts,
+    // Undocumented but stable Bun option (maps to POSIX_SPAWN_SETSID).
+    // See module docstring for why this beats a `setsid` wrapper.
+    detached: true,
+  } as typeof opts) as Subprocess<Stdin, Stdout, Stderr>;
+}
+
+/**
+ * Kill the entire process group of `proc` with SIGTERM, then escalate
+ * to SIGKILL after `graceMs` if the process hasn't exited.
+ *
+ * Resolves when the process is reaped (proc.exited resolves), regardless
+ * of which signal finally killed it. Safe to call multiple times — the
+ * second call is a no-op once the process is gone.
+ *
+ * Errors during signalling (other than ESRCH = "process is already
+ * gone") are logged and swallowed. The caller is past the point of
+ * recovery once kill is needed.
+ */
+export async function killProcessGroup(
+  proc: Subprocess<
+    SpawnOptions.Writable,
+    SpawnOptions.Readable,
+    SpawnOptions.Readable
+  >,
+  graceMs: number = 5000,
+): Promise<void> {
+  const pid = proc.pid;
+  if (typeof pid !== "number" || pid <= 0) return;
+
+  if (!signalGroup(pid, "SIGTERM")) {
+    // ESRCH path — already dead. proc.exited has already resolved or is
+    // about to. Just await it.
+    await proc.exited;
+    return;
+  }
+
+  // Race the natural exit against the grace window.
+  const escalated = await Promise.race([
+    proc.exited.then(() => false),
+    new Promise<true>((resolve) => setTimeout(() => resolve(true), graceMs)),
+  ]);
+
+  if (!escalated) return;
+
+  log.warn("processGroup: SIGTERM ignored within grace, escalating to SIGKILL", {
+    pid,
+    graceMs,
+  });
+  signalGroup(pid, "SIGKILL");
+  // SIGKILL can't be ignored; proc.exited resolves shortly.
+  await proc.exited;
+}
+
+/**
+ * Send `signal` to every process in the group whose pgid is `pid`.
+ * Returns true if the signal was delivered (or the kernel accepted it),
+ * false if the group is already gone (ESRCH).
+ *
+ * Wraps `process.kill` with negative pid — the POSIX convention for
+ * "this entire process group". Anything other than ESRCH is logged
+ * and treated as a delivered signal (best-effort; the caller still
+ * waits on proc.exited).
+ */
+function signalGroup(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") return false;
+    log.warn("processGroup: kill failed", {
+      pid,
+      signal,
+      code,
+      error: (e as Error).message,
+    });
+    return true;
+  }
+}

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -47,6 +47,8 @@ export interface MemoryStore {
   ): Promise<Array<{ role: Role; text: string }>>;
   /** Most recent N turns across all conversations for one persona, full rows, oldest first. */
   recentTurnsForDisplay(persona: string, n: number): Promise<Turn[]>;
+  /** Delete all turns for a (persona, conversation) pair. Used by /reset. */
+  deleteConversation(persona: string, conversation: string): Promise<number>;
   /** Close the underlying SQLite connection. Safe to call once; idempotent thereafter. */
   close(): Promise<void>;
 }
@@ -79,6 +81,7 @@ class SqliteMemoryStore implements MemoryStore {
   private appendStmt;
   private recentStmt;
   private recentDisplayStmt;
+  private deleteStmt;
   private closed = false;
 
   constructor(private db: Database) {
@@ -104,6 +107,9 @@ class SqliteMemoryStore implements MemoryStore {
          ORDER BY created_at DESC, id DESC
          LIMIT ?
        ) ORDER BY created_at ASC, id ASC`,
+    );
+    this.deleteStmt = db.prepare(
+      "DELETE FROM turns WHERE persona = ? AND conversation = ?",
     );
   }
 
@@ -144,6 +150,14 @@ class SqliteMemoryStore implements MemoryStore {
     if (this.closed) return;
     this.closed = true;
     this.db.close();
+  }
+
+  async deleteConversation(
+    persona: string,
+    conversation: string,
+  ): Promise<number> {
+    const result = this.deleteStmt.run(persona, conversation);
+    return result.changes;
   }
 }
 

--- a/src/orchestrator/fallback.ts
+++ b/src/orchestrator/fallback.ts
@@ -32,6 +32,15 @@ export async function* runWithFallback(
   const estimatedBytes = estimatePayloadBytes(req);
 
   for (let i = 0; i < chain.length; i++) {
+    // Short-circuit if the channel layer has already aborted — otherwise
+    // every harness in the chain spawns a subprocess just to discover the
+    // signal and kill itself, which is wasteful when the user just typed
+    // /stop and meant it.
+    if (req.signal?.aborted) {
+      yield { type: "error", error: "stopped", recoverable: false };
+      return;
+    }
+
     const harness = chain[i]!;
     const isLast = i === chain.length - 1;
 

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -40,8 +40,10 @@ export interface TurnInput {
   harnesses: Harness[];
   /** Open memory store; runTurn appends to it on success. */
   memory: MemoryStore;
-  /** Per-harness timeout. */
-  timeoutMs: number;
+  /** Kill subprocess after this long with no chunk on stdout. Resets per chunk. */
+  idleTimeoutMs: number;
+  /** Hard wall-clock ceiling regardless of activity. */
+  hardTimeoutMs: number;
   /** Number of prior turns to load. Default 20. */
   historyLimit?: number;
   /** Skip loading prior turns AND skip persisting this one. Default false. */
@@ -84,7 +86,8 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
     userMessage: input.userMessage,
     history,
     workingDir: input.agentDir,
-    timeoutMs: input.timeoutMs,
+    idleTimeoutMs: input.idleTimeoutMs,
+    hardTimeoutMs: input.hardTimeoutMs,
     signal: input.signal,
   })) {
     if (chunk.type === "text") finalText += chunk.text;

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -48,6 +48,8 @@ export interface TurnInput {
   noHistory?: boolean;
   /** Extra text appended to the system prompt. Used by nightly to inject distillation directives. */
   systemPromptSuffix?: string;
+  /** External abort signal from channel layer (e.g. /stop command). Propagated to harnesses. */
+  signal?: AbortSignal;
 }
 
 export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
@@ -83,6 +85,7 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
     history,
     workingDir: input.agentDir,
     timeoutMs: input.timeoutMs,
+    signal: input.signal,
   })) {
     if (chunk.type === "text") finalText += chunk.text;
     if (chunk.type === "done") {

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -194,6 +194,39 @@ describe("/status", () => {
       ctx({ activeTurn: handle }),
     );
     expect(r!.reply).toMatch(/active:\s+yes \(\d+\.\d+s\)/);
+    // No 'running:' line when no progress note has been captured.
+    expect(r!.reply).not.toContain("running:");
+  });
+
+  test("includes 'running:' line with last progress note when present", async () => {
+    const controller = new AbortController();
+    const handle: ActiveTurnHandle = {
+      controller,
+      startTime: Date.now() - 1500,
+      lastProgressNote: "tool_execution_start: BashTool",
+    };
+    const r = await handleSlashCommand(
+      "/status",
+      ctx({ activeTurn: handle }),
+    );
+    expect(r!.reply).toContain("running: tool_execution_start: BashTool");
+  });
+
+  test("truncates very long progress notes to keep /status readable", async () => {
+    const longNote = "a".repeat(500);
+    const handle: ActiveTurnHandle = {
+      controller: new AbortController(),
+      startTime: Date.now(),
+      lastProgressNote: longNote,
+    };
+    const r = await handleSlashCommand(
+      "/status",
+      ctx({ activeTurn: handle }),
+    );
+    expect(r!.reply).toContain("running:");
+    expect(r!.reply).toContain("…");
+    // Must not embed the entire 500-char note.
+    expect(r!.reply.length).toBeLessThan(longNote.length);
   });
 
   test("uptime formatter handles seconds, minutes, hours, days", async () => {

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -161,6 +161,24 @@ describe("/reset", () => {
     expect(r!.reply).toContain("1 turn ");
     expect(r!.reply).not.toContain("1 turns");
   });
+
+  test("aborts an in-flight turn so the post-reset persist doesn't refill the cleared conversation", async () => {
+    const controller = new AbortController();
+    const handle: ActiveTurnHandle = {
+      controller,
+      startTime: Date.now() - 2_500,
+    };
+    const r = await handleSlashCommand("/reset", ctx({ activeTurn: handle }));
+    expect(controller.signal.aborted).toBe(true);
+    // Reply mentions the in-flight stop so the user knows the reset
+    // really did clean up everything, not just the persisted history.
+    expect(r!.reply).toMatch(/stopped an in-flight turn that was \d+\.\ds in/);
+  });
+
+  test("no in-flight mention when there's no active turn", async () => {
+    const r = await handleSlashCommand("/reset", ctx());
+    expect(r!.reply).not.toContain("in-flight");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Unit tests for the slash command dispatcher (src/channels/commands.ts).
+ *
+ * The dispatcher is pure-ish: it reads the supplied context and mutates
+ * what's passed in (memory store, harness chain, AbortController).
+ * These tests exercise each command with stub contexts — no Telegram, no
+ * subprocesses. End-to-end "/stop kills a hung Gemini turn" lives in
+ * channels-telegram.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  handleSlashCommand,
+  nominalContextWindow,
+  type ActiveTurnHandle,
+  type SlashCommandContext,
+} from "../src/channels/commands.ts";
+import type { Harness, HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
+import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
+
+class StubHarness implements Harness {
+  constructor(
+    public readonly id: string,
+    private readonly _available: boolean = true,
+  ) {}
+  async available(): Promise<boolean> {
+    return this._available;
+  }
+  async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    yield { type: "done", finalText: "" };
+  }
+}
+
+let memory: MemoryStore;
+beforeEach(async () => {
+  memory = await openMemoryStore(":memory:");
+});
+afterEach(async () => {
+  await memory.close();
+});
+
+function ctx(
+  overrides: Partial<SlashCommandContext> = {},
+): SlashCommandContext {
+  return {
+    chatId: 42,
+    persona: "phantom",
+    conversation: "telegram:42",
+    memory,
+    harnesses: [new StubHarness("claude"), new StubHarness("pi")],
+    startedAt: Date.now() - 65_000, // ~1m 5s of fake uptime
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recognition + parsing
+// ---------------------------------------------------------------------------
+
+describe("handleSlashCommand recognition", () => {
+  test("returns null for non-slash text — caller falls through to LLM", async () => {
+    const r = await handleSlashCommand("hello there", ctx());
+    expect(r).toBeNull();
+  });
+
+  test("returns null for unknown slash commands so personas can handle them", async () => {
+    const r = await handleSlashCommand("/remember the milk", ctx());
+    expect(r).toBeNull();
+  });
+
+  test("strips @BotName suffix (Telegram group convention)", async () => {
+    const r = await handleSlashCommand("/help@PhantomBot", ctx());
+    expect(r).not.toBeNull();
+    expect(r!.reply).toContain("/stop");
+  });
+
+  test("is case-insensitive on the command itself", async () => {
+    const r = await handleSlashCommand("/HELP", ctx());
+    expect(r).not.toBeNull();
+    expect(r!.reply).toContain("/stop");
+  });
+
+  test("tolerates leading/trailing whitespace", async () => {
+    const r = await handleSlashCommand("   /help   ", ctx());
+    expect(r).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /stop
+// ---------------------------------------------------------------------------
+
+describe("/stop", () => {
+  test("aborts the active turn's controller", async () => {
+    const controller = new AbortController();
+    const handle: ActiveTurnHandle = {
+      controller,
+      startTime: Date.now() - 1500,
+    };
+    const r = await handleSlashCommand("/stop", ctx({ activeTurn: handle }));
+    expect(controller.signal.aborted).toBe(true);
+    expect(r!.reply).toContain("stopped");
+    // Includes the elapsed time so the user knows what got killed.
+    expect(r!.reply).toMatch(/\d+\.\d+s/);
+  });
+
+  test("with no active turn replies politely instead of aborting nothing", async () => {
+    const r = await handleSlashCommand("/stop", ctx());
+    expect(r!.reply).toContain("no active turn");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /reset
+// ---------------------------------------------------------------------------
+
+describe("/reset", () => {
+  test("deletes turns for the active conversation only", async () => {
+    // Seed two conversations under the same persona.
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "user",
+      text: "a",
+    });
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "assistant",
+      text: "b",
+    });
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:99",
+      role: "user",
+      text: "should survive",
+    });
+
+    const r = await handleSlashCommand("/reset", ctx());
+    expect(r!.reply).toContain("2 turns");
+
+    expect(await memory.recentTurns("phantom", "telegram:42", 10)).toEqual([]);
+    expect(await memory.recentTurns("phantom", "telegram:99", 10)).toEqual([
+      { role: "user", text: "should survive" },
+    ]);
+  });
+
+  test("reports zero gracefully when there's nothing to clear", async () => {
+    const r = await handleSlashCommand("/reset", ctx());
+    expect(r!.reply).toContain("0 turns");
+  });
+
+  test("singular noun for exactly one turn deleted", async () => {
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "user",
+      text: "lonely",
+    });
+    const r = await handleSlashCommand("/reset", ctx());
+    expect(r!.reply).toContain("1 turn ");
+    expect(r!.reply).not.toContain("1 turns");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /status
+// ---------------------------------------------------------------------------
+
+describe("/status", () => {
+  test("reports primary harness, chain, uptime, context %, and active state", async () => {
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "user",
+      text: "x".repeat(400), // ~100 tokens at 4 chars/token
+    });
+    const r = await handleSlashCommand("/status", ctx());
+    expect(r!.reply).toContain("harness: claude");
+    expect(r!.reply).toContain("claude → pi");
+    expect(r!.reply).toMatch(/uptime:\s+1m \d+s/);
+    expect(r!.reply).toContain("context:");
+    expect(r!.reply).toContain("active:  no");
+  });
+
+  test("shows active turn elapsed time when one is running", async () => {
+    const controller = new AbortController();
+    const handle: ActiveTurnHandle = {
+      controller,
+      startTime: Date.now() - 800,
+    };
+    const r = await handleSlashCommand(
+      "/status",
+      ctx({ activeTurn: handle }),
+    );
+    expect(r!.reply).toMatch(/active:\s+yes \(\d+\.\d+s\)/);
+  });
+
+  test("uptime formatter handles seconds, minutes, hours, days", async () => {
+    const cases: Array<[number, RegExp]> = [
+      [Date.now() - 5_000, /uptime:\s+5s/],
+      [Date.now() - 65_000, /uptime:\s+1m 5s/],
+      [Date.now() - (3_600_000 + 120_000), /uptime:\s+1h 2m/],
+      [Date.now() - 3 * 24 * 3_600_000 - 4 * 3_600_000, /uptime:\s+3d 4h/],
+    ];
+    for (const [startedAt, re] of cases) {
+      const r = await handleSlashCommand("/status", ctx({ startedAt }));
+      expect(r!.reply).toMatch(re);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /harness
+// ---------------------------------------------------------------------------
+
+describe("/harness", () => {
+  test("with no arg lists current chain and marks the primary", async () => {
+    const r = await handleSlashCommand("/harness", ctx());
+    expect(r!.reply).toContain("→ claude");
+    expect(r!.reply).toMatch(/\s+pi/);
+    expect(r!.reply).toContain("/harness <id>");
+  });
+
+  test("annotates unavailable harnesses without removing them from the list", async () => {
+    const r = await handleSlashCommand(
+      "/harness",
+      ctx({
+        harnesses: [
+          new StubHarness("claude", true),
+          new StubHarness("pi", false),
+        ],
+      }),
+    );
+    expect(r!.reply).toContain("pi (unavailable)");
+  });
+
+  test("switches primary by reordering the chain in place", async () => {
+    const harnesses = [new StubHarness("claude"), new StubHarness("pi")];
+    const r = await handleSlashCommand("/harness pi", ctx({ harnesses }));
+    expect(r!.reply).toContain("switched to pi");
+    expect(harnesses.map((h) => h.id)).toEqual(["pi", "claude"]);
+  });
+
+  test("rejects unknown harness ids with the available list", async () => {
+    const r = await handleSlashCommand("/harness doesnotexist", ctx());
+    expect(r!.reply).toContain("unknown harness");
+    expect(r!.reply).toContain("claude, pi");
+  });
+
+  test("refuses to switch to an unavailable harness so we don't burn a turn discovering it", async () => {
+    const harnesses = [
+      new StubHarness("claude", true),
+      new StubHarness("pi", false),
+    ];
+    const r = await handleSlashCommand("/harness pi", ctx({ harnesses }));
+    expect(r!.reply).toContain("isn't available");
+    // Chain unchanged.
+    expect(harnesses.map((h) => h.id)).toEqual(["claude", "pi"]);
+  });
+
+  test("noop when the requested harness is already primary", async () => {
+    const harnesses = [new StubHarness("claude"), new StubHarness("pi")];
+    const r = await handleSlashCommand(
+      "/harness claude",
+      ctx({ harnesses }),
+    );
+    expect(r!.reply).toContain("already primary");
+    expect(harnesses.map((h) => h.id)).toEqual(["claude", "pi"]);
+  });
+
+  test("empty chain reports a clean error rather than dividing by zero", async () => {
+    const r = await handleSlashCommand("/harness", ctx({ harnesses: [] }));
+    expect(r!.reply).toContain("no harnesses");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /help
+// ---------------------------------------------------------------------------
+
+describe("/help", () => {
+  test("lists every command we own", async () => {
+    const r = await handleSlashCommand("/help", ctx());
+    expect(r!.reply).toContain("/stop");
+    expect(r!.reply).toContain("/reset");
+    expect(r!.reply).toContain("/status");
+    expect(r!.reply).toContain("/harness");
+    expect(r!.reply).toContain("/help");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Internal helpers exposed for testability
+// ---------------------------------------------------------------------------
+
+describe("nominalContextWindow", () => {
+  test("returns sensible defaults per harness id", () => {
+    expect(nominalContextWindow("claude")).toBe(200_000);
+    expect(nominalContextWindow("gemini")).toBe(1_000_000);
+    expect(nominalContextWindow("pi")).toBe(64_000);
+    expect(nominalContextWindow("unknown")).toBe(128_000);
+  });
+});

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -740,6 +740,234 @@ describe("runTelegramServer typing refresh", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Slash commands via the polling loop
+// ---------------------------------------------------------------------------
+
+describe("runTelegramServer slash commands", () => {
+  test("/help is handled by the channel layer (no harness call)", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "/help",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]!.text).toContain("/stop");
+    expect(transport.sent[0]!.text).toContain("/status");
+  });
+
+  test("/reset clears prior history for this chat (and only this chat)", async () => {
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:1001",
+      role: "user",
+      text: "old",
+    });
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:9999",
+      role: "user",
+      text: "untouched",
+    });
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "/reset",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "x" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(
+      await memory.recentTurns("phantom", "telegram:1001", 10),
+    ).toEqual([]);
+    expect(
+      await memory.recentTurns("phantom", "telegram:9999", 10),
+    ).toEqual([{ role: "user", text: "untouched" }]);
+    expect(transport.sent[0]!.text).toContain("cleared 1 turn");
+  });
+
+  test("/stop aborts an in-flight turn and suppresses the would-be reply", async () => {
+    // A harness that yields one text chunk then waits 5s (long enough that
+    // the test-level abort is the only way it ever finishes within the
+    // bun-test default timeout).
+    class AbortableHarness implements Harness {
+      readonly id = "abortable";
+      lastSignalAborted: boolean | undefined;
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "thinking…" };
+        await new Promise<void>((resolve) => {
+          if (req.signal?.aborted) return resolve();
+          const onAbort = () => {
+            this.lastSignalAborted = true;
+            resolve();
+          };
+          req.signal?.addEventListener("abort", onAbort, { once: true });
+          setTimeout(resolve, 5000);
+        });
+        yield {
+          type: "error",
+          error: "stopped",
+          recoverable: false,
+        };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "kick off something slow",
+    });
+    // /stop arrives ~30ms later, after the harness is already in-flight.
+    setTimeout(() => {
+      transport.pendingUpdates.push({
+        updateId: 2,
+        chatId: 1001,
+        fromUserId: 42,
+        text: "/stop",
+      });
+    }, 30);
+
+    const harness = new AbortableHarness();
+    const ac = new AbortController();
+    // Stop the polling loop after a moment; the turn worker drain in the
+    // server's `finally` will wait for the aborted turn to resolve.
+    setTimeout(() => ac.abort(), 200);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      signal: ac.signal,
+    });
+
+    // The /stop reply lands. The aborted turn does NOT send a follow-up
+    // (no "(error: stopped)" leak).
+    const stopReplies = transport.sent.filter((s) =>
+      s.text.startsWith("stopped"),
+    );
+    expect(stopReplies.length).toBe(1);
+    const errorReplies = transport.sent.filter((s) =>
+      s.text.includes("(error:"),
+    );
+    expect(errorReplies).toEqual([]);
+    expect(harness.lastSignalAborted).toBe(true);
+    // No turn was persisted (failed turn → no history).
+    const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
+    expect(stored).toEqual([]);
+  });
+
+  test("/status reports the current primary harness", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "/status",
+    });
+    const claude = new ScriptedHarness("claude", []);
+    const pi = new ScriptedHarness("pi", []);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [claude, pi],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]!.text).toContain("harness: claude");
+    expect(transport.sent[0]!.text).toContain("claude → pi");
+  });
+
+  test("/harness <id> switches the primary so the next turn uses it", async () => {
+    const claude = new ScriptedHarness("claude", [
+      { type: "done", finalText: "from claude" },
+    ]);
+    const pi = new ScriptedHarness("pi", [
+      { type: "done", finalText: "from pi" },
+    ]);
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push(
+      { updateId: 1, chatId: 1001, fromUserId: 42, text: "/harness pi" },
+      { updateId: 2, chatId: 1001, fromUserId: 42, text: "hi" },
+    );
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [claude, pi],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    // After the switch, the second message hits pi, not claude.
+    expect(pi.invocations).toBe(1);
+    expect(claude.invocations).toBe(0);
+    const userReply = transport.sent.find((s) => s.text === "from pi");
+    expect(userReply).toBeDefined();
+  });
+
+  test("unknown /commands fall through to the LLM (so personas can own /remember etc.)", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "/remember the milk",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "noted" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(1);
+    expect(harness.lastRequest?.userMessage).toBe("/remember the milk");
+    expect(transport.sent).toEqual([{ chatId: 1001, text: "noted" }]);
+  });
+});
+
 describe("HttpTelegramTransport AbortSignal", () => {
   test("aborted fetch returns empty result without throwing", async () => {
     // Replace globalThis.fetch with one that throws AbortError immediately

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -55,8 +55,13 @@ class FakeTransport implements TelegramTransport {
         : offset;
     return { updates, nextOffset };
   }
-  async sendMessage(chatId: number, text: string): Promise<void> {
+  edited: Array<{ chatId: number; messageId: number; text: string }> = [];
+  deleted: Array<{ chatId: number; messageId: number }> = [];
+  private nextMessageId = 1;
+  async sendMessage(chatId: number, text: string): Promise<number> {
+    const id = this.nextMessageId++;
     this.sent.push({ chatId, text });
+    return id;
   }
   async sendTyping(chatId: number): Promise<void> {
     this.typing.push(chatId);
@@ -76,6 +81,16 @@ class FakeTransport implements TelegramTransport {
   ): Promise<{ data: Buffer; mime: string }> {
     this.downloadedFileIds.push(fileId);
     return { data: this.fakeFileBytes, mime: "audio/ogg" };
+  }
+  async editMessage(
+    chatId: number,
+    messageId: number,
+    text: string,
+  ): Promise<void> {
+    this.edited.push({ chatId, messageId, text });
+  }
+  async deleteMessage(chatId: number, messageId: number): Promise<void> {
+    this.deleted.push({ chatId, messageId });
   }
 }
 
@@ -188,7 +203,7 @@ const baseConfig = (
   overrides: Partial<NonNullable<Config["channels"]["telegram"]>> = {},
 ): Config => ({
   defaultPersona: "phantom",
-  turnTimeoutMs: 5_000,
+  harnessIdleTimeoutMs: 5_000, harnessHardTimeoutMs: 5_000,
   personasDir: join(workdir, "personas"),
   memoryDbPath: join(workdir, "memory.sqlite"),
   configPath: join(workdir, "config.toml"),
@@ -1005,5 +1020,228 @@ describe("HttpTelegramTransport AbortSignal", () => {
     } finally {
       (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Long-turn placeholder lifecycle (Option B from the design discussion)
+//
+// A turn that goes silent for placeholderThresholdMs gets a "⏳ working…"
+// message posted; that message is edited every placeholderEditMs; on
+// completion it is deleted and the real reply is sent as a NEW message
+// (so Telegram pushes a notification — the load-bearing reason we picked
+// delete-then-send over edit-into-reply).
+// ---------------------------------------------------------------------------
+
+describe("placeholder lifecycle", () => {
+  test("fast turn: no placeholder ever posted, no edits, no deletes", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "ping",
+    });
+    const harness = new ScriptedHarness("fast", [
+      { type: "done", finalText: "pong" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+      // Long threshold relative to the turn — won't fire.
+      placeholderThresholdMs: 5_000,
+      placeholderEditMs: 60_000,
+    });
+
+    expect(transport.sent).toEqual([{ chatId: 1001, text: "pong" }]);
+    expect(transport.edited).toEqual([]);
+    expect(transport.deleted).toEqual([]);
+  });
+
+  test("slow turn: placeholder posted + edited + deleted; final reply sent fresh", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 2002,
+      fromUserId: 42,
+      text: "build the thing",
+    });
+    // Slow harness: emits a progress note partway through, then sleeps
+    // long enough that the placeholder fires AND gets edited at least once.
+    class SlowProgressHarness implements Harness {
+      readonly id = "slow";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "progress", note: "tool_execution_start: BashTool" };
+        await new Promise((r) => setTimeout(r, 250));
+        yield {
+          type: "done",
+          finalText: "built it",
+          meta: { harnessId: this.id },
+        };
+      }
+    }
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new SlowProgressHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+      placeholderThresholdMs: 50, // post quickly
+      placeholderEditMs: 80, // edit at least once before the 250ms hold ends
+    });
+
+    // The placeholder was posted (first sendMessage), then deleted, then
+    // the real reply was sent as a NEW message.
+    expect(transport.sent.length).toBe(2);
+    expect(transport.sent[0]!.text).toContain("⏳ working");
+    expect(transport.sent[1]!.text).toBe("built it");
+    // At least one edit happened.
+    expect(transport.edited.length).toBeGreaterThanOrEqual(1);
+    expect(transport.edited[0]!.text).toContain("⏳ working");
+    // The placeholder message was deleted before the final reply went out.
+    expect(transport.deleted.length).toBe(1);
+    const placeholderId = transport.sent[0]!.chatId === 2002 ? 1 : 0;
+    expect(transport.deleted[0]).toEqual({
+      chatId: 2002,
+      messageId: placeholderId === 0 ? 0 : 1, // FakeTransport assigns id=1 first
+    });
+  });
+
+  test("placeholder edits include the most recent progress note", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 3003,
+      fromUserId: 42,
+      text: "do work",
+    });
+    class ProgressHarness implements Harness {
+      readonly id = "progressive";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "progress", note: "step 1: cloning" };
+        await new Promise((r) => setTimeout(r, 100));
+        yield { type: "progress", note: "step 2: building" };
+        await new Promise((r) => setTimeout(r, 100));
+        yield { type: "done", finalText: "ok", meta: { harnessId: this.id } };
+      }
+    }
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new ProgressHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+      placeholderThresholdMs: 30,
+      placeholderEditMs: 60,
+    });
+
+    // Some edit must mention the latest progress note.
+    const allEditedText = transport.edited.map((e) => e.text).join("\n");
+    // Either step 1 or step 2 will appear, depending on edit timing.
+    expect(allEditedText).toMatch(/step [12]:/);
+  });
+
+  test("/stop during long turn: placeholder is cleaned up, no duplicate result message", async () => {
+    const transport = new FakeTransport();
+    // Use AbortableHarness pattern from the slow-turn tests: blocks on
+    // signal, yields a stopped error when aborted.
+    class AbortableHarness implements Harness {
+      readonly id = "abortable";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(resolve, 5_000);
+          req.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(t);
+              resolve();
+            },
+            { once: true },
+          );
+        });
+        if (req.signal?.aborted) {
+          yield { type: "error", error: "stopped", recoverable: false };
+        } else {
+          yield { type: "done", finalText: "shouldn't get here" };
+        }
+      }
+    }
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 4004,
+      fromUserId: 42,
+      text: "do something long",
+    });
+    // Inject a /stop after the placeholder has had time to fire.
+    setTimeout(() => {
+      transport.pendingUpdates.push({
+        updateId: 2,
+        chatId: 4004,
+        fromUserId: 42,
+        text: "/stop",
+      });
+    }, 200);
+    // Stop the polling loop after a moment; the worker drain in the
+    // server's `finally` waits for the aborted turn to resolve.
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 400);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new AbortableHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      signal: ac.signal,
+      placeholderThresholdMs: 50,
+      placeholderEditMs: 60,
+    });
+
+    // Three categories of message in `sent`: the placeholder (⏳…), the
+    // /stop ack (stopped …), and ideally NO duplicate "(error: stopped)".
+    const replyTexts = transport.sent.map((s) => s.text);
+    expect(replyTexts.some((t) => /^stopped \(/.test(t))).toBe(true);
+    expect(replyTexts.some((t) => t.includes("(error: stopped)"))).toBe(false);
+    // Placeholder posted then deleted.
+    const placeholderTexts = replyTexts.filter((t) => t.includes("⏳ working"));
+    expect(placeholderTexts.length).toBeGreaterThanOrEqual(1);
+    expect(transport.deleted.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("formatElapsed", () => {
+  test("formats sub-minute as plain seconds", async () => {
+    const { formatElapsed } = await import("../src/channels/telegram.ts");
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(45_000)).toBe("45s");
+  });
+
+  test("formats minutes + seconds", async () => {
+    const { formatElapsed } = await import("../src/channels/telegram.ts");
+    expect(formatElapsed(65_000)).toBe("1m 5s");
+    expect(formatElapsed(7 * 60_000 + 12_000)).toBe("7m 12s");
+  });
+
+  test("formats hours + minutes for very long turns", async () => {
+    const { formatElapsed } = await import("../src/channels/telegram.ts");
+    expect(formatElapsed(2 * 3_600_000 + 15 * 60_000 + 4_000)).toBe("2h 15m");
   });
 });

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -1156,6 +1156,75 @@ describe("placeholder lifecycle", () => {
     expect(allEditedText).toMatch(/step [12]:/);
   });
 
+  test("placeholder race: sendMessage that resolves AFTER the turn ends doesn't leak the interval or orphan the message", async () => {
+    // Reproduces the race the PR-#56 review flagged: the post timer
+    // fires near the end of the turn, the IIFE awaits sendMessage, the
+    // turn finishes (clearing the post timer no-op'ed because it had
+    // already fired), and the IIFE THEN tries to arm a setInterval and
+    // store a messageId that nobody will ever clean up.
+    //
+    // SlowSendTransport extends FakeTransport with a deliberate ~150ms
+    // sendMessage latency. Combined with placeholderThresholdMs = 50
+    // and a turn that finishes in ~80ms, the IIFE is guaranteed to
+    // outlive the turn.
+    class SlowSendTransport extends FakeTransport {
+      override async sendMessage(chatId: number, text: string): Promise<number> {
+        if (text.includes("⏳ working")) {
+          await new Promise((r) => setTimeout(r, 150));
+        }
+        return super.sendMessage(chatId, text);
+      }
+    }
+    const transport = new SlowSendTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 5005,
+      fromUserId: 42,
+      text: "do brief work",
+    });
+    class BriefHarness implements Harness {
+      readonly id = "brief";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        // Just over the placeholder threshold — long enough to trigger
+        // the post timer, short enough to finish before sendMessage
+        // resolves.
+        await new Promise((r) => setTimeout(r, 80));
+        yield { type: "done", finalText: "done", meta: { harnessId: this.id } };
+      }
+    }
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new BriefHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+      placeholderThresholdMs: 50,
+      placeholderEditMs: 200,
+    });
+
+    // Give any leaked setInterval a window to tick — if the race fix is
+    // wrong, we'd see editMessage calls landing here.
+    const editsAfterCleanup = transport.edited.length;
+    await new Promise((r) => setTimeout(r, 350));
+
+    // No edit should have fired after the turn cleanup completed —
+    // proves the interval is NOT armed.
+    expect(transport.edited.length).toBe(editsAfterCleanup);
+    // The placeholder did get posted (slow sendMessage), and then it
+    // got deleted by the IIFE's disposed-branch self-cleanup.
+    const placeholderSends = transport.sent.filter((s) => s.text.includes("⏳ working"));
+    expect(placeholderSends.length).toBe(1);
+    expect(transport.deleted.length).toBeGreaterThanOrEqual(1);
+    // Final reply landed.
+    const finalReplies = transport.sent.filter((s) => s.text === "done");
+    expect(finalReplies.length).toBe(1);
+  });
+
   test("/stop during long turn: placeholder is cleaned up, no duplicate result message", async () => {
     const transport = new FakeTransport();
     // Use AbortableHarness pattern from the slow-turn tests: blocks on
@@ -1227,21 +1296,21 @@ describe("placeholder lifecycle", () => {
   });
 });
 
-describe("formatElapsed", () => {
+describe("formatElapsedMs", () => {
   test("formats sub-minute as plain seconds", async () => {
-    const { formatElapsed } = await import("../src/channels/telegram.ts");
-    expect(formatElapsed(0)).toBe("0s");
-    expect(formatElapsed(45_000)).toBe("45s");
+    const { formatElapsedMs } = await import("../src/lib/format.ts");
+    expect(formatElapsedMs(0)).toBe("0s");
+    expect(formatElapsedMs(45_000)).toBe("45s");
   });
 
   test("formats minutes + seconds", async () => {
-    const { formatElapsed } = await import("../src/channels/telegram.ts");
-    expect(formatElapsed(65_000)).toBe("1m 5s");
-    expect(formatElapsed(7 * 60_000 + 12_000)).toBe("7m 12s");
+    const { formatElapsedMs } = await import("../src/lib/format.ts");
+    expect(formatElapsedMs(65_000)).toBe("1m 5s");
+    expect(formatElapsedMs(7 * 60_000 + 12_000)).toBe("7m 12s");
   });
 
   test("formats hours + minutes for very long turns", async () => {
-    const { formatElapsed } = await import("../src/channels/telegram.ts");
-    expect(formatElapsed(2 * 3_600_000 + 15 * 60_000 + 4_000)).toBe("2h 15m");
+    const { formatElapsedMs } = await import("../src/lib/format.ts");
+    expect(formatElapsedMs(2 * 3_600_000 + 15 * 60_000 + 4_000)).toBe("2h 15m");
   });
 });

--- a/tests/cli-create-persona.test.ts
+++ b/tests/cli-create-persona.test.ts
@@ -22,7 +22,7 @@ beforeEach(async () => {
   process.env.PHANTOMBOT_STATE = join(workdir, "state.json");
   config = {
     defaultPersona: "phantom",
-    turnTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -30,7 +30,7 @@ beforeEach(async () => {
   process.env.XDG_DATA_HOME = workdir;
   config = {
     defaultPersona: "phantom",
-    turnTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -49,7 +49,7 @@ beforeEach(async () => {
   await mkdir(join(workdir, "personas"), { recursive: true });
   config = {
     defaultPersona: "phantom",
-    turnTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-memory.test.ts
+++ b/tests/cli-memory.test.ts
@@ -43,7 +43,7 @@ beforeEach(async () => {
   indexPath = join(workdir, "index.sqlite");
   config = {
     defaultPersona: "phantom",
-    turnTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -24,7 +24,7 @@ beforeEach(async () => {
   await mkdir(join(workdir, "personas", "phantom"), { recursive: true });
   config = {
     defaultPersona: "phantom",
-    turnTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -26,8 +26,9 @@ class FakeTransport implements TelegramTransport {
   }> {
     return { updates: [], nextOffset: 0 };
   }
-  async sendMessage(chatId: number, text: string): Promise<void> {
+  async sendMessage(chatId: number, text: string): Promise<number> {
     this.sent.push({ chatId, text });
+    return 1;
   }
   async sendTyping(): Promise<void> {}
   async sendRecording(): Promise<void> {}
@@ -41,6 +42,8 @@ class FakeTransport implements TelegramTransport {
   async downloadFile(): Promise<{ data: Buffer; mime: string }> {
     return { data: Buffer.alloc(0), mime: "" };
   }
+  async editMessage(): Promise<void> {}
+  async deleteMessage(): Promise<void> {}
 }
 
 const SAVED_KEY = process.env.PHANTOMBOT_OPENAI_API_KEY;
@@ -56,7 +59,7 @@ afterEach(() => {
 function baseConfig(): Config {
   return {
     defaultPersona: "phantom",
-    turnTimeoutMs: 1000,
+    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000,
     personasDir: "/tmp",
     memoryDbPath: ":memory:",
     configPath: "/tmp/c.toml",

--- a/tests/cli-persona.test.ts
+++ b/tests/cli-persona.test.ts
@@ -65,7 +65,7 @@ afterEach(async () => {
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
     defaultPersona: "phantom",
-    turnTimeoutMs: 1000,
+    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000,
     personasDir,
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath,

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -34,7 +34,7 @@ beforeEach(async () => {
   );
   config = {
     defaultPersona: "phantom",
-    turnTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-task.test.ts
+++ b/tests/cli-task.test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
   store = await openTaskStore(join(workdir, "tasks.sqlite"));
   config = {
     defaultPersona: "phantom",
-    turnTimeoutMs: 1000,
+    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "tasks.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -48,7 +48,7 @@ beforeEach(async () => {
 
   config = {
     defaultPersona: "phantom",
-    turnTimeoutMs: 5000,
+    harnessIdleTimeoutMs: 5000, harnessHardTimeoutMs: 5000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -100,8 +100,12 @@ max_payload_bytes = 500000
     );
     const c = await loadConfig();
     expect(c.defaultPersona).toBe("robbie");
-    // Legacy turn_timeout_s maps to harnessHardTimeoutMs for back-compat.
+    // Legacy turn_timeout_s preserves pre-PR-#56 semantics: a single
+    // wall-clock cap with no separate idle ceiling. Aliases to BOTH
+    // idle and hard so an unmodified legacy config doesn't get the
+    // stricter 120s idle default applied silently.
     expect(c.harnessHardTimeoutMs).toBe(120_000);
+    expect(c.harnessIdleTimeoutMs).toBe(120_000);
     expect(c.harnesses.chain).toEqual(["pi", "claude"]);
     expect(c.harnesses.claude.model).toBe("sonnet");
     expect(c.harnesses.claude.fallbackModel).toBe("");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -54,7 +54,8 @@ describe("loadConfig — defaults (no file)", () => {
   test("returns built-in defaults when no config file exists", async () => {
     const c = await loadConfig();
     expect(c.defaultPersona).toBe("phantom");
-    expect(c.turnTimeoutMs).toBe(120_000);
+    expect(c.harnessIdleTimeoutMs).toBe(120_000);
+    expect(c.harnessHardTimeoutMs).toBe(3_600_000);
     expect(c.harnesses.chain).toEqual(["claude"]);
     expect(c.harnesses.claude).toEqual({
       bin: "claude",
@@ -99,7 +100,8 @@ max_payload_bytes = 500000
     );
     const c = await loadConfig();
     expect(c.defaultPersona).toBe("robbie");
-    expect(c.turnTimeoutMs).toBe(120_000);
+    // Legacy turn_timeout_s maps to harnessHardTimeoutMs for back-compat.
+    expect(c.harnessHardTimeoutMs).toBe(120_000);
     expect(c.harnesses.chain).toEqual(["pi", "claude"]);
     expect(c.harnesses.claude.model).toBe("sonnet");
     expect(c.harnesses.claude.fallbackModel).toBe("");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -54,7 +54,7 @@ describe("loadConfig — defaults (no file)", () => {
   test("returns built-in defaults when no config file exists", async () => {
     const c = await loadConfig();
     expect(c.defaultPersona).toBe("phantom");
-    expect(c.turnTimeoutMs).toBe(600_000);
+    expect(c.turnTimeoutMs).toBe(120_000);
     expect(c.harnesses.chain).toEqual(["claude"]);
     expect(c.harnesses.claude).toEqual({
       bin: "claude",

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -27,7 +27,7 @@ function newRequest(overrides: Partial<HarnessRequest> = {}): HarnessRequest {
     userMessage: "hi",
     history: [],
     workingDir: process.cwd(),
-    timeoutMs: 5_000,
+    idleTimeoutMs: 5_000, hardTimeoutMs: 5_000,
     ...overrides,
   };
 }
@@ -196,7 +196,7 @@ describe("ClaudeHarness.invoke (subprocess)", () => {
   test("timeout: emits recoverable error, does NOT emit done with partial text (state-machine fix)", async () => {
     process.env.FAKE_CLAUDE_MODE = "hang";
     const chunks = await collect(
-      mkHarness().invoke(newRequest({ timeoutMs: 200 })),
+      mkHarness().invoke(newRequest({ idleTimeoutMs: 200, hardTimeoutMs: 200 })),
     );
     const dones = chunks.filter((c) => c.type === "done");
     const errors = chunks.filter((c) => c.type === "error");

--- a/tests/harnesses-gemini.test.ts
+++ b/tests/harnesses-gemini.test.ts
@@ -21,7 +21,7 @@ function newRequest(overrides: Partial<HarnessRequest> = {}): HarnessRequest {
     userMessage: "hi",
     history: [],
     workingDir: process.cwd(),
-    timeoutMs: 5_000,
+    idleTimeoutMs: 5_000, hardTimeoutMs: 5_000,
     ...overrides,
   };
 }
@@ -145,7 +145,7 @@ describe("GeminiHarness.invoke (end-to-end via fake-gemini.sh)", () => {
   test("hang + low timeout → SIGTERM kill, recoverable timeout error", async () => {
     process.env.FAKE_GEMINI_MODE = "hang";
     const chunks = await collect(
-      harness().invoke(newRequest({ timeoutMs: 100 })),
+      harness().invoke(newRequest({ idleTimeoutMs: 100, hardTimeoutMs: 100 })),
     );
     delete process.env.FAKE_GEMINI_MODE;
     expect(chunks.find((c) => c.type === "done")).toBeUndefined();
@@ -166,7 +166,7 @@ describe("GeminiHarness.invoke (end-to-end via fake-gemini.sh)", () => {
     const start = Date.now();
     const chunks = await collect(
       new GeminiHarness({ bin: FAKE_GEMINI, model: "" }).invoke(
-        newRequest({ userMessage: big, timeoutMs: 30_000 }),
+        newRequest({ userMessage: big, idleTimeoutMs: 30_000, hardTimeoutMs: 30_000 }),
       ),
     );
     const elapsed = Date.now() - start;

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -23,7 +23,7 @@ function newRequest(overrides: Partial<HarnessRequest> = {}): HarnessRequest {
     userMessage: "hi",
     history: [],
     workingDir: process.cwd(),
-    timeoutMs: 5_000,
+    idleTimeoutMs: 5_000, hardTimeoutMs: 5_000,
     ...overrides,
   };
 }
@@ -204,7 +204,7 @@ describe("PiHarness.invoke (subprocess)", () => {
   test("timeout emits recoverable error and NO done", async () => {
     process.env.FAKE_PI_MODE = "hang";
     const chunks = await collect(
-      mkHarness().invoke(newRequest({ timeoutMs: 200 })),
+      mkHarness().invoke(newRequest({ idleTimeoutMs: 200, hardTimeoutMs: 200 })),
     );
     const dones = chunks.filter((c) => c.type === "done");
     const errors = chunks.filter((c) => c.type === "error");

--- a/tests/lib-audio.test.ts
+++ b/tests/lib-audio.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 function makeConfig(provider: Config["voice"]["provider"]): Config {
   const base: Omit<Config, "voice"> = {
     defaultPersona: "x",
-    turnTimeoutMs: 1,
+    harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1,
     personasDir: "/tmp",
     memoryDbPath: "/tmp/m.sqlite",
     configPath: "/tmp/c.toml",

--- a/tests/lib-embedJob.test.ts
+++ b/tests/lib-embedJob.test.ts
@@ -252,7 +252,7 @@ describe("defaultEmbedder", () => {
   test("returns undefined when provider is not gemini", () => {
     const e = defaultEmbedder({
       defaultPersona: "x",
-      turnTimeoutMs: 1,
+      harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1,
       personasDir: "/tmp",
       memoryDbPath: "/tmp/m.sqlite",
       configPath: "/tmp/c.toml",
@@ -272,7 +272,7 @@ describe("defaultEmbedder", () => {
   test("returns undefined when provider is gemini but apiKey is empty", () => {
     const e = defaultEmbedder({
       defaultPersona: "x",
-      turnTimeoutMs: 1,
+      harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1,
       personasDir: "/tmp",
       memoryDbPath: "/tmp/m.sqlite",
       configPath: "/tmp/c.toml",

--- a/tests/lib-harnessRunner.test.ts
+++ b/tests/lib-harnessRunner.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the kill coordinator: idle timer reset, hard timer, and
+ * abort-signal hookup. The coordinator is what every harness leans on
+ * to translate "subprocess wedged for 120s" into a recoverable error.
+ *
+ * Real subprocess + real timers — the kill semantics are precisely the
+ * thing we want to verify against the kernel, not against a stub.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createKillCoordinator,
+  killCauseToErrorChunk,
+} from "../src/lib/harnessRunner.ts";
+import { spawnInNewSession } from "../src/lib/processGroup.ts";
+
+const trackedPids: number[] = [];
+afterEach(() => {
+  for (const pid of trackedPids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+  trackedPids.length = 0;
+});
+
+describe("createKillCoordinator — idle timer", () => {
+  test("touch() prevents idle kill while the process is producing output", async () => {
+    // Process emits a line every 50ms for ~500ms total. Idle window is
+    // 200ms, so without touch() it would fire mid-stream. With touch()
+    // it never fires.
+    const proc = spawnInNewSession(
+      [
+        "sh",
+        "-c",
+        "for i in 1 2 3 4 5 6 7 8; do echo $i; sleep 0.05; done",
+      ],
+      { stdin: "ignore", stdout: "pipe", stderr: "ignore" },
+    );
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 200,
+      hardTimeoutMs: 5000,
+      harnessId: "test",
+    });
+
+    const decoder = new TextDecoder();
+    let bytes = 0;
+    for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+      killer.touch();
+      bytes += decoder.decode(chunk, { stream: true }).length;
+    }
+    await killer.dispose();
+
+    expect(killer.killCause()).toBeUndefined();
+    expect(bytes).toBeGreaterThan(8); // 8 lines of "n\n"
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("idle timer fires when stdout goes silent past idleTimeoutMs", async () => {
+    // Process emits one line then sleeps. We touch() once after the
+    // first line, then stop reading. Idle timer should fire and kill
+    // the process group.
+    const proc = spawnInNewSession(
+      ["sh", "-c", "echo first; sleep 30"],
+      { stdin: "ignore", stdout: "pipe", stderr: "ignore" },
+    );
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 150,
+      hardTimeoutMs: 10_000,
+      harnessId: "test",
+    });
+
+    const decoder = new TextDecoder();
+    const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+    const { value } = await reader.read();
+    if (value) killer.touch();
+    expect(decoder.decode(value)).toContain("first");
+    // Don't read again. Don't touch again. Idle timer fires after 150ms.
+
+    await proc.exited;
+    await killer.dispose();
+    reader.releaseLock();
+
+    expect(killer.killCause()).toBe("idle");
+  });
+});
+
+describe("createKillCoordinator — hard timer", () => {
+  test("hard timer fires regardless of touch() activity", async () => {
+    // Process keeps emitting (so idle never fires) but hard cap is short.
+    const proc = spawnInNewSession(
+      [
+        "sh",
+        "-c",
+        "while true; do echo tick; sleep 0.05; done",
+      ],
+      { stdin: "ignore", stdout: "pipe", stderr: "ignore" },
+    );
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 5_000,
+      hardTimeoutMs: 250,
+      harnessId: "test",
+    });
+
+    for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+      killer.touch(); // keep idle timer happy
+      void chunk;
+    }
+    await killer.dispose();
+
+    expect(killer.killCause()).toBe("timeout");
+  });
+});
+
+describe("createKillCoordinator — abort signal", () => {
+  test("AbortSignal triggers the same kill path with cause='aborted'", async () => {
+    const proc = spawnInNewSession(["sleep", "30"], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const ac = new AbortController();
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 30_000,
+      hardTimeoutMs: 30_000,
+      signal: ac.signal,
+      harnessId: "test",
+    });
+
+    setTimeout(() => ac.abort(), 50);
+    await proc.exited;
+    await killer.dispose();
+
+    expect(killer.killCause()).toBe("aborted");
+  });
+
+  test("pre-aborted signal kills immediately on coordinator creation", async () => {
+    const proc = spawnInNewSession(["sleep", "30"], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const ac = new AbortController();
+    ac.abort();
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 30_000,
+      hardTimeoutMs: 30_000,
+      signal: ac.signal,
+      harnessId: "test",
+    });
+
+    await proc.exited;
+    await killer.dispose();
+    expect(killer.killCause()).toBe("aborted");
+  });
+});
+
+describe("killCauseToErrorChunk", () => {
+  test("undefined cause → undefined chunk (process exited normally)", () => {
+    expect(killCauseToErrorChunk(undefined, "claude", 1000, 100)).toBeUndefined();
+  });
+
+  test("timeout cause → recoverable error mentioning the hard cap", () => {
+    const c = killCauseToErrorChunk("timeout", "claude", 60_000, 1000);
+    expect(c).toMatchObject({
+      type: "error",
+      recoverable: true,
+    });
+    expect(c?.error).toContain("60000ms");
+    expect(c?.error).toContain("hard wall-clock");
+  });
+
+  test("idle cause → recoverable error mentioning 'no output'", () => {
+    const c = killCauseToErrorChunk("idle", "gemini", 60_000, 200);
+    expect(c).toMatchObject({
+      type: "error",
+      recoverable: true,
+    });
+    expect(c?.error).toContain("200ms");
+    expect(c?.error).toContain("no output");
+  });
+
+  test("aborted cause → non-recoverable 'stopped'", () => {
+    const c = killCauseToErrorChunk("aborted", "pi", 1000, 100);
+    expect(c).toMatchObject({
+      type: "error",
+      error: "stopped",
+      recoverable: false,
+    });
+  });
+});

--- a/tests/lib-processGroup.test.ts
+++ b/tests/lib-processGroup.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the process-group spawn + kill helpers.
+ *
+ * These actually spawn real subprocesses (cheap shells) and signal them.
+ * No mocks here — the whole point of the helpers is that the kernel
+ * routes signals to the right pids, and we can only verify that against
+ * a real OS.
+ *
+ * The orphan-grandchild test is the load-bearing one: it demonstrates
+ * the actual bug fix (gemini-usage-hung-TCP scenario, kw-openclaw
+ * 2026-05-02). If it ever stops passing, phantombot has lost the
+ * ability to clean up after wedged subprocesses.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  killProcessGroup,
+  spawnInNewSession,
+} from "../src/lib/processGroup.ts";
+
+function isAlive(pid: number): boolean {
+  try {
+    // signal 0 = "are you there?" — no signal sent, just permission/existence check
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ESRCH") return false;
+    // EPERM means the process exists but we can't signal it. For our
+    // tests, all processes are owned by us, so this shouldn't happen.
+    throw e;
+  }
+}
+
+/**
+ * After a kill, a process can briefly remain in the kernel's process
+ * table as a zombie (state Z) until its parent reaps it via wait().
+ * `kill 0` returns success on zombies — they're "alive" by that test.
+ * For grandchildren whose parent we just killed, init takes over
+ * reaping but the window can be tens of ms. Poll briefly.
+ */
+async function isFullyDead(pid: number, withinMs = 1000): Promise<boolean> {
+  const deadline = Date.now() + withinMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    // If still in table, check whether it's a zombie (state Z = the
+    // process has terminated but isn't reaped). A zombie counts as
+    // dead for our purposes — its work is done.
+    try {
+      const stat = await Bun.file(`/proc/${pid}/stat`).text();
+      const fields = stat.split(" ");
+      // Field 3 in /proc/<pid>/stat is the state code.
+      if (fields[2] === "Z") return true;
+    } catch {
+      // /proc entry vanished — process is gone.
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  return false;
+}
+
+async function readUntilNewline(
+  stream: ReadableStream<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  for await (const chunk of stream) {
+    buf += decoder.decode(chunk, { stream: true });
+    if (buf.includes("\n")) return buf.split("\n")[0]!;
+  }
+  return buf;
+}
+
+// Cleanup safety net: track every grandchild pid we discover so a
+// failing test never leaks a 60s sleep into someone's process table.
+const trackedPids: number[] = [];
+afterEach(() => {
+  for (const pid of trackedPids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+  trackedPids.length = 0;
+});
+
+describe("spawnInNewSession", () => {
+  test("starts the binary with the same pid==pgid (the kill-the-group precondition)", async () => {
+    // We can't observe pgid directly without /proc, but we CAN verify
+    // that the process started and is reachable via its own pid.
+    const proc = spawnInNewSession(["sleep", "30"], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+    expect(isAlive(proc.pid!)).toBe(true);
+    // Send to negative pid → kills the group. If pgid != pid, this would
+    // either ESRCH or kill an unrelated group; either way the process
+    // would NOT die. We assert it does die, which proves pid == pgid.
+    process.kill(-proc.pid!, "SIGTERM");
+    await proc.exited;
+    expect(isAlive(proc.pid!)).toBe(false);
+  });
+});
+
+describe("killProcessGroup — orphan grandchild fix", () => {
+  test("SIGTERM to the group reaps both parent AND grandchild", async () => {
+    // Shell spawns a backgrounded sleep, prints its pid, then waits.
+    // Without process-group kill, killing the shell would leave the
+    // sleep (the "grandchild") running forever — that's the kw-openclaw
+    // gemini-usage bug, reproduced in miniature.
+    const proc = spawnInNewSession(
+      ["sh", "-c", "sleep 30 & echo $!; wait"],
+      { stdin: "ignore", stdout: "pipe", stderr: "ignore" },
+    );
+    trackedPids.push(proc.pid!);
+
+    const firstLine = await readUntilNewline(
+      proc.stdout as ReadableStream<Uint8Array>,
+    );
+    const grandchildPid = Number(firstLine.trim());
+    expect(Number.isInteger(grandchildPid)).toBe(true);
+    expect(grandchildPid).toBeGreaterThan(0);
+    trackedPids.push(grandchildPid);
+
+    expect(isAlive(grandchildPid)).toBe(true);
+    expect(isAlive(proc.pid!)).toBe(true);
+
+    await killProcessGroup(proc, 1000);
+
+    // Both parent and grandchild are gone — the whole point of the fix.
+    // Grandchild may briefly be a zombie before init reaps it; isFullyDead
+    // accepts either truly-gone or zombie state.
+    expect(await isFullyDead(grandchildPid)).toBe(true);
+    expect(await isFullyDead(proc.pid!)).toBe(true);
+  });
+});
+
+describe("killProcessGroup — SIGTERM→SIGKILL escalation", () => {
+  test("escalates to SIGKILL when SIGTERM is trapped/ignored", async () => {
+    // Use a Bun process that registers a no-op SIGTERM handler so the
+    // signal is delivered but the process keeps running. Only SIGKILL
+    // (which can't be trapped) terminates it. Without escalation,
+    // killProcessGroup would hang forever — proc.exited never resolves.
+    //
+    // We use bun-as-the-child rather than `sh -c "trap '' TERM; sleep 30"`
+    // because the shell's child sleep would receive the same SIGTERM
+    // (it's in the group too), die, and the shell would exit with it.
+    const proc = spawnInNewSession(
+      [
+        process.execPath,
+        "-e",
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 60_000);",
+      ],
+      { stdin: "ignore", stdout: "ignore", stderr: "ignore" },
+    );
+    trackedPids.push(proc.pid!);
+
+    // Give Bun a moment to register the handler before we signal.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const start = Date.now();
+    await killProcessGroup(proc, 250);
+    const elapsedMs = Date.now() - start;
+
+    // SIGTERM ignored → grace window → SIGKILL → process dies.
+    // Lower bound: must wait at least the grace period.
+    // Upper bound: should be quick once SIGKILL fires (well under 2s).
+    expect(elapsedMs).toBeGreaterThanOrEqual(200);
+    expect(elapsedMs).toBeLessThan(3000);
+    expect(isAlive(proc.pid!)).toBe(false);
+  });
+
+  test("does NOT escalate when the process exits cleanly during the grace window", async () => {
+    // Cooperative shell: receives SIGTERM and exits immediately.
+    const proc = spawnInNewSession(["sleep", "30"], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const start = Date.now();
+    await killProcessGroup(proc, 5000);
+    const elapsedMs = Date.now() - start;
+
+    // SIGTERM honored → process exits within milliseconds; we should NOT
+    // sit out the full 5s grace.
+    expect(elapsedMs).toBeLessThan(500);
+    expect(isAlive(proc.pid!)).toBe(false);
+  });
+});
+
+describe("killProcessGroup — already-dead handling", () => {
+  test("safe to call after the process has already exited", async () => {
+    const proc = spawnInNewSession(["true"], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+    // Should not throw, should not hang.
+    await killProcessGroup(proc, 100);
+  });
+});

--- a/tests/orchestrator-fallback.test.ts
+++ b/tests/orchestrator-fallback.test.ts
@@ -38,7 +38,7 @@ function newRequest(overrides: Partial<HarnessRequest> = {}): HarnessRequest {
     userMessage: "user msg",
     history: [],
     workingDir: process.cwd(),
-    timeoutMs: 5_000,
+    idleTimeoutMs: 5_000, hardTimeoutMs: 5_000,
     ...overrides,
   };
 }

--- a/tests/orchestrator-turn.test.ts
+++ b/tests/orchestrator-turn.test.ts
@@ -63,7 +63,8 @@ const baseInput = () => ({
   conversation: "cli:default",
   agentDir,
   memory,
-  timeoutMs: 1_000,
+  idleTimeoutMs: 1_000,
+  hardTimeoutMs: 5_000,
 });
 
 describe("runTurn — successful path", () => {

--- a/tests/probe-pi-argmax.test.ts
+++ b/tests/probe-pi-argmax.test.ts
@@ -34,7 +34,7 @@ describe.skipIf(!RUN)("Pi ARG_MAX probe", () => {
         userMessage: padding,
         history: [],
         workingDir: process.cwd(),
-        timeoutMs: 30_000,
+        idleTimeoutMs: 30_000, hardTimeoutMs: 30_000,
       };
 
       let result: "ok" | "error" = "ok";


### PR DESCRIPTION
## Summary

Fixes the cluster of agent-timeout failures we hit on kw-openclaw (Lena stuck on a `gemini usage` TCP wedge for 6+ minutes, Kai unable to be `/stop`'d while building a PR response) by reworking the harness execution path end-to-end.

This is two commits stacked: kai's `slash-commands-and-abort` foundation (slash dispatcher before the LLM, AbortController plumbing, per-chat queue), plus the four real gaps we identified in the design discussion.

## What's new

**1. Process-group spawn + SIGTERM→SIGKILL escalation** (`src/lib/processGroup.ts`)
- Each harness subprocess gets its own session/pgroup via Bun's `detached: true` (pid == pgid == sid)
- Kill signals route to the whole group via `process.kill(-pid, sig)` — grandchildren die with the parent
- 5s grace period between SIGTERM and SIGKILL for processes that ignore SIGTERM
- Fixes the `gemini usage` orphan: the wedged TCP-read subprocess now dies when its parent does

**2. Idle + hard timeouts** (`src/lib/harnessRunner.ts`, replaces wall-clock cap)
- `harness_idle_timeout_s` (default 120s) — kill if no chunk on stdout for this long, resets per chunk
- `harness_hard_timeout_s` (default 3600s) — absolute ceiling regardless of activity
- Productive 30-min builds with continuous tool events never trip idle; wedged subprocesses do
- Legacy `turn_timeout_s` aliases to hard for back-compat
- Coordinator factored out of all three harnesses so kill semantics stay aligned

**3. Long-turn placeholder with completion notification** (Option B from the design discussion)
- After 30s silent, post \"⏳ working… 30s elapsed\"
- Edit every 60s with elapsed + last progress note (\"6m 12s — currently: tool_execution_start: BashTool\")
- On completion: **delete placeholder, send result as new message** — Telegram pushes a notification on new messages but not on edits, so this delete-then-send is what makes your phone buzz when a 10-min Kai-builds-a-PR turn finishes
- Cleaned up on /stop and on errors too — no orphan ⏳ messages

**4. /status enrichment** (`src/channels/commands.ts`)
- Tracks last progress note in ActiveTurnHandle as chunks arrive
- /status appends \"running: <last tool>\" line — answers \"is it stuck or just busy?\"

**Plus kai's foundation** (commit f061cbf):
- `/stop`, `/reset`, `/status`, `/harness`, `/help` handled inline before the LLM in the polling loop
- Per-chat AbortController tracking; /stop aborts via controller.abort()
- Per-chat promise chain so /stop and /status work even when a turn is hung
- AbortSignal threaded through HarnessRequest → all three harnesses

## Test plan

- [x] Full suite: **509 pass, 1 skip, 0 fail** (up from 487 — 23 new tests)
- [x] Typecheck clean (`bun tsc --noEmit`)
- [x] Real-subprocess orphan-kill test: spawns `sh -c 'sleep 30 & echo \$!; wait'`, kills the parent, verifies the `sleep` grandchild is dead
- [x] SIGTERM→SIGKILL escalation test: spawns a Bun process with empty SIGTERM handler, verifies graceful → forced kill within the 5s window
- [x] Idle timer test: process emits chunk every 50ms, idle window 200ms — never killed (touch resets)
- [x] Idle fire test: process emits one line then sleeps; reader stops touching → idle fires with cause='idle'
- [x] Hard timer test: process keeps emitting (idle stays happy) but hits hard cap → killed with cause='timeout'
- [x] Placeholder lifecycle: fast turn = no placeholder; slow turn = posted + edited + deleted + fresh result; /stop = placeholder cleaned up, no duplicate result
- [x] /status running line: shows last progress note when present, omits when absent, truncates very long notes

## Deployment notes

After this merges and v1.0.55 publishes:
1. `phantombot update --force --restart` on each persona's host (lena, kai, jake on kw-openclaw; robbie on Hetzner)
2. Drop the legacy `turn_timeout_s = 600` from each `~/.config/phantombot/config.toml` so the new 120s idle / 3600s hard defaults take effect — or set them explicitly:
   \`\`\`toml
   harness_idle_timeout_s = 120
   harness_hard_timeout_s = 3600
   \`\`\`

## Bugs this fixes

- **Lena stuck on `gemini usage`** (kw-openclaw, 2026-05-02 21:00 UTC): hung TCP read in a grandchild; only died after orphan kill propagation
- **Kai unable to be /stop'd** building a PR response: blocked LLM meant /stop went into the same queue and waited 10min for the timeout
- **600s timeout firing on legitimate work**: replaced with idle timer that distinguishes \"working\" (constant tool events) from \"wedged\" (silent stdout)