### PR TITLE
ci: build darwin-arm64 binary alongside linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,12 +87,28 @@ jobs:
             ./src/index.ts \
             --outfile "dist/phantombot-${TAG}-linux-arm64"
 
+      - name: Build darwin-arm64 (Apple Silicon)
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # Cross-compiled from the Linux runner; Bun emits an unsigned
+          # Mach-O. First-run on macOS will be quarantined by Gatekeeper —
+          # see release notes for the `xattr -d com.apple.quarantine` step.
+          # No darwin-x64 build: no current deploy target uses Intel Macs.
+          bun build --compile --target=bun-darwin-arm64 \
+            ./src/index.ts \
+            --outfile "dist/phantombot-${TAG}-darwin-arm64"
+
       - name: Compute SHA256SUMS
         working-directory: dist
         env:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          sha256sum "phantombot-${TAG}-linux-x64" "phantombot-${TAG}-linux-arm64" > SHA256SUMS
+          sha256sum \
+            "phantombot-${TAG}-linux-x64" \
+            "phantombot-${TAG}-linux-arm64" \
+            "phantombot-${TAG}-darwin-arm64" \
+            > SHA256SUMS
           cat SHA256SUMS
 
       - name: Write release notes to file
@@ -107,10 +123,15 @@ jobs:
           Binaries:
           - phantombot-${TAG}-linux-x64 — x86-64, baseline (no AVX2 required)
           - phantombot-${TAG}-linux-arm64 — ARM64
+          - phantombot-${TAG}-darwin-arm64 — macOS Apple Silicon (unsigned; see below)
 
           Verify with: sha256sum -c SHA256SUMS
 
           Install with: phantombot update
+
+          macOS note: the darwin-arm64 binary is cross-compiled and unsigned.
+          On first run, clear the Gatekeeper quarantine attribute:
+            xattr -d com.apple.quarantine ./phantombot-${TAG}-darwin-arm64
           EOF
 
       - name: Create GitHub Release with binary assets
@@ -128,4 +149,5 @@ jobs:
             --notes-file release-notes.md \
             "dist/phantombot-${TAG}-linux-x64" \
             "dist/phantombot-${TAG}-linux-arm64" \
+            "dist/phantombot-${TAG}-darwin-arm64" \
             "dist/SHA256SUMS"


### PR DESCRIPTION
## Summary
- Add a `bun-darwin-arm64` cross-compile step to the PR-merge release workflow
- Include the new binary in `SHA256SUMS` and the `gh release create` upload list
- Document the unsigned-Mach-O / Gatekeeper-quarantine workaround in the release notes template

## Why
First step toward macOS Apple Silicon support. Scope is intentionally tiny: just produce a binary so we can validate that the runtime works on darwin-arm64 hardware before touching `install.sh` or `phantombot update`. No darwin-x64 build (no current deploy target uses Intel Macs).

Bun cross-compiles darwin from the Linux runner — no `macos-latest` runner needed, no extra cost. The Mach-O is unsigned; first-run on Mac requires `xattr -d com.apple.quarantine ./phantombot-vX.Y.Z-darwin-arm64`. Notarization is out of scope (paid Apple Developer ID pipeline).

## Test plan
- [ ] Workflow run succeeds on PR merge
- [ ] Release `v1.0.<this-PR>` includes `phantombot-v1.0.<N>-darwin-arm64` and the SHA matches `SHA256SUMS`
- [ ] Download the binary on Andrew's M3 Mac, clear quarantine, run `./phantombot --version` — confirms version string matches the tag
- [ ] Smoke-test core CLI subcommands (`persona`, `harness`, `telegram`) on the Mac

Follow-ups (separate PRs, deferred until binary is verified):
- `install.sh` darwin support (arch detection + `shasum -a 256` fallback)
- `src/cli/update.ts` `detectSupportedArch` to accept darwin
- Optional: launchd unit for `phantombot install` on macOS
