### PR TITLE
fix: add ~/.pi/agent/bin to systemd unit PATH

### DIFF
--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -97,7 +97,7 @@ Type=simple
 ExecStart=${exec}
 Restart=on-failure
 RestartSec=5
-Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="PATH=%h/.pi/agent/bin:%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ${ENVIRONMENT_FILE_LINES}
 StandardOutput=journal
 StandardError=journal
@@ -121,7 +121,7 @@ Description=Phantombot heartbeat — mechanical 30-minute maintenance pass
 [Service]
 Type=oneshot
 ExecStart=${exec}
-Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="PATH=%h/.pi/agent/bin:%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ${ENVIRONMENT_FILE_LINES}
 StandardOutput=journal
 StandardError=journal
@@ -156,7 +156,7 @@ Wants=network-online.target
 Type=oneshot
 ExecStart=${exec}
 TimeoutStartSec=2700
-Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="PATH=%h/.pi/agent/bin:%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ${ENVIRONMENT_FILE_LINES}
 StandardOutput=journal
 StandardError=journal
@@ -189,7 +189,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 ExecStart=${exec}
-Environment="PATH=%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="PATH=%h/.pi/agent/bin:%h/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ${ENVIRONMENT_FILE_LINES}
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Problem

Pi CLI installs to `~/.pi/agent/bin/pi` by default. That directory isn't in systemd's fixed PATH, so when phantombot's orchestrator spawns `pi`, Bun returns:

> error: Executable not found in $PATH: "pi"

The harness's `available()` method only validates absolute paths — with `bin = "pi"` (PATH lookup) it always returns `true`, so the chain never falls through cleanly. It blows up on spawn instead.

## Fix

Prepends `%h/.pi/agent/bin` to the `Environment=PATH` line in all four unit templates (user/system × normal/fast-channel).

## Tested

- All 20 systemd unit tests pass
- PATH now resolves `~/.pi/agent/bin` before `~/.local/bin`