### PR TITLE
feat(ask): --stream flag for low-latency voice agent

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -959,6 +959,14 @@ async function processChatMessage(
       systemPromptSuffix: willReplyWithVoice
         ? `${TELEGRAM_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
         : TELEGRAM_REPLY_INSTRUCTION,
+      // Pre-tool narration: ON for text-out (the user sees streamed
+      // text as it lands, so a "checking your calendar..." sentence
+      // before a tool call usefully fills the silence). OFF for
+      // voice-out: the reply is synthesized as one clip at the end,
+      // so narration would just lengthen the spoken output without
+      // helping with perceived latency. VOICE_REPLY_INSTRUCTION
+      // already forbids work narration too, so off is consistent.
+      toolNarration: !willReplyWithVoice,
     })) {
       if (chunk.type === "text") {
         reply += chunk.text;

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -45,6 +45,17 @@ export interface RunAskInput {
   conversation?: string;
   /** Persist + load history for this conversation. Default false (stateless). */
   history?: boolean;
+  /**
+   * Stream assistant text to `out` as `text` chunks arrive, instead of
+   * buffering and writing the final reply at the end. Lets downstream
+   * consumers (e.g. the voice agent's Twilio relay) start TTS on the
+   * first sentence while the rest is still being generated.
+   *
+   * Tool-call chatter never reaches us as `text` chunks — runTurn
+   * surfaces those as `progress`/`heartbeat` — so streaming is safe:
+   * what hits stdout is exactly the assistant's spoken reply.
+   */
+  stream?: boolean;
   /** Test injection points. */
   config?: Config;
   memory?: MemoryStore;
@@ -86,6 +97,7 @@ export async function runAsk(input: RunAskInput): Promise<number> {
     input.memory ?? (await openMemoryStore(config.memoryDbPath));
   const ownsMemory = !input.memory;
 
+  const stream = input.stream === true;
   let finalText = "";
   let succeeded = false;
   try {
@@ -101,8 +113,23 @@ export async function runAsk(input: RunAskInput): Promise<number> {
       noHistory: !input.history,
       signal: input.signal,
     })) {
-      if (chunk.type === "text") finalText += chunk.text;
+      if (chunk.type === "text") {
+        finalText += chunk.text;
+        if (stream) {
+          // Flush each text chunk straight to stdout as it lands.
+          // text chunks are guaranteed assistant-spoken text only —
+          // tool calls / chain-of-thought come through as
+          // progress/heartbeat and are dropped here, same as
+          // non-stream mode.
+          out.write(chunk.text);
+        }
+      }
       if (chunk.type === "done") {
+        // In non-stream mode we prefer the harness's authoritative
+        // finalText (it may be reformatted). In stream mode we've
+        // already flushed everything, so we just mark success and
+        // skip the final write below — re-emitting finalText would
+        // duplicate the reply on stdout.
         finalText = chunk.finalText;
         succeeded = true;
       }
@@ -120,10 +147,13 @@ export async function runAsk(input: RunAskInput): Promise<number> {
     return 1;
   }
 
-  out.write(finalText);
+  if (!stream) {
+    out.write(finalText);
+  }
   // Trail a newline if the harness didn't, so shell consumers don't get
   // a half-line at the prompt. Idempotent: if finalText already ends
-  // with \n we leave it alone.
+  // with \n we leave it alone. Applies to both modes: a streamed run
+  // also benefits from a clean line terminator.
   if (!finalText.endsWith("\n")) out.write("\n");
   return 0;
 }
@@ -157,6 +187,12 @@ export default defineCommand({
         "Persist this turn and load prior turns for the conversation. Default off (stateless).",
       default: false,
     },
+    stream: {
+      type: "boolean",
+      description:
+        "Stream assistant text to stdout as chunks arrive (lower latency for downstream consumers).",
+      default: false,
+    },
   },
   async run({ args }) {
     let prompt = String(args.prompt ?? "");
@@ -174,6 +210,7 @@ export default defineCommand({
       persona: args.persona ? String(args.persona) : undefined,
       conversation: args.conversation ? String(args.conversation) : undefined,
       history: Boolean(args.history),
+      stream: Boolean(args.stream),
     });
   },
 });

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -98,7 +98,17 @@ export async function runAsk(input: RunAskInput): Promise<number> {
   const ownsMemory = !input.memory;
 
   const stream = input.stream === true;
-  let finalText = "";
+  // Two distinct accumulators on purpose:
+  //   `streamedText`  — exactly what we wrote to `out` in stream mode
+  //                     (concatenation of `chunk.text` deltas).
+  //   `harnessFinal`  — the harness's authoritative `chunk.finalText`,
+  //                     which may be reformatted vs the deltas.
+  // Non-stream mode writes `harnessFinal` at the end; stream mode has
+  // already flushed `streamedText`. The trailing-newline check must
+  // consult whichever string was actually emitted, otherwise we can
+  // either drop a needed newline or append a redundant one.
+  let streamedText = "";
+  let harnessFinal = "";
   let succeeded = false;
   try {
     for await (const chunk of runTurn({
@@ -122,7 +132,6 @@ export async function runAsk(input: RunAskInput): Promise<number> {
       signal: input.signal,
     })) {
       if (chunk.type === "text") {
-        finalText += chunk.text;
         if (stream) {
           // Flush each text chunk straight to stdout as it lands.
           // text chunks are guaranteed assistant-spoken text only —
@@ -130,15 +139,11 @@ export async function runAsk(input: RunAskInput): Promise<number> {
           // progress/heartbeat and are dropped here, same as
           // non-stream mode.
           out.write(chunk.text);
+          streamedText += chunk.text;
         }
       }
       if (chunk.type === "done") {
-        // In non-stream mode we prefer the harness's authoritative
-        // finalText (it may be reformatted). In stream mode we've
-        // already flushed everything, so we just mark success and
-        // skip the final write below — re-emitting finalText would
-        // duplicate the reply on stdout.
-        finalText = chunk.finalText;
+        harnessFinal = chunk.finalText;
         succeeded = true;
       }
     }
@@ -156,13 +161,16 @@ export async function runAsk(input: RunAskInput): Promise<number> {
   }
 
   if (!stream) {
-    out.write(finalText);
+    out.write(harnessFinal);
   }
-  // Trail a newline if the harness didn't, so shell consumers don't get
-  // a half-line at the prompt. Idempotent: if finalText already ends
-  // with \n we leave it alone. Applies to both modes: a streamed run
-  // also benefits from a clean line terminator.
-  if (!finalText.endsWith("\n")) out.write("\n");
+  // Trail a newline if the emitted text didn't, so shell consumers
+  // don't get a half-line at the prompt. Idempotent. Crucially, in
+  // stream mode we check what we actually streamed (`streamedText`)
+  // rather than the harness's reformatted `finalText` — the two can
+  // disagree, and only what we wrote determines whether stdout ends
+  // on a newline.
+  const emitted = stream ? streamedText : harnessFinal;
+  if (!emitted.endsWith("\n")) out.write("\n");
   return 0;
 }
 

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -111,6 +111,14 @@ export async function runAsk(input: RunAskInput): Promise<number> {
       idleTimeoutMs: config.harnessIdleTimeoutMs,
       hardTimeoutMs: config.harnessHardTimeoutMs,
       noHistory: !input.history,
+      // Streaming consumers benefit from pre-tool narration: the
+      // assistant's intent sentence flushes to stdout before the
+      // tool's silence begins. Non-streaming consumers see the whole
+      // reply at the end anyway, so narration is just bloat there.
+      // `phantombot ask --stream` is also what the voice agent's
+      // Twilio relay calls into — Twilio gets the same benefit for
+      // free, no Twilio-specific code path needed.
+      toolNarration: stream,
       signal: input.signal,
     })) {
       if (chunk.type === "text") {

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -24,7 +24,10 @@
 import { homedir } from "node:os";
 
 import { runWithFallback } from "./fallback.ts";
-import { buildSystemPrompt } from "../persona/builder.ts";
+import {
+  buildSystemPrompt,
+  PRE_TOOL_NARRATION_INSTRUCTION,
+} from "../persona/builder.ts";
 import { loadPersona } from "../persona/loader.ts";
 import type { Harness, HarnessChunk } from "../harnesses/types.ts";
 import type { MemoryStore } from "../memory/store.ts";
@@ -62,6 +65,27 @@ export interface TurnInput {
   noHistory?: boolean;
   /** Extra text appended to the system prompt. Used by nightly to inject distillation directives. */
   systemPromptSuffix?: string;
+  /**
+   * Append PRE_TOOL_NARRATION_INSTRUCTION to the system prompt — asks
+   * the model to say one short sentence before each tool call so
+   * streaming channels have something to render during the silence
+   * while a tool runs.
+   *
+   * Off by default. Channels that stream assistant text in real time
+   * should set this true:
+   *   - Telegram text-in/text-out (text streams as it lands)
+   *   - `phantombot ask --stream` (stdout flushes per text chunk;
+   *     Twilio's voice relay tee'd off this)
+   *
+   * Leave false for one-shot consumers — the CLI's `ask` (no stream),
+   * nightly distillation, the heartbeat — where there's no live
+   * channel to fill silence on.
+   *
+   * Telegram voice-in/voice-out should also leave this false: the
+   * voice reply is one synthesized clip at the end, not a stream, so
+   * narration would just bloat the spoken output.
+   */
+  toolNarration?: boolean;
   /** External abort signal from channel layer (e.g. /stop command). Propagated to harnesses. */
   signal?: AbortSignal;
 }
@@ -86,9 +110,20 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
     },
     undefined, // vector-search retrieval reserved for a later phase
   );
-  const systemPrompt = input.systemPromptSuffix
-    ? baseSystemPrompt + "\n\n" + input.systemPromptSuffix
-    : baseSystemPrompt;
+  // Channel-layer overlays in append order:
+  //   1. systemPromptSuffix — caller-provided (e.g. Telegram's
+  //      reply-style + voice-brevity rules; nightly's distillation
+  //      directives).
+  //   2. PRE_TOOL_NARRATION_INSTRUCTION — opt-in via toolNarration,
+  //      added LAST so its directive sits closest to the user message
+  //      and is the most prominent format-of-reply rule the model sees.
+  const overlays: string[] = [];
+  if (input.systemPromptSuffix) overlays.push(input.systemPromptSuffix);
+  if (input.toolNarration) overlays.push(PRE_TOOL_NARRATION_INSTRUCTION);
+  const systemPrompt =
+    overlays.length > 0
+      ? baseSystemPrompt + "\n\n" + overlays.join("\n\n")
+      : baseSystemPrompt;
 
   let finalText = "";
   let succeeded = false;

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -109,6 +109,60 @@ the day. Don't try to do nightly's job mid-conversation; just capture
 well and the nightly cycle handles synthesis.`;
 
 /**
+ * Optional channel-level overlay: ask the model to narrate one short
+ * sentence before each tool call so streaming channels (Telegram text,
+ * Twilio voice via `phantombot ask --stream`) have something to render
+ * during the silence while a tool runs.
+ *
+ * Why a model-driven nudge and not a harness-emitted filler:
+ *   - Harness-emitted filler ("checking your email…") would be in
+ *     English. Many users converse with the agent in other languages —
+ *     the leak is jarring. Letting the model write the line means it
+ *     comes out in whatever language the conversation is already in.
+ *   - The harnesses already flush text the moment it arrives (Claude
+ *     streams partial deltas; Pi/Gemini emit text_delta / message
+ *     events one at a time). So as long as the model produces a
+ *     sentence BEFORE the tool_use block, that sentence reaches the
+ *     channel before the silence — no harness change needed.
+ *
+ * Channels enable this via `TurnInput.toolNarration: true`. Off by
+ * default so CLI/nightly turns aren't padded with intent narration.
+ *
+ * Voice notes (Telegram voice in → voice out) deliberately do NOT
+ * enable this — VOICE_REPLY_INSTRUCTION already says "no narration of
+ * your work," and voice-note replies are one-shot anyway, so there's
+ * no streaming silence to fill.
+ *
+ * Exported for testing.
+ */
+export const PRE_TOOL_NARRATION_INSTRUCTION =
+  `# Narration before tool calls
+
+You're in a streaming channel — the user sees / hears your reply as
+you produce it, not all at once at the end. While a tool runs the
+channel goes silent, which is unsettling for the user.
+
+Rule: before each tool call, say ONE short sentence describing what
+you're about to do. Then run the tool. Examples:
+
+  "Checking your calendar..."
+  "Looking at your email now..."
+  "One sec, asking Home Assistant..."
+
+Use the user's language — match whatever language the conversation
+is in. (Don't always say it in English. If the user wrote to you in
+Spanish, narrate in Spanish.)
+
+One sentence per tool call, no more. Don't pile multiple
+narrations together ahead of time, and don't repeat yourself across
+back-to-back tools — vary the wording. Keep each sentence short
+(under ~12 words) so it's quick to read or speak.
+
+Never narrate after the tool finishes ("got it!", "done!"). The
+narration is purely to fill the pre-tool silence; once the result
+is in, just answer.`;
+
+/**
  * System-level credential discovery + hygiene. Injected into every
  * persona's prompt so the agent has a consistent contract for finding
  * credentials and persisting new ones, regardless of which persona is

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -1029,6 +1029,72 @@ describe("runTelegramServer system-prompt suffixes", () => {
     expect(prompt).not.toContain("text-to-speech");
     expect(prompt).not.toContain("Reply length (this turn only)");
   });
+
+  test("text-in + text-out: pre-tool narration is enabled (streamed text fills tool-call silence)", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hi",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    const prompt = harness.lastRequest?.systemPrompt ?? "";
+    expect(prompt).toContain("Narration before tool calls");
+  });
+
+  test("voice-in + voice-out: pre-tool narration is suppressed (one-shot synthesized clip, no live channel to fill)", async () => {
+    const originalFetch = globalThis.fetch;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (
+      url: string | URL | Request,
+    ) => {
+      const u = String(url);
+      if (u.includes("audio/transcriptions")) {
+        return new Response(JSON.stringify({ text: "hello" }), { status: 200 });
+      }
+      return new Response(Buffer.from([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "audio/ogg" },
+      });
+    }) as unknown as typeof fetch;
+    try {
+      const transport = new FakeTransport();
+      transport.pendingUpdates.push({
+        updateId: 1,
+        chatId: 1001,
+        fromUserId: 42,
+        text: "",
+        voice: { fileId: "f", mimeType: "audio/ogg", durationS: 2 },
+      });
+      const harness = new ScriptedHarness("fake", [
+        { type: "done", finalText: "ok" },
+      ]);
+      await runTelegramServer({
+        config: withVoiceConfig(),
+        memory,
+        harnesses: [harness],
+        agentDir,
+        persona: "phantom",
+        transport,
+        oneShot: true,
+      });
+      const prompt = harness.lastRequest?.systemPrompt ?? "";
+      expect(prompt).not.toContain("Narration before tool calls");
+    } finally {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/cli-ask.test.ts
+++ b/tests/cli-ask.test.ts
@@ -275,6 +275,106 @@ describe("runAsk — pre-tool narration", () => {
   });
 });
 
+describe("runAsk — streaming sink behavior", () => {
+  // A sink that records each individual write() call so we can tell
+  // delta-by-delta streaming apart from a single final write.
+  class RecordingSink {
+    writes: string[] = [];
+    get buf(): string {
+      return this.writes.join("");
+    }
+    write(s: string): boolean {
+      this.writes.push(s);
+      return true;
+    }
+  }
+
+  test("--stream flushes each text delta to out as it arrives", async () => {
+    // Three deltas pre-tool, then a final reformatted finalText. If
+    // streaming is wired, the sink sees each delta separately *before*
+    // the done chunk lands. If it isn't, we'd see a single finalText
+    // write at the end (the non-stream behavior).
+    const harness = new ScriptedHarness("h", [
+      { type: "text", text: "Checking your inboxes" },
+      { type: "text", text: " now" },
+      { type: "text", text: "..." },
+      { type: "done", finalText: "Checking your inboxes now... done." },
+    ]);
+    const out = new RecordingSink();
+    const code = await runAsk({
+      prompt: "any new mail?",
+      stream: true,
+      config,
+      memory,
+      harnesses: [harness],
+      out,
+      err: new CapturingSink(),
+    });
+    expect(code).toBe(0);
+    // Each delta arrives as its own write() call — proves we didn't
+    // buffer-then-emit. The trailing "\n" is the cleanup write at the
+    // end (streamedText didn't end with \n, so ask.ts adds one).
+    expect(out.writes).toEqual([
+      "Checking your inboxes",
+      " now",
+      "...",
+      "\n",
+    ]);
+    // And critically: the harness's authoritative finalText is *not*
+    // re-emitted — that would duplicate the reply on stdout. We only
+    // see the streamed deltas plus the cleanup newline.
+    expect(out.buf).toBe("Checking your inboxes now...\n");
+    expect(out.buf).not.toContain("done.");
+  });
+
+  test("non-stream mode writes finalText once at the end (no per-delta flushes)", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "text", text: "partial " },
+      { type: "text", text: "draft" },
+      { type: "done", finalText: "Final reformatted reply." },
+    ]);
+    const out = new RecordingSink();
+    const code = await runAsk({
+      prompt: "q",
+      // stream defaults to false
+      config,
+      memory,
+      harnesses: [harness],
+      out,
+      err: new CapturingSink(),
+    });
+    expect(code).toBe(0);
+    // Exactly two writes: the harness's finalText, then the trailing
+    // newline. The mid-stream text deltas were correctly suppressed.
+    expect(out.writes).toEqual(["Final reformatted reply.", "\n"]);
+  });
+
+  test("stream mode trailing-newline check uses streamed bytes, not finalText", async () => {
+    // Regression for Kai's note: the trailing-newline check used to
+    // consult `chunk.finalText` even in stream mode. If finalText ends
+    // in "\n" but the streamed deltas didn't, we'd skip the cleanup
+    // newline and leave stdout on a half-line. This test pins the
+    // behavior: streamed bytes have no \n, finalText does, and we
+    // still emit the cleanup \n.
+    const harness = new ScriptedHarness("h", [
+      { type: "text", text: "hello" },
+      // finalText differs from the deltas (reformatted) AND ends in \n.
+      { type: "done", finalText: "hello\n" },
+    ]);
+    const out = new RecordingSink();
+    await runAsk({
+      prompt: "q",
+      stream: true,
+      config,
+      memory,
+      harnesses: [harness],
+      out,
+      err: new CapturingSink(),
+    });
+    expect(out.writes).toEqual(["hello", "\n"]);
+  });
+});
+
 describe("runAsk — persona override", () => {
   test("--persona <name> uses the named persona, not the default", async () => {
     const altDir = join(workdir, "personas", "lena");

--- a/tests/cli-ask.test.ts
+++ b/tests/cli-ask.test.ts
@@ -238,6 +238,43 @@ describe("readAllStdin — TTY guard", () => {
   });
 });
 
+describe("runAsk — pre-tool narration", () => {
+  test("--stream enables PRE_TOOL_NARRATION_INSTRUCTION (Twilio relay rides this)", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runAsk({
+      prompt: "hi",
+      stream: true,
+      config,
+      memory,
+      harnesses: [harness],
+      out: new CapturingSink(),
+      err: new CapturingSink(),
+    });
+    const prompt = harness.lastRequest?.systemPrompt ?? "";
+    expect(prompt).toContain("Narration before tool calls");
+    expect(prompt).toMatch(/user'?s language/i);
+  });
+
+  test("plain ask (no --stream) does NOT enable narration", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runAsk({
+      prompt: "hi",
+      // stream defaults to false
+      config,
+      memory,
+      harnesses: [harness],
+      out: new CapturingSink(),
+      err: new CapturingSink(),
+    });
+    const prompt = harness.lastRequest?.systemPrompt ?? "";
+    expect(prompt).not.toContain("Narration before tool calls");
+  });
+});
+
 describe("runAsk — persona override", () => {
   test("--persona <name> uses the named persona, not the default", async () => {
     const altDir = join(workdir, "personas", "lena");

--- a/tests/orchestrator-turn.test.ts
+++ b/tests/orchestrator-turn.test.ts
@@ -195,6 +195,79 @@ describe("runTurn — successful path", () => {
     expect(captured?.systemPrompt).toContain("# I am Phantom");
   });
 
+  test("toolNarration off by default — narration block is NOT in the prompt", async () => {
+    let captured: HarnessRequest | undefined;
+    const harness = new ScriptedHarness(
+      "fake",
+      [{ type: "done", finalText: "ok" }],
+      (req) => {
+        captured = req;
+      },
+    );
+
+    await collect(
+      runTurn({
+        ...baseInput(),
+        userMessage: "hi",
+        harnesses: [harness],
+      }),
+    );
+
+    expect(captured?.systemPrompt).not.toContain("Narration before tool calls");
+  });
+
+  test("toolNarration: true appends PRE_TOOL_NARRATION_INSTRUCTION", async () => {
+    let captured: HarnessRequest | undefined;
+    const harness = new ScriptedHarness(
+      "fake",
+      [{ type: "done", finalText: "ok" }],
+      (req) => {
+        captured = req;
+      },
+    );
+
+    await collect(
+      runTurn({
+        ...baseInput(),
+        userMessage: "hi",
+        harnesses: [harness],
+        toolNarration: true,
+      }),
+    );
+
+    const prompt = captured?.systemPrompt ?? "";
+    expect(prompt).toContain("Narration before tool calls");
+    // Multilingual nudge: the rule must explicitly say "use the user's
+    // language" so non-English speakers don't get English filler leaking
+    // into their conversations.
+    expect(prompt).toMatch(/user'?s language/i);
+  });
+
+  test("toolNarration coexists with systemPromptSuffix — both land in the prompt", async () => {
+    let captured: HarnessRequest | undefined;
+    const harness = new ScriptedHarness(
+      "fake",
+      [{ type: "done", finalText: "ok" }],
+      (req) => {
+        captured = req;
+      },
+    );
+
+    await collect(
+      runTurn({
+        ...baseInput(),
+        userMessage: "hi",
+        harnesses: [harness],
+        systemPromptSuffix: "# CUSTOM SUFFIX MARKER",
+        toolNarration: true,
+      }),
+    );
+
+    const prompt = captured?.systemPrompt ?? "";
+    expect(prompt).toContain("# CUSTOM SUFFIX MARKER");
+    expect(prompt).toContain("Narration before tool calls");
+  });
+
   test("uses the done chunk's finalText (not the running text accumulation) for persistence", async () => {
     const harness = new ScriptedHarness("fake", [
       { type: "text", text: "draft " },


### PR DESCRIPTION
## Why

The voice agent calls `phantombot ask ...` per turn. In non-stream mode the answer arrives as one final blob, so Twilio TTS can't speak until generation finishes — calendar/quick-fact questions take ~25-30s end to end on a live call.

## What

Adds an opt-in `--stream` flag (and `stream` field on `RunAskInput`):
- When set, assistant `text` chunks are flushed to stdout as they arrive.
- When unset (default), behaviour is unchanged: harness's authoritative `finalText` is written once at the end.

Tool calls and chain-of-thought never reach us as `text` chunks — runTurn surfaces those as `progress`/`heartbeat` and we drop them in both modes. So what hits stdout in stream mode is exactly the assistant's spoken reply, same as before.

The `done` event sets `succeeded` and we skip the final write in stream mode (otherwise we'd duplicate the reply on stdout).

## Caller side

The voice-agent repo's streaming path is gated behind `VOICE_AGENT_STREAM_ASK=1` and shells out to a separate binary via `PHANTOMBOT_STREAM_BIN`. After this lands, both can collapse to the single binary with `--stream` flipped on.

## Risk

Low. Flag is off by default; no existing caller passes it. Contained to `src/cli/ask.ts`.

## Test plan

- [x] Smoke test: `phantombot ask --stream "hello"` prints chunks and exits 0.
- [ ] Live Twilio call with voice-agent on `VOICE_AGENT_STREAM_ASK=1` — confirm latency drop and no duplicate reply on stdout.
