### PR TITLE
feat: heartbeat chunks + chunk-driven typing indicator (no timers, no fakes)

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -282,16 +282,15 @@ export interface RunTelegramServerInput {
   /** Signal to stop the loop cleanly. */
   signal?: AbortSignal;
   /**
-   * Optional FIXED refresh interval for the typing indicator pulse,
-   * in milliseconds. When unset (production default), each pulse
-   * picks a random value from {4, 6, 8, 10}s so long chats don't feel
-   * like they're hitting a metronome. When the harness is actively
-   * emitting text, we ALSO refresh on every chunk (throttled to 1 per
-   * 2s) so the indicator stays solid during real typing.
-   *
-   * Tests pass an explicit value to make the cadence deterministic.
+   * Minimum gap between two `sendChatAction` calls (ms). Used to throttle
+   * the per-chunk refresh so a fast stream-json burst doesn't fire
+   * dozens of typing actions per second. Default 2000ms — well under
+   * Telegram's ~5s chat-action lifetime, so the indicator stays solid
+   * during continuous activity but vanishes within ~5s when the harness
+   * goes silent (the truthful "frozen / no signal" cue). Tests pass a
+   * smaller value for determinism.
    */
-  typingRefreshMs?: number;
+  typingThrottleMs?: number;
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -504,41 +503,25 @@ async function processChatMessage(
       ? input.transport.sendRecording(msg.chatId)
       : input.transport.sendTyping(msg.chatId);
 
-  // Initial nudge so the user sees "typing…" immediately.
-  void sendStatus();
-
-  // Throttle ONLY for the text-chunk-driven path: a fast stream-json
-  // burst could otherwise fire dozens of typing actions per second.
-  // The pulse self-rate-limits via its own interval (always >= 4s in
-  // production, or whatever a test sets), so it bypasses the throttle.
-  // Initialised at 0 (not Date.now()) so the FIRST text chunk always
-  // lands immediately — the user sees `typing…` snap on the moment
-  // real output starts. Subsequent chunks within 2s get throttled.
-  let lastChunkRefreshAt = 0;
-  const refreshOnChunk = () => {
+  // Indicator policy: refresh on EVERY harness chunk (text, heartbeat,
+  // progress). When chunks stop, the indicator naturally expires after
+  // ~5s — that vanishing IS the user-visible "harness has gone silent /
+  // possibly frozen" signal. No background timer, no fake pulse: the
+  // indicator's presence is a true reflection of the harness's current
+  // activity. The throttle just prevents stream-json bursts from
+  // hitting Telegram's per-bot rate cap.
+  const throttleMs = input.typingThrottleMs ?? 2000;
+  let lastSendStatusAt = 0;
+  const refreshIndicator = () => {
     const now = Date.now();
-    if (now - lastChunkRefreshAt < 2000) return;
-    lastChunkRefreshAt = now;
+    if (now - lastSendStatusAt < throttleMs) return;
+    lastSendStatusAt = now;
     void sendStatus();
   };
 
-  // Pulse cadence: in production, each interval is randomly picked from
-  // {4, 6, 8, 10}s so a long silent stretch doesn't feel mechanical.
-  // Tests inject a fixed value via `typingRefreshMs` for determinism.
-  const fixedPulseMs = input.typingRefreshMs;
-  const nextPulseMs = (): number =>
-    fixedPulseMs ?? PULSE_INTERVALS_MS[
-      Math.floor(Math.random() * PULSE_INTERVALS_MS.length)
-    ]!;
-  let pulseTimer: ReturnType<typeof setTimeout> = setTimeout(() => {}, 0);
-  clearTimeout(pulseTimer);
-  const schedulePulse = (): void => {
-    pulseTimer = setTimeout(() => {
-      void sendStatus();
-      schedulePulse();
-    }, nextPulseMs());
-  };
-  schedulePulse();
+  // Initial nudge so the user sees "typing…" the moment we start
+  // working, before the first chunk lands.
+  refreshIndicator();
 
   // Register the AbortController so /stop can find us.
   const controller = new AbortController();
@@ -579,10 +562,12 @@ async function processChatMessage(
     })) {
       if (chunk.type === "text") {
         reply += chunk.text;
-        // Real text is flowing — keep the typing indicator solid by
-        // refreshing on every chunk. Throttled to 1/2s so a fast
-        // stream-json burst doesn't fire dozens of actions.
-        refreshOnChunk();
+        refreshIndicator();
+      }
+      if (chunk.type === "heartbeat") {
+        // Model is alive (chain-of-thought / tool start / etc.) — keep
+        // the indicator visible without surfacing the content.
+        refreshIndicator();
       }
       if (chunk.type === "progress") {
         progressCount++;
@@ -593,6 +578,7 @@ async function processChatMessage(
           chatId: msg.chatId,
           note: chunk.note.slice(0, 200),
         });
+        refreshIndicator();
       }
       if (chunk.type === "done") {
         reply = chunk.finalText;
@@ -607,7 +593,6 @@ async function processChatMessage(
     errored = (e as Error).message;
     log.error("telegram: turn threw", { error: errored });
   } finally {
-    clearTimeout(pulseTimer);
     // Only deregister if we're still the active turn for this chat.
     // (Defensive: a /reset or /stop could have replaced us.)
     if (activeTurns.get(msg.chatId) === turnHandle) {
@@ -697,18 +682,6 @@ async function processChatMessage(
  * turns aren't affected — those run unattended and don't want a
  * confirmation gate, and verbose CLI output is fine.
  */
-/**
- * Candidate intervals (ms) for the random typing-indicator pulse.
- * One is picked per pulse so the cadence varies across a long turn —
- * a fixed-cadence pulse felt mechanical, like a heartbeat monitor.
- * Range chosen around Telegram's ~5s chat-action lifetime: 4s gives
- * an essentially-solid indicator, 10s leaves a clear ~5s gap. Mixing
- * them keeps the user from learning to predict the next pulse.
- *
- * Exported for tests that want to assert intervals fall in this set.
- */
-export const PULSE_INTERVALS_MS = [4000, 6000, 8000, 10000] as const;
-
 export const TELEGRAM_REPLY_INSTRUCTION =
   `# Reply style (Telegram chat)
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -282,15 +282,14 @@ export interface RunTelegramServerInput {
   /** Signal to stop the loop cleanly. */
   signal?: AbortSignal;
   /**
-   * How often to refresh the "typing…" indicator while a turn is in
-   * flight. Telegram's chat-action expires after ~5s; the default 8s
-   * refresh deliberately leaves a ~3s gap between pulses, so the user
-   * sees `typing…` come and go rather than a frozen-looking permanent
-   * indicator. The pulse is the primary "I'm alive" signal — replaces
-   * the canned `⏳ working… 30s elapsed` placeholder we tried in
-   * PR #56, which was English-only noise without the per-tool
-   * progress notes the harnesses don't reliably emit. Tests use a
-   * smaller value to verify the refresh fires at all.
+   * Optional FIXED refresh interval for the typing indicator pulse,
+   * in milliseconds. When unset (production default), each pulse
+   * picks a random value from {4, 6, 8, 10}s so long chats don't feel
+   * like they're hitting a metronome. When the harness is actively
+   * emitting text, we ALSO refresh on every chunk (throttled to 1 per
+   * 2s) so the indicator stays solid during real typing.
+   *
+   * Tests pass an explicit value to make the cadence deterministic.
    */
   typingRefreshMs?: number;
   out?: WriteSink;
@@ -499,19 +498,47 @@ async function processChatMessage(
   }
 
   // Send the right indicator depending on which way we'll reply.
-  // Refresh both kinds every typingRefreshMs while the harness works.
   const willReplyWithVoice = isVoice && ttsSupported(input.config);
   const sendStatus = () =>
     willReplyWithVoice
       ? input.transport.sendRecording(msg.chatId)
       : input.transport.sendTyping(msg.chatId);
+
+  // Initial nudge so the user sees "typing…" immediately.
   void sendStatus();
-  // Refresh interval defaults to 8s (5s indicator-on / 3s gap pulse) —
-  // see RunTelegramServerInput for the full rationale.
-  const refreshMs = input.typingRefreshMs ?? 8000;
-  const typingTimer = setInterval(() => {
+
+  // Throttle ONLY for the text-chunk-driven path: a fast stream-json
+  // burst could otherwise fire dozens of typing actions per second.
+  // The pulse self-rate-limits via its own interval (always >= 4s in
+  // production, or whatever a test sets), so it bypasses the throttle.
+  // Initialised at 0 (not Date.now()) so the FIRST text chunk always
+  // lands immediately — the user sees `typing…` snap on the moment
+  // real output starts. Subsequent chunks within 2s get throttled.
+  let lastChunkRefreshAt = 0;
+  const refreshOnChunk = () => {
+    const now = Date.now();
+    if (now - lastChunkRefreshAt < 2000) return;
+    lastChunkRefreshAt = now;
     void sendStatus();
-  }, refreshMs);
+  };
+
+  // Pulse cadence: in production, each interval is randomly picked from
+  // {4, 6, 8, 10}s so a long silent stretch doesn't feel mechanical.
+  // Tests inject a fixed value via `typingRefreshMs` for determinism.
+  const fixedPulseMs = input.typingRefreshMs;
+  const nextPulseMs = (): number =>
+    fixedPulseMs ?? PULSE_INTERVALS_MS[
+      Math.floor(Math.random() * PULSE_INTERVALS_MS.length)
+    ]!;
+  let pulseTimer: ReturnType<typeof setTimeout> = setTimeout(() => {}, 0);
+  clearTimeout(pulseTimer);
+  const schedulePulse = (): void => {
+    pulseTimer = setTimeout(() => {
+      void sendStatus();
+      schedulePulse();
+    }, nextPulseMs());
+  };
+  schedulePulse();
 
   // Register the AbortController so /stop can find us.
   const controller = new AbortController();
@@ -550,7 +577,13 @@ async function processChatMessage(
         ? `${TELEGRAM_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
         : TELEGRAM_REPLY_INSTRUCTION,
     })) {
-      if (chunk.type === "text") reply += chunk.text;
+      if (chunk.type === "text") {
+        reply += chunk.text;
+        // Real text is flowing — keep the typing indicator solid by
+        // refreshing on every chunk. Throttled to 1/2s so a fast
+        // stream-json burst doesn't fire dozens of actions.
+        refreshOnChunk();
+      }
       if (chunk.type === "progress") {
         progressCount++;
         // Stash the latest progress note on the active-turn handle so
@@ -574,7 +607,7 @@ async function processChatMessage(
     errored = (e as Error).message;
     log.error("telegram: turn threw", { error: errored });
   } finally {
-    clearInterval(typingTimer);
+    clearTimeout(pulseTimer);
     // Only deregister if we're still the active turn for this chat.
     // (Defensive: a /reset or /stop could have replaced us.)
     if (activeTurns.get(msg.chatId) === turnHandle) {
@@ -664,6 +697,18 @@ async function processChatMessage(
  * turns aren't affected — those run unattended and don't want a
  * confirmation gate, and verbose CLI output is fine.
  */
+/**
+ * Candidate intervals (ms) for the random typing-indicator pulse.
+ * One is picked per pulse so the cadence varies across a long turn —
+ * a fixed-cadence pulse felt mechanical, like a heartbeat monitor.
+ * Range chosen around Telegram's ~5s chat-action lifetime: 4s gives
+ * an essentially-solid indicator, 10s leaves a clear ~5s gap. Mixing
+ * them keeps the user from learning to predict the next pulse.
+ *
+ * Exported for tests that want to assert intervals fall in this set.
+ */
+export const PULSE_INTERVALS_MS = [4000, 6000, 8000, 10000] as const;
+
 export const TELEGRAM_REPLY_INSTRUCTION =
   `# Reply style (Telegram chat)
 

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -256,7 +256,19 @@ export function renderStdinPayload(req: HarnessRequest): string {
  *
  * Claude's stream-json schema is documented in the Claude Code docs but
  * informally: each line has a `type` (system / user / assistant / result)
- * and a `message` payload. We only need the assistant text content.
+ * and a `message` payload. The assistant content is an array of blocks
+ * with their own `type`: `text`, `thinking`, `tool_use`, `tool_result`.
+ *
+ * Channel layers want two distinct signals from us:
+ *   - `text` blocks → user-visible reply (concatenate, surface verbatim).
+ *   - Anything else (`thinking`, `tool_use`, `tool_result`, …) → "model
+ *     is alive" tick, no payload. The actual content stays inside the
+ *     subprocess; we just emit `heartbeat` so the channel can refresh
+ *     its typing indicator without leaking chain-of-thought.
+ *
+ * If a single assistant message contains BOTH text and non-text blocks,
+ * we prefer the text chunk (it carries strictly more signal — text
+ * implicitly proves the model is alive too).
  *
  * Exported for testing.
  */
@@ -271,16 +283,20 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   if (!Array.isArray(content)) return undefined;
 
   let text = "";
+  let sawNonText = false;
   for (const part of content) {
     if (typeof part === "object" && part !== null) {
       const p = part as Record<string, unknown>;
       if (p.type === "text" && typeof p.text === "string") {
         text += p.text;
+      } else if (typeof p.type === "string") {
+        sawNonText = true;
       }
     }
   }
-  if (!text) return undefined;
-  return { type: "text", text };
+  if (text) return { type: "text", text };
+  if (sawNonText) return { type: "heartbeat" };
+  return undefined;
 }
 
 async function consumeStderr(

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -174,10 +174,16 @@ export class GeminiHarness implements Harness {
           // ahead of the stream (e.g. terminal-color warnings, "YOLO
           // mode is enabled"). Surfaced as low-noise progress notes
           // rather than dropped, so they show up in /status diagnostics.
+          // Also logged at debug level so a future gemini-cli schema
+          // change that produces unexpected non-JSON shows up in the
+          // journal without needing to reproduce live.
           let parsed: unknown;
           try {
             parsed = JSON.parse(trimmed);
           } catch {
+            log.debug("gemini: non-JSON stdout line", {
+              line: trimmed.slice(0, 200),
+            });
             yield { type: "progress", note: trimmed.slice(0, 200) };
             continue;
           }

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -2,16 +2,20 @@
  * Google Gemini CLI harness — wraps `gemini` (the open-source agentic
  * CLI from google-gemini/gemini-cli).
  *
- * Spawn shape: `gemini -p <new_user_message> -o text -y [-m <model>]`.
+ * Spawn shape: `gemini -p <new_user_message> -o stream-json -y [-m <model>]`.
  *   - `-p` (required) puts the binary in non-interactive headless mode.
  *     Per `gemini --help`, the -p value is appended to whatever's on
  *     stdin — so we send the system prompt + prior turns via stdin and
  *     use -p for just the new user message. This keeps the argv small
  *     enough that ARG_MAX isn't a concern (Pi has the same problem and
  *     guards it with maxPayloadBytes; gemini's stdin+argv split avoids it).
- *   - `-o text` (v1): collect all stdout, emit one text + one done
- *     chunk on exit 0. Stream-json upgrade is a follow-up — needs a
- *     real schema sample, not a guess.
+ *   - `-o stream-json` emits one JSON object per line for every internal
+ *     event: init, user-echo, tool_use, tool_result, assistant-message
+ *     deltas, and a final result with token stats. We map those into
+ *     phantombot's HarnessChunk taxonomy (see parseGeminiEvent below).
+ *     This replaces the v1 `-o text` mode, which collapsed everything
+ *     to a single blob and gave the channel layer no way to distinguish
+ *     "model is thinking" from "model is silent / wedged."
  *   - `-y` (yolo): auto-approve all tool calls. Required for headless
  *     because the default mode prompts for approval, which would block
  *     forever in a non-interactive subprocess. Same posture phantombot
@@ -103,7 +107,7 @@ export class GeminiHarness implements Harness {
     const stdinPayload = renderStdinPayload(req);
     const args: string[] = [
       "-p", req.userMessage,
-      "-o", "text",
+      "-o", "stream-json",
       "-y",
     ];
     if (this.config.model && this.config.model.length > 0) {
@@ -152,16 +156,59 @@ export class GeminiHarness implements Harness {
 
     void consumeStderr(proc.stderr);
 
+    let buffer = "";
     let finalText = "";
+    let resultMeta: Record<string, unknown> | undefined;
     const decoder = new TextDecoder();
 
     try {
       for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
         killer.touch();
-        finalText += decoder.decode(chunk, { stream: true });
+        buffer += decoder.decode(chunk, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          // Tolerate non-JSON noise that gemini-cli sometimes prints
+          // ahead of the stream (e.g. terminal-color warnings, "YOLO
+          // mode is enabled"). Surfaced as low-noise progress notes
+          // rather than dropped, so they show up in /status diagnostics.
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(trimmed);
+          } catch {
+            yield { type: "progress", note: trimmed.slice(0, 200) };
+            continue;
+          }
+          const c = parseGeminiEvent(parsed);
+          if (!c) continue;
+          if (c.type === "text") finalText += c.text;
+          if (c.type === "done") {
+            // gemini's `result` event carries the authoritative stats.
+            // We hold them in resultMeta and emit a single done chunk
+            // after the loop so the orchestrator sees one terminal event.
+            resultMeta = c.meta;
+            continue;
+          }
+          yield c;
+        }
       }
       // Flush any pending bytes in the decoder.
-      finalText += decoder.decode();
+      buffer += decoder.decode();
+      const tail = buffer.trim();
+      if (tail) {
+        try {
+          const c = parseGeminiEvent(JSON.parse(tail));
+          if (c) {
+            if (c.type === "text") finalText += c.text;
+            if (c.type === "done") resultMeta = c.meta;
+            else yield c;
+          }
+        } catch {
+          /* drop trailing partial line */
+        }
+      }
     } finally {
       await killer.dispose();
     }
@@ -182,7 +229,7 @@ export class GeminiHarness implements Harness {
     if (code !== 0) {
       yield {
         type: "error",
-        error: `gemini exited with code ${code}${finalText ? `: ${finalText.slice(0, 200)}` : ""}`,
+        error: `gemini exited with code ${code}`,
         // 127 = "command not found"; not recoverable by retrying the next harness
         // (the binary itself is missing). Other non-zero exits are typically
         // model/network/auth issues that the next harness in the chain can handle.
@@ -191,11 +238,6 @@ export class GeminiHarness implements Harness {
       return;
     }
 
-    // v1 emits the whole reply as one text chunk + a done. Stream-json
-    // upgrade is a follow-up.
-    if (finalText.length > 0) {
-      yield { type: "text", text: finalText };
-    }
     yield {
       type: "done",
       finalText,
@@ -203,9 +245,77 @@ export class GeminiHarness implements Harness {
         harnessId: this.id,
         model: this.config.model || "(default)",
         replyBytes: Buffer.byteLength(finalText, "utf8"),
+        ...(resultMeta ?? {}),
       },
     };
   }
+}
+
+/**
+ * Translate one gemini stream-json event line into a HarnessChunk.
+ *
+ * Schema (verified against gemini-cli v0.40.x with `-o stream-json`):
+ *
+ *   {"type":"init","session_id":"...","model":"..."}
+ *   {"type":"message","role":"user","content":"..."}            // input echo
+ *   {"type":"tool_use","tool_name":"...","tool_id":"...",
+ *      "parameters":{...}}
+ *   {"type":"tool_result","tool_id":"...","status":"success"}
+ *   {"type":"message","role":"assistant","content":"...",
+ *      "delta":true}                                             // reply token
+ *   {"type":"result","status":"...","stats":{
+ *      "total_tokens":N, "input_tokens":N, "output_tokens":N,
+ *      "duration_ms":N, "tool_calls":N, ... }}
+ *
+ * Mapping rules:
+ *   - assistant message (delta or full) → `text` chunk
+ *   - tool_use → `progress` chunk; the note is "tool: <name>" so /status
+ *     can surface "currently: tool: run_shell_command" without the channel
+ *     layer needing gemini-specific knowledge
+ *   - tool_result → `heartbeat` (signal only; the actual output already
+ *     went into the model's context for synthesis)
+ *   - result → synthetic `done` chunk carrying the stats as meta
+ *   - init / user-echo → ignored (no signal value for the user)
+ *
+ * Exported for testing.
+ */
+export function parseGeminiEvent(parsed: unknown): HarnessChunk | undefined {
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  const type = obj.type;
+  if (typeof type !== "string") return undefined;
+
+  if (type === "message") {
+    if (obj.role !== "assistant") return undefined;
+    const content = obj.content;
+    if (typeof content !== "string" || content.length === 0) return undefined;
+    return { type: "text", text: content };
+  }
+
+  if (type === "tool_use") {
+    const name =
+      typeof obj.tool_name === "string" ? obj.tool_name : "(unknown tool)";
+    return { type: "progress", note: `tool: ${name}` };
+  }
+
+  if (type === "tool_result") {
+    return { type: "heartbeat" };
+  }
+
+  if (type === "result") {
+    // Caller treats this as a "done"-shaped event for stats capture.
+    const stats =
+      typeof obj.stats === "object" && obj.stats !== null
+        ? (obj.stats as Record<string, unknown>)
+        : undefined;
+    return {
+      type: "done",
+      finalText: "", // caller maintains its own running concat from text chunks
+      meta: stats ? { stats } : undefined,
+    };
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -203,14 +203,16 @@ export function renderPayload(req: HarnessRequest): string {
  *   {"type":"session", ...}    // emitted at startup
  *   {"type":"message_start"|"message_end", ...}
  *
- * Only `assistantMessageEvent.type === "text_delta"` events contribute
- * to the assistant's reply. `thinking_delta` events are the model's
- * chain-of-thought and must be excluded — they'd otherwise leak the
- * model's reasoning into the user-facing reply.
+ * `text_delta` events contribute to the user-facing reply.
+ * `thinking_delta` events are the model's chain-of-thought; we deliberately
+ * do NOT surface their content (would leak reasoning into the reply), but
+ * we DO emit a payload-less `heartbeat` so the channel layer can refresh
+ * its typing indicator. When the user sees `typing…` come and go in real
+ * time, that's pi actually thinking — the indicator vanishing means the
+ * model has gone silent (and may be wedged on a tool call).
  *
- * Tool execution events (when they appear in the schema for tool-using
- * runs) would map to progress chunks here. Not yet observed in the
- * --print --mode json output for plain conversational turns.
+ * Other unknown event types (tool_use_*, etc.) also fold into heartbeats
+ * so we don't pretend the model is silent during legitimate work.
  *
  * Exported for testing.
  */
@@ -227,10 +229,15 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
     if (typeof delta === "string" && delta.length > 0) {
       return { type: "text", text: delta };
     }
+    return undefined;
   }
 
-  // tool_use_start (or whatever pi names it for this version) would map to
-  // a progress chunk here when we observe it in the wild.
+  // thinking_delta + any other assistantMessageEvent type → heartbeat.
+  // We intentionally do NOT include the content in the chunk (would leak
+  // chain-of-thought to the user). The signal is just "pi is alive."
+  if (typeof ame.type === "string") {
+    return { type: "heartbeat" };
+  }
 
   return undefined;
 }

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -44,7 +44,16 @@ export interface HarnessRequest {
 export type HarnessChunk =
   /** Streamed assistant text. Concatenate all `text` chunks for the final reply. */
   | { type: "text"; text: string }
-  /** Out-of-band progress (e.g. "running tool X"). Useful for keeping channels alive on long turns. */
+  /**
+   * Payload-less "model is alive" tick. Emitted on internal events the
+   * channel layer shouldn't surface (chain-of-thought tokens,
+   * tool_use block starts) but that prove the harness is working.
+   * Channel adapters use these to refresh their typing/working
+   * indicator — when heartbeats stop, the indicator naturally
+   * expires, which is the truthful "frozen" signal.
+   */
+  | { type: "heartbeat" }
+  /** Out-of-band progress with a human-readable note (e.g. "running tool X"). */
   | { type: "progress"; note: string }
   /** Final marker. `finalText` is the full assistant reply (sum of all `text` chunks). */
   | { type: "done"; finalText: string; meta?: Record<string, unknown> }

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -96,27 +96,6 @@ class ScriptedHarness implements Harness {
   }
 }
 
-/**
- * A harness that pauses for `holdMs` between yielding the first text chunk
- * and the done chunk — used to verify typing-indicator refresh behavior.
- */
-class SlowHarness implements Harness {
-  invocations = 0;
-  constructor(
-    public readonly id: string,
-    private readonly holdMs: number,
-  ) {}
-  async available(): Promise<boolean> {
-    return true;
-  }
-  async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
-    this.invocations++;
-    yield { type: "text", text: "thinking…" };
-    await new Promise((r) => setTimeout(r, this.holdMs));
-    yield { type: "text", text: "done" };
-    yield { type: "done", finalText: "thinking…done", meta: { harnessId: this.id } };
-  }
-}
 
 // ---------------------------------------------------------------------------
 // parseGetUpdatesResult
@@ -644,39 +623,12 @@ describe("runTelegramServer AbortSignal", () => {
   });
 });
 
-describe("runTelegramServer typing refresh", () => {
-  test("refreshes the typing indicator while a slow harness is working", async () => {
-    const transport = new FakeTransport();
-    transport.pendingUpdates.push({
-      updateId: 1,
-      chatId: 1001,
-      fromUserId: 42,
-      text: "hi",
-    });
-    // Hold the harness for 250ms so we get >1 typing refresh at 50ms cadence.
-    const harness = new SlowHarness("slow", 250);
-    await runTelegramServer({
-      config: baseConfig(),
-      memory,
-      harnesses: [harness],
-      agentDir,
-      persona: "phantom",
-      transport,
-      typingRefreshMs: 50,
-      oneShot: true,
-    });
-    // 1 initial sendTyping + at least 2 refresh ticks during the 250ms hold.
-    // We don't assert an exact count to stay scheduling-tolerant; > 2 is the contract.
-    expect(transport.typing.length).toBeGreaterThan(2);
-    // All typing calls were for the right chat
-    expect(transport.typing.every((c) => c === 1001)).toBe(true);
-    // The reply was sent.
-    expect(transport.sent).toEqual([
-      { chatId: 1001, text: "thinking…done" },
-    ]);
-  });
+// ---------------------------------------------------------------------------
+// Typing indicator: chunk-driven only (no timers, no random pulses)
+// ---------------------------------------------------------------------------
 
-  test("clears the typing interval when the turn completes (no stray refreshes after)", async () => {
+describe("runTelegramServer typing indicator", () => {
+  test("initial nudge fires once at turn start", async () => {
     const transport = new FakeTransport();
     transport.pendingUpdates.push({
       updateId: 1,
@@ -694,31 +646,28 @@ describe("runTelegramServer typing refresh", () => {
       agentDir,
       persona: "phantom",
       transport,
-      typingRefreshMs: 50,
       oneShot: true,
     });
-    const baseline = transport.typing.length;
-    // Wait longer than the refresh interval — no further typing should appear.
-    await new Promise((r) => setTimeout(r, 150));
-    expect(transport.typing.length).toBe(baseline);
+    // Just the initial sendStatus — the harness emitted no streamable
+    // chunks (only `done`).
+    expect(transport.typing).toEqual([1001]);
   });
 
-  test("text chunks trigger an extra typing refresh (so the indicator stays solid during streaming)", async () => {
-    // Streaming harness: emits text chunks at 50ms intervals for ~250ms.
-    // Pulse cadence is set high enough (5_000ms) that the pulse won't fire
-    // during the test window; any typing actions beyond the initial one
-    // must come from the chunk-driven refresh path.
+  test("refreshes on text + heartbeat + progress chunks (with throttle disabled)", async () => {
     class StreamingHarness implements Harness {
       readonly id = "streaming";
       async available(): Promise<boolean> {
         return true;
       }
       async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
-        for (let i = 0; i < 5; i++) {
-          yield { type: "text", text: `chunk ${i} ` };
-          await new Promise((r) => setTimeout(r, 50));
-        }
-        yield { type: "done", finalText: "chunk 0 chunk 1 chunk 2 chunk 3 chunk 4 " };
+        yield { type: "heartbeat" };
+        await new Promise((r) => setTimeout(r, 10));
+        yield { type: "text", text: "hi " };
+        await new Promise((r) => setTimeout(r, 10));
+        yield { type: "progress", note: "tool: BashTool" };
+        await new Promise((r) => setTimeout(r, 10));
+        yield { type: "text", text: "there" };
+        yield { type: "done", finalText: "hi there", meta: { harnessId: this.id } };
       }
     }
     const transport = new FakeTransport();
@@ -735,55 +684,74 @@ describe("runTelegramServer typing refresh", () => {
       agentDir,
       persona: "phantom",
       transport,
-      typingRefreshMs: 5_000, // pulse won't fire in this window
+      typingThrottleMs: 1, // disable throttle for this test
       oneShot: true,
     });
-    // 1 initial sendStatus + at least 1 chunk-driven refresh during the
-    // ~250ms streaming window. The chunk path is throttled to 1 per 2s,
-    // so we expect 2 total (initial + first chunk past the throttle —
-    // which is the 0ms-old initial, so the first chunk goes through;
-    // subsequent chunks within 2s get throttled out).
-    expect(transport.typing.length).toBeGreaterThanOrEqual(2);
+    // 1 initial + 4 chunks (heartbeat, text, progress, text). `done`
+    // doesn't refresh.
+    expect(transport.typing.length).toBeGreaterThanOrEqual(5);
+    expect(transport.typing.every((c) => c === 1001)).toBe(true);
   });
 
-  test("PULSE_INTERVALS_MS exposes exactly the documented set {4,6,8,10}s", async () => {
-    const { PULSE_INTERVALS_MS } = await import("../src/channels/telegram.ts");
-    expect([...PULSE_INTERVALS_MS]).toEqual([4000, 6000, 8000, 10000]);
-  });
-
-  test("random pulse: with no typingRefreshMs override, every interval picked falls in PULSE_INTERVALS_MS", async () => {
-    // Stub Math.random so we can exercise every index in the set.
-    const realRandom = Math.random;
-    const sequence = [0.0, 0.3, 0.6, 0.99]; // → 0, 1, 2, 3
-    let i = 0;
-    Math.random = () => sequence[i++ % sequence.length]!;
-    try {
-      const transport = new FakeTransport();
-      transport.pendingUpdates.push({
-        updateId: 1,
-        chatId: 1001,
-        fromUserId: 42,
-        text: "x",
-      });
-      // Quick harness — we only care that production code path (no
-      // typingRefreshMs) doesn't blow up and produces ≥1 typing call.
-      const harness = new ScriptedHarness("fake", [
-        { type: "done", finalText: "ok" },
-      ]);
-      await runTelegramServer({
-        config: baseConfig(),
-        memory,
-        harnesses: [harness],
-        agentDir,
-        persona: "phantom",
-        transport,
-        oneShot: true,
-        // typingRefreshMs intentionally NOT set → exercises random-pulse path.
-      });
-      expect(transport.typing.length).toBeGreaterThanOrEqual(1);
-    } finally {
-      Math.random = realRandom;
+  test("throttle: rapid chunks within the window collapse to one sendStatus", async () => {
+    class BurstHarness implements Harness {
+      readonly id = "burst";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        for (let i = 0; i < 10; i++) {
+          yield { type: "heartbeat" };
+        }
+        yield { type: "done", finalText: "" };
+      }
     }
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "x",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new BurstHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      typingThrottleMs: 5_000,
+      oneShot: true,
+    });
+    // Initial nudge sets lastSendStatusAt; all 10 burst chunks fall
+    // inside the 5_000ms window and get throttled out → just the initial.
+    expect(transport.typing.length).toBe(1);
+  });
+
+  test("no background timer: no sendStatus calls land after the turn completes", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hi",
+    });
+    const harness = new ScriptedHarness("fast", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    const baseline = transport.typing.length;
+    // Wait well past anything that could plausibly be a stale timer.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(transport.typing.length).toBe(baseline);
   });
 });
 

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -234,7 +234,11 @@ describe("runTelegramServer dispatch", () => {
       oneShot: true,
     });
 
-    expect(transport.typing).toEqual([1001]);
+    // 1+ typing actions (initial + chunk-driven refresh on text), all
+    // for the right chat. Exact count varies with chunk timing — the
+    // contract is "the user saw `typing…`," not a precise sequence.
+    expect(transport.typing.length).toBeGreaterThanOrEqual(1);
+    expect(transport.typing.every((c) => c === 1001)).toBe(true);
     expect(transport.sent).toEqual([{ chatId: 1001, text: "hi alice" }]);
     const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
     expect(stored).toEqual([
@@ -697,6 +701,89 @@ describe("runTelegramServer typing refresh", () => {
     // Wait longer than the refresh interval — no further typing should appear.
     await new Promise((r) => setTimeout(r, 150));
     expect(transport.typing.length).toBe(baseline);
+  });
+
+  test("text chunks trigger an extra typing refresh (so the indicator stays solid during streaming)", async () => {
+    // Streaming harness: emits text chunks at 50ms intervals for ~250ms.
+    // Pulse cadence is set high enough (5_000ms) that the pulse won't fire
+    // during the test window; any typing actions beyond the initial one
+    // must come from the chunk-driven refresh path.
+    class StreamingHarness implements Harness {
+      readonly id = "streaming";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        for (let i = 0; i < 5; i++) {
+          yield { type: "text", text: `chunk ${i} ` };
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        yield { type: "done", finalText: "chunk 0 chunk 1 chunk 2 chunk 3 chunk 4 " };
+      }
+    }
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "stream me",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new StreamingHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      typingRefreshMs: 5_000, // pulse won't fire in this window
+      oneShot: true,
+    });
+    // 1 initial sendStatus + at least 1 chunk-driven refresh during the
+    // ~250ms streaming window. The chunk path is throttled to 1 per 2s,
+    // so we expect 2 total (initial + first chunk past the throttle —
+    // which is the 0ms-old initial, so the first chunk goes through;
+    // subsequent chunks within 2s get throttled out).
+    expect(transport.typing.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("PULSE_INTERVALS_MS exposes exactly the documented set {4,6,8,10}s", async () => {
+    const { PULSE_INTERVALS_MS } = await import("../src/channels/telegram.ts");
+    expect([...PULSE_INTERVALS_MS]).toEqual([4000, 6000, 8000, 10000]);
+  });
+
+  test("random pulse: with no typingRefreshMs override, every interval picked falls in PULSE_INTERVALS_MS", async () => {
+    // Stub Math.random so we can exercise every index in the set.
+    const realRandom = Math.random;
+    const sequence = [0.0, 0.3, 0.6, 0.99]; // → 0, 1, 2, 3
+    let i = 0;
+    Math.random = () => sequence[i++ % sequence.length]!;
+    try {
+      const transport = new FakeTransport();
+      transport.pendingUpdates.push({
+        updateId: 1,
+        chatId: 1001,
+        fromUserId: 42,
+        text: "x",
+      });
+      // Quick harness — we only care that production code path (no
+      // typingRefreshMs) doesn't blow up and produces ≥1 typing call.
+      const harness = new ScriptedHarness("fake", [
+        { type: "done", finalText: "ok" },
+      ]);
+      await runTelegramServer({
+        config: baseConfig(),
+        memory,
+        harnesses: [harness],
+        agentDir,
+        persona: "phantom",
+        transport,
+        oneShot: true,
+        // typingRefreshMs intentionally NOT set → exercises random-pulse path.
+      });
+      expect(transport.typing.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      Math.random = realRandom;
+    }
   });
 });
 

--- a/tests/fixtures/fake-gemini.sh
+++ b/tests/fixtures/fake-gemini.sh
@@ -3,18 +3,17 @@
 #
 # Mirrors the surface of the real google-gemini/gemini-cli that the
 # GeminiHarness invokes:
-#   gemini -p <user_message> -o text -y [-m <model>]
+#   gemini -p <user_message> -o stream-json -y [-m <model>]
 #
 # Modes (set via FAKE_GEMINI_MODE):
-#   normal    — read stdin, echo "<reply prefix>" + last line of stdin + " | " + prompt arg, exit 0
+#   normal    — emit a fake stream-json transcript: init → tool_use →
+#               tool_result → assistant text deltas (whose content
+#               echoes the prompt + last stdin line so tests can
+#               verify stdin/argv plumbing) → result. Exit 0.
 #   error     — print "auth failed" to stderr, exit 1
 #   notfound  — exit 127 (simulates "command not found"-ish)
 #   hang      — sleep forever (timeout test)
 #   echo-args — print all argv joined with " | " on stdout, exit 0 (arg-shape test)
-#
-# Note: the real gemini -p reads stdin and appends the -p value. For
-# the normal-mode reply we synthesize something deterministic so tests
-# can assert on the output without needing a real model.
 
 mode="${FAKE_GEMINI_MODE:-normal}"
 
@@ -37,9 +36,29 @@ while IFS= read -r line; do
   fi
 done
 
+# JSON-escape a string for embedding inside a JSON-string literal.
+# Handles backslash, double-quote, and newline — enough for the
+# deterministic test payloads below.
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  printf '%s' "$s"
+}
+
 case "$mode" in
   normal)
-    printf 'GEMINI_REPLY: stdin=%s prompt=%s\n' "$last_stdin_line" "$prompt"
+    printf '{"type":"init","session_id":"fake","model":"fake-model"}\n'
+    printf '{"type":"tool_use","tool_name":"echo","tool_id":"t1","parameters":{}}\n'
+    printf '{"type":"tool_result","tool_id":"t1","status":"success"}\n'
+    # Two assistant deltas so the harness must concatenate them.
+    body=$(printf 'GEMINI_REPLY: stdin=%s prompt=%s' "$last_stdin_line" "$prompt")
+    head="${body:0:20}"
+    tail="${body:20}"
+    printf '{"type":"message","role":"assistant","content":"%s","delta":true}\n' "$(json_escape "$head")"
+    printf '{"type":"message","role":"assistant","content":"%s","delta":true}\n' "$(json_escape "$tail")"
+    printf '{"type":"result","status":"success","stats":{"total_tokens":42,"input_tokens":30,"output_tokens":12}}\n'
     exit 0
     ;;
   error)
@@ -53,9 +72,19 @@ case "$mode" in
     exec sleep 3600
     ;;
   echo-args)
-    # Joined argv on stdout for the arg-shape assertion.
-    IFS=' | '
-    printf '%s' "$*"
+    # Wrap argv inside a single fake assistant message so the harness's
+    # stream-json parser still picks up the content as `text`. The test
+    # asserts on substrings.
+    joined=""
+    for a in "$@"; do
+      if [ -z "$joined" ]; then
+        joined="$a"
+      else
+        joined="$joined | $a"
+      fi
+    done
+    printf '{"type":"message","role":"assistant","content":"%s","delta":true}\n' "$(json_escape "$joined")"
+    printf '{"type":"result","status":"success","stats":{}}\n'
     exit 0
     ;;
   *)

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -115,12 +115,36 @@ describe("parseStreamJson", () => {
     expect(parseStreamJson({ type: "result" })).toBeUndefined();
   });
 
-  test("returns undefined for assistant messages with no text parts (e.g. pure tool_use)", () => {
+  test("emits heartbeat for assistant messages with only non-text parts (e.g. pure tool_use)", () => {
     const c = parseStreamJson({
       type: "assistant",
       message: { content: [{ type: "tool_use", name: "Bash", input: {} }] },
     });
-    expect(c).toBeUndefined();
+    expect(c).toEqual({ type: "heartbeat" });
+  });
+
+  test("emits heartbeat for thinking blocks (and does NOT leak the content)", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: {
+        content: [{ type: "thinking", thinking: "internal chain-of-thought" }],
+      },
+    });
+    expect(c).toEqual({ type: "heartbeat" });
+    expect(JSON.stringify(c)).not.toContain("chain-of-thought");
+  });
+
+  test("text takes precedence: when a message has both text and tool_use, text wins (no heartbeat)", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "hello" },
+          { type: "tool_use", name: "Bash", input: {} },
+        ],
+      },
+    });
+    expect(c).toEqual({ type: "text", text: "hello" });
   });
 
   test("returns undefined for malformed input", () => {

--- a/tests/harnesses-gemini.test.ts
+++ b/tests/harnesses-gemini.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
 import {
   GeminiHarness,
+  parseGeminiEvent,
   renderStdinPayload,
 } from "../src/harnesses/gemini.ts";
 import type { HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
@@ -80,6 +81,84 @@ describe("renderStdinPayload (Gemini)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// parseGeminiEvent — pure mapper from stream-json to HarnessChunk
+// ---------------------------------------------------------------------------
+
+describe("parseGeminiEvent", () => {
+  test("assistant message → text chunk", () => {
+    expect(
+      parseGeminiEvent({
+        type: "message",
+        role: "assistant",
+        content: "hello",
+        delta: true,
+      }),
+    ).toEqual({ type: "text", text: "hello" });
+  });
+
+  test("user-echo message → undefined (no signal)", () => {
+    expect(
+      parseGeminiEvent({
+        type: "message",
+        role: "user",
+        content: "the prompt",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("tool_use → progress chunk with tool name in note", () => {
+    expect(
+      parseGeminiEvent({
+        type: "tool_use",
+        tool_name: "run_shell_command",
+        tool_id: "x",
+        parameters: {},
+      }),
+    ).toEqual({ type: "progress", note: "tool: run_shell_command" });
+  });
+
+  test("tool_use without tool_name → progress with placeholder", () => {
+    const c = parseGeminiEvent({ type: "tool_use" });
+    expect(c?.type).toBe("progress");
+  });
+
+  test("tool_result → heartbeat", () => {
+    expect(
+      parseGeminiEvent({
+        type: "tool_result",
+        tool_id: "x",
+        status: "success",
+      }),
+    ).toEqual({ type: "heartbeat" });
+  });
+
+  test("result → done with stats meta", () => {
+    const c = parseGeminiEvent({
+      type: "result",
+      status: "success",
+      stats: { total_tokens: 100, duration_ms: 500 },
+    });
+    expect(c?.type).toBe("done");
+    if (c?.type !== "done") return;
+    expect(c.finalText).toBe("");
+    expect(c.meta?.stats).toEqual({ total_tokens: 100, duration_ms: 500 });
+  });
+
+  test("init → undefined (session-start chatter)", () => {
+    expect(
+      parseGeminiEvent({ type: "init", session_id: "x", model: "y" }),
+    ).toBeUndefined();
+  });
+
+  test("malformed input → undefined", () => {
+    expect(parseGeminiEvent(null)).toBeUndefined();
+    expect(parseGeminiEvent("string")).toBeUndefined();
+    expect(parseGeminiEvent({})).toBeUndefined();
+    expect(parseGeminiEvent({ type: 42 })).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // End-to-end via the fake-gemini fixture
 // ---------------------------------------------------------------------------
 
@@ -91,7 +170,7 @@ describe("GeminiHarness.invoke (end-to-end via fake-gemini.sh)", () => {
     return new GeminiHarness({ bin: FAKE_GEMINI, model: "" });
   }
 
-  test("normal: stdin received, -p value used as prompt, exit 0 → text + done", async () => {
+  test("normal: stream-json events parsed; stdin + -p both reach the model; exit 0 → text + heartbeat + progress + done", async () => {
     process.env.FAKE_GEMINI_MODE = "normal";
     const chunks = await collect(
       harness().invoke(
@@ -106,18 +185,32 @@ describe("GeminiHarness.invoke (end-to-end via fake-gemini.sh)", () => {
       ),
     );
     delete process.env.FAKE_GEMINI_MODE;
-    // text chunk includes both stdin (last line) and the -p value
-    const textChunk = chunks.find((c) => c.type === "text");
-    expect(textChunk).toBeDefined();
-    if (textChunk?.type !== "text") return;
-    expect(textChunk.text).toContain("prompt=the new question");
-    expect(textChunk.text).toContain("Assistant: ok"); // last stdin line
-    // done chunk follows
+
+    // The fake's tool_use → progress chunk; tool_result → heartbeat;
+    // assistant deltas → text chunks (concatenated by the harness loop).
+    const progressChunks = chunks.filter((c) => c.type === "progress");
+    expect(progressChunks.length).toBe(1);
+    if (progressChunks[0]?.type === "progress") {
+      expect(progressChunks[0].note).toBe("tool: echo");
+    }
+
+    const heartbeats = chunks.filter((c) => c.type === "heartbeat");
+    expect(heartbeats.length).toBeGreaterThanOrEqual(1);
+
+    const textChunks = chunks.filter(
+      (c): c is { type: "text"; text: string } => c.type === "text",
+    );
+    const fullText = textChunks.map((c) => c.text).join("");
+    expect(fullText).toContain("prompt=the new question");
+    expect(fullText).toContain("Assistant: ok"); // last stdin line
+
+    // Final done carries the concatenated text and the result-event stats.
     const done = chunks.find((c) => c.type === "done");
     expect(done).toBeDefined();
     if (done?.type !== "done") return;
-    expect(done.finalText).toBe(textChunk.text);
+    expect(done.finalText).toBe(fullText);
     expect(done.meta?.harnessId).toBe("gemini");
+    expect(done.meta?.stats).toMatchObject({ total_tokens: 42 });
   });
 
   test("error: non-zero exit → recoverable error chunk; no done", async () => {
@@ -182,7 +275,7 @@ describe("GeminiHarness.invoke (end-to-end via fake-gemini.sh)", () => {
     expect(err.recoverable).toBe(true);
   });
 
-  test("argv shape: -p <user> -o text -y; -m only when model is non-empty", async () => {
+  test("argv shape: -p <user> -o stream-json -y; -m only when model is non-empty", async () => {
     process.env.FAKE_GEMINI_MODE = "echo-args";
     // No model.
     const noModel = await collect(
@@ -196,7 +289,7 @@ describe("GeminiHarness.invoke (end-to-end via fake-gemini.sh)", () => {
     expect(text1.text).toContain("-p");
     expect(text1.text).toContain("the message");
     expect(text1.text).toContain("-o");
-    expect(text1.text).toContain("text");
+    expect(text1.text).toContain("stream-json");
     expect(text1.text).toContain("-y");
     expect(text1.text).not.toContain("-m");
 

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -76,7 +76,7 @@ describe("parsePiEvent", () => {
     expect(c).toEqual({ type: "text", text: "hi" });
   });
 
-  test("ignores thinking_delta — those are the model's chain-of-thought, not the reply", () => {
+  test("emits heartbeat for thinking_delta (and does NOT leak the chain-of-thought content)", () => {
     const c = parsePiEvent({
       type: "message_update",
       assistantMessageEvent: {
@@ -87,10 +87,12 @@ describe("parsePiEvent", () => {
       },
       message: {},
     });
-    expect(c).toBeUndefined();
+    expect(c).toEqual({ type: "heartbeat" });
+    // The reasoning content MUST NOT appear in the chunk.
+    expect(JSON.stringify(c)).not.toContain("internal reasoning");
   });
 
-  test("ignores text_start / text_end / thinking_start / thinking_end markers", () => {
+  test("emits heartbeat for text_start / text_end / thinking_start / thinking_end markers", () => {
     for (const ameType of [
       "text_start",
       "text_end",
@@ -103,7 +105,7 @@ describe("parsePiEvent", () => {
           assistantMessageEvent: { type: ameType, contentIndex: 0 },
           message: {},
         }),
-      ).toBeUndefined();
+      ).toEqual({ type: "heartbeat" });
     }
   });
 


### PR DESCRIPTION
## Summary

Replaces the random-pulse approach with **pure event-driven** typing indicator refresh. Every refresh corresponds to an actual signal the harness emitted. When the harness goes silent, the Telegram chat-action lapses after ~5s — and that vanishing IS the truthful "model has gone quiet / possibly frozen" cue.

Per the design discussion: "if people read the code and see random shit here, they will feel defrauded." Now there's no random shit.

## New chunk type

`HarnessChunk` gains a **`heartbeat`** variant — payload-less; means "model is alive and producing reasoning, but nothing user-visible yet." The content of thinking blocks / tool deltas stays inside the harness subprocess; the channel layer just sees the existence of activity.

## All three harnesses now emit real signals

| Harness | Signal source | Emits |
|---|---|---|
| **Claude** stream-json | `assistant` content blocks of type `thinking` / `tool_use` / `tool_result` | `heartbeat` |
| **Pi** --mode json | `assistantMessageEvent` of type `thinking_delta` and other non-text variants | `heartbeat` |
| **Gemini** stream-json (NEW) | `tool_use` / `tool_result` events | `progress` (with tool name) / `heartbeat` |

**Chain-of-thought content is never embedded in the chunk** — explicit test assertions verify this for both Claude and Pi.

## Gemini port: -o text → -o stream-json

The biggest individual change. New `parseGeminiEvent` pure mapper covers the full schema (verified against gemini-cli v0.40.1):

- `init` → ignored (session-start chatter)
- `message` `role:user` → ignored (input echo)
- `message` `role:assistant` → `text` chunk
- `tool_use` → `progress` with `note: "tool: <name>"` — also feeds `/status` running-line, no gemini-specific knowledge needed elsewhere
- `tool_result` → `heartbeat`
- `result` → `done` carrying `stats` (token counts + duration) in meta

Final `done` chunk now includes `meta.stats` for logging / `/status`.

## Telegram channel

- **All timer code deleted**: no `setInterval`, no `setTimeout`-pulse, no random interval picker, no `PULSE_INTERVALS_MS` export, no `typingRefreshMs` injection point.
- New `typingThrottleMs` (default 2000ms) prevents stream-json bursts from spamming Telegram's chat-action endpoint.
- Indicator refreshes on every `text` / `heartbeat` / `progress` chunk, plus an initial nudge at turn start. `done` doesn't refresh.
- Post-turn `finally` no longer needs a timer cleanup.

## UX consequences

- **Active streaming** → indicator solid (real chunks ≥ once per 2s)
- **Silent thinking past ~5s** → indicator vanishes; user knows the bot is currently quiet
- **Tool execution** → indicator stays on (every tool_use/tool_result emits a chunk)
- **Frozen subprocess** (TCP wedge etc.) → no chunks → indicator vanishes after ~5s, signalling the user something is wrong

## Test plan

- [x] **515 pass, 1 skip, 0 fail** (up from 506 — 9 new tests)
- [x] Claude / Pi parser tests assert heartbeat emission AND that reasoning content is NOT leaked into the chunk
- [x] New `parseGeminiEvent` describe block covers all 6 event types + malformed input
- [x] New `typing indicator` describe block in `channels-telegram.test.ts`: initial nudge, multi-chunk-type refresh, throttle collapse, no-stale-timers
- [x] `fake-gemini.sh` rewritten to emit stream-json shape, JSON-escaped payloads
- [x] Smoke-tested against real `gemini` binary (v0.40.1): text + done chunks land with full token-stat meta

## Diff stats

`+445 / -214` across 10 files. Two new exports (`heartbeat` chunk type, `parseGeminiEvent`); all timer/random code deleted.