### PR TITLE
fix(telegram+harness): no-reply, interrupt UX, interrupt context, gemini sandbox

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -112,7 +112,7 @@ function handleStop(ctx: SlashCommandContext): SlashCommandResult {
     return { reply: "no active turn to stop" };
   }
   const elapsedS = ((Date.now() - ctx.activeTurn.startTime) / 1000).toFixed(1);
-  ctx.activeTurn.controller.abort();
+  ctx.activeTurn.controller.abort("stop");
   log.info("commands: /stop fired", { chatId: ctx.chatId, elapsedS });
   return { reply: `stopped (was running ${elapsedS}s)` };
 }
@@ -130,7 +130,7 @@ async function handleReset(
     const elapsedS = (
       (Date.now() - ctx.activeTurn.startTime) / 1000
     ).toFixed(1);
-    ctx.activeTurn.controller.abort();
+    ctx.activeTurn.controller.abort("reset");
     stoppedNote = ` (and stopped an in-flight turn that was ${elapsedS}s in)`;
   }
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -204,6 +204,18 @@ function guessMimeFromPath(path: string): string {
   return "audio/ogg";
 }
 
+/**
+ * Render an AbortSignal.reason as a short string for logging.
+ * Callers pass plain strings ("stop", "reset", "interrupt"); the DOM
+ * default for a parameterless abort() is a DOMException — fold it down
+ * to its message so journalctl stays readable.
+ */
+function abortReasonString(reason: unknown): string {
+  if (typeof reason === "string") return reason;
+  if (reason instanceof Error) return reason.message;
+  return "aborted";
+}
+
 interface TelegramRawUpdate {
   update_id?: number;
   message?: {
@@ -411,7 +423,26 @@ export async function runTelegramServer(
           // Unrecognized /command — fall through to the LLM.
         }
 
-        // Regular message: enqueue onto this chat's serial chain.
+        // Regular message. If a turn is already in flight for this
+        // chat, abort it — the user typing again means "pay attention
+        // to this instead." The aborted turn returns silently via the
+        // wasAborted path; only the new turn's reply lands. Same UX
+        // as Claude Code's "type to interrupt." The new task still
+        // chains off `prev` (the aborted turn's worker promise) so
+        // the harness's process group has time to clean up before we
+        // spawn the next subprocess.
+        const active = activeTurns.get(msg.chatId);
+        if (active) {
+          log.info("telegram: new message — interrupting active turn", {
+            chatId: msg.chatId,
+            elapsedS: (
+              (Date.now() - active.startTime) / 1000
+            ).toFixed(1),
+          });
+          active.controller.abort("interrupt");
+        }
+
+        // Enqueue onto this chat's serial chain.
         const prev = chatChains.get(msg.chatId) ?? Promise.resolve();
         const next = prev.then(() =>
           processChatMessage(msg, {
@@ -600,14 +631,18 @@ async function processChatMessage(
     }
   }
 
-  // /stop: the controller was aborted from outside. The reply text
-  // already came through from the slash command handler — don't send
-  // a second "(error: stopped)" message.
-  const wasStopped = controller.signal.aborted;
-  if (wasStopped) {
-    log.info("telegram: turn stopped by /stop", {
+  // The controller was aborted from outside. Causes:
+  //   - "stop"      — /stop slash command (slash handler already replied).
+  //   - "reset"     — /reset slash command (handler replied).
+  //   - "interrupt" — a new message arrived for this chat; the new
+  //                   turn supersedes us. Stay silent so only the new
+  //                   reply lands.
+  // In every case, suppress the would-be reply.
+  if (controller.signal.aborted) {
+    log.info("telegram: turn aborted", {
       chatId: msg.chatId,
       durationMs: Date.now() - startedAt,
+      reason: abortReasonString(controller.signal.reason),
     });
     return;
   }

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -633,17 +633,48 @@ async function processChatMessage(
 
   // The controller was aborted from outside. Causes:
   //   - "stop"      — /stop slash command (slash handler already replied).
-  //   - "reset"     — /reset slash command (handler replied).
+  //   - "reset"     — /reset slash command (handler replied; history wiped).
   //   - "interrupt" — a new message arrived for this chat; the new
   //                   turn supersedes us. Stay silent so only the new
   //                   reply lands.
   // In every case, suppress the would-be reply.
   if (controller.signal.aborted) {
+    const reason = abortReasonString(controller.signal.reason);
     log.info("telegram: turn aborted", {
       chatId: msg.chatId,
       durationMs: Date.now() - startedAt,
-      reason: abortReasonString(controller.signal.reason),
+      reason,
     });
+    // Persist a synthetic interrupted-pair so the next turn knows what
+    // the user just said and that the agent never got to respond.
+    // Without this, follow-ups like "actually use blue instead" land
+    // with no referent in history and the model is surprised. Skip
+    // when:
+    //   - reason === "reset"  → /reset just wiped this conversation;
+    //                           writing here would un-wipe it.
+    //   - msg.text.length === 0 → voice message aborted before STT
+    //                             completed; nothing meaningful to log.
+    if (reason !== "reset" && msg.text.length > 0) {
+      try {
+        await input.memory.appendTurn({
+          persona: input.persona,
+          conversation: `telegram:${msg.chatId}`,
+          role: "user",
+          text: msg.text,
+        });
+        await input.memory.appendTurn({
+          persona: input.persona,
+          conversation: `telegram:${msg.chatId}`,
+          role: "assistant",
+          text: "[interrupted before reply]",
+        });
+      } catch (e) {
+        log.warn("telegram: failed to persist interrupted-pair", {
+          chatId: msg.chatId,
+          error: (e as Error).message,
+        });
+      }
+    }
     return;
   }
 

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -349,6 +349,18 @@ export function renderStdinPayload(req: HarnessRequest): string {
   return parts.join("\n\n") + (parts.length > 0 ? "\n\n" : "");
 }
 
+/**
+ * Per-invocation banner lines that gemini-cli always prints — useless
+ * noise at info level. Anything else (auth failures, quota errors,
+ * network warnings) gets surfaced so journalctl shows it without needing
+ * PHANTOMBOT_LOG_LEVEL=debug.
+ */
+const GEMINI_STDERR_BANNER_PATTERNS: readonly RegExp[] = [
+  /^Warning: 256-color support not detected/i,
+  /^YOLO mode is enabled/i,
+  /^Ripgrep is not available/i,
+];
+
 async function consumeStderr(
   stream: ReadableStream<Uint8Array>,
 ): Promise<void> {
@@ -360,9 +372,13 @@ async function consumeStderr(
       const lines = buf.split("\n");
       buf = lines.pop() ?? "";
       for (const line of lines) {
-        if (line.trim()) {
-          log.debug("gemini stderr", { text: line.slice(0, 500) });
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        if (GEMINI_STDERR_BANNER_PATTERNS.some((re) => re.test(trimmed))) {
+          log.debug("gemini stderr (banner)", { text: trimmed.slice(0, 500) });
+          continue;
         }
+        log.info("gemini stderr", { text: trimmed.slice(0, 500) });
       }
     }
   } catch {

--- a/src/orchestrator/fallback.ts
+++ b/src/orchestrator/fallback.ts
@@ -92,6 +92,25 @@ export async function* runWithFallback(
         yield chunk;
         return;
       }
+      // Empty `done` = the harness exited cleanly but produced no
+      // assistant text (gemini SIGTERMed mid-stream by an updater
+      // restart, or a tool-only run with no final message). On a
+      // non-last harness, fall through — pi getting a chance is far
+      // better than the user seeing "(no reply)". On the last harness,
+      // yield it and let the channel surface "(no reply)" so the user
+      // knows something happened.
+      if (
+        chunk.type === "done" &&
+        chunk.finalText.length === 0 &&
+        !isLast
+      ) {
+        log.warn(
+          "orchestrator: harness produced empty reply, falling through",
+          { harnessId: harness.id },
+        );
+        recoverableError = true;
+        break;
+      }
       yield chunk;
       if (chunk.type === "done") succeeded = true;
     }

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -21,6 +21,8 @@
  * to catch them and present cleanly.
  */
 
+import { homedir } from "node:os";
+
 import { runWithFallback } from "./fallback.ts";
 import { buildSystemPrompt } from "../persona/builder.ts";
 import { loadPersona } from "../persona/loader.ts";
@@ -36,6 +38,16 @@ export interface TurnInput {
   userMessage: string;
   /** Path to the persona directory (BOOT.md / SOUL.md / IDENTITY.md etc. live here). */
   agentDir: string;
+  /**
+   * cwd for harness subprocesses. Defaults to the running user's home
+   * dir. Set to `agentDir` (or anything else) to scope down. Affects:
+   *   - pi:     where relative-path tools resolve (no sandbox).
+   *   - claude: same + the "trusted dir" framing for the workspace.
+   *   - gemini: the *workspace sandbox root* — gemini hard-rejects tool
+   *             calls that touch paths outside cwd + its temp dir.
+   * Persona files load via absolute paths regardless of this setting.
+   */
+  workingDir?: string;
   /** Harness chain in priority order; first that succeeds wins. */
   harnesses: Harness[];
   /** Open memory store; runTurn appends to it on success. */
@@ -85,7 +97,7 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
     systemPrompt,
     userMessage: input.userMessage,
     history,
-    workingDir: input.agentDir,
+    workingDir: input.workingDir ?? homedir(),
     idleTimeoutMs: input.idleTimeoutMs,
     hardTimeoutMs: input.hardTimeoutMs,
     signal: input.signal,

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -900,9 +900,16 @@ describe("runTelegramServer slash commands", () => {
     );
     expect(errorReplies).toEqual([]);
     expect(harness.lastSignalAborted).toBe(true);
-    // No turn was persisted (failed turn → no history).
+    // The aborted turn persists a synthetic interrupted-pair so the
+    // next user message has context for follow-ups like "actually do X
+    // instead." Skipped only when the abort reason is "reset" (history
+    // was just wiped) or the message text is empty (voice STT aborted
+    // before it ran).
     const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
-    expect(stored).toEqual([]);
+    expect(stored).toEqual([
+      { role: "user", text: "kick off something slow" },
+      { role: "assistant", text: "[interrupted before reply]" },
+    ]);
   });
 
   test("a second non-slash message interrupts an in-flight turn (no reply for the aborted one)", async () => {
@@ -986,10 +993,13 @@ describe("runTelegramServer slash commands", () => {
       s.text.includes("(error:"),
     );
     expect(errorReplies).toEqual([]);
-    // Only the second turn was persisted (aborted first turn never reached
-    // the on-success persist branch, so its user message isn't in history).
+    // History records the interrupted message + a synthetic "[interrupted
+    // before reply]" so the model has context for the follow-up. Then
+    // the second turn's successful user/assistant pair lands as normal.
     const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
     expect(stored.map((t) => t.text)).toEqual([
+      "kick off something slow",
+      "[interrupted before reply]",
       "actually do this instead",
       "second reply",
     ]);

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -905,6 +905,96 @@ describe("runTelegramServer slash commands", () => {
     expect(stored).toEqual([]);
   });
 
+  test("a second non-slash message interrupts an in-flight turn (no reply for the aborted one)", async () => {
+    // First message kicks off a slow harness; ~30ms later a second
+    // message arrives. The first turn should be aborted — no reply
+    // sent — and the second message's reply should land.
+    class InterruptableHarness implements Harness {
+      readonly id = "interruptable";
+      invocations = 0;
+      abortedSignals: boolean[] = [];
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        const turn = ++this.invocations;
+        if (turn === 1) {
+          // Slow turn — only ends when aborted.
+          yield { type: "text", text: "thinking…" };
+          await new Promise<void>((resolve) => {
+            if (req.signal?.aborted) return resolve();
+            req.signal?.addEventListener(
+              "abort",
+              () => {
+                this.abortedSignals.push(true);
+                resolve();
+              },
+              { once: true },
+            );
+            setTimeout(resolve, 5_000);
+          });
+          yield { type: "error", error: "stopped", recoverable: false };
+          return;
+        }
+        // Second turn — a fresh, fast reply.
+        yield { type: "text", text: "second reply" };
+        yield { type: "done", finalText: "second reply" };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "kick off something slow",
+    });
+    setTimeout(() => {
+      transport.pendingUpdates.push({
+        updateId: 2,
+        chatId: 1001,
+        fromUserId: 42,
+        text: "actually do this instead",
+      });
+    }, 30);
+
+    const harness = new InterruptableHarness();
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 300);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      signal: ac.signal,
+    });
+
+    // First turn was aborted (signal fired).
+    expect(harness.abortedSignals).toEqual([true]);
+    // Second turn ran.
+    expect(harness.invocations).toBe(2);
+    // Exactly one user-visible reply: the second turn's.
+    const userReplies = transport.sent.filter(
+      (s) => !s.text.startsWith("/"),
+    );
+    expect(userReplies.length).toBe(1);
+    expect(userReplies[0]!.text).toBe("second reply");
+    // No "(error:" leak from the aborted first turn.
+    const errorReplies = transport.sent.filter((s) =>
+      s.text.includes("(error:"),
+    );
+    expect(errorReplies).toEqual([]);
+    // Only the second turn was persisted (aborted first turn never reached
+    // the on-success persist branch, so its user message isn't in history).
+    const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
+    expect(stored.map((t) => t.text)).toEqual([
+      "actually do this instead",
+      "second reply",
+    ]);
+  });
+
   test("/status reports the current primary harness", async () => {
     const transport = new FakeTransport();
     transport.pendingUpdates.push({

--- a/tests/orchestrator-fallback.test.ts
+++ b/tests/orchestrator-fallback.test.ts
@@ -130,3 +130,45 @@ describe("runWithFallback — maxPayloadBytes precheck", () => {
     expect(chunks.map((c) => c.type)).toEqual(["done"]);
   });
 });
+
+describe("runWithFallback — empty done falls through", () => {
+  test("non-last harness emitting done with empty finalText falls through", async () => {
+    // Repro of the gemini "(no reply)" bug: gemini exits 0 (e.g.
+    // SIGTERMed by an updater restart, or did tool calls without a
+    // final assistant message) and yields done with empty finalText.
+    // Without the fall-through, the orchestrator considered this
+    // success and the user got "(no reply)" instead of pi's reply.
+    const empty = new FakeHarness("gemini-like", [
+      { type: "progress", note: "tool: do_something" },
+      { type: "done", finalText: "" },
+    ]);
+    const filler = new FakeHarness("pi-like", [
+      { type: "text", text: "real reply" },
+      { type: "done", finalText: "real reply" },
+    ]);
+    const chunks = await collect(
+      runWithFallback([empty, filler], newRequest()),
+    );
+    expect(empty.invocations).toBe(1);
+    expect(filler.invocations).toBe(1);
+    // The empty done is suppressed; pi's progress + real reply land.
+    expect(chunks.map((c) => c.type)).toEqual(["progress", "text", "done"]);
+    const last = chunks[chunks.length - 1];
+    expect(last && last.type === "done" ? last.finalText : "").toBe(
+      "real reply",
+    );
+  });
+
+  test("LAST harness emitting done with empty finalText still yields the empty done", async () => {
+    // We deliberately preserve the existing "(no reply)" surface on the
+    // last harness so the user sees that something happened — better
+    // than no reply at all when there are no more harnesses to try.
+    const empty = new FakeHarness("only", [
+      { type: "done", finalText: "" },
+    ]);
+    const chunks = await collect(runWithFallback([empty], newRequest()));
+    expect(empty.invocations).toBe(1);
+    expect(chunks.map((c) => c.type)).toEqual(["done"]);
+    expect(chunks[0]).toMatchObject({ type: "done", finalText: "" });
+  });
+});

--- a/tests/orchestrator-turn.test.ts
+++ b/tests/orchestrator-turn.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { runTurn } from "../src/orchestrator/turn.ts";
 import {
@@ -90,6 +90,49 @@ describe("runTurn — successful path", () => {
       { role: "user", text: "hello" },
       { role: "assistant", text: "hi there" },
     ]);
+  });
+
+  test("workingDir defaults to the running user's home dir (gemini sandbox spans the whole user account)", async () => {
+    let captured: HarnessRequest | undefined;
+    const harness = new ScriptedHarness(
+      "fake",
+      [{ type: "done", finalText: "ok" }],
+      (req) => {
+        captured = req;
+      },
+    );
+
+    await collect(
+      runTurn({
+        ...baseInput(),
+        userMessage: "x",
+        harnesses: [harness],
+      }),
+    );
+
+    expect(captured?.workingDir).toBe(homedir());
+  });
+
+  test("workingDir override is respected (callers can scope down)", async () => {
+    let captured: HarnessRequest | undefined;
+    const harness = new ScriptedHarness(
+      "fake",
+      [{ type: "done", finalText: "ok" }],
+      (req) => {
+        captured = req;
+      },
+    );
+
+    await collect(
+      runTurn({
+        ...baseInput(),
+        userMessage: "x",
+        harnesses: [harness],
+        workingDir: agentDir,
+      }),
+    );
+
+    expect(captured?.workingDir).toBe(agentDir);
   });
 
   test("passes loaded history to the harness", async () => {


### PR DESCRIPTION
## Summary

Four related fixes for Lena's slow / empty-reply behaviour, all motivated by what showed up in her journal once we bumped gemini stderr to `info`. Validated live on Lena's box across a real-work session.

### 1. `18a2a9d` — empty-done falls through to next harness
gemini exits 0 with `finalText=""` (SIGTERMed mid-stream by an updater restart, or a tool-only run that never produces an assistant message). The orchestrator was treating this as success and the channel sent `"(no reply)"` — even though pi was sitting right there in the chain. Now: empty `done` from a non-last harness is recoverable; chain falls through. Last-harness empty-done still surfaces `"(no reply)"` so the user knows something happened.

### 2. `92f41e3` — new message interrupts in-flight turn
Before: a second non-slash message queued behind the first on the per-chat serial chain, so users had to wait for a 1–3 min gemini turn (or remember `/stop`) before getting a reply to a new instruction. After: when a non-slash message arrives for a chat with an active turn, the polling loop calls `controller.abort("interrupt")` on the in-flight turn before enqueueing the new one. Same UX as Claude Code's "type to interrupt." `/stop` and `/reset` now also pass string reasons so the new `telegram: turn aborted` log line distinguishes the three causes for journalctl post-mortems.

### 3. `394addd` — aborted turns persist `[interrupted before reply]`
Without this the user's interrupted message vanished from history, and follow-ups like *"actually use blue instead"* landed with no referent — the model had no idea what was being re-described. The aborted turn now writes a synthetic user + `"[interrupted before reply]"` assistant pair to memory before returning. Skipped on `reason === "reset"` (history was just wiped) and on empty `msg.text` (voice STT aborted before transcript). Pattern matches phantomops's `__interrupted__` marker — validated as the right shape for the surprise problem without porting their full `--session` JSONL hydration model.

### 4. `af596da` — default harness cwd to user's home, not persona dir
Lena's journal showed every gemini turn failing tool calls with `Path not in workspace` — gemini-cli sandboxes itself to cwd, and phantombot was launching it in the persona dir (`~/.local/share/phantombot/personas/<name>/`). She couldn't access `~/Projects/phantombot/www` where her actual work lives, so every `list_directory` / `write_file` got rejected and the model produced vague empty replies. Pi has no sandbox and Claude (in `--permission-mode bypassPermissions`) accepts absolute paths, so this only mattered for gemini in practice — but the fix is harness-agnostic: change the default cwd to `os.homedir()`. `TurnInput` grows an optional `workingDir` field for callers that want to scope down.

### Side benefit (in commit 1)
Bumped gemini stderr from `debug` to `info` (per-invocation banners filtered out). This is what surfaced both root causes above (workspace sandbox + Google `MODEL_CAPACITY_EXHAUSTED` 429s) — they were invisible at the default log level before.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 521 pass / 0 fail (was 516)
- [x] New tests cover: empty-done fallthrough, last-harness empty-done preservation, interrupt-on-new-message, persisted interrupted-pair, `workingDir` default + override
- [x] Live test on Lena's box: interrupt fired correctly (`telegram: new message — interrupting active turn elapsedS=5.1` → `gemini.invoke killed: aborted` → `telegram: turn aborted reason=interrupt` → fresh turn started)
- [x] Live test: workspace fix confirmed — first post-deploy turn completed in 18s with replyChars=284 and zero `Path not in workspace` errors
- [ ] Open: still observing how the empty-done fallthrough behaves under live Google rate-limit conditions