### PR TITLE
fix(pi): emit progress for tool events instead of heartbeat

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -261,10 +261,10 @@ export function renderStdinPayload(req: HarnessRequest): string {
  *
  * Channel layers want two distinct signals from us:
  *   - `text` blocks → user-visible reply (concatenate, surface verbatim).
- *   - Anything else (`thinking`, `tool_use`, `tool_result`, …) → "model
- *     is alive" tick, no payload. The actual content stays inside the
- *     subprocess; we just emit `heartbeat` so the channel can refresh
- *     its typing indicator without leaking chain-of-thought.
+ *   - Anything else (`thinking`, `tool_use`, `tool_result`, …) → `progress`
+ *     so the channel layer can flush pending narration before the model
+ *     runs its tool. Actual content stays inside the subprocess; we never
+ *     leak chain-of-thought.
  *
  * If a single assistant message contains BOTH text and non-text blocks,
  * we prefer the text chunk (it carries strictly more signal — text
@@ -295,7 +295,7 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
     }
   }
   if (text) return { type: "text", text };
-  if (sawNonText) return { type: "heartbeat" };
+  if (sawNonText) return { type: "progress" };
   return undefined;
 }
 

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -251,24 +251,28 @@ export function renderStdinPayload(req: HarnessRequest): string {
 
 /**
  * Translate one stream-json line into a HarnessChunk. Returns undefined for
- * lines we want to ignore (e.g. tool-use events that the agent handles
- * internally and doesn't need to surface to phantombot).
+ * lines we want to ignore.
  *
  * Claude's stream-json schema is documented in the Claude Code docs but
  * informally: each line has a `type` (system / user / assistant / result)
  * and a `message` payload. The assistant content is an array of blocks
  * with their own `type`: `text`, `thinking`, `tool_use`, `tool_result`.
  *
- * Channel layers want two distinct signals from us:
+ * Channel layers want three distinct signals from us:
  *   - `text` blocks → user-visible reply (concatenate, surface verbatim).
- *   - Anything else (`thinking`, `tool_use`, `tool_result`, …) → `progress`
- *     so the channel layer can flush pending narration before the model
- *     runs its tool. Actual content stays inside the subprocess; we never
- *     leak chain-of-thought.
+ *   - `tool_use` blocks → `progress` so the channel layer can flush pending
+ *     narration before the model runs its tool.
+ *   - `thinking` / `tool_result` → `heartbeat` (refreshes typing indicator,
+ *     but does NOT flush narration — mirrors pi.ts behavior).
  *
  * If a single assistant message contains BOTH text and non-text blocks,
- * we prefer the text chunk (it carries strictly more signal — text
- * implicitly proves the model is alive too).
+ * text wins (it carries strictly more signal). If it has both tool_use
+ * and thinking, progress wins (tool_use is the signal that matters).
+ * Thinking-only messages get a heartbeat — they don't fragment the
+ * narration bubble.
+ *
+ * Actual content stays inside the subprocess; we never leak
+ * chain-of-thought.
  *
  * Exported for testing.
  */
@@ -283,19 +287,23 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   if (!Array.isArray(content)) return undefined;
 
   let text = "";
-  let sawNonText = false;
+  let toolName: string | undefined;
+  let sawOtherNonText = false;
   for (const part of content) {
     if (typeof part === "object" && part !== null) {
       const p = part as Record<string, unknown>;
       if (p.type === "text" && typeof p.text === "string") {
         text += p.text;
+      } else if (p.type === "tool_use") {
+        toolName = typeof p.name === "string" ? p.name : toolName ?? "tool";
       } else if (typeof p.type === "string") {
-        sawNonText = true;
+        sawOtherNonText = true;
       }
     }
   }
   if (text) return { type: "text", text };
-  if (sawNonText) return { type: "progress" };
+  if (toolName) return { type: "progress", note: `tool: ${toolName}` };
+  if (sawOtherNonText) return { type: "heartbeat" };
   return undefined;
 }
 

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -8,7 +8,7 @@
  *
  * Stream-json events translated to phantombot HarnessChunks:
  *   message_update with text_delta  → { type: "text", text }
- *   tool_execution_start            → { type: "progress", note: "running <tool>" }
+ *   tool_execution_start            → { type: "progress", note: "tool: <name>" }
  *   anything else (agent_start,
  *     tool_execution_end, turn_end,
  *     extension_*) → ignored        (the done chunk is emitted from process exit)
@@ -211,14 +211,25 @@ export function renderPayload(req: HarnessRequest): string {
  * time, that's pi actually thinking — the indicator vanishing means the
  * model has gone silent (and may be wedged on a tool call).
  *
- * Other unknown event types (tool_use_*, etc.) also fold into heartbeats
- * so we don't pretend the model is silent during legitimate work.
+ * tool_use_* event types inside assistantMessageEvent → `progress`
+ * so the channel layer flushes narration into a bubble before the tool
+ * runs. thinking_delta + other event types → `heartbeat`.
  *
  * Exported for testing.
  */
 export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
   if (typeof parsed !== "object" || parsed === null) return undefined;
   const obj = parsed as Record<string, unknown>;
+
+  // tool_execution_start is a top-level event pi emits just before
+  // it invokes a tool. Emit as `progress` so the channel layer
+  // flushes any buffered narration into a bubble before the tool
+  // runs (keeping the user oriented during the silence).
+  if (obj.type === "tool_execution_start") {
+    const toolName = typeof obj.tool_name === "string" ? obj.tool_name : undefined;
+    return { type: "progress", note: toolName ? `tool: ${toolName}` : "tool" };
+  }
+
   if (obj.type !== "message_update") return undefined;
 
   const ame = obj.assistantMessageEvent;
@@ -232,10 +243,18 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
     return undefined;
   }
 
-  // thinking_delta + any other assistantMessageEvent type → heartbeat.
-  // We intentionally do NOT include the content in the chunk (would leak
-  // chain-of-thought to the user). The signal is just "pi is alive."
   if (typeof ame.type === "string") {
+    // tool_use_* assistantMessageEvent: the model has decided to call
+    // a tool — emit `progress` so the channel layer flushes narration
+    // into a bubble before the tool runs. Previously these were mapped
+    // to heartbeats, which kept the typing indicator alive but never
+    // triggered a bubble flush (defeating the purpose of PR #74).
+    if ((ame.type as string).startsWith("tool_use")) {
+      return { type: "progress", note: "tool" };
+    }
+    // thinking_delta + anything else → heartbeat.
+    // We intentionally do NOT include the content in the chunk (would leak
+    // chain-of-thought to the user). The signal is just "pi is alive."
     return { type: "heartbeat" };
   }
 

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -249,7 +249,7 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
     // into a bubble before the tool runs. Previously these were mapped
     // to heartbeats, which kept the typing indicator alive but never
     // triggered a bubble flush (defeating the purpose of PR #74).
-    if ((ame.type as string).startsWith("tool_use")) {
+    if (ame.type.startsWith("tool_use")) {
       return { type: "progress", note: "tool" };
     }
     // thinking_delta + anything else → heartbeat.

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -115,26 +115,26 @@ describe("parseStreamJson", () => {
     expect(parseStreamJson({ type: "result" })).toBeUndefined();
   });
 
-  test("emits heartbeat for assistant messages with only non-text parts (e.g. pure tool_use)", () => {
+  test("emits progress for assistant messages with only non-text parts (e.g. pure tool_use)", () => {
     const c = parseStreamJson({
       type: "assistant",
       message: { content: [{ type: "tool_use", name: "Bash", input: {} }] },
     });
-    expect(c).toEqual({ type: "heartbeat" });
+    expect(c).toEqual({ type: "progress" });
   });
 
-  test("emits heartbeat for thinking blocks (and does NOT leak the content)", () => {
+  test("emits progress for thinking blocks (and does NOT leak the content)", () => {
     const c = parseStreamJson({
       type: "assistant",
       message: {
         content: [{ type: "thinking", thinking: "internal chain-of-thought" }],
       },
     });
-    expect(c).toEqual({ type: "heartbeat" });
+    expect(c).toEqual({ type: "progress" });
     expect(JSON.stringify(c)).not.toContain("chain-of-thought");
   });
 
-  test("text takes precedence: when a message has both text and tool_use, text wins (no heartbeat)", () => {
+  test("text takes precedence: when a message has both text and tool_use, text wins (no progress)", () => {
     const c = parseStreamJson({
       type: "assistant",
       message: {

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -115,23 +115,58 @@ describe("parseStreamJson", () => {
     expect(parseStreamJson({ type: "result" })).toBeUndefined();
   });
 
-  test("emits progress for assistant messages with only non-text parts (e.g. pure tool_use)", () => {
+  test("progress for tool_use blocks with tool name in note", () => {
     const c = parseStreamJson({
       type: "assistant",
       message: { content: [{ type: "tool_use", name: "Bash", input: {} }] },
     });
-    expect(c).toEqual({ type: "progress" });
+    expect(c).toEqual({ type: "progress", note: "tool: Bash" });
   });
 
-  test("emits progress for thinking blocks (and does NOT leak the content)", () => {
+  test("heartbeat for thinking blocks (no flush — mirrors pi.ts)", () => {
     const c = parseStreamJson({
       type: "assistant",
       message: {
         content: [{ type: "thinking", thinking: "internal chain-of-thought" }],
       },
     });
-    expect(c).toEqual({ type: "progress" });
-    expect(JSON.stringify(c)).not.toContain("chain-of-thought");
+    expect(c).toEqual({ type: "heartbeat" });
+  });
+
+  test("heartbeat for tool_result blocks (no flush)", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: "abc", content: "done" }],
+      },
+    });
+    expect(c).toEqual({ type: "heartbeat" });
+  });
+
+  test("progress when tool_use present, even if thinking also present", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "thinking", thinking: "hm..." },
+          { type: "tool_use", name: "Read", input: {} },
+        ],
+      },
+    });
+    expect(c).toEqual({ type: "progress", note: "tool: Read" });
+  });
+
+  test("heartbeat for thinking + tool_result (no tool_use)", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "thinking", thinking: "hm..." },
+          { type: "tool_result", tool_use_id: "abc", content: "ok" },
+        ],
+      },
+    });
+    expect(c).toEqual({ type: "heartbeat" });
   });
 
   test("text takes precedence: when a message has both text and tool_use, text wins (no progress)", () => {

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -92,6 +92,31 @@ describe("parsePiEvent", () => {
     expect(JSON.stringify(c)).not.toContain("internal reasoning");
   });
 
+  test("emits progress for tool_execution_start (top-level event)", () => {
+    const c = parsePiEvent({
+      type: "tool_execution_start",
+      tool_name: "run_shell_command",
+    });
+    expect(c).toEqual({ type: "progress", note: "tool: run_shell_command" });
+  });
+
+  test("emits progress for tool_execution_start without a tool_name", () => {
+    const c = parsePiEvent({ type: "tool_execution_start" });
+    expect(c).toEqual({ type: "progress", note: "tool" });
+  });
+
+  test("emits progress for tool_use assistantMessageEvent (not heartbeat)", () => {
+    for (const ameType of ["tool_use_start", "tool_use_end", "tool_use"]) {
+      expect(
+        parsePiEvent({
+          type: "message_update",
+          assistantMessageEvent: { type: ameType, contentIndex: 0 },
+          message: {},
+        }),
+      ).toEqual({ type: "progress", note: "tool" });
+    }
+  });
+
   test("emits heartbeat for text_start / text_end / thinking_start / thinking_end markers", () => {
     for (const ameType of [
       "text_start",


### PR DESCRIPTION
## Problem

PR #74 (telegram narration bubbles) added a working mechanism: when a harness emits a `progress` chunk, the Telegram channel layer calls `flushNarration()` which sends buffered text as a separate bubble before the tool runs.

The pi harness's `parsePiEvent()` was never wired up to emit `progress` — it mapped all non-`text_delta` events to `heartbeat`. Heartbeats only refresh the typing indicator and never trigger `flushNarration()`. Result: zero progress events per turn, all text lands in one bubble at the end. The feature was dead code for pi agents.

Evidence from Kai's own logs reviewing PR #75: `progressEvents: 0, flushedChars: 0`.

## Fix

Two changes to `parsePiEvent()`:

1. **`tool_execution_start`** (top-level pi event) → `{ type: "progress", note: "tool: <name>" }`
2. **`tool_use_*`** (assistantMessageEvent subtype) → `{ type: "progress", note: "tool" }`

`thinking_delta` and other event types remain `heartbeat` — unchanged.

## Why this works

The channel layer's progress handler calls `flushNarration()`, which sends buffered text as a Telegram message and re-arms the typing indicator. Multiple progress events without intervening text are harmless no-ops (flushNarration checks for whitespace-only pending text before sending).

## Tests

Two new test cases verifying:
- `tool_execution_start` → progress with tool name
- `tool_use_start` / `tool_use_end` / `tool_use` → progress

All existing tests pass unchanged.