### PR TITLE
feat: Telegram chat-style prompt + 8s typing pulse + drop placeholder

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -24,7 +24,6 @@ import {
   transcribe,
   ttsSupported,
 } from "../lib/audio.ts";
-import { formatElapsedMs, truncateLine } from "../lib/format.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import type { MemoryStore } from "../memory/store.ts";
@@ -61,8 +60,7 @@ export interface TelegramTransport {
     timeoutS: number,
     signal?: AbortSignal,
   ): Promise<{ updates: TelegramMessage[]; nextOffset: number }>;
-  /** Send a text message; returns the new message_id (used for later edit/delete). */
-  sendMessage(chatId: number, text: string): Promise<number>;
+  sendMessage(chatId: number, text: string): Promise<void>;
   sendTyping(chatId: number): Promise<void>;
   /** Send an OGG-Opus voice note. */
   sendVoice(chatId: number, audio: Buffer, mime: string): Promise<void>;
@@ -70,10 +68,6 @@ export interface TelegramTransport {
   sendRecording(chatId: number): Promise<void>;
   /** Download a file by Telegram file_id; returns audio bytes + content-type. */
   downloadFile(fileId: string): Promise<{ data: Buffer; mime: string }>;
-  /** Edit an existing text message in place. Best-effort; failures are swallowed. */
-  editMessage(chatId: number, messageId: number, text: string): Promise<void>;
-  /** Delete a message by id. Best-effort; failures are swallowed. */
-  deleteMessage(chatId: number, messageId: number): Promise<void>;
 }
 
 /**
@@ -118,7 +112,7 @@ export class HttpTelegramTransport implements TelegramTransport {
     return parseGetUpdatesResult(body.result ?? [], offset);
   }
 
-  async sendMessage(chatId: number, text: string): Promise<number> {
+  async sendMessage(chatId: number, text: string): Promise<void> {
     const url = `https://api.telegram.org/bot${this.token}/sendMessage`;
     // Telegram caps message length at 4096 chars. Truncate gracefully.
     const safe = text.length > 4000 ? text.slice(0, 4000) + "\n…[truncated]" : text;
@@ -132,55 +126,7 @@ export class HttpTelegramTransport implements TelegramTransport {
         chatId,
         status: res.status,
       });
-      return 0;
     }
-    // Telegram returns the sent message in `result.message_id`. Callers
-    // that don't care can ignore it; the placeholder pipeline uses it
-    // for later editMessage/deleteMessage.
-    try {
-      const body = (await res.json()) as {
-        ok?: boolean;
-        result?: { message_id?: number };
-      };
-      return body.ok && typeof body.result?.message_id === "number"
-        ? body.result.message_id
-        : 0;
-    } catch {
-      return 0;
-    }
-  }
-
-  async editMessage(
-    chatId: number,
-    messageId: number,
-    text: string,
-  ): Promise<void> {
-    if (messageId === 0) return;
-    const url = `https://api.telegram.org/bot${this.token}/editMessageText`;
-    const safe = text.length > 4000 ? text.slice(0, 4000) + "\n…[truncated]" : text;
-    await fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        chat_id: chatId,
-        message_id: messageId,
-        text: safe,
-      }),
-    }).catch(() => {
-      /* edits are best-effort — placeholder editMessage failing isn't fatal */
-    });
-  }
-
-  async deleteMessage(chatId: number, messageId: number): Promise<void> {
-    if (messageId === 0) return;
-    const url = `https://api.telegram.org/bot${this.token}/deleteMessage`;
-    await fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ chat_id: chatId, message_id: messageId }),
-    }).catch(() => {
-      /* deletes are best-effort — leaving an orphan placeholder isn't fatal */
-    });
   }
 
   async sendTyping(chatId: number): Promise<void> {
@@ -337,25 +283,16 @@ export interface RunTelegramServerInput {
   signal?: AbortSignal;
   /**
    * How often to refresh the "typing…" indicator while a turn is in
-   * flight. Telegram's chat-action lasts only ~5s, so without refresh
-   * the indicator disappears after ~5s and the user thinks the bot
-   * stopped responding. Default 4000 ms. Tests use a smaller value.
+   * flight. Telegram's chat-action expires after ~5s; the default 8s
+   * refresh deliberately leaves a ~3s gap between pulses, so the user
+   * sees `typing…` come and go rather than a frozen-looking permanent
+   * indicator. The pulse is the primary "I'm alive" signal — replaces
+   * the canned `⏳ working… 30s elapsed` placeholder we tried in
+   * PR #56, which was English-only noise without the per-tool
+   * progress notes the harnesses don't reliably emit. Tests use a
+   * smaller value to verify the refresh fires at all.
    */
   typingRefreshMs?: number;
-  /**
-   * How long a turn can run silently before we post a "⏳ working…"
-   * placeholder message. Below this, short turns finish without any
-   * extra noise in the chat. Default 30_000 ms. Tests use smaller.
-   */
-  placeholderThresholdMs?: number;
-  /**
-   * How often we edit the placeholder with new elapsed time + last
-   * progress note while the turn is still running. Telegram allows
-   * ~1 edit/sec; we default to a generous 60_000 ms because the
-   * placeholder exists to reassure the user, not to render a real-time
-   * console. Tests override.
-   */
-  placeholderEditMs?: number;
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -569,7 +506,9 @@ async function processChatMessage(
       ? input.transport.sendRecording(msg.chatId)
       : input.transport.sendTyping(msg.chatId);
   void sendStatus();
-  const refreshMs = input.typingRefreshMs ?? 4000;
+  // Refresh interval defaults to 8s (5s indicator-on / 3s gap pulse) —
+  // see RunTelegramServerInput for the full rationale.
+  const refreshMs = input.typingRefreshMs ?? 8000;
   const typingTimer = setInterval(() => {
     void sendStatus();
   }, refreshMs);
@@ -581,73 +520,6 @@ async function processChatMessage(
     startTime: startedAt,
   };
   activeTurns.set(msg.chatId, turnHandle);
-
-  // Long-turn placeholder lifecycle. Three states:
-  //   1. Silent  — turn is fast, no placeholder needed.
-  //   2. Posted  — turn went past placeholderThresholdMs (default 30s);
-  //                we sent a "⏳ working… 30s elapsed" message and have
-  //                its message_id. Periodically edit it with elapsed
-  //                time + last progress note.
-  //   3. Cleanup — turn finished. Delete the placeholder, then send the
-  //                final reply as a NEW message (Option B in the design
-  //                discussion: a fresh message triggers a Telegram push
-  //                notification; an edit does not).
-  const placeholderThresholdMs = input.placeholderThresholdMs ?? 30_000;
-  const placeholderEditMs = input.placeholderEditMs ?? 60_000;
-  let placeholderMsgId: number | undefined;
-  let placeholderEditTimer: ReturnType<typeof setInterval> | undefined;
-  // `disposed` plus `placeholderPostPromise` together close the post-IIFE
-  // race: if the turn finishes between when the post timer fires and when
-  // sendMessage resolves, the IIFE bails before storing the messageId or
-  // arming the edit interval (otherwise we'd leak a setInterval forever
-  // and leave an orphan ⏳ message in the chat).
-  let disposed = false;
-  let placeholderPostPromise: Promise<void> | undefined;
-  const renderPlaceholder = (): string => {
-    const elapsedMs = Date.now() - startedAt;
-    const note = turnHandle.lastProgressNote;
-    return note
-      ? `⏳ working… ${formatElapsedMs(elapsedMs)} — currently: ${truncateLine(note, 120)}`
-      : `⏳ working… ${formatElapsedMs(elapsedMs)} elapsed`;
-  };
-  const placeholderPostTimer = setTimeout(() => {
-    placeholderPostPromise = (async () => {
-      let id = 0;
-      try {
-        id = await input.transport.sendMessage(
-          msg.chatId,
-          renderPlaceholder(),
-        );
-      } catch (e) {
-        log.warn("telegram: placeholder post failed", {
-          error: (e as Error).message,
-          chatId: msg.chatId,
-        });
-        return;
-      }
-      // The turn may have finished while sendMessage was in flight. If so,
-      // delete the message we just posted (the cleanup phase already ran
-      // with placeholderMsgId still undefined, so it was skipped) and do
-      // NOT arm the edit interval.
-      if (disposed) {
-        if (id > 0) {
-          await input.transport.deleteMessage(msg.chatId, id).catch(() => {});
-        }
-        return;
-      }
-      if (id > 0) {
-        placeholderMsgId = id;
-        placeholderEditTimer = setInterval(() => {
-          if (disposed || placeholderMsgId === undefined) return;
-          void input.transport.editMessage(
-            msg.chatId,
-            placeholderMsgId,
-            renderPlaceholder(),
-          );
-        }, placeholderEditMs);
-      }
-    })();
-  }, placeholderThresholdMs);
 
   let reply = "";
   let errored: string | undefined;
@@ -664,13 +536,19 @@ async function processChatMessage(
       idleTimeoutMs: input.config.harnessIdleTimeoutMs,
       hardTimeoutMs: input.config.harnessHardTimeoutMs,
       signal: controller.signal,
-      // Voice-in + voice-out: append a brevity directive for this turn
-      // only. Keeps voice notes short + spoken-friendly without putting
-      // brevity rules in persona files (which would also throttle text
-      // replies, where verbosity is fine).
+      // Channel-layer prompt suffix:
+      //   - Always: TELEGRAM_REPLY_INSTRUCTION — short conversational
+      //     replies + plan-then-confirm before long jobs (git/build/
+      //     deploy or anything that would spawn more than one tool call).
+      //   - Voice-out: stack VOICE_REPLY_INSTRUCTION on top — stricter
+      //     1-3 sentence limit and no markdown so TTS doesn't read out
+      //     headers/bullets.
+      // Living at the channel layer (not in persona files) keeps these
+      // rules from leaking into CLI/nightly turns, where verbosity is
+      // fine and the user isn't on a phone.
       systemPromptSuffix: willReplyWithVoice
-        ? VOICE_REPLY_INSTRUCTION
-        : undefined,
+        ? `${TELEGRAM_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
+        : TELEGRAM_REPLY_INSTRUCTION,
     })) {
       if (chunk.type === "text") reply += chunk.text;
       if (chunk.type === "progress") {
@@ -696,12 +574,7 @@ async function processChatMessage(
     errored = (e as Error).message;
     log.error("telegram: turn threw", { error: errored });
   } finally {
-    // Mark disposed BEFORE awaiting in-flight placeholder work so the
-    // post IIFE (if still running) sees the flag and bails.
-    disposed = true;
     clearInterval(typingTimer);
-    clearTimeout(placeholderPostTimer);
-    if (placeholderEditTimer) clearInterval(placeholderEditTimer);
     // Only deregister if we're still the active turn for this chat.
     // (Defensive: a /reset or /stop could have replaced us.)
     if (activeTurns.get(msg.chatId) === turnHandle) {
@@ -709,28 +582,11 @@ async function processChatMessage(
     }
   }
 
-  // Always clean up the placeholder if one was posted, so the chat
-  // doesn't end up with an orphan "⏳ working…" message regardless of
-  // outcome (success / error / stop). Awaits any in-flight post first
-  // so a placeholder that races with completion is still observed and
-  // deleted.
-  const cleanupPlaceholder = async (): Promise<void> => {
-    if (placeholderPostPromise) {
-      await placeholderPostPromise;
-    }
-    if (placeholderMsgId !== undefined) {
-      await input.transport.deleteMessage(msg.chatId, placeholderMsgId);
-      placeholderMsgId = undefined;
-    }
-  };
-
   // /stop: the controller was aborted from outside. The reply text
   // already came through from the slash command handler — don't send
-  // a second "(error: stopped)" message. We DO still delete the
-  // placeholder so the user isn't left with a stale "working…" line.
+  // a second "(error: stopped)" message.
   const wasStopped = controller.signal.aborted;
   if (wasStopped) {
-    await cleanupPlaceholder();
     log.info("telegram: turn stopped by /stop", {
       chatId: msg.chatId,
       durationMs: Date.now() - startedAt,
@@ -745,14 +601,11 @@ async function processChatMessage(
       : "(no reply)";
 
   // Voice in → voice out (when TTS is configured AND no error).
-  // Text in → text out, always. Order: delete placeholder FIRST, then
-  // send the real reply. Telegram pushes a notification on a new
-  // message but not on an edit, so this delete-then-new sequence is
-  // what guarantees the user's phone buzzes when a long turn finishes
-  // ("Option B" from the design discussion).
+  // Text in → text out, always. The reply lands as a fresh message,
+  // so Telegram pushes a notification — important when the user kicked
+  // off a long job and walked away from the chat.
   let sentAsVoice = false;
   try {
-    await cleanupPlaceholder();
     if (willReplyWithVoice && !errored && reply.length > 0) {
       const r = await synthesize(input.config, reply);
       if (r.ok) {
@@ -791,22 +644,59 @@ async function processChatMessage(
 }
 
 /**
- * System-prompt suffix appended for voice-in / voice-out turns only.
+ * System-prompt suffix applied to EVERY Telegram turn.
  *
- * Why this exists: a chat reply that's fine as a Telegram text message
- * — say 4-6 sentences, with some narration of what the agent did —
- * becomes a 90-second voice note when synthesized via TTS. Users
- * report it sounds like a YouTuber explaining their workflow.
+ * Two purposes:
  *
- * Target: ~100 tokens (~60 words / ~30 seconds of speech). Concrete
- * numbers in the instruction so the model has something to anchor on,
- * but the real win is killing narration ("Let me check…", "Right,
- * here's what I found…") and markdown formatting that TTS reads
- * awkwardly.
+ * 1. Reply style. The user is on a phone with a narrow column. Long
+ *    walls of text and meta-narration ("Let me check…", "Right,
+ *    here's what I found…") read poorly there. Default to short,
+ *    conversational answers; structured-and-clear is fine when the
+ *    user explicitly asks for a detailed report.
  *
- * Lives at the channel layer (not in persona files) so brevity is
- * triggered ONLY when the input arrived as voice AND the reply will be
- * synthesized — text replies stay as detailed as the persona wants.
+ * 2. Plan-then-confirm before long jobs. A Telegram round-trip is
+ *    seconds, but a misaligned 10-minute build burns the user's time
+ *    AND tokens. Asking the agent to outline the plan and wait for
+ *    confirmation when it's about to do something irreversible (git
+ *    push, deploy) or expensive (multi-tool-call work) avoids that.
+ *
+ * Lives at the channel layer (not in persona files) so CLI / nightly
+ * turns aren't affected — those run unattended and don't want a
+ * confirmation gate, and verbose CLI output is fine.
+ */
+export const TELEGRAM_REPLY_INSTRUCTION =
+  `# Reply style (Telegram chat)
+
+You're chatting via Telegram. Default to short, conversational
+replies — typically 1-4 sentences. The user is usually on a phone,
+and the narrow column makes long walls of text hard to read. Skip
+narration ("Let me…", "Right, here's what I found…"); answer directly.
+
+Longer replies are fine when the user explicitly asks for a detailed
+report or analysis. Use clear structure (headings, lists) when the
+content earns it.
+
+# Confirm before long jobs
+
+Before starting any of these, briefly outline your plan in 2-3
+sentences and ask the user to confirm or adjust:
+
+- Anything involving git, build, or deploy operations
+- Anything where you're going to spawn more than one tool call
+
+Telegram round-trips are slow and tokens aren't free — confirming up
+front beats producing the wrong thing minutes later. For
+straightforward questions, just answer.`;
+
+/**
+ * Voice-only overlay, stacked on top of TELEGRAM_REPLY_INSTRUCTION
+ * when the reply will be synthesized via TTS.
+ *
+ * Why this exists separately: the chat-style instruction allows
+ * "longer when asked" and structured markdown — both wrong for TTS,
+ * which reads bullets/headers awkwardly and turns 4-sentence replies
+ * into 90-second voice notes. This overlay tightens the length cap
+ * to 1-3 sentences and forbids markdown.
  */
 export const VOICE_REPLY_INSTRUCTION =
   `# Reply length (this turn only)

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -20,22 +20,13 @@ export function truncateLine(s: string, max: number): string {
 }
 
 /**
- * Format a wall-clock duration (in MILLISECONDS) for the long-turn
- * placeholder line. Always shows the largest two units, dropping
- * subseconds entirely.
+ * Format a wall-clock duration in seconds as a short two-unit string.
+ * Used by /status to show uptime + active-turn elapsed time.
  *
- *   45_000   → "45s"
- *   65_000   → "1m 5s"
- *   8_000_000 → "2h 13m"
- */
-export function formatElapsedMs(ms: number): string {
-  return formatElapsedSeconds(Math.floor(ms / 1000));
-}
-
-/**
- * Same shape as formatElapsedMs but takes seconds. Used by /status,
- * which already speaks in seconds. Adds a `Nd Nh` form for uptimes
- * that exceed a day — placeholders never run that long.
+ *   45      → "45s"
+ *   65      → "1m 5s"
+ *   8_000   → "2h 13m"
+ *   90_000  → "1d 1h"
  */
 export function formatElapsedSeconds(s: number): string {
   if (s < 60) return `${s}s`;

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -55,13 +55,8 @@ class FakeTransport implements TelegramTransport {
         : offset;
     return { updates, nextOffset };
   }
-  edited: Array<{ chatId: number; messageId: number; text: string }> = [];
-  deleted: Array<{ chatId: number; messageId: number }> = [];
-  private nextMessageId = 1;
-  async sendMessage(chatId: number, text: string): Promise<number> {
-    const id = this.nextMessageId++;
+  async sendMessage(chatId: number, text: string): Promise<void> {
     this.sent.push({ chatId, text });
-    return id;
   }
   async sendTyping(chatId: number): Promise<void> {
     this.typing.push(chatId);
@@ -81,16 +76,6 @@ class FakeTransport implements TelegramTransport {
   ): Promise<{ data: Buffer; mime: string }> {
     this.downloadedFileIds.push(fileId);
     return { data: this.fakeFileBytes, mime: "audio/ogg" };
-  }
-  async editMessage(
-    chatId: number,
-    messageId: number,
-    text: string,
-  ): Promise<void> {
-    this.edited.push({ chatId, messageId, text });
-  }
-  async deleteMessage(chatId: number, messageId: number): Promise<void> {
-    this.deleted.push({ chatId, messageId });
   }
 }
 
@@ -522,10 +507,14 @@ describe("runTelegramServer voice round-trip", () => {
 });
 
 // ---------------------------------------------------------------------------
-// VOICE_REPLY_INSTRUCTION — brevity directive for voice-in/voice-out turns
+// Channel-layer system-prompt suffixes:
+//   - TELEGRAM_REPLY_INSTRUCTION applies to every Telegram turn
+//     (short conversational + plan-then-confirm before long jobs)
+//   - VOICE_REPLY_INSTRUCTION stacks on top for voice-in/voice-out
+//     (stricter 1-3 sentence limit + no markdown for TTS)
 // ---------------------------------------------------------------------------
 
-describe("runTelegramServer voice brevity instruction", () => {
+describe("runTelegramServer system-prompt suffixes", () => {
   const SAVED_KEY = process.env.PHANTOMBOT_OPENAI_API_KEY;
   beforeEach(() => {
     process.env.PHANTOMBOT_OPENAI_API_KEY = "test-key";
@@ -546,7 +535,7 @@ describe("runTelegramServer voice brevity instruction", () => {
     };
   }
 
-  test("voice-in + voice-out: harness sees the brevity directive", async () => {
+  test("voice-in + voice-out: harness sees BOTH the chat-style and the voice-brevity instructions", async () => {
     const originalFetch = globalThis.fetch;
     (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (
       url: string | URL | Request,
@@ -582,18 +571,20 @@ describe("runTelegramServer voice brevity instruction", () => {
         oneShot: true,
       });
       expect(harness.invocations).toBe(1);
-      expect(harness.lastRequest?.systemPrompt).toContain(
-        "Reply length (this turn only)",
-      );
-      expect(harness.lastRequest?.systemPrompt).toContain("text-to-speech");
-      // Match across the line break that the constant naturally has.
-      expect(harness.lastRequest?.systemPrompt).toMatch(/1-3\s+sentences/);
+      const prompt = harness.lastRequest?.systemPrompt ?? "";
+      // Telegram chat-style suffix is present.
+      expect(prompt).toContain("Reply style (Telegram chat)");
+      expect(prompt).toContain("Confirm before long jobs");
+      // Voice overlay is also present (stacked on top).
+      expect(prompt).toContain("Reply length (this turn only)");
+      expect(prompt).toContain("text-to-speech");
+      expect(prompt).toMatch(/1-3\s+sentences/);
     } finally {
       (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
     }
   });
 
-  test("text-in + text-out: NO brevity directive (chat verbosity is fine)", async () => {
+  test("text-in + text-out: harness sees ONLY the chat-style instruction (no voice overlay)", async () => {
     const transport = new FakeTransport();
     transport.pendingUpdates.push({
       updateId: 1,
@@ -613,59 +604,13 @@ describe("runTelegramServer voice brevity instruction", () => {
       transport,
       oneShot: true,
     });
-    expect(harness.lastRequest?.systemPrompt).not.toContain(
-      "Reply length (this turn only)",
-    );
-  });
-
-  test("voice-in but TTS unavailable (text reply): NO brevity directive", async () => {
-    // Voice came in, but the configured provider can't TTS the reply,
-    // so we'll send text. No need for the brevity directive.
-    const originalFetch = globalThis.fetch;
-    (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (
-      url: string | URL | Request,
-    ) => {
-      if (String(url).includes("audio/transcriptions")) {
-        return new Response(JSON.stringify({ text: "hi" }), { status: 200 });
-      }
-      throw new Error(`unexpected fetch: ${url}`);
-    }) as unknown as typeof fetch;
-    try {
-      const cfg = baseConfig();
-      // azure_edge has TTS but no STT — but we want the OPPOSITE shape:
-      // STT works, TTS doesn't. Force it by deleting the TTS key after STT.
-      cfg.voice = {
-        provider: "openai",
-        openai: { model: "tts-1", voice: "nova", speed: 1 },
-      };
-      // ttsSupported reads env at call time; flip it to "no" right before.
-      const saved = process.env.PHANTOMBOT_OPENAI_API_KEY;
-      // Keep the key (STT needs it) — we'll instead just check the
-      // willReplyWithVoice gate by forcing voice provider to a config
-      // that has STT but not TTS for the current key shape. Simpler:
-      // intercept ttsSupported indirectly by using azure_edge for TTS
-      // with no STT — but azure has no STT either. The cleanest test
-      // is to verify: voice in + provider=none → text reply path.
-      // For that we need provider with STT but not TTS. ElevenLabs has
-      // both; openai has both. Azure has TTS but no STT. There's no
-      // built-in "STT only" provider. So we synthesize the gate by
-      // forcing willReplyWithVoice=false via a different route:
-      // text-in trivially gives willReplyWithVoice=false (test 2 above).
-      // Voice-in always implies STT support (otherwise the user gets
-      // a "voice transcription disabled" message, no harness call).
-      // So the only paths are voice-in/voice-out and text-in/text-out.
-      // This third branch (voice-in/text-out) requires a provider
-      // mismatch we don't ship. Skip with a doc comment.
-      void saved; // unused
-    } finally {
-      (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
-    }
-    // No assertions: this test exists to document why the third branch
-    // isn't reachable in v1 (no provider in our matrix has STT-only).
-    // If a future provider does (e.g. a "transcribe-only" Whisper
-    // gateway), the brevity directive should NOT fire — same gate as
-    // willReplyWithVoice in src/channels/telegram.ts.
-    expect(true).toBe(true);
+    const prompt = harness.lastRequest?.systemPrompt ?? "";
+    // The chat-style instruction is always applied for Telegram turns.
+    expect(prompt).toContain("Reply style (Telegram chat)");
+    expect(prompt).toContain("Confirm before long jobs");
+    // The voice-only overlay must NOT leak into text replies.
+    expect(prompt).not.toContain("text-to-speech");
+    expect(prompt).not.toContain("Reply length (this turn only)");
   });
 });
 
@@ -1020,297 +965,5 @@ describe("HttpTelegramTransport AbortSignal", () => {
     } finally {
       (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
     }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Long-turn placeholder lifecycle (Option B from the design discussion)
-//
-// A turn that goes silent for placeholderThresholdMs gets a "⏳ working…"
-// message posted; that message is edited every placeholderEditMs; on
-// completion it is deleted and the real reply is sent as a NEW message
-// (so Telegram pushes a notification — the load-bearing reason we picked
-// delete-then-send over edit-into-reply).
-// ---------------------------------------------------------------------------
-
-describe("placeholder lifecycle", () => {
-  test("fast turn: no placeholder ever posted, no edits, no deletes", async () => {
-    const transport = new FakeTransport();
-    transport.pendingUpdates.push({
-      updateId: 1,
-      chatId: 1001,
-      fromUserId: 42,
-      text: "ping",
-    });
-    const harness = new ScriptedHarness("fast", [
-      { type: "done", finalText: "pong" },
-    ]);
-    await runTelegramServer({
-      config: baseConfig(),
-      memory,
-      harnesses: [harness],
-      agentDir,
-      persona: "phantom",
-      transport,
-      oneShot: true,
-      // Long threshold relative to the turn — won't fire.
-      placeholderThresholdMs: 5_000,
-      placeholderEditMs: 60_000,
-    });
-
-    expect(transport.sent).toEqual([{ chatId: 1001, text: "pong" }]);
-    expect(transport.edited).toEqual([]);
-    expect(transport.deleted).toEqual([]);
-  });
-
-  test("slow turn: placeholder posted + edited + deleted; final reply sent fresh", async () => {
-    const transport = new FakeTransport();
-    transport.pendingUpdates.push({
-      updateId: 1,
-      chatId: 2002,
-      fromUserId: 42,
-      text: "build the thing",
-    });
-    // Slow harness: emits a progress note partway through, then sleeps
-    // long enough that the placeholder fires AND gets edited at least once.
-    class SlowProgressHarness implements Harness {
-      readonly id = "slow";
-      async available(): Promise<boolean> {
-        return true;
-      }
-      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
-        yield { type: "progress", note: "tool_execution_start: BashTool" };
-        await new Promise((r) => setTimeout(r, 250));
-        yield {
-          type: "done",
-          finalText: "built it",
-          meta: { harnessId: this.id },
-        };
-      }
-    }
-    await runTelegramServer({
-      config: baseConfig(),
-      memory,
-      harnesses: [new SlowProgressHarness()],
-      agentDir,
-      persona: "phantom",
-      transport,
-      oneShot: true,
-      placeholderThresholdMs: 50, // post quickly
-      placeholderEditMs: 80, // edit at least once before the 250ms hold ends
-    });
-
-    // The placeholder was posted (first sendMessage), then deleted, then
-    // the real reply was sent as a NEW message.
-    expect(transport.sent.length).toBe(2);
-    expect(transport.sent[0]!.text).toContain("⏳ working");
-    expect(transport.sent[1]!.text).toBe("built it");
-    // At least one edit happened.
-    expect(transport.edited.length).toBeGreaterThanOrEqual(1);
-    expect(transport.edited[0]!.text).toContain("⏳ working");
-    // The placeholder message was deleted before the final reply went out.
-    expect(transport.deleted.length).toBe(1);
-    const placeholderId = transport.sent[0]!.chatId === 2002 ? 1 : 0;
-    expect(transport.deleted[0]).toEqual({
-      chatId: 2002,
-      messageId: placeholderId === 0 ? 0 : 1, // FakeTransport assigns id=1 first
-    });
-  });
-
-  test("placeholder edits include the most recent progress note", async () => {
-    const transport = new FakeTransport();
-    transport.pendingUpdates.push({
-      updateId: 1,
-      chatId: 3003,
-      fromUserId: 42,
-      text: "do work",
-    });
-    class ProgressHarness implements Harness {
-      readonly id = "progressive";
-      async available(): Promise<boolean> {
-        return true;
-      }
-      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
-        yield { type: "progress", note: "step 1: cloning" };
-        await new Promise((r) => setTimeout(r, 100));
-        yield { type: "progress", note: "step 2: building" };
-        await new Promise((r) => setTimeout(r, 100));
-        yield { type: "done", finalText: "ok", meta: { harnessId: this.id } };
-      }
-    }
-    await runTelegramServer({
-      config: baseConfig(),
-      memory,
-      harnesses: [new ProgressHarness()],
-      agentDir,
-      persona: "phantom",
-      transport,
-      oneShot: true,
-      placeholderThresholdMs: 30,
-      placeholderEditMs: 60,
-    });
-
-    // Some edit must mention the latest progress note.
-    const allEditedText = transport.edited.map((e) => e.text).join("\n");
-    // Either step 1 or step 2 will appear, depending on edit timing.
-    expect(allEditedText).toMatch(/step [12]:/);
-  });
-
-  test("placeholder race: sendMessage that resolves AFTER the turn ends doesn't leak the interval or orphan the message", async () => {
-    // Reproduces the race the PR-#56 review flagged: the post timer
-    // fires near the end of the turn, the IIFE awaits sendMessage, the
-    // turn finishes (clearing the post timer no-op'ed because it had
-    // already fired), and the IIFE THEN tries to arm a setInterval and
-    // store a messageId that nobody will ever clean up.
-    //
-    // SlowSendTransport extends FakeTransport with a deliberate ~150ms
-    // sendMessage latency. Combined with placeholderThresholdMs = 50
-    // and a turn that finishes in ~80ms, the IIFE is guaranteed to
-    // outlive the turn.
-    class SlowSendTransport extends FakeTransport {
-      override async sendMessage(chatId: number, text: string): Promise<number> {
-        if (text.includes("⏳ working")) {
-          await new Promise((r) => setTimeout(r, 150));
-        }
-        return super.sendMessage(chatId, text);
-      }
-    }
-    const transport = new SlowSendTransport();
-    transport.pendingUpdates.push({
-      updateId: 1,
-      chatId: 5005,
-      fromUserId: 42,
-      text: "do brief work",
-    });
-    class BriefHarness implements Harness {
-      readonly id = "brief";
-      async available(): Promise<boolean> {
-        return true;
-      }
-      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
-        // Just over the placeholder threshold — long enough to trigger
-        // the post timer, short enough to finish before sendMessage
-        // resolves.
-        await new Promise((r) => setTimeout(r, 80));
-        yield { type: "done", finalText: "done", meta: { harnessId: this.id } };
-      }
-    }
-    await runTelegramServer({
-      config: baseConfig(),
-      memory,
-      harnesses: [new BriefHarness()],
-      agentDir,
-      persona: "phantom",
-      transport,
-      oneShot: true,
-      placeholderThresholdMs: 50,
-      placeholderEditMs: 200,
-    });
-
-    // Give any leaked setInterval a window to tick — if the race fix is
-    // wrong, we'd see editMessage calls landing here.
-    const editsAfterCleanup = transport.edited.length;
-    await new Promise((r) => setTimeout(r, 350));
-
-    // No edit should have fired after the turn cleanup completed —
-    // proves the interval is NOT armed.
-    expect(transport.edited.length).toBe(editsAfterCleanup);
-    // The placeholder did get posted (slow sendMessage), and then it
-    // got deleted by the IIFE's disposed-branch self-cleanup.
-    const placeholderSends = transport.sent.filter((s) => s.text.includes("⏳ working"));
-    expect(placeholderSends.length).toBe(1);
-    expect(transport.deleted.length).toBeGreaterThanOrEqual(1);
-    // Final reply landed.
-    const finalReplies = transport.sent.filter((s) => s.text === "done");
-    expect(finalReplies.length).toBe(1);
-  });
-
-  test("/stop during long turn: placeholder is cleaned up, no duplicate result message", async () => {
-    const transport = new FakeTransport();
-    // Use AbortableHarness pattern from the slow-turn tests: blocks on
-    // signal, yields a stopped error when aborted.
-    class AbortableHarness implements Harness {
-      readonly id = "abortable";
-      async available(): Promise<boolean> {
-        return true;
-      }
-      async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
-        await new Promise<void>((resolve) => {
-          const t = setTimeout(resolve, 5_000);
-          req.signal?.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(t);
-              resolve();
-            },
-            { once: true },
-          );
-        });
-        if (req.signal?.aborted) {
-          yield { type: "error", error: "stopped", recoverable: false };
-        } else {
-          yield { type: "done", finalText: "shouldn't get here" };
-        }
-      }
-    }
-    transport.pendingUpdates.push({
-      updateId: 1,
-      chatId: 4004,
-      fromUserId: 42,
-      text: "do something long",
-    });
-    // Inject a /stop after the placeholder has had time to fire.
-    setTimeout(() => {
-      transport.pendingUpdates.push({
-        updateId: 2,
-        chatId: 4004,
-        fromUserId: 42,
-        text: "/stop",
-      });
-    }, 200);
-    // Stop the polling loop after a moment; the worker drain in the
-    // server's `finally` waits for the aborted turn to resolve.
-    const ac = new AbortController();
-    setTimeout(() => ac.abort(), 400);
-    await runTelegramServer({
-      config: baseConfig(),
-      memory,
-      harnesses: [new AbortableHarness()],
-      agentDir,
-      persona: "phantom",
-      transport,
-      signal: ac.signal,
-      placeholderThresholdMs: 50,
-      placeholderEditMs: 60,
-    });
-
-    // Three categories of message in `sent`: the placeholder (⏳…), the
-    // /stop ack (stopped …), and ideally NO duplicate "(error: stopped)".
-    const replyTexts = transport.sent.map((s) => s.text);
-    expect(replyTexts.some((t) => /^stopped \(/.test(t))).toBe(true);
-    expect(replyTexts.some((t) => t.includes("(error: stopped)"))).toBe(false);
-    // Placeholder posted then deleted.
-    const placeholderTexts = replyTexts.filter((t) => t.includes("⏳ working"));
-    expect(placeholderTexts.length).toBeGreaterThanOrEqual(1);
-    expect(transport.deleted.length).toBeGreaterThanOrEqual(1);
-  });
-});
-
-describe("formatElapsedMs", () => {
-  test("formats sub-minute as plain seconds", async () => {
-    const { formatElapsedMs } = await import("../src/lib/format.ts");
-    expect(formatElapsedMs(0)).toBe("0s");
-    expect(formatElapsedMs(45_000)).toBe("45s");
-  });
-
-  test("formats minutes + seconds", async () => {
-    const { formatElapsedMs } = await import("../src/lib/format.ts");
-    expect(formatElapsedMs(65_000)).toBe("1m 5s");
-    expect(formatElapsedMs(7 * 60_000 + 12_000)).toBe("7m 12s");
-  });
-
-  test("formats hours + minutes for very long turns", async () => {
-    const { formatElapsedMs } = await import("../src/lib/format.ts");
-    expect(formatElapsedMs(2 * 3_600_000 + 15 * 60_000 + 4_000)).toBe("2h 15m");
   });
 });

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -26,9 +26,8 @@ class FakeTransport implements TelegramTransport {
   }> {
     return { updates: [], nextOffset: 0 };
   }
-  async sendMessage(chatId: number, text: string): Promise<number> {
+  async sendMessage(chatId: number, text: string): Promise<void> {
     this.sent.push({ chatId, text });
-    return 1;
   }
   async sendTyping(): Promise<void> {}
   async sendRecording(): Promise<void> {}
@@ -42,8 +41,6 @@ class FakeTransport implements TelegramTransport {
   async downloadFile(): Promise<{ data: Buffer; mime: string }> {
     return { data: Buffer.alloc(0), mime: "" };
   }
-  async editMessage(): Promise<void> {}
-  async deleteMessage(): Promise<void> {}
 }
 
 const SAVED_KEY = process.env.PHANTOMBOT_OPENAI_API_KEY;


### PR DESCRIPTION
## Summary

Three streamlining changes to the Telegram experience.

## 1. Channel-layer prompt suffix for Telegram turns

New `TELEGRAM_REPLY_INSTRUCTION` applied to every Telegram turn:

- **Default to short, conversational replies** (1-4 sentences). The user is on a phone with a narrow column. Longer replies are explicitly allowed when the user asks for a detailed report or analysis.
- **Plan-then-confirm before long jobs**: any git/build/deploy work, or anything that would spawn more than one tool call. The agent outlines its plan in 2-3 sentences and asks for confirmation. This avoids burning 10 minutes producing the wrong thing — the Telegram round-trip is fast enough to align up front.

`VOICE_REPLY_INSTRUCTION` still applies (stacked on top of the chat-style instruction) for voice-out turns, where the stricter 1-3 sentence + no-markdown rules matter for TTS playback.

## 2. Typing indicator: 4s → 8s refresh

Telegram's chat-action expires after ~5s. Refreshing every 8s creates a deliberate pulse: indicator visible for ~5s, gone for ~3s, back again. The user sees activity without staring at a frozen \"is typing…\" header.

## 3. Drop the long-turn placeholder entirely

The \"⏳ working… 30s elapsed\" message from PR #56 was:
- **English-only noise** that would alienate non-English-speaking users
- Almost never carrying the per-tool detail it was designed to show — the harnesses don't reliably emit progress chunks (only Pi's tool_execution_start would have, and it's not yet observed in the wild for plain conversational turns)

The 8s typing pulse is now the sole \"still alive\" signal during long silences.

Removed code:
- `placeholderThresholdMs` / `placeholderEditMs` config knobs
- All placeholder state + timers + IIFE + the race fix from the PR #56 review
- `cleanupPlaceholder` helper
- `TelegramTransport.editMessage` + `deleteMessage` (unused without the placeholder pipeline)
- `sendMessage`'s `Promise<number>` return type (was only used to capture the placeholder messageId)
- `formatElapsedMs` from `src/lib/format.ts` (orphan; `formatElapsedSeconds` stays for `/status`)
- All placeholder lifecycle / race / `formatElapsedMs` tests (~290 lines)

## Test plan

- [x] **503 pass, 1 skip, 0 fail** (down from 510 by removing placeholder tests; up by one new chat-style suffix assertion)
- [x] Typecheck clean
- [x] Updated suffix-injection tests verify both stacking paths:
  - voice-in + voice-out → harness sees both `Reply style (Telegram chat)` AND `Reply length (this turn only)`
  - text-in + text-out → harness sees `Reply style (Telegram chat)` but NOT the voice overlay

## Diff stats

`4 files changed, 110 insertions(+), 579 deletions(-)` — net code reduction.

## Deployment notes

After merge + v1.0.57 publishes:
\`\`\`
phantombot update --force --restart
\`\`\`
on each persona host. The chat behavior change takes effect on the next turn — agents will start outlining plans before long jobs and will be more conversational by default.