### PR TITLE
docs(readme): move Quick Start under install curl, add BotFather/userinfobot guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,34 @@ When Phantom is asked to *"SSH to the home lab and write a note to the Obsidian 
 curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh
 ```
 
+### Quick start
+
+After `install.sh` completes:
+
+**Getting a Telegram bot token:**
+
+1. Open Telegram and chat with [@BotFather](https://t.me/BotFather)
+2. Send `/newbot` and follow the prompts to name your bot
+3. Copy the token — it'll look like `1234567890:ABCdef...`
+
+**Getting your Telegram user ID:**
+
+1. Open Telegram and chat with [@userinfobot](https://t.me/userinfobot)
+2. Send any message (or `/start`)
+3. Copy the numeric ID it returns
+
+Then run:
+
+```bash
+phantombot persona   # TUI — create or import (OpenClaw works) your first persona
+phantombot harness   # primary harness — pi recommended; claude/gemini as fallback
+phantombot telegram  # paste your @BotFather bot token + allowlisted user IDs
+phantombot voice     # (optional) pick TTS/STT provider for voice messages
+
+phantombot run       # foreground — Ctrl-C to stop.
+phantombot install   # install as a systemd --user service (survives logout)
+```
+
 The script:
 
 - Detects host arch (`x86_64` / `aarch64`).
@@ -56,22 +84,6 @@ phantombot update --force --restart     # cron-friendly: no prompts, restart aft
 ```
 
 Updates download to `${binPath}.update.tmp`, SHA256-verify, atomically rename over the live binary, and clean up after themselves — no `.bak` files left in your install dir.
-
----
-
-## Quick start
-
-After `install.sh` completes:
-
-```bash
-phantombot persona # TUI — create or import (OpenClaw works) your first persona
-phantombot harness # primary harness — pi recommended; claude/gemini as fallback
-phantombot telegram # paste your @BotFather bot token + allowlisted user IDs
-phantombot voice # (optional) pick TTS/STT provider for voice messages
-
-phantombot run # foreground — Ctrl-C to stop.
-phantombot install # install as a systemd --user service (survives logout)
-```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,23 @@ After `install.sh` completes:
 2. Send any message (or `/start`)
 3. Copy the numeric ID it returns
 
+### Before you configure a harness
+
+Phantombot doesn't bundle an AI model — it delegates to one you already have installed. We call the AI tool a **harness**: phantombot passes your persona + conversation to it, the harness runs its own tools (Bash, file access, web search), and phantombot relays the result to Telegram.
+
+**You must install and authenticate at least one harness yourself before `phantombot harness` will work:**
+
+- **Pi** *(recommended primary)* — install `pi` from Inflection, then run `pi` once to authenticate.
+- **Claude Code** — `npm install -g @anthropic-ai/claude-code`, then `claude /login` for OAuth.
+- **Gemini CLI** — install Google's Gemini CLI, then `gemini` and follow the `/auth` flow (or set `GEMINI_API_KEY` in `~/.env`).
+
+**Primary vs. fallback:** The primary handles every turn by default. If it fails (auth expiry, rate limit, transient error), phantombot automatically tries the fallback. Pi as primary + Claude as fallback is the recommended combo — you get Pi's speed and personality day-to-day, with Claude catching errors seamlessly.
+
 Then run:
 
 ```bash
 phantombot persona   # TUI — create or import (OpenClaw works) your first persona
-phantombot harness   # primary harness — pi recommended; claude/gemini as fallback
+phantombot harness   # TUI — picks up installed harnesses; choose primary + fallback
 phantombot telegram  # paste your @BotFather bot token + allowlisted user IDs
 phantombot voice     # (optional) pick TTS/STT provider for voice messages
 


### PR DESCRIPTION
## What

- Moves **Quick Start** to a subsection under **Install**, right after the install curl command — so new users see setup steps immediately after the one-liner
- Adds step-by-step instructions for the two most common sticking points:
  - Getting a Telegram bot token from @BotFather
  - Getting a Telegram user ID from @userinfobot
- Removes the redundant standalone Quick Start section

## Why

The Quick Start was buried after "Environment overrides" and "update" docs — users had to scroll past install internals to reach setup steps. BotFather and userinfobot are referenced in Prerequisites but never explained.
