### PR TITLE
chore: point installer + updater at phantomyard/phantombot

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When Phantom is asked to *"SSH to the home lab and write a note to the Obsidian 
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/andrewagrahamhodges/phantombot/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh
 ```
 
 The script:
@@ -100,7 +100,7 @@ sudo loginctl enable-linger $USER
 > ⚠️ **The build target must remain `bun-linux-x64-baseline`.** If you "optimise" to plain `bun-linux-x64`, the binary will SIGILL on launch on any host without AVX2 (e.g. older silicon used by some self-hosters).
 
 ```bash
-git clone https://github.com/andrewagrahamhodges/phantombot.git
+git clone https://github.com/phantomyard/phantombot.git
 cd phantombot
 bun install
 bun run build                # → ./dist/phantombot (~98 MB, linux-x64-baseline)

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # phantombot installer.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/andrewagrahamhodges/phantombot/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh
 #
 # What it does:
 #   1. Detects host arch (x86_64 → x64, aarch64 → arm64).
@@ -25,7 +25,7 @@
 
 set -eu
 
-REPO="andrewagrahamhodges/phantombot"
+REPO="phantomyard/phantombot"
 INSTALL_DIR="${PHANTOMBOT_INSTALL_DIR:-$HOME/.local/bin}"
 
 # --- arch detection ------------------------------------------------------

--- a/src/lib/githubReleases.ts
+++ b/src/lib/githubReleases.ts
@@ -5,12 +5,11 @@
  * No GitHub auth needed because the repo is public; if the API ever rate-
  * limits us (60/h unauth), GITHUB_TOKEN in env is honored for higher caps.
  *
- * Repo coordinates default to the current upstream and are env-overridable
- * (PHANTOMBOT_UPDATE_REPO=owner/name) so the impending repo rename can be
- * staged through env without a phantombot rebuild.
+ * Repo coordinates are env-overridable (PHANTOMBOT_UPDATE_REPO=owner/name)
+ * so a future repo move can be staged through env without a rebuild.
  */
 
-const DEFAULT_REPO = "andrewagrahamhodges/phantombot";
+const DEFAULT_REPO = "phantomyard/phantombot";
 
 /** What kind of host arch the running phantombot needs an asset for. */
 export type SupportedArch = "x64" | "arm64";


### PR DESCRIPTION
## Summary
- Repo moved from `andrewagrahamhodges/phantombot` to the `phantomyard` org. This PR updates every hard-coded reference so `install.sh`, `phantombot update`, and the README all point at the new home.
- Touched: `install.sh` (usage comment + `REPO`), `README.md` (curl one-liner + `git clone` URL), `src/lib/githubReleases.ts` (`DEFAULT_REPO` + tightened the now-stale "impending rename" comment).
- `PHANTOMBOT_UPDATE_REPO` env override is preserved as the escape hatch for already-installed binaries that need to be redirected without a rebuild.

## Test plan
- [ ] `bun run typecheck` / `bun test` clean
- [ ] Spot-check rendered README links resolve to `github.com/phantomyard/phantombot`
- [ ] After merge: confirm `curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh` fetches the new release end-to-end on a fresh host
- [ ] After next release: confirm `phantombot update --check` on an old binary still works (it'll hit the old org until users reinstall — `PHANTOMBOT_UPDATE_REPO=phantomyard/phantombot` is the workaround)