### PR TITLE
feat(telegram): flush narration as separate bubble before each tool call

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -6,10 +6,16 @@
  * memory uses conversation key `telegram:<chatId>` so DMs and groups are
  * isolated from the CLI's `cli:default` history.
  *
- * Streaming: we send `sendChatAction(typing)` at the start of each turn so
- * the user sees "Phantom is typing…" while the harness runs, then post the
- * final reply as one message. Live token-by-token edits would be nicer but
- * Telegram rate-limits edits at ~1/sec — not worth the complexity for v1.
+ * Streaming: we send `sendChatAction(typing)` at the start of each turn,
+ * refresh it on every harness chunk, and — for text-out turns — flush
+ * any buffered prose as a separate Telegram message right before each
+ * tool call (signalled by a `progress` chunk). That makes one-line
+ * narrations like "Checking your inboxes…" land *before* the silent
+ * tool-run window instead of arriving stapled to the back of the final
+ * answer. Voice-out skips chunked flushing — voice is one synthesized
+ * clip at the end, mid-turn flushes would just bloat the audio.
+ * Token-by-token live edits would be nicer still but Telegram
+ * rate-limits edits at ~1/sec — not worth the complexity.
  *
  * Auth gating: if `allowedUserIds` is empty, anyone who DMs the bot is
  * answered. We log a warning at startup so this isn't accidental.
@@ -931,10 +937,53 @@ async function processChatMessage(
   };
   activeTurns.set(msg.chatId, turnHandle);
 
-  let reply = "";
+  // Streaming-narration accumulators. The text-out path flushes
+  // buffered prose as a separate Telegram message right before each
+  // tool call (signalled by a `progress` chunk), so the user sees
+  // "Checking your inboxes…" land *before* the silent tool-run window.
+  // Without this, the entire turn batches into one bubble at the end
+  // and narration is invisible.
+  //
+  //   streamedReply  — running sum of `text` chunks seen so far
+  //   flushedReply   — what's already been sent as narration bubbles;
+  //                    a prefix of streamedReply (and, in the happy
+  //                    path, of the final reply too)
+  //   finalReply     — set on the `done` chunk; authoritative full
+  //                    text the harness wants delivered
+  //
+  // Voice-out skips flushing entirely — voice is one synthesized clip
+  // at the end, so mid-turn flushes would just bloat the audio.
+  let streamedReply = "";
+  let flushedReply = "";
+  let finalReply: string | undefined;
   let errored: string | undefined;
   let progressCount = 0;
   let chosenHarness: string | undefined;
+
+  // Flush whatever's buffered since the last flush as a narration
+  // bubble. No-ops in voice-out (we synthesize once at the end) and
+  // when there's nothing meaningful to send (whitespace-only). Logs
+  // and swallows send failures rather than aborting the turn — a
+  // dropped narration bubble is a cosmetic loss, not a correctness
+  // one.
+  const flushNarration = async () => {
+    if (willReplyWithVoice) return;
+    const pending = streamedReply.slice(flushedReply.length);
+    if (pending.trim().length === 0) return;
+    flushedReply = streamedReply;
+    try {
+      await input.transport.sendMessage(msg.chatId, pending);
+    } catch (e) {
+      log.warn("telegram: narration flush failed", {
+        error: (e as Error).message,
+        chatId: msg.chatId,
+      });
+    }
+    // Sending a real message replaces the typing indicator — re-arm
+    // it so the user sees we're still working on the next step.
+    refreshIndicator();
+  };
+
   try {
     for await (const chunk of runTurn({
       persona: input.persona,
@@ -969,7 +1018,7 @@ async function processChatMessage(
       toolNarration: !willReplyWithVoice,
     })) {
       if (chunk.type === "text") {
-        reply += chunk.text;
+        streamedReply += chunk.text;
         refreshIndicator();
       }
       if (chunk.type === "heartbeat") {
@@ -986,10 +1035,15 @@ async function processChatMessage(
           chatId: msg.chatId,
           note: chunk.note.slice(0, 200),
         });
+        // A tool is about to run — flush whatever narration the model
+        // emitted before this point so the user sees it during the
+        // silence. (Inside the loop so multi-tool turns get one
+        // bubble per tool, not one wall at the end.)
+        await flushNarration();
         refreshIndicator();
       }
       if (chunk.type === "done") {
-        reply = chunk.finalText;
+        finalReply = chunk.finalText;
         const meta = chunk.meta as { harnessId?: unknown } | undefined;
         if (typeof meta?.harnessId === "string") {
           chosenHarness = meta.harnessId;
@@ -1055,20 +1109,46 @@ async function processChatMessage(
     return;
   }
 
-  const outText = errored
-    ? `(error: ${errored})`
-    : reply.length > 0
-      ? reply
-      : "(no reply)";
+  // The authoritative full reply: prefer the harness's `done.finalText`
+  // (which may have been reformatted), fall back to whatever streamed.
+  const fullReply = finalReply ?? streamedReply;
+
+  // Compute what to send in the FINAL bubble (post-tool answer):
+  //   - error: surface the diagnostic
+  //   - flushed prefix matches: send only the suffix (the part of the
+  //     answer the user hasn't seen yet)
+  //   - flushed prefix doesn't match (harness reformatted): send the
+  //     full reply. We accept some duplication of the narration text
+  //     over silently truncating the answer.
+  //   - nothing came back AND nothing was flushed: "(no reply)"
+  //   - nothing came back BUT we flushed: stay silent (the narration
+  //     bubbles are the user-visible reply)
+  let outText: string;
+  if (errored) {
+    outText = `(error: ${errored})`;
+  } else if (fullReply.length === 0) {
+    outText = flushedReply.length > 0 ? "" : "(no reply)";
+  } else if (
+    flushedReply.length > 0 &&
+    fullReply.startsWith(flushedReply)
+  ) {
+    outText = fullReply.slice(flushedReply.length);
+  } else {
+    outText = fullReply;
+  }
 
   // Voice in → voice out (when TTS is configured AND no error).
   // Text in → text out, always. The reply lands as a fresh message,
   // so Telegram pushes a notification — important when the user kicked
   // off a long job and walked away from the chat.
+  //
+  // Voice-out always synthesizes the *full* reply (ignoring the chunked
+  // outText), since flushNarration is a no-op for voice and the user
+  // expects one coherent audio clip.
   let sentAsVoice = false;
   try {
-    if (willReplyWithVoice && !errored && reply.length > 0) {
-      const r = await synthesize(input.config, reply);
+    if (willReplyWithVoice && !errored && fullReply.length > 0) {
+      const r = await synthesize(input.config, fullReply);
       if (r.ok) {
         await input.transport.sendVoice(
           msg.chatId,
@@ -1080,9 +1160,17 @@ async function processChatMessage(
         log.warn("telegram: TTS failed; falling back to text", {
           error: r.error,
         });
-        await input.transport.sendMessage(msg.chatId, outText);
+        // TTS failure fallback: send the full reply as text (not the
+        // prefix-trimmed outText) since we never flushed narration on
+        // the voice path — there's nothing to dedupe against.
+        await input.transport.sendMessage(msg.chatId, fullReply);
       }
-    } else {
+    } else if (outText.length > 0) {
+      // Empty outText is intentional silence: we already flushed the
+      // narration bubbles and the harness produced nothing further
+      // (and there's no error to surface). Skipping the send avoids
+      // a stray "(no reply)" tacked onto the end of a perfectly
+      // delivered turn.
       await input.transport.sendMessage(msg.chatId, outText);
     }
   } catch (e) {
@@ -1096,6 +1184,7 @@ async function processChatMessage(
     chatId: msg.chatId,
     durationMs: Date.now() - startedAt,
     replyChars: outText.length,
+    flushedChars: flushedReply.length,
     progressEvents: progressCount,
     harness: chosenHarness ?? (errored ? "(error)" : "(unknown)"),
     modality: sentAsVoice ? "voice" : "text",

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1039,8 +1039,9 @@ async function processChatMessage(
         // emitted before this point so the user sees it during the
         // silence. (Inside the loop so multi-tool turns get one
         // bubble per tool, not one wall at the end.)
+        // flushNarration() re-arms the typing indicator after sending,
+        // so we don't need to call refreshIndicator() again here.
         await flushNarration();
-        refreshIndicator();
       }
       if (chunk.type === "done") {
         finalReply = chunk.finalText;

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -1098,6 +1098,443 @@ describe("runTelegramServer system-prompt suffixes", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Pre-tool narration: flush buffered prose as a separate Telegram message
+// before each tool call so the user sees "Checking your inboxes…" land
+// during the silent tool-run window instead of stapled to the back of the
+// final answer. Voice-out skips chunked flushing.
+// ---------------------------------------------------------------------------
+
+describe("runTelegramServer narration flush (text-out)", () => {
+  test("text → progress → text → done sends two messages: narration first, answer second", async () => {
+    class NarrationHarness implements Harness {
+      readonly id = "narration";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "Checking your inboxes…" };
+        yield { type: "progress", note: "tool: gog mail-search" };
+        yield { type: "text", text: "Found 3 threads from Turtle Crossing." };
+        yield {
+          type: "done",
+          finalText:
+            "Checking your inboxes…Found 3 threads from Turtle Crossing.",
+        };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "any new email from turtle crossing?",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new NarrationHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.sent.map((s) => s.text)).toEqual([
+      "Checking your inboxes…",
+      "Found 3 threads from Turtle Crossing.",
+    ]);
+    // Both bubbles land in the right chat.
+    expect(transport.sent.every((s) => s.chatId === 1001)).toBe(true);
+  });
+
+  test("multi-tool turn: one narration bubble per tool, then the final answer", async () => {
+    class MultiToolHarness implements Harness {
+      readonly id = "multitool";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "Checking your calendar…" };
+        yield { type: "progress", note: "tool: gog calendar-list" };
+        yield { type: "text", text: "Now scanning your inboxes…" };
+        yield { type: "progress", note: "tool: gog mail-search" };
+        yield {
+          type: "text",
+          text: "Calendar is clear; you have 2 unread emails.",
+        };
+        yield {
+          type: "done",
+          finalText:
+            "Checking your calendar…Now scanning your inboxes…Calendar is clear; you have 2 unread emails.",
+        };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "any urgent emails or calendar blockers?",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new MultiToolHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.sent.map((s) => s.text)).toEqual([
+      "Checking your calendar…",
+      "Now scanning your inboxes…",
+      "Calendar is clear; you have 2 unread emails.",
+    ]);
+  });
+
+  test("no progress chunk: behaves like before — single bubble with full reply", async () => {
+    // Regression guard: turns that don't trigger a tool (the agent
+    // answers from context) shouldn't be split into multiple bubbles.
+    class NoToolHarness implements Harness {
+      readonly id = "no-tool";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "The capital of France is Paris." };
+        yield {
+          type: "done",
+          finalText: "The capital of France is Paris.",
+        };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "what's the capital of France?",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new NoToolHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.sent).toEqual([
+      { chatId: 1001, text: "The capital of France is Paris." },
+    ]);
+  });
+
+  test("whitespace-only buffer between text chunks does NOT flush an empty bubble", async () => {
+    // The model could plausibly emit a stray space or newline before
+    // the first real word. We don't want a Telegram bubble containing
+    // just " " — that shows up as a blank message.
+    class WhitespaceHarness implements Harness {
+      readonly id = "whitespace";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "  \n " };
+        yield { type: "progress", note: "tool: noop" };
+        yield { type: "text", text: "real answer" };
+        yield { type: "done", finalText: "  \n real answer" };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "anything?",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new WhitespaceHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    // No empty/whitespace narration bubble; the full reply lands as
+    // one message. The leading whitespace was never flushed, so the
+    // prefix-match path doesn't trigger and we send `fullReply` whole.
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]!.text).toBe("  \n real answer");
+  });
+
+  test("flushed prefix matches finalText: post-tool message is the suffix only (no duplication)", async () => {
+    // Happy path: streamed text concatenated equals finalText. The
+    // post-tool bubble must contain only the bytes the user hasn't
+    // already seen — no echo of the narration sentence.
+    class CleanFinalHarness implements Harness {
+      readonly id = "clean-final";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "Looking that up…\n" };
+        yield { type: "progress", note: "tool: web-search" };
+        yield { type: "text", text: "It's 42." };
+        // finalText exactly equals the concatenation of text chunks.
+        yield { type: "done", finalText: "Looking that up…\nIt's 42." };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "ultimate question?",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new CleanFinalHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.sent.map((s) => s.text)).toEqual([
+      "Looking that up…\n",
+      "It's 42.",
+    ]);
+  });
+
+  test("harness reformats final reply: send full final, accept duplication over truncation", async () => {
+    // Pathological case: the harness reformatted finalText so it no
+    // longer starts with what we flushed. Better to send the full
+    // (slightly duplicated) answer than to slice off bytes the user
+    // needs to see.
+    class ReformatHarness implements Harness {
+      readonly id = "reformat";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "Checking…" };
+        yield { type: "progress", note: "tool: search" };
+        yield { type: "text", text: "Result is X." };
+        // Harness reformatted — finalText doesn't start with "Checking…"
+        yield { type: "done", finalText: "Result: X (after a check)." };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "any results?",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new ReformatHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    // First bubble: the narration we flushed before the tool fired.
+    // Second bubble: the full reformatted final, NOT a sliced suffix
+    // (because the prefix didn't match). User sees a duplicated word
+    // — acceptable. Truncating would be worse.
+    expect(transport.sent).toHaveLength(2);
+    expect(transport.sent[0]!.text).toBe("Checking…");
+    expect(transport.sent[1]!.text).toBe("Result: X (after a check).");
+  });
+
+  test("narration flushed but model emits nothing further: no '(no reply)' tacked on", async () => {
+    // Model said "Checking…", a tool ran, and… nothing came back.
+    // We've already shown the user something — don't bolt
+    // "(no reply)" onto the end. Stay quiet.
+    class SilentAfterToolHarness implements Harness {
+      readonly id = "silent-after-tool";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "Checking…" };
+        yield { type: "progress", note: "tool: search" };
+        yield { type: "done", finalText: "Checking…" };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "anything?",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new SilentAfterToolHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    // Just the narration bubble. No "(no reply)" follow-up.
+    expect(transport.sent.map((s) => s.text)).toEqual(["Checking…"]);
+  });
+
+  test("error after a flushed narration bubble: error message follows the narration", async () => {
+    // Narration landed, then the tool blew up. The error diagnostic
+    // still has to surface — we suppress "(no reply)" specifically,
+    // not real errors.
+    class ErrorAfterToolHarness implements Harness {
+      readonly id = "error-after-tool";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "Checking…" };
+        yield { type: "progress", note: "tool: search" };
+        yield { type: "error", error: "boom", recoverable: false };
+      }
+    }
+
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "anything?",
+    });
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [new ErrorAfterToolHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.sent.map((s) => s.text)).toEqual([
+      "Checking…",
+      "(error: boom)",
+    ]);
+  });
+});
+
+describe("runTelegramServer narration flush (voice-out)", () => {
+  const SAVED_KEY = process.env.PHANTOMBOT_OPENAI_API_KEY;
+  beforeEach(() => {
+    process.env.PHANTOMBOT_OPENAI_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    if (SAVED_KEY === undefined) delete process.env.PHANTOMBOT_OPENAI_API_KEY;
+    else process.env.PHANTOMBOT_OPENAI_API_KEY = SAVED_KEY;
+  });
+
+  function withVoiceConfig(): Config {
+    const c = baseConfig();
+    return {
+      ...c,
+      voice: {
+        provider: "openai",
+        openai: { model: "tts-1", voice: "nova", speed: 1 },
+      },
+    };
+  }
+
+  test("voice-in/voice-out: progress chunks do NOT flush text bubbles; full reply synthesized at end", async () => {
+    // Voice replies are one synthesized clip — chunked text flushes
+    // would just bloat the audio AND leak text into a voice-only
+    // conversation. The flush function is gated off for voice.
+    const originalFetch = globalThis.fetch;
+    let ttsBodyText: string | undefined;
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const u = String(url);
+      if (u.includes("audio/transcriptions")) {
+        return new Response(JSON.stringify({ text: "hello" }), {
+          status: 200,
+        });
+      }
+      if (u.includes("audio/speech")) {
+        // Capture the text we sent to TTS so the assertion can verify
+        // we synthesized the FULL reply, not just the post-tool suffix.
+        const body = init?.body && typeof init.body === "string"
+          ? (JSON.parse(init.body) as { input?: string })
+          : {};
+        ttsBodyText = body.input;
+        return new Response(Buffer.from([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "audio/ogg" },
+        });
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    }) as unknown as typeof fetch;
+
+    try {
+      class NarrationHarness implements Harness {
+        readonly id = "narration-voice";
+        async available(): Promise<boolean> {
+          return true;
+        }
+        async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+          yield { type: "text", text: "Checking…" };
+          yield { type: "progress", note: "tool: search" };
+          yield { type: "text", text: "Done." };
+          yield { type: "done", finalText: "Checking…Done." };
+        }
+      }
+
+      const transport = new FakeTransport();
+      transport.pendingUpdates.push({
+        updateId: 1,
+        chatId: 1001,
+        fromUserId: 42,
+        text: "",
+        voice: { fileId: "abc", mimeType: "audio/ogg", durationS: 2 },
+      });
+      await runTelegramServer({
+        config: withVoiceConfig(),
+        memory,
+        harnesses: [new NarrationHarness()],
+        agentDir,
+        persona: "phantom",
+        transport,
+        oneShot: true,
+      });
+
+      // No text bubbles emitted — voice-out path stays silent on text.
+      expect(transport.sent).toEqual([]);
+      // One voice clip went out with the FULL reply (not just the
+      // suffix), since the voice path ignores `flushedReply`.
+      expect(transport.voiceSent).toHaveLength(1);
+      expect(ttsBodyText).toBe("Checking…Done.");
+    } finally {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AbortSignal plumbing
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to #73. Today the Telegram channel batches the entire turn into one bubble at the end, so the pre-tool narration that PR #73 wired up ("Checking your inboxes…") gets stapled to the front of the final answer instead of arriving during the silent tool-run window — exactly the gap it was supposed to fill.

This PR makes the text-out path flush whatever prose has accumulated since the last flush as its own Telegram message right when a `progress` chunk arrives (i.e. just before a tool fires). Multi-tool turns get one bubble per tool, then the post-tool answer.

## What the user sees

**Before:**
> User: any new email from turtle crossing?
> *[15s of silence, typing indicator]*
> Robbie: Checking your inboxes now... Found 3 threads, most recent is Corinne's renewal-notice forward from today...

**After:**
> User: any new email from turtle crossing?
> Robbie: Checking your inboxes now…
> *[15s, typing indicator]*
> Robbie: Found 3 threads, most recent is Corinne's renewal-notice forward from today...

Bigger payoff on multi-tool turns — "any urgent emails or calendar blockers?" now lands as three messages ("Checking your calendar…" → "Now scanning your inboxes…" → final answer) instead of 30 seconds of dead air.

## Mechanics

Three accumulators:
- `streamedReply` — running sum of `text` chunks
- `flushedReply`  — what's already been sent as narration bubbles
- `finalReply`    — authoritative full text from the `done` chunk

On each `progress` chunk: send `streamedReply.slice(flushedReply.length)` if it has non-whitespace content, then update `flushedReply`.

After the loop, the final bubble logic handles four cases:
- **Happy path**: `finalReply.startsWith(flushedReply)` → send only the suffix (no duplicated narration)
- **Reformat**: prefix doesn't match → send full `finalReply`. Duplication beats truncation; we'd rather show the whole answer with a repeated word than slice off bytes the user needs.
- **Silent after tool**: model emitted nothing further → stay quiet (the narration bubbles are the user-visible reply; don't tack on "(no reply)").
- **Error**: surface the diagnostic regardless of what was flushed.

## Voice-out is unchanged

Voice replies are one synthesized clip at the end, so chunked text flushes would both bloat the audio and leak text into a voice-only conversation. The flush function is gated off via `willReplyWithVoice` and the voice path always synthesizes the full reply (not the prefix-trimmed `outText`).

## Test coverage

9 new tests in `tests/channels-telegram.test.ts`:
1. Happy path two-bubble flow (text → progress → text → done)
2. Multi-tool one-bubble-per-tool
3. No-progress regression: single bubble with full reply
4. Whitespace-only buffer doesn't flush an empty bubble
5. Prefix-match: post-tool message is the suffix only (no duplication)
6. Harness reformat: full reply sent (graceful fallback)
7. Silent after tool: no "(no reply)" tacked on
8. Error after a flushed narration bubble: error follows the narration
9. Voice-out: progress chunks do NOT flush; full reply synthesized at end

611/0 fail, typecheck clean.

## Test plan

- [x] Full test suite green (`bun test` → 611 pass / 0 fail / 1 skip)
- [x] Typecheck clean (`bun run typecheck`)
- [ ] Manual: text → tool → text turn lands as two Telegram bubbles in order
- [ ] Manual: multi-tool turn lands as one bubble per tool + one final answer
- [ ] Manual: voice-in/voice-out turn still arrives as a single voice clip
- [ ] Manual: no-tool turn (e.g. "thanks") still lands as one bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)