### PR TITLE
feat(telegram): pass arbitrary attachments through to the harness

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -15,7 +15,10 @@
  * answered. We log a warning at startup so this isn't accidental.
  */
 
-import type { Config } from "../config.ts";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { type Config, xdgDataHome } from "../config.ts";
 import type { Harness } from "../harnesses/types.ts";
 import {
   type AudioSupport,
@@ -33,19 +36,97 @@ import {
   handleSlashCommand,
 } from "./commands.ts";
 
+/**
+ * Telegram bot-API hard cap on file downloads. `getFile` rejects requests
+ * for larger files outright, regardless of attachment type. Documented at
+ * https://core.telegram.org/bots/api#getfile. Client-side uploads can be
+ * much bigger, but bots literally cannot fetch them through this API —
+ * the right user-facing behavior is to surface the size and move on, not
+ * to silently drop.
+ */
+const TELEGRAM_BOT_DOWNLOAD_CAP_BYTES = 20 * 1024 * 1024;
+
+/** Per-chat inbox where Telegram attachments are saved. */
+export function inboxDir(chatId: number): string {
+  return join(xdgDataHome(), "phantombot", "inbox", String(chatId));
+}
+
+/**
+ * Build the user message handed to the harness for an attachment-bearing
+ * Telegram message. Caption + a single bracketed line that names the
+ * absolute file path (or explains why we couldn't fetch it). The agent
+ * decides what to do — read it, ignore it, ask for clarification.
+ *
+ * Exported for testing.
+ */
+export function formatAttachmentUserText(args: {
+  caption: string | undefined;
+  attachment: TelegramAttachment;
+  /** Absolute path on disk if the download succeeded. */
+  savedPath?: string;
+  /** Set when the file was over Telegram's bot-API download cap. */
+  oversizeBytes?: number;
+  /** Set when getFile or the actual download threw. */
+  downloadError?: string;
+}): string {
+  const captionPart = (args.caption ?? "").trim();
+  let line: string;
+  if (args.savedPath) {
+    line = `[attached: ${args.savedPath}]`;
+  } else if (args.oversizeBytes !== undefined) {
+    const mb = (args.oversizeBytes / 1024 / 1024).toFixed(1);
+    line = `[attached but too large to fetch: ${args.attachment.fileName} (${mb} MB > 20 MB Telegram bot-API cap)]`;
+  } else {
+    line = `[attached but couldn't download: ${args.attachment.fileName}${args.downloadError ? ` (${args.downloadError})` : ""}]`;
+  }
+  return captionPart ? `${captionPart}\n\n${line}` : line;
+}
+
+export interface TelegramAttachment {
+  /** Telegram file_id; pass to getFile + the resulting file_path URL. */
+  fileId: string;
+  /** Filename to use on disk. Either Telegram's `file_name` (documents,
+   *  audio, video) or synthesized from the message id + kind + mime. */
+  fileName: string;
+  /** Bytes if Telegram included it. Used to skip the download when the
+   *  file is over Telegram's bot-API cap (getFile rejects > 20 MB). */
+  fileSize?: number;
+  /** MIME type if Telegram included one. */
+  mimeType?: string;
+  /** The Telegram message field this came from — useful for log clarity. */
+  kind:
+    | "document"
+    | "photo"
+    | "audio"
+    | "video"
+    | "video_note"
+    | "animation"
+    | "sticker";
+}
+
 export interface TelegramMessage {
   updateId: number;
   chatId: number;
   fromUserId: number;
   fromUsername?: string;
-  /** For text messages — the text. For voice messages — empty string until STT runs. */
+  /** For text messages — the text. For voice messages — empty string until
+   *  STT runs. For attachment-only messages — empty until processChatMessage
+   *  rewrites it to "<caption>\n\n[attached: <path>]". */
   text: string;
-  /** Set when the incoming message was a voice note. */
+  /** Caption accompanying media (Telegram delivers `caption` not `text`
+   *  for media messages). Empty when absent. */
+  caption?: string;
+  /** Set when the incoming message was a voice note. Voice keeps its
+   *  dedicated STT path; it is NOT carried via `attachment`. */
   voice?: {
     fileId: string;
     mimeType: string;
     durationS: number;
   };
+  /** Any non-voice attachment (photo, document, audio, video, etc.).
+   *  Downloaded to the per-chat inbox and surfaced to the harness as
+   *  an absolute path the agent can `read`. */
+  attachment?: TelegramAttachment;
 }
 
 export interface TelegramTransport {
@@ -216,18 +297,175 @@ function abortReasonString(reason: unknown): string {
   return "aborted";
 }
 
+interface TelegramRawFile {
+  file_id?: string;
+  file_size?: number;
+  mime_type?: string;
+  file_name?: string;
+}
+
+interface TelegramRawPhotoSize {
+  file_id?: string;
+  file_size?: number;
+  width?: number;
+  height?: number;
+}
+
 interface TelegramRawUpdate {
   update_id?: number;
   message?: {
+    message_id?: number;
     chat?: { id?: number };
     from?: { id?: number; username?: string };
     text?: string;
+    caption?: string;
     voice?: {
       duration?: number;
       mime_type?: string;
       file_id?: string;
     };
+    document?: TelegramRawFile;
+    audio?: TelegramRawFile;
+    video?: TelegramRawFile;
+    video_note?: TelegramRawFile;
+    animation?: TelegramRawFile;
+    sticker?: TelegramRawFile;
+    photo?: TelegramRawPhotoSize[];
   };
+}
+
+/**
+ * Walk a raw message looking for an attachment. Photos are an array of
+ * sizes; we pick the largest. Voice is intentionally skipped — it has its
+ * own STT path. Returns undefined when the message has nothing
+ * attachment-shaped.
+ *
+ * Exported for testing.
+ */
+export function extractAttachment(
+  msg: NonNullable<TelegramRawUpdate["message"]>,
+): TelegramAttachment | undefined {
+  const msgId = typeof msg.message_id === "number" ? msg.message_id : 0;
+
+  // Documents/audio/video/etc. all have the same shape: file_id + optional
+  // file_name, mime_type, file_size. Walked in priority order.
+  const simpleKinds: Array<{
+    field: TelegramAttachment["kind"];
+    raw: TelegramRawFile | undefined;
+  }> = [
+    { field: "document", raw: msg.document },
+    { field: "audio", raw: msg.audio },
+    { field: "video", raw: msg.video },
+    { field: "video_note", raw: msg.video_note },
+    { field: "animation", raw: msg.animation },
+    { field: "sticker", raw: msg.sticker },
+  ];
+  for (const { field, raw } of simpleKinds) {
+    if (raw && typeof raw.file_id === "string") {
+      return {
+        fileId: raw.file_id,
+        fileName: raw.file_name ?? synthesizeFileName(msgId, field, raw.mime_type),
+        fileSize: typeof raw.file_size === "number" ? raw.file_size : undefined,
+        mimeType: raw.mime_type,
+        kind: field,
+      };
+    }
+  }
+
+  // Photos: pick the largest size. file_size may be missing on some
+  // sizes; rank by (file_size ?? width*height ?? 0) descending.
+  if (Array.isArray(msg.photo) && msg.photo.length > 0) {
+    const sized = msg.photo
+      .filter((p): p is TelegramRawPhotoSize & { file_id: string } =>
+        typeof p?.file_id === "string",
+      )
+      .map((p) => ({
+        p,
+        rank:
+          p.file_size ??
+          (typeof p.width === "number" && typeof p.height === "number"
+            ? p.width * p.height
+            : 0),
+      }))
+      .sort((a, b) => b.rank - a.rank);
+    const best = sized[0]?.p;
+    if (best) {
+      return {
+        fileId: best.file_id,
+        fileName: synthesizeFileName(msgId, "photo", "image/jpeg"),
+        fileSize: typeof best.file_size === "number" ? best.file_size : undefined,
+        mimeType: "image/jpeg",
+        kind: "photo",
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function synthesizeFileName(
+  msgId: number,
+  kind: TelegramAttachment["kind"],
+  mimeType: string | undefined,
+): string {
+  return `${msgId}-${kind}${extensionFromMime(mimeType)}`;
+}
+
+/**
+ * Map a MIME to a file extension. Conservative: handles the common ones
+ * we'll actually see from Telegram (photo, voice, audio, video, common
+ * documents); unknown → ".bin" so we still write *something* the agent
+ * can `read`. Exported for testing.
+ */
+export function extensionFromMime(mime: string | undefined): string {
+  if (!mime) return ".bin";
+  const m = mime.toLowerCase().split(";")[0]!.trim();
+  switch (m) {
+    case "image/jpeg":
+    case "image/jpg":
+      return ".jpg";
+    case "image/png":
+      return ".png";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    case "image/heic":
+      return ".heic";
+    case "application/pdf":
+      return ".pdf";
+    case "text/plain":
+      return ".txt";
+    case "text/markdown":
+      return ".md";
+    case "text/csv":
+      return ".csv";
+    case "application/json":
+      return ".json";
+    case "application/zip":
+      return ".zip";
+    case "audio/ogg":
+      return ".ogg";
+    case "audio/mpeg":
+      return ".mp3";
+    case "audio/mp4":
+      return ".m4a";
+    case "video/mp4":
+      return ".mp4";
+    case "video/quicktime":
+      return ".mov";
+    case "video/webm":
+      return ".webm";
+    default:
+      // Generic fallback: take everything after the slash, strip
+      // anything non-alphanumeric, cap at 8 chars. So "application/
+      // vnd.openxmlformats-officedocument.wordprocessingml.document"
+      // becomes ".vndopenx" — ugly but unique-ish, and the absolute
+      // path the agent gets includes the kind, so it's fine.
+      const sub = m.split("/")[1] ?? "";
+      const cleaned = sub.replace(/[^a-z0-9]/g, "").slice(0, 8);
+      return cleaned ? `.${cleaned}` : ".bin";
+  }
 }
 
 /**
@@ -254,6 +492,28 @@ export function parseGetUpdatesResult(
       continue;
     }
 
+    // Attachments take priority over plain text, but if BOTH text and an
+    // attachment are present (rare; Telegram normally uses `caption` not
+    // `text` for media), use text as the caption.
+    const attachment = extractAttachment(msg);
+    if (attachment) {
+      const captionFromMedia =
+        typeof msg.caption === "string" ? msg.caption : undefined;
+      const captionFromText =
+        typeof msg.text === "string" && msg.text.length > 0
+          ? msg.text
+          : undefined;
+      updates.push({
+        updateId: u.update_id,
+        chatId: msg.chat.id,
+        fromUserId: msg.from.id,
+        fromUsername: msg.from.username,
+        text: "", // filled by processChatMessage after download
+        caption: captionFromMedia ?? captionFromText,
+        attachment,
+      });
+      continue;
+    }
     if (typeof msg.text === "string" && msg.text.length > 0) {
       updates.push({
         updateId: u.update_id,
@@ -393,6 +653,15 @@ export async function runTelegramServer(
           persona: input.persona,
           voice: isVoice,
           voiceDurationS: msg.voice?.durationS,
+          attachment: msg.attachment
+            ? {
+                kind: msg.attachment.kind,
+                fileName: msg.attachment.fileName,
+                fileSize: msg.attachment.fileSize,
+                mimeType: msg.attachment.mimeType,
+              }
+            : undefined,
+          captionLength: msg.caption?.length,
         });
 
         // Slash commands: handled INLINE so they bypass the per-chat queue
@@ -525,6 +794,62 @@ async function processChatMessage(
       );
       return;
     }
+  }
+
+  // Non-voice attachment: download to per-chat inbox, then rewrite the
+  // user-facing text to "<caption>\n\n[attached: <abs-path>]". The
+  // harness decides what to do with the file — read, ignore, ask. We
+  // never inspect or transform contents.
+  if (msg.attachment) {
+    const att = msg.attachment;
+    let savedPath: string | undefined;
+    let oversizeBytes: number | undefined;
+    let downloadError: string | undefined;
+
+    if (
+      att.fileSize !== undefined &&
+      att.fileSize > TELEGRAM_BOT_DOWNLOAD_CAP_BYTES
+    ) {
+      oversizeBytes = att.fileSize;
+      log.warn("telegram: attachment over bot-API cap, not downloading", {
+        chatId: msg.chatId,
+        kind: att.kind,
+        fileName: att.fileName,
+        fileSize: att.fileSize,
+      });
+    } else {
+      try {
+        const dir = inboxDir(msg.chatId);
+        await mkdir(dir, { recursive: true });
+        const path = join(dir, `${msg.updateId}-${att.fileName}`);
+        const file = await input.transport.downloadFile(att.fileId);
+        await writeFile(path, file.data);
+        savedPath = path;
+        log.info("telegram: attachment saved", {
+          chatId: msg.chatId,
+          kind: att.kind,
+          path,
+          bytes: file.data.byteLength,
+          mime: file.mime,
+        });
+      } catch (e) {
+        downloadError = (e as Error).message;
+        log.error("telegram: attachment download failed", {
+          chatId: msg.chatId,
+          kind: att.kind,
+          fileName: att.fileName,
+          error: downloadError,
+        });
+      }
+    }
+
+    msg.text = formatAttachmentUserText({
+      caption: msg.caption,
+      attachment: att,
+      savedPath,
+      oversizeBytes,
+      downloadError,
+    });
   }
 
   // Send the right indicator depending on which way we'll reply.

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -15,7 +15,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   HttpTelegramTransport,
+  extensionFromMime,
+  extractAttachment,
+  formatAttachmentUserText,
+  inboxDir,
   parseGetUpdatesResult,
+  type TelegramAttachment,
   type TelegramMessage,
   type TelegramTransport,
   runTelegramServer,
@@ -36,6 +41,8 @@ class FakeTransport implements TelegramTransport {
   recording: number[] = [];
   downloadedFileIds: string[] = [];
   fakeFileBytes = Buffer.from([0x4f, 0x67, 0x67, 0x53]); // "OggS" magic
+  /** Per-fileId override for `downloadFile`. */
+  fileResponses: Map<string, { data: Buffer; mime: string } | Error> = new Map();
   receivedSignals: Array<AbortSignal | undefined> = [];
   async getUpdates(
     offset: number,
@@ -75,6 +82,9 @@ class FakeTransport implements TelegramTransport {
     fileId: string,
   ): Promise<{ data: Buffer; mime: string }> {
     this.downloadedFileIds.push(fileId);
+    const override = this.fileResponses.get(fileId);
+    if (override instanceof Error) throw override;
+    if (override) return override;
     return { data: this.fakeFileBytes, mime: "audio/ogg" };
   }
 }
@@ -140,6 +150,211 @@ describe("parseGetUpdatesResult", () => {
   test("preserves prior offset on empty result", () => {
     expect(parseGetUpdatesResult([], 555).nextOffset).toBe(555);
   });
+
+  test("extracts a document attachment with caption", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 300,
+          message: {
+            message_id: 77,
+            chat: { id: 1 },
+            from: { id: 42 },
+            caption: "look at this",
+            document: {
+              file_id: "doc-abc",
+              file_name: "report.pdf",
+              file_size: 12345,
+              mime_type: "application/pdf",
+            },
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates).toHaveLength(1);
+    expect(r.updates[0]).toMatchObject({
+      updateId: 300,
+      chatId: 1,
+      fromUserId: 42,
+      text: "",
+      caption: "look at this",
+      attachment: {
+        kind: "document",
+        fileId: "doc-abc",
+        fileName: "report.pdf",
+        fileSize: 12345,
+        mimeType: "application/pdf",
+      },
+    });
+  });
+
+  test("extracts a photo and picks the largest size", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 301,
+          message: {
+            message_id: 88,
+            chat: { id: 1 },
+            from: { id: 42 },
+            photo: [
+              { file_id: "small", file_size: 100, width: 90, height: 67 },
+              { file_id: "medium", file_size: 8_000, width: 320, height: 240 },
+              { file_id: "large", file_size: 50_000, width: 800, height: 600 },
+            ],
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates[0]?.attachment).toMatchObject({
+      kind: "photo",
+      fileId: "large",
+      fileName: "88-photo.jpg",
+      fileSize: 50_000,
+      mimeType: "image/jpeg",
+    });
+  });
+
+  test("attachment takes priority over plain text (text becomes caption)", () => {
+    // Defensive: Telegram normally uses `caption` for media, not `text`,
+    // but if we ever see both, the attachment is the main thing.
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 302,
+          message: {
+            message_id: 91,
+            chat: { id: 1 },
+            from: { id: 42 },
+            text: "fallback caption from text field",
+            document: {
+              file_id: "doc-x",
+              file_name: "x.txt",
+              mime_type: "text/plain",
+            },
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates[0]?.caption).toBe("fallback caption from text field");
+    expect(r.updates[0]?.attachment?.fileId).toBe("doc-x");
+  });
+
+  test("voice still routes through the voice path, not attachment", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 303,
+          message: {
+            chat: { id: 1 },
+            from: { id: 42 },
+            voice: { file_id: "voice-1", duration: 3, mime_type: "audio/ogg" },
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates[0]?.voice?.fileId).toBe("voice-1");
+    expect(r.updates[0]?.attachment).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractAttachment / extensionFromMime / formatAttachmentUserText
+// ---------------------------------------------------------------------------
+
+describe("extensionFromMime", () => {
+  test("known images and docs", () => {
+    expect(extensionFromMime("image/png")).toBe(".png");
+    expect(extensionFromMime("application/pdf")).toBe(".pdf");
+    expect(extensionFromMime("text/markdown")).toBe(".md");
+    expect(extensionFromMime("audio/mpeg")).toBe(".mp3");
+  });
+
+  test("ignores parameters after the semicolon", () => {
+    expect(extensionFromMime("text/plain; charset=utf-8")).toBe(".txt");
+  });
+
+  test("unknown mime falls back to alphanumeric subtype slice", () => {
+    expect(extensionFromMime("application/x-custom-type")).toBe(".xcustomt");
+  });
+
+  test("missing or empty mime → .bin", () => {
+    expect(extensionFromMime(undefined)).toBe(".bin");
+    expect(extensionFromMime("")).toBe(".bin");
+  });
+});
+
+describe("extractAttachment", () => {
+  test("synthesizes filename when document has none", () => {
+    const att = extractAttachment({
+      message_id: 5,
+      chat: { id: 1 },
+      from: { id: 42 },
+      document: { file_id: "d1", mime_type: "image/png" },
+    });
+    expect(att?.fileName).toBe("5-document.png");
+  });
+
+  test("returns undefined for plain-text-only messages", () => {
+    expect(
+      extractAttachment({ chat: { id: 1 }, from: { id: 42 }, text: "hi" }),
+    ).toBeUndefined();
+  });
+});
+
+describe("formatAttachmentUserText", () => {
+  const att: TelegramAttachment = {
+    fileId: "f1",
+    fileName: "report.pdf",
+    fileSize: 1024,
+    mimeType: "application/pdf",
+    kind: "document",
+  };
+
+  test("caption + saved path", () => {
+    expect(
+      formatAttachmentUserText({
+        caption: "have a look",
+        attachment: att,
+        savedPath: "/inbox/1/55-report.pdf",
+      }),
+    ).toBe("have a look\n\n[attached: /inbox/1/55-report.pdf]");
+  });
+
+  test("no caption + saved path", () => {
+    expect(
+      formatAttachmentUserText({
+        caption: undefined,
+        attachment: att,
+        savedPath: "/inbox/1/55-report.pdf",
+      }),
+    ).toBe("[attached: /inbox/1/55-report.pdf]");
+  });
+
+  test("oversize file surfaces the cap and the size", () => {
+    const text = formatAttachmentUserText({
+      caption: "big file",
+      attachment: att,
+      oversizeBytes: 50 * 1024 * 1024,
+    });
+    expect(text).toContain("big file");
+    expect(text).toContain("[attached but too large to fetch: report.pdf");
+    expect(text).toContain("50.0 MB > 20 MB");
+  });
+
+  test("download error surfaces the error message", () => {
+    expect(
+      formatAttachmentUserText({
+        caption: undefined,
+        attachment: att,
+        downloadError: "ECONNRESET",
+      }),
+    ).toBe("[attached but couldn't download: report.pdf (ECONNRESET)]");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -187,6 +402,177 @@ const baseConfig = (
   },
   embeddings: { provider: "none" },
   voice: { provider: "none" },
+});
+
+describe("runTelegramServer attachment dispatch", () => {
+  let savedXdgDataHome: string | undefined;
+
+  beforeEach(() => {
+    // Isolate the inbox dir into the per-test workdir so tests don't
+    // pollute the real ~/.local/share/phantombot/inbox/.
+    savedXdgDataHome = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = workdir;
+  });
+
+  afterEach(() => {
+    if (savedXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = savedXdgDataHome;
+  });
+
+  test("downloads document, saves to inbox, harness sees [attached: <path>]", async () => {
+    const transport = new FakeTransport();
+    transport.fileResponses.set("doc-abc", {
+      data: Buffer.from("hello-pdf-bytes"),
+      mime: "application/pdf",
+    });
+    transport.pendingUpdates.push({
+      updateId: 555,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "",
+      caption: "look at this report",
+      attachment: {
+        fileId: "doc-abc",
+        fileName: "report.pdf",
+        fileSize: 15,
+        mimeType: "application/pdf",
+        kind: "document",
+      },
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "got it" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.downloadedFileIds).toEqual(["doc-abc"]);
+    const expectedPath = join(
+      inboxDir(1001),
+      "555-report.pdf",
+    );
+    const onDisk = await import("node:fs/promises").then((m) =>
+      m.readFile(expectedPath, "utf8"),
+    );
+    expect(onDisk).toBe("hello-pdf-bytes");
+    expect(harness.lastRequest?.userMessage).toBe(
+      `look at this report\n\n[attached: ${expectedPath}]`,
+    );
+    expect(transport.sent.map((s) => s.text)).toEqual(["got it"]);
+  });
+
+  test("oversize attachment skips download and surfaces the cap to the harness", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 556,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "",
+      caption: "big one",
+      attachment: {
+        fileId: "huge",
+        fileName: "huge.zip",
+        fileSize: 50 * 1024 * 1024, // 50 MB > 20 MB cap
+        mimeType: "application/zip",
+        kind: "document",
+      },
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "noted" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.downloadedFileIds).toEqual([]);
+    expect(harness.lastRequest?.userMessage).toContain(
+      "[attached but too large to fetch: huge.zip",
+    );
+    expect(harness.lastRequest?.userMessage).toContain("50.0 MB > 20 MB");
+    expect(harness.lastRequest?.userMessage).toContain("big one");
+  });
+
+  test("download failure surfaces the error to the harness (no crash)", async () => {
+    const transport = new FakeTransport();
+    transport.fileResponses.set("flaky", new Error("ECONNRESET"));
+    transport.pendingUpdates.push({
+      updateId: 557,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "",
+      attachment: {
+        fileId: "flaky",
+        fileName: "fail.png",
+        mimeType: "image/png",
+        kind: "photo",
+      },
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.downloadedFileIds).toEqual(["flaky"]);
+    expect(harness.lastRequest?.userMessage).toBe(
+      "[attached but couldn't download: fail.png (ECONNRESET)]",
+    );
+  });
+
+  test("attachment with no caption: user message is the bracketed line only", async () => {
+    const transport = new FakeTransport();
+    transport.fileResponses.set("photo-1", {
+      data: Buffer.from([0xff, 0xd8, 0xff]),
+      mime: "image/jpeg",
+    });
+    transport.pendingUpdates.push({
+      updateId: 558,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "",
+      attachment: {
+        fileId: "photo-1",
+        fileName: "558-photo.jpg",
+        fileSize: 3,
+        mimeType: "image/jpeg",
+        kind: "photo",
+      },
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    const expectedPath = join(inboxDir(1001), "558-558-photo.jpg");
+    expect(harness.lastRequest?.userMessage).toBe(`[attached: ${expectedPath}]`);
+  });
 });
 
 describe("runTelegramServer dispatch", () => {


### PR DESCRIPTION
> Stacked on top of #64. Review & merge that one first; the GitHub diff for this PR will then automatically rebase to main and show only the attachment work.

## Summary

Phantombot was silently dropping every non-voice attachment (photos, documents, audio files, video, stickers, GIFs) because \`parseGetUpdatesResult\` only recognized \`text\` and \`voice\` fields. From the user's POV the message simply never arrived.

This PR is a deliberate **dumb pipe** — no type-aware preprocessing or content inspection. We download whatever Telegram delivers, save it under \`~/.local/share/phantombot/inbox/<chatId>/<msgId>-<filename>\`, and rewrite the user-facing message to:

\`\`\`
<caption-if-any>

[attached: <absolute-path>]
\`\`\`

The harness decides what to do — \`read\` the file (vision for images, text for docs/code/logs), ignore it, or ask the user for clarification. Phantombot never inspects, transforms, or summarizes the bytes. (Voice keeps its existing dedicated STT path — confirmed working great in production, no need to disturb it.)

### Implementation

- **Parser**: walks every known attachment field (\`document\`, \`photo[]\`, \`audio\`, \`video\`, \`video_note\`, \`animation\`, \`sticker\`), extracts \`file_id\` + optional \`file_name\`, \`mime_type\`, \`file_size\`. For photos (which arrive as an array of sizes), picks the largest by \`file_size\` (or \`width*height\` if size is missing).
- **Filename**: Telegram's \`file_name\` if present; else \`<msg_id>-<kind>.<ext-from-mime>\`. The MIME→extension table covers the common ones; unknown MIMEs get an alphanumeric subtype slice (capped at 8 chars), worst case \`.bin\`.
- **Per-chat inbox**: \`xdgDataHome()/phantombot/inbox/<chatId>/\` so attachments don't pollute the persona dir and grow forever (cleanup is a future cron concern).
- **Edge cases**:
  - **>20 MB** → skip download, surface \`[attached but too large to fetch: <name> (X MB > 20 MB Telegram bot-API cap)]\` so the agent can still acknowledge it. Telegram's \`getFile\` itself caps there regardless of attachment type.
  - **Download error** → \`[attached but couldn't download: <name> (<reason>)]\`.
  - **No caption** → user message is just the bracketed line.
  - **Slash-command path** unaffected: attachment messages have \`text === ""\`, so \`text.startsWith("/")\` is false.

### Live validation on Lena's box

\`\`\`
telegram: incoming   attachment={kind:"photo", fileName:"2201-photo.jpg", fileSize:55778, mimeType:"image/jpeg"}, captionLength:23
telegram: attachment saved   path=/home/lena/.local/share/phantombot/inbox/7995070089/918260260-2201-photo.jpg
orchestrator: trying harness gemini
telegram: complete   durationMs=56624  replyChars=848  progressEvents=13  harness=gemini  ok=true
\`\`\`

The harness's actual invocation argv was:
\`\`\`
gemini -p "Ok, can you see it now?  [attached: /home/lena/.local/share/phantombot/inbox/7995070089/918260260-2201-photo.jpg]" -o stream-json -y
\`\`\`

56s end-to-end, 848-char reply, 13 tool events, no rate-limit retries.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` — 539 pass / 0 fail (was 521)
- [x] New tests cover: parser (document, photo with multiple sizes, attachment-with-text fallback, voice still routed separately), \`extensionFromMime\` (known/unknown/parameterized/empty), \`extractAttachment\` (synthesized filename, text-only returns undefined), \`formatAttachmentUserText\` (caption+saved, no-caption+saved, oversize, download-error), and 4 integration tests through \`runTelegramServer\` (document download, oversize skip, download failure surface, no-caption case).
- [x] Live: photo with caption → fetched, saved, gemini took the turn cleanly.
- [ ] Try a PDF, a code file, a >20 MB upload — should all behave per the design.