### PR TITLE
feat(cli): add `phantombot ask` for one-shot prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ phantombot/
 
 ## Architecture at a glance
 
-- **Citty CLI dispatcher** (`src/cli/index.ts`) → subcommand → orchestrator (for turn-spending commands like `run`, `tick`, `nightly`).
+- **Citty CLI dispatcher** (`src/cli/index.ts`) → subcommand → orchestrator (for turn-spending commands like `run`, `ask`, `tick`, `nightly`).
 - **One-turn coordinator** (`src/orchestrator/turn.ts`) loads persona files, loads recent turns from memory, builds system prompt, runs the harness chain, and persists the user+assistant turns on success.
 - **Harness chain** (`src/orchestrator/fallback.ts`) tries primary; if it returns a recoverable error, falls through to the next.
 - **Channels listen** (`src/channels/telegram.ts`); `phantombot run` is the long-running process.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ mkdir -p ~/.local/bin && cp dist/phantombot ~/.local/bin/
 | Command | What it does |
 |---|---|
 | `phantombot run` | Foreground long-running listener (Ctrl-C to stop) |
+| `phantombot ask "<prompt>"` | One-shot prompt through the persona + harness chain. Prints the assistant's reply to stdout and exits. Stateless by default — pass `--history --conversation <id>` to thread. Built for non-interactive callers (shell scripts, the Twilio voice-agent's `askRobbie` relay) that want the bot's brain without a Telegram conversation. |
 | `phantombot install` | Install systemd --user units (main + heartbeat + nightly + tick) |
 | `phantombot uninstall` | Remove the systemd units |
 | `phantombot update [--check] [--force] [--restart]` | Atomic, SHA256-verified self-update |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,9 +50,9 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 ```
 phantombot ask "what's on my calendar?"
   → ask.ts: load config, resolve persona, open memory, build harness chain
-  → orchestrator.turn.runTurn(...)
+  → orchestrator.turn.runTurn({ noHistory: true, conversation: "cli:ask", ... })
        → loadPersona(agentDir) → { boot, memory, tools, identitySource, ... }
-       → memory.recentTurns(persona, "cli:default", 20) → [{role,text}, ...]
+       → memory.recentTurns(persona, "cli:ask", 20) → [] (skipped: noHistory)
        → buildSystemPrompt(persona, channelCtx) → systemPrompt
        → orchestrator.fallback.runWithFallback([claude, pi], req)
             → estimatePayloadBytes(req) → bytes
@@ -68,8 +68,8 @@ phantombot ask "what's on my calendar?"
                  → on exit 0: yield {type:"done", finalText, meta:{harnessId,model}}
                  → on exit !=0: yield error/recoverable: code !== 127
             → if recoverable error and chain has more: try pi.invoke(req)
-       → on done chunk: memory.appendTurn(user) + memory.appendTurn(assistant)
-  → ask.ts: write text chunks to stdout as they arrive, "\n" on done
+       → on done chunk: skip persistence (noHistory). With --history, append both turns.
+  → ask.ts: write the harness's final assistant text to stdout, ensure trailing "\n"
   → exit 0 / 1 / 2
 ```
 
@@ -77,7 +77,7 @@ phantombot ask "what's on my calendar?"
 
 1. **Streaming display in the REPL.** Text chunks are written to stdout as they arrive. Looks responsive, but if the harness reformats the final reply (claude sometimes does), the user sees draft text replaced by the canonical version when `done` arrives — currently we just persist the canonical version, which may differ from what was on screen. Acceptable trade-off for v1.
 
-2. **History scope.** Both `ask` and `chat` use conversation key `cli:default` so they share memory per persona. If a future channels phase lands, channel adapters would use distinct keys (`telegram:42`, `signal:abc`).
+2. **History scope.** `phantombot ask` is stateless by default (conversation `cli:ask`, `noHistory: true`) — fitted to non-interactive callers like the Twilio voice-agent that don't want their tool-calls polluting the persona's rolling memory. Pass `--history --conversation <id>` to thread asks together. The Telegram channel uses distinct keys per chat (`telegram:<chat_id>`).
 
 3. **Multi-line REPL input.** Currently line-by-line via node:readline. Long pasted content works (terminal sends it as one line); explicit multi-line mode (Esc-Enter) is not implemented. Add if it bites.
 

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -161,7 +161,13 @@ export default defineCommand({
   async run({ args }) {
     let prompt = String(args.prompt ?? "");
     if (prompt === "-") {
-      prompt = await readAllStdin();
+      try {
+        prompt = await readAllStdin();
+      } catch (e) {
+        process.stderr.write(`phantombot ask: ${(e as Error).message}\n`);
+        process.exitCode = 2;
+        return;
+      }
     }
     process.exitCode = await runAsk({
       prompt,
@@ -172,9 +178,24 @@ export default defineCommand({
   },
 });
 
-async function readAllStdin(): Promise<string> {
+/**
+ * Read all of stdin to a string. Refuses to read from a TTY — if the
+ * caller asked for `-` but stdin isn't piped, we'd hang forever waiting
+ * for an EOF that only arrives on Ctrl-D. Failing fast with a clear
+ * message is friendlier than a silent hang. (Flagged by Kai in PR #71.)
+ */
+export async function readAllStdin(
+  stdin: NodeJS.ReadStream = process.stdin,
+): Promise<string> {
+  if (stdin.isTTY) {
+    throw new Error(
+      'cannot read prompt from "-": stdin is a TTY. ' +
+        'Pipe input (e.g. `echo "hi" | phantombot ask -`) ' +
+        "or pass the prompt as an argument.",
+    );
+  }
   const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
+  for await (const chunk of stdin) {
     chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
   }
   return Buffer.concat(chunks).toString("utf8");

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -1,0 +1,181 @@
+/**
+ * `phantombot ask <prompt>` — fire a single prompt through the same
+ * persona + harness chain that backs the long-running `run` listener,
+ * print the assistant's final reply to stdout, and exit.
+ *
+ * Designed for callers that want Robbie's brain as a one-shot tool:
+ *   - the voice agent's old `ask_robbie` relay (formerly an HTTP POST to
+ *     OpenClaw on 127.0.0.1:18789);
+ *   - shell scripts and other local tooling that want a quick answer
+ *     without standing up a Telegram conversation.
+ *
+ * Defaults to `--no-history`, so each invocation is stateless. The
+ * persona files (SOUL.md, IDENTITY.md, MEMORY.md, etc.) are still loaded
+ * into the system prompt every call — only the rolling conversation
+ * history is suppressed. Pass `--history` plus `--conversation <id>` to
+ * thread asks together (e.g. for a multi-turn debugging session).
+ *
+ * Output is the FINAL assistant text only — no progress chatter, no
+ * tool-call traces, no trailing newline beyond what the harness emits.
+ * That keeps `phantombot ask` cleanly composable with shell pipes and
+ * `child_process.exec` callers.
+ *
+ * Exit codes:
+ *   0  success
+ *   1  generic failure (lock contention, harness chain produced no text)
+ *   2  configuration error (no harnesses, persona missing, missing prompt)
+ */
+
+import { defineCommand } from "citty";
+import { existsSync } from "node:fs";
+
+import { type Config, loadConfig, personaDir } from "../config.ts";
+import { buildHarnessChain } from "../harnesses/buildChain.ts";
+import type { Harness } from "../harnesses/types.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { openMemoryStore, type MemoryStore } from "../memory/store.ts";
+import { runTurn } from "../orchestrator/turn.ts";
+
+export interface RunAskInput {
+  /** The user prompt. Required. */
+  prompt: string;
+  /** Override the persona (default: config.defaultPersona). */
+  persona?: string;
+  /** Conversation key for history scoping. Default "cli:ask". */
+  conversation?: string;
+  /** Persist + load history for this conversation. Default false (stateless). */
+  history?: boolean;
+  /** Test injection points. */
+  config?: Config;
+  memory?: MemoryStore;
+  harnesses?: Harness[];
+  out?: WriteSink;
+  err?: WriteSink;
+  signal?: AbortSignal;
+}
+
+export async function runAsk(input: RunAskInput): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+
+  const prompt = input.prompt?.trim();
+  if (!prompt) {
+    err.write("phantombot ask: empty prompt\n");
+    return 2;
+  }
+
+  const config = input.config ?? (await loadConfig());
+  const persona = input.persona ?? config.defaultPersona;
+  const agentDir = personaDir(config, persona);
+  if (!existsSync(agentDir)) {
+    err.write(
+      `phantombot ask: persona '${persona}' not found at ${agentDir}\n`,
+    );
+    return 2;
+  }
+
+  const harnesses = input.harnesses ?? buildHarnessChain(config, err);
+  if (harnesses.length === 0) {
+    err.write(
+      "phantombot ask: no harnesses configured. Run `phantombot harness` to pick at least one.\n",
+    );
+    return 2;
+  }
+
+  const memory =
+    input.memory ?? (await openMemoryStore(config.memoryDbPath));
+  const ownsMemory = !input.memory;
+
+  let finalText = "";
+  let succeeded = false;
+  try {
+    for await (const chunk of runTurn({
+      persona,
+      conversation: input.conversation ?? "cli:ask",
+      userMessage: prompt,
+      agentDir,
+      harnesses,
+      memory,
+      idleTimeoutMs: config.harnessIdleTimeoutMs,
+      hardTimeoutMs: config.harnessHardTimeoutMs,
+      noHistory: !input.history,
+      signal: input.signal,
+    })) {
+      if (chunk.type === "text") finalText += chunk.text;
+      if (chunk.type === "done") {
+        finalText = chunk.finalText;
+        succeeded = true;
+      }
+    }
+  } catch (e) {
+    err.write(`phantombot ask: ${(e as Error).message}\n`);
+    if (ownsMemory) await memory.close();
+    return 1;
+  }
+
+  if (ownsMemory) await memory.close();
+
+  if (!succeeded) {
+    err.write("phantombot ask: harness chain produced no final reply\n");
+    return 1;
+  }
+
+  out.write(finalText);
+  // Trail a newline if the harness didn't, so shell consumers don't get
+  // a half-line at the prompt. Idempotent: if finalText already ends
+  // with \n we leave it alone.
+  if (!finalText.endsWith("\n")) out.write("\n");
+  return 0;
+}
+
+export default defineCommand({
+  meta: {
+    name: "ask",
+    description:
+      "Run one prompt through the persona + harness chain, print the reply to stdout, and exit. Stateless by default; pass --history --conversation <id> to thread.",
+  },
+  args: {
+    prompt: {
+      type: "positional",
+      required: true,
+      description:
+        'The prompt to send. Quote it if it has spaces. Pass "-" to read from stdin instead.',
+    },
+    persona: {
+      type: "string",
+      description:
+        "Persona name to use (default: the configured default persona).",
+    },
+    conversation: {
+      type: "string",
+      description:
+        'Conversation key for history scoping (default: "cli:ask"). Only meaningful with --history.',
+    },
+    history: {
+      type: "boolean",
+      description:
+        "Persist this turn and load prior turns for the conversation. Default off (stateless).",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    let prompt = String(args.prompt ?? "");
+    if (prompt === "-") {
+      prompt = await readAllStdin();
+    }
+    process.exitCode = await runAsk({
+      prompt,
+      persona: args.persona ? String(args.persona) : undefined,
+      conversation: args.conversation ? String(args.conversation) : undefined,
+      history: Boolean(args.history),
+    });
+  },
+});
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,13 +8,17 @@
  *   install         - install systemd --user unit so phantombot survives logout
  *   uninstall       - remove the systemd unit
  *   run             - run the bot in the foreground (Ctrl-C to stop)
+ *   ask             - one-shot prompt through the persona + harness chain
  *
- * Dev/debug commands (ask, chat, doctor, history, list-personas, etc.)
- * have been removed as part of the v0.1 surface lock.
+ * Dev/debug commands (chat, doctor, history, list-personas, etc.) were
+ * removed as part of the v0.1 surface lock. `ask` was reintroduced for
+ * external programs that want Robbie's brain as a non-interactive tool
+ * (e.g. the Twilio voice-agent's `askRobbie` relay).
  */
 
 import { defineCommand } from "citty";
 import { VERSION } from "../version.ts";
+import askCmd from "./ask.ts";
 import personaCmd from "./persona.ts";
 import telegramCmd from "./telegram.ts";
 import harnessCmd from "./harness.ts";
@@ -48,6 +52,7 @@ export const mainCommand = defineCommand({
     install: installCmd,
     uninstall: uninstallCmd,
     run: runCmd,
+    ask: askCmd,
     memory: memoryCmd,
     notify: notifyCmd,
     heartbeat: heartbeatCmd,

--- a/tests/cli-ask.test.ts
+++ b/tests/cli-ask.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runAsk } from "../src/cli/ask.ts";
+import type { Config } from "../src/config.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessRequest,
+} from "../src/harnesses/types.ts";
+import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
+
+class ScriptedHarness implements Harness {
+  invocations = 0;
+  lastRequest?: HarnessRequest;
+  constructor(
+    public readonly id: string,
+    private readonly script: HarnessChunk[],
+  ) {}
+  async available(): Promise<boolean> {
+    return true;
+  }
+  async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    this.invocations++;
+    this.lastRequest = req;
+    for (const c of this.script) yield c;
+  }
+}
+
+class CapturingSink {
+  buf = "";
+  write(s: string): boolean {
+    this.buf += s;
+    return true;
+  }
+}
+
+let workdir: string;
+let memory: MemoryStore;
+let config: Config;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-ask-"));
+  memory = await openMemoryStore(join(workdir, "memory.sqlite"));
+
+  const personaDir = join(workdir, "personas", "phantom");
+  await mkdir(personaDir, { recursive: true });
+  await writeFile(join(personaDir, "BOOT.md"), "# Phantom\n", "utf8");
+
+  config = {
+    defaultPersona: "phantom",
+    harnessIdleTimeoutMs: 5000,
+    harnessHardTimeoutMs: 5000,
+    personasDir: join(workdir, "personas"),
+    memoryDbPath: join(workdir, "memory.sqlite"),
+    configPath: join(workdir, "config.toml"),
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1 },
+      gemini: { bin: "gemini", model: "" },
+    },
+    channels: {},
+    embeddings: { provider: "none" },
+    voice: { provider: "none" },
+  };
+});
+
+afterEach(async () => {
+  await memory.close();
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("runAsk — happy path", () => {
+  test("prints the harness's final reply to stdout and exits 0", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "text", text: "Hi! " },
+      { type: "text", text: "I'm Robbie." },
+      { type: "done", finalText: "Hi! I'm Robbie." },
+    ]);
+    const out = new CapturingSink();
+    const err = new CapturingSink();
+    const code = await runAsk({
+      prompt: "who are you?",
+      config,
+      memory,
+      harnesses: [harness],
+      out,
+      err,
+    });
+    expect(code).toBe(0);
+    expect(out.buf).toBe("Hi! I'm Robbie.\n");
+    expect(err.buf).toBe("");
+    expect(harness.invocations).toBe(1);
+    expect(harness.lastRequest?.userMessage).toBe("who are you?");
+    // noHistory default → empty history passed in.
+    expect(harness.lastRequest?.history).toEqual([]);
+  });
+
+  test("preserves trailing newline if harness already supplied one", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "answer\n" },
+    ]);
+    const out = new CapturingSink();
+    const code = await runAsk({
+      prompt: "q",
+      config,
+      memory,
+      harnesses: [harness],
+      out,
+      err: new CapturingSink(),
+    });
+    expect(code).toBe(0);
+    expect(out.buf).toBe("answer\n");
+  });
+});
+
+describe("runAsk — statelessness", () => {
+  test("default (no --history): no turns persisted to memory", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runAsk({
+      prompt: "first",
+      config,
+      memory,
+      harnesses: [harness],
+      out: new CapturingSink(),
+      err: new CapturingSink(),
+    });
+    const turns = await memory.recentTurns("phantom", "cli:ask", 50);
+    expect(turns).toEqual([]);
+  });
+
+  test("with history: persists user + assistant turns to the named conversation", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runAsk({
+      prompt: "remember this",
+      history: true,
+      conversation: "voice-agent:call-42",
+      config,
+      memory,
+      harnesses: [harness],
+      out: new CapturingSink(),
+      err: new CapturingSink(),
+    });
+    const turns = await memory.recentTurns("phantom", "voice-agent:call-42", 50);
+    expect(turns).toHaveLength(2);
+    expect(turns[0]!.role).toBe("user");
+    expect(turns[0]!.text).toBe("remember this");
+    expect(turns[1]!.role).toBe("assistant");
+    expect(turns[1]!.text).toBe("ok");
+  });
+});
+
+describe("runAsk — error paths", () => {
+  test("empty prompt → exit 2 with stderr message", async () => {
+    const err = new CapturingSink();
+    const code = await runAsk({
+      prompt: "   ",
+      config,
+      memory,
+      harnesses: [new ScriptedHarness("h", [])],
+      out: new CapturingSink(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.buf).toContain("empty prompt");
+  });
+
+  test("missing persona dir → exit 2", async () => {
+    const cfg = { ...config, defaultPersona: "ghost" };
+    const err = new CapturingSink();
+    const code = await runAsk({
+      prompt: "hi",
+      config: cfg,
+      memory,
+      harnesses: [new ScriptedHarness("h", [])],
+      out: new CapturingSink(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.buf).toContain("persona 'ghost' not found");
+  });
+
+  test("no harnesses → exit 2", async () => {
+    const err = new CapturingSink();
+    const code = await runAsk({
+      prompt: "hi",
+      config,
+      memory,
+      harnesses: [],
+      out: new CapturingSink(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.buf).toContain("no harnesses configured");
+  });
+
+  test("harness produces no done chunk → exit 1", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "text", text: "partial..." },
+    ]);
+    const err = new CapturingSink();
+    const code = await runAsk({
+      prompt: "hi",
+      config,
+      memory,
+      harnesses: [harness],
+      out: new CapturingSink(),
+      err,
+    });
+    expect(code).toBe(1);
+    expect(err.buf).toContain("no final reply");
+  });
+});
+
+describe("runAsk — persona override", () => {
+  test("--persona <name> uses the named persona, not the default", async () => {
+    const altDir = join(workdir, "personas", "lena");
+    await mkdir(altDir, { recursive: true });
+    await writeFile(join(altDir, "BOOT.md"), "# Lena\n", "utf8");
+
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "from lena" },
+    ]);
+    const out = new CapturingSink();
+    const code = await runAsk({
+      prompt: "hi",
+      persona: "lena",
+      config,
+      memory,
+      harnesses: [harness],
+      out,
+      err: new CapturingSink(),
+    });
+    expect(code).toBe(0);
+    expect(out.buf).toBe("from lena\n");
+  });
+});

--- a/tests/cli-ask.test.ts
+++ b/tests/cli-ask.test.ts
@@ -3,7 +3,9 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { runAsk } from "../src/cli/ask.ts";
+import { Readable } from "node:stream";
+
+import { readAllStdin, runAsk } from "../src/cli/ask.ts";
 import type { Config } from "../src/config.ts";
 import type {
   Harness,
@@ -216,6 +218,23 @@ describe("runAsk — error paths", () => {
     });
     expect(code).toBe(1);
     expect(err.buf).toContain("no final reply");
+  });
+});
+
+describe("readAllStdin — TTY guard", () => {
+  test("throws fast when stdin is a TTY (does not hang)", async () => {
+    const fakeTty = new Readable({ read() {} }) as unknown as NodeJS.ReadStream;
+    (fakeTty as { isTTY: boolean }).isTTY = true;
+    await expect(readAllStdin(fakeTty)).rejects.toThrow(/stdin is a TTY/);
+  });
+
+  test("reads piped input normally when stdin is not a TTY", async () => {
+    const piped = Readable.from([
+      Buffer.from("hello "),
+      Buffer.from("world"),
+    ]) as unknown as NodeJS.ReadStream;
+    (piped as { isTTY: boolean }).isTTY = false;
+    expect(await readAllStdin(piped)).toBe("hello world");
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -20,6 +20,7 @@ describe("phantombot CLI dispatcher", () => {
     const subs = mainCommand.subCommands ?? {};
     const names = Object.keys(subs).sort();
     expect(names).toEqual([
+      "ask",
       "embedding",
       "env",
       "harness",


### PR DESCRIPTION
## Summary
- Adds `phantombot ask "<prompt>"` — a stateless one-shot through the persona + harness chain. Prints the assistant's final reply to stdout and exits.
- Designed primarily for the Twilio voice-agent's `askRobbie` relay (replacing the old HTTP POST to OpenClaw at `127.0.0.1:18789`), but useful for any local script that wants Robbie's brain without a Telegram conversation.
- Stateless by default (`noHistory: true`, conversation key `cli:ask`); pass `--history --conversation <id>` to thread asks.
- 9 new test cases; existing dispatcher whitelist test updated.

## Test plan
- [x] `bun tsc --noEmit` clean
- [x] `bun test` — 590 pass / 1 skip / 0 fail (591 across 55 files)
- [ ] After merge & release: `phantombot update` on this VPS, smoke-test with `phantombot ask "who are you?"`
- [ ] Propagate to lena/kai/jake on kw-openclaw via the documented two-step (binary swap + manual `systemctl --user restart` with explicit `XDG_RUNTIME_DIR`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)