### PR TITLE
install.sh: drop "not a TTY" error wording from piped install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -219,10 +219,11 @@ if [ -n "${PHANTOMBOT_SKIP_TUI:-}" ]; then
 fi
 
 # If stdin is not a TTY (e.g. piped from `curl … | sh`), the @clack
-# prompts will misbehave. Detect and print the next-step hint instead.
+# prompts in `phantombot persona` will misbehave — exit cleanly with
+# a next-step hint instead of trying to exec the TUI.
 if [ ! -t 0 ] || [ ! -t 1 ]; then
-  printf '\nphantombot: not a TTY (script was piped). Run this next to set up your first persona:\n' >&2
-  printf '  phantombot persona\n\n' >&2
+  printf '\nnext, run this to set up your first persona:\n'
+  printf '  phantombot persona\n\n'
   exit 0
 fi
 


### PR DESCRIPTION
## Why
When the user runs `curl … | sh`, the installer prints:

```
phantombot: not a TTY (script was piped). Run this next to set up your first persona:
  phantombot persona
```

The wording reads like an error/warning even though it's just a benign hint that the persona TUI was skipped. The PATH-source instructions printed just above already tell the user what to do next.

## What
- Replace the `phantombot: not a TTY (script was piped)` message with a clean positive next-step note: `next, run this to set up your first persona: phantombot persona`.
- Drop the `>&2` redirect — it's a hint, not an error.
- Keep the TTY detection itself: piping `curl … | sh` closes stdin, so we still need to skip `exec phantombot persona` (@clack prompts misbehave on non-interactive stdin).

## Test
- `sh -n install.sh` passes.
- Simulated piped invocation (`echo '' | sh …`): prints clean next-step hint, exits 0.
- Interactive path (TTY) is untouched.