### PR TITLE
ci(pages): switch to official GitHub Pages actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,19 +6,44 @@ on:
       - main
     paths:
       - 'www/**'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping queued runs in between.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Prepare site
+        run: |
+          mkdir -p _site
+          cp -r www/. _site/
+          echo "phantombot.bot" > _site/CNAME
+          touch _site/.nojekyll
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./www
-          cname: phantombot.bot
+          path: ./_site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What

Replace the legacy `peaceiris/actions-gh-pages` deploy with the official GitHub Pages actions flow (`actions/upload-pages-artifact` + `actions/deploy-pages`).

## Why

Current state is broken: the existing workflow successfully pushes a `gh-pages` branch on every `www/**` change, but the repo's Pages source is set to `main /` — so the published site has been serving the entire repo root rather than `www/`, ignoring the work the deploy job does.

This change drops the long-lived `gh-pages` branch entirely. `www/` on `main` becomes the single source of truth; the workflow uploads it as a Pages artifact and deploys directly. Adds `.nojekyll` for safety and preserves the `phantombot.bot` CNAME.

## Follow-up after merge

1. Switch the repo's Pages source from "Deploy from a branch" to "GitHub Actions" (one API call or one click in Settings → Pages).
2. The workflow runs automatically on the merge commit and publishes.
3. Delete the now-orphan `gh-pages` branch.

Robbie will handle steps 1–3 once this is merged.