### PR TITLE
Deploy landing page to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,24 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'www/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./www
+          cname: phantombot.bot

--- a/www/CNAME
+++ b/www/CNAME
@@ -1,1 +1,0 @@
-phantombot.bot

--- a/www/CNAME
+++ b/www/CNAME
@@ -1,0 +1,1 @@
+phantombot.bot


### PR DESCRIPTION
This PR adds a GitHub Action to automatically deploy the 'www/' directory to the 'gh-pages' branch and configures the 'CNAME' for phantombot.bot.