### PR TITLE
fix(cli/telegram): scrub real Telegram ID from placeholders + fixtures

### DIFF
--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -127,7 +127,7 @@ export async function runTelegram(input: RunInput = {}): Promise<number> {
   const allowedRaw = await p.text({
     message:
       "Allowed Telegram user IDs (comma-separated; empty = anyone, with a warning)",
-    placeholder: "7995070089",
+    placeholder: "123456789",
     defaultValue: currentAllowed,
   });
   if (p.isCancel(allowedRaw)) {
@@ -177,7 +177,7 @@ async function updateAllowedUsersOnly(
   const allowedRaw = await p.text({
     message:
       "Allowed Telegram user IDs (comma-separated; empty = anyone, with a warning)",
-    placeholder: "7995070089",
+    placeholder: "123456789",
     defaultValue: currentAllowed,
   });
   if (p.isCancel(allowedRaw)) {

--- a/tests/cli-telegram.test.ts
+++ b/tests/cli-telegram.test.ts
@@ -81,13 +81,13 @@ describe("parseOpenClawTelegram", () => {
           accounts: {
             default: {
               botToken: "111:abc",
-              execApprovals: { approvers: ["7995070089"] },
+              execApprovals: { approvers: ["123456789"] },
             },
           },
         },
       },
     });
-    expect(r).toEqual({ token: "111:abc", allowedUserIds: [7995070089] });
+    expect(r).toEqual({ token: "111:abc", allowedUserIds: [123456789] });
   });
 
   test("supports the older flat layout", () => {


### PR DESCRIPTION
## Summary
- The `phantombot telegram` setup wizard was showing Andrew's real Telegram user ID (`7995070089`) as the placeholder text in the "Allowed Telegram user IDs" prompt — visible to anyone running the CLI on a fresh install. Minor PII leak.
- Same ID was reused as a fixture in `cli-telegram.test.ts`.
- Replaced all four occurrences (two prompts in `src/cli/telegram.ts`, two fixtures in `tests/cli-telegram.test.ts`) with the conventional fake `123456789`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test tests/cli-telegram.test.ts` — 8/8 pass
- [x] `grep 7995070089` across the tree — zero matches