### PR TITLE
ci: add typecheck + test on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   pull_request:
     branches: [main]
 
+# Explicit least-privilege scope. `pull_request` defaults to read-only
+# already, but stating it makes the intended attack surface auditable
+# and survives any future change in org/repo defaults.
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: ci
+
+# Runs on every PR targeting main. No `push:` block on purpose — the
+# `pull_request` event already restricts this to branches with an open PR
+# (equivalent to GitLab's "MR branch" behaviour). Branch protection on main
+# wires `typecheck` and `test` as required status checks; release.yml then
+# fires on PR-merged-to-main and cuts the actual binary release.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    # Per-job concurrency so a new push to the PR cancels the in-flight run
+    # of *this* job only — the sibling `test` job has its own group and
+    # cancels independently.
+    concurrency:
+      group: ci-typecheck-${{ github.head_ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # Pinned to match release.yml so CI gates against the same Bun
+          # the release job will actually build with.
+          bun-version: 1.x
+      - run: bun install --frozen-lockfile
+      - run: bun tsc --noEmit
+
+  test:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ci-test-${{ github.head_ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.x
+      - run: bun install --frozen-lockfile
+      - run: bun test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs **`typecheck`** and **`test`** as two parallel jobs on every PR targeting `main`.
- **Trigger:** `pull_request` to `main` only. No `push:` block — `pull_request` already restricts runs to branches with an open PR (the GitHub equivalent of GitLab's "MR branch" gating).
- **Bun:** `oven-sh/setup-bun@v2`, pinned to `1.x` to match `release.yml` so CI gates against the same Bun the release job will actually build with.
- **Concurrency:** per-job groups (`ci-typecheck-\${{ github.head_ref }}`, `ci-test-\${{ github.head_ref }}`) with `cancel-in-progress: true`, so a new push to a PR cancels the in-flight run of each job independently.
- **Does not touch `release.yml`** — that workflow already runs on PR-merged-to-main and stays as the release job.

## Follow-up (out of scope for this PR)
Once this PR shows a green run, wire `typecheck` and `test` into the branch-protection rule on `main` as required status checks. (Branch protection lets you select check names once they've been observed at least once.)

## Test plan
- [ ] This PR's own `typecheck` and `test` jobs go green
- [ ] Push a no-op commit to confirm the in-flight runs get cancelled (concurrency works)
- [ ] After merge: open a follow-up PR and confirm both checks fire on it too