### PR TITLE
feat(install/update): macOS launchd support

### DIFF
--- a/src/cli/embedding.ts
+++ b/src/cli/embedding.ts
@@ -17,7 +17,7 @@ import {
   type EmbedResult,
 } from "../lib/geminiEmbed.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
-import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
 import { maybePromptRestart } from "./harness.ts";
 
 const DEFAULT_MODEL = "gemini-embedding-001";

--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -11,7 +11,11 @@ import * as p from "@clack/prompts";
 
 import { type Config, loadConfig } from "../config.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
-import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import {
+  defaultServiceControl,
+  restartCommand,
+  type ServiceControl,
+} from "../lib/platform.ts";
 
 export type HarnessId = "claude" | "pi" | "gemini";
 export const SUPPORTED_HARNESSES: ReadonlyArray<HarnessId> = [
@@ -149,9 +153,10 @@ const defaultConfirm: ConfirmFn = async (message) => {
 /**
  * Shared post-apply hook for the config-mutating TUIs.
  *
- * Two steps. Always: re-render the on-disk systemd unit if it's stale (a
- * pre-Phase-29 unit lacks `EnvironmentFile=` and silently swallows the
- * .env secrets the TUI just wrote). Then: if phantombot is running, offer
+ * Two steps. Always: re-render the on-disk service-manager unit if it's
+ * stale (a pre-Phase-29 systemd unit lacks `EnvironmentFile=` and
+ * silently swallows the .env secrets the TUI just wrote; the launchd
+ * plist has analogous templating). Then: if phantombot is running, offer
  * to restart it inline so the change takes effect.
  *
  * `confirm` is parameterized so tests can drive the full ordering
@@ -169,7 +174,7 @@ export async function maybePromptRestart(
   );
   if (!proceed) {
     p.note(
-      "skipped — restart later with: systemctl --user restart phantombot",
+      `skipped — restart later with: ${restartCommand()}`,
       "Restart",
     );
     return;
@@ -182,10 +187,11 @@ export async function maybePromptRestart(
 }
 
 /**
- * Re-render the installed systemd unit if it's stale; print a one-line
- * notice when it happened (and surface the backup path so a hand-edit is
- * recoverable). Exposed so tests can verify the rewrite path without
- * going through the @clack confirm prompt in maybePromptRestart.
+ * Re-render the installed service-manager unit if it's stale; print a
+ * one-line notice when it happened (and surface the backup path so a
+ * hand-edit is recoverable). Exposed so tests can verify the rewrite
+ * path without going through the @clack confirm prompt in
+ * maybePromptRestart.
  */
 export async function maybeUpgradeUnit(
   svc: ServiceControl,
@@ -193,8 +199,8 @@ export async function maybeUpgradeUnit(
   const r = await svc.rerenderUnitIfStale();
   if (r.rerendered) {
     const note = r.backupPath
-      ? `systemd unit upgraded to current template\nprevious contents saved to ${r.backupPath}`
-      : "systemd unit upgraded to current template";
+      ? `service-manager unit upgraded to current template\nprevious contents saved to ${r.backupPath}`
+      : "service-manager unit upgraded to current template";
     p.note(note, "Unit");
   }
   return r;

--- a/src/cli/import-persona.ts
+++ b/src/cli/import-persona.ts
@@ -34,7 +34,11 @@ import {
 } from "../lib/personaArchive.ts";
 import { adoptAsDefaultIfMissing } from "../lib/personaDefault.ts";
 import { ensurePersonaScaffold } from "../lib/personaScaffold.ts";
-import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import {
+  defaultServiceControl,
+  restartCommand,
+  type ServiceControl,
+} from "../lib/platform.ts";
 import { defaultEnvFilePath, updateEnvFile } from "../lib/envFile.ts";
 import { parseOpenClawVoice } from "../lib/voice.ts";
 import { applyVoiceConfig } from "./voice.ts";
@@ -442,7 +446,7 @@ async function maybeRestartHint(
   if (await svc.isActive()) {
     out.write(
       "\nphantombot is currently running. Restart to pick up the imported persona/config:\n" +
-        "  systemctl --user restart phantombot\n",
+        `  ${restartCommand()}\n`,
     );
   }
 }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,6 +1,9 @@
 /**
- * `phantombot install` — write a systemd --user unit for `phantombot run`,
- * reload, enable, start.
+ * `phantombot install` — write the host-appropriate service-manager
+ * units for `phantombot run` and start them.
+ *
+ *   - Linux  → systemd --user units in ~/.config/systemd/user/
+ *   - macOS  → launchd plists in ~/Library/LaunchAgents/
  *
  * Requires the compiled binary (process.execPath ends in 'phantombot' or
  * the user passes --bin). Running from `bun src/index.ts` won't work
@@ -11,6 +14,17 @@
 import { defineCommand } from "citty";
 import { basename } from "node:path";
 
+import {
+  BunLaunchctlRunner,
+  defaultPlistPath,
+  guiDomain,
+  heartbeatPlistPath as launchdHeartbeatPath,
+  installPhantombotPlists,
+  type LaunchctlRunner,
+  nightlyPlistPath as launchdNightlyPath,
+  tickPlistPath as launchdTickPath,
+} from "../lib/launchd.ts";
+import { currentPlatform, logsCommand, restartCommand } from "../lib/platform.ts";
 import {
   BunSystemctlRunner,
   buildSystemctlEnv,
@@ -25,12 +39,16 @@ import type { WriteSink } from "../lib/io.ts";
 
 export interface RunInstallInput {
   binPath?: string;
+  /** systemd unit path (Linux) — defaults to ~/.config/systemd/user/phantombot.service. */
   unitPath?: string;
+  /** launchd plist path (macOS) — defaults to ~/Library/LaunchAgents/dev.phantombot.phantombot.plist. */
+  plistPath?: string;
   /**
-   * Optional path overrides for the heartbeat/nightly companion units —
-   * pass-through to installPhantombotUnit. Tests use these to keep all
-   * unit writes inside a tmpdir; production leaves them undefined and
-   * the helper picks the per-user XDG locations.
+   * Optional path overrides for the heartbeat/nightly/tick companion
+   * units — pass-through to the platform-specific install helpers.
+   * Tests use these to keep all unit writes inside a tmpdir; production
+   * leaves them undefined and the helper picks the per-user XDG / Library
+   * locations.
    */
   heartbeatServicePath?: string;
   heartbeatTimerPath?: string;
@@ -38,12 +56,24 @@ export interface RunInstallInput {
   nightlyTimerPath?: string;
   tickServicePath?: string;
   tickTimerPath?: string;
+  heartbeatPlistPath?: string;
+  nightlyPlistPath?: string;
+  tickPlistPath?: string;
   out?: WriteSink;
   err?: WriteSink;
   /** Override systemctl runner for testing. */
   systemctl?: SystemctlRunner;
+  /** Override launchctl runner for testing. */
+  launchctl?: LaunchctlRunner;
   /** Override systemd-env detection for testing. */
   ensureSystemdEnv?: () => UserSystemdEnv;
+  /**
+   * Override the platform check for testing. Defaults to currentPlatform()
+   * which reads process.platform.
+   */
+  platform?: "linux" | "darwin" | "unsupported";
+  /** Override gui domain (e.g. "gui/501") on darwin. Defaults to gui/<current uid>. */
+  domain?: string;
 }
 
 export async function runInstall(input: RunInstallInput = {}): Promise<number> {
@@ -59,6 +89,26 @@ export async function runInstall(input: RunInstallInput = {}): Promise<number> {
     return 2;
   }
 
+  const platform = input.platform ?? currentPlatform();
+  switch (platform) {
+    case "linux":
+      return runInstallLinux(input, binPath, out, err);
+    case "darwin":
+      return runInstallDarwin(input, binPath, out, err);
+    default:
+      err.write(
+        `phantombot install supports linux and darwin only; this host reports platform=${process.platform}\n`,
+      );
+      return 2;
+  }
+}
+
+async function runInstallLinux(
+  input: RunInstallInput,
+  binPath: string,
+  out: WriteSink,
+  err: WriteSink,
+): Promise<number> {
   const sysEnv = input.ensureSystemdEnv
     ? input.ensureSystemdEnv()
     : ensureUserSystemdEnv();
@@ -92,8 +142,45 @@ export async function runInstall(input: RunInstallInput = {}): Promise<number> {
   if (!result.installed) return 1;
 
   out.write(
-    `\nview logs:    journalctl --user -u phantombot -f\n` +
-      `restart:      systemctl --user restart phantombot\n` +
+    `\nview logs:    ${logsCommand()}\n` +
+      `restart:      ${restartCommand()}\n` +
+      `uninstall:    phantombot uninstall\n`,
+  );
+  return 0;
+}
+
+async function runInstallDarwin(
+  input: RunInstallInput,
+  binPath: string,
+  out: WriteSink,
+  err: WriteSink,
+): Promise<number> {
+  const launchctl = input.launchctl ?? new BunLaunchctlRunner();
+  let domain: string;
+  try {
+    domain = input.domain ?? guiDomain();
+  } catch (e) {
+    err.write(`cannot determine launchd gui domain: ${(e as Error).message}\n`);
+    return 2;
+  }
+
+  const result = await installPhantombotPlists({
+    binPath,
+    plistPath: input.plistPath ?? defaultPlistPath(),
+    heartbeatPlistPath:
+      input.heartbeatPlistPath ?? launchdHeartbeatPath(),
+    nightlyPlistPath: input.nightlyPlistPath ?? launchdNightlyPath(),
+    tickPlistPath: input.tickPlistPath ?? launchdTickPath(),
+    domain,
+    launchctl,
+    out,
+    err,
+  });
+  if (!result.installed) return 1;
+
+  out.write(
+    `\nview logs:    ${logsCommand()}\n` +
+      `restart:      ${restartCommand()}\n` +
       `uninstall:    phantombot uninstall\n`,
   );
   return 0;
@@ -103,7 +190,7 @@ export default defineCommand({
   meta: {
     name: "install",
     description:
-      "Install a systemd --user unit for phantombot run, reload, enable, and start it.",
+      "Install the host-appropriate service unit for `phantombot run` (systemd --user on Linux, launchd LaunchAgent on macOS) and start it.",
   },
   async run() {
     const code = await runInstall();

--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -33,7 +33,7 @@ import {
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import { listArchives } from "../lib/personaArchive.ts";
-import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
 import { loadState, saveState } from "../state.ts";
 import { runCreatePersona } from "./create-persona.ts";
 import { runImportPersona } from "./import-persona.ts";

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -16,6 +16,7 @@ import {
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import type { WriteSink } from "../lib/io.ts";
+import { logsCommand, statusCommand } from "../lib/platform.ts";
 import {
   acquireRunLock,
   defaultLockPath,
@@ -68,8 +69,8 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   if (!isLockHandle(lock)) {
     err.write(
       `phantombot is already running (pid ${Number.isFinite(lock.pid) ? lock.pid : "unknown"}; lock at ${lock.path})\n` +
-        "view logs:    journalctl --user -u phantombot -f\n" +
-        "status:       systemctl --user status phantombot\n" +
+        `view logs:    ${logsCommand()}\n` +
+        `status:       ${statusCommand()}\n` +
         "stop the other instance first, or remove the lock if it's stale.\n",
     );
     return 1;

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -13,7 +13,7 @@ import * as p from "@clack/prompts";
 
 import { type Config, loadConfig } from "../config.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
-import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
 import { telegramGetMe, type GetMeResult } from "../lib/telegramApi.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { maybePromptRestart } from "./harness.ts";

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -1,10 +1,25 @@
 /**
- * `phantombot uninstall` — stop, disable, remove the systemd --user unit.
- * Best-effort; missing unit / inactive service are not errors.
+ * `phantombot uninstall` — stop, disable, remove the host-appropriate
+ * service-manager units. Best-effort; missing units / inactive services
+ * are not errors.
+ *
+ *   - Linux  → systemctl --user stop/disable + remove unit files
+ *   - macOS  → launchctl bootout + remove plists
  */
 
 import { defineCommand } from "citty";
 
+import {
+  BunLaunchctlRunner,
+  defaultPlistPath,
+  guiDomain,
+  heartbeatPlistPath as launchdHeartbeatPath,
+  type LaunchctlRunner,
+  nightlyPlistPath as launchdNightlyPath,
+  tickPlistPath as launchdTickPath,
+  uninstallPhantombotPlists,
+} from "../lib/launchd.ts";
+import { currentPlatform } from "../lib/platform.ts";
 import {
   BunSystemctlRunner,
   buildSystemctlEnv,
@@ -18,10 +33,17 @@ import type { WriteSink } from "../lib/io.ts";
 
 export interface RunUninstallInput {
   unitPath?: string;
+  plistPath?: string;
+  heartbeatPlistPath?: string;
+  nightlyPlistPath?: string;
+  tickPlistPath?: string;
   systemctl?: SystemctlRunner;
+  launchctl?: LaunchctlRunner;
   out?: WriteSink;
   err?: WriteSink;
   ensureSystemdEnv?: () => UserSystemdEnv;
+  platform?: "linux" | "darwin" | "unsupported";
+  domain?: string;
 }
 
 export async function runUninstall(
@@ -29,7 +51,26 @@ export async function runUninstall(
 ): Promise<number> {
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
+  const platform = input.platform ?? currentPlatform();
 
+  switch (platform) {
+    case "linux":
+      return runUninstallLinux(input, out, err);
+    case "darwin":
+      return runUninstallDarwin(input, out, err);
+    default:
+      err.write(
+        `phantombot uninstall supports linux and darwin only; this host reports platform=${process.platform}\n`,
+      );
+      return 2;
+  }
+}
+
+async function runUninstallLinux(
+  input: RunUninstallInput,
+  out: WriteSink,
+  err: WriteSink,
+): Promise<number> {
   const sysEnv = input.ensureSystemdEnv
     ? input.ensureSystemdEnv()
     : ensureUserSystemdEnv();
@@ -39,9 +80,7 @@ export async function runUninstall(
         "skipping systemctl calls and just removing the unit file (if any).\n",
     );
   } else if (sysEnv.autoSet) {
-    out.write(
-      `auto-detected XDG_RUNTIME_DIR=${sysEnv.runtimeDir}\n`,
-    );
+    out.write(`auto-detected XDG_RUNTIME_DIR=${sysEnv.runtimeDir}\n`);
   }
 
   const unitPath = input.unitPath ?? defaultUnitPath();
@@ -53,10 +92,39 @@ export async function runUninstall(
   return 0;
 }
 
+async function runUninstallDarwin(
+  input: RunUninstallInput,
+  out: WriteSink,
+  err: WriteSink,
+): Promise<number> {
+  const launchctl = input.launchctl ?? new BunLaunchctlRunner();
+  let domain: string;
+  try {
+    domain = input.domain ?? guiDomain();
+  } catch (e) {
+    err.write(`cannot determine launchd gui domain: ${(e as Error).message}\n`);
+    return 2;
+  }
+
+  await uninstallPhantombotPlists({
+    plistPath: input.plistPath ?? defaultPlistPath(),
+    heartbeatPlistPath: input.heartbeatPlistPath ?? launchdHeartbeatPath(),
+    nightlyPlistPath: input.nightlyPlistPath ?? launchdNightlyPath(),
+    tickPlistPath: input.tickPlistPath ?? launchdTickPath(),
+    domain,
+    launchctl,
+    out,
+    err,
+  });
+  out.write("uninstall complete\n");
+  return 0;
+}
+
 export default defineCommand({
   meta: {
     name: "uninstall",
-    description: "Stop, disable, and remove the phantombot systemd --user unit.",
+    description:
+      "Stop, disable, and remove the phantombot service-manager units (systemd --user on Linux, launchd LaunchAgent on macOS).",
   },
   async run() {
     const code = await runUninstall();

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -26,14 +26,15 @@ import {
   downloadAndVerify,
 } from "../lib/binaryUpdate.ts";
 import {
-  detectSupportedArch,
+  detectSupportedTarget,
   findLatestRelease,
   type LatestRelease,
 } from "../lib/githubReleases.ts";
 import {
   defaultServiceControl,
+  restartCommand,
   type ServiceControl,
-} from "../lib/systemd.ts";
+} from "../lib/platform.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { VERSION } from "../version.ts";
 
@@ -45,10 +46,15 @@ export interface RunUpdateInput {
   binPath?: string;
   /**
    * Raw arch string (matches `process.arch`); converted via
-   * detectSupportedArch internally. Defaults to process.arch. Tests pass
-   * a value like "ia32" to exercise the unsupported-arch refusal.
+   * detectSupportedTarget internally. Defaults to process.arch. Tests
+   * pass a value like "ia32" to exercise the unsupported-arch refusal.
    */
   procArch?: string;
+  /**
+   * Raw platform string (matches `process.platform`). Defaults to
+   * process.platform. Tests use this to exercise darwin / linux / unsupported.
+   */
+  procPlatform?: string;
   /** Defaults to VERSION constant. Tests override. */
   currentVersion?: string;
   /** Inject for testing. */
@@ -66,11 +72,13 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
   const err = input.err ?? process.stderr;
   const currentVersion = input.currentVersion ?? VERSION;
   const procArch = input.procArch ?? process.arch;
-  const arch = detectSupportedArch(procArch);
+  const procPlatform = input.procPlatform ?? process.platform;
+  const target = detectSupportedTarget(procPlatform, procArch);
 
-  if (!arch) {
+  if (!target) {
     err.write(
-      `phantombot is only released for linux-x64 and linux-arm64; this machine reports arch=${procArch}\n`,
+      `phantombot is only released for linux-x64, linux-arm64, and darwin-arm64; ` +
+        `this machine reports platform=${procPlatform} arch=${procArch}\n`,
     );
     return 1;
   }
@@ -97,7 +105,7 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
 
   // 1. Discover latest release.
   const r = await findLatestRelease({
-    arch,
+    target,
     fetchImpl: input.fetchImpl,
   });
   if (!r.ok) {
@@ -179,15 +187,13 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
       out.write("restarted phantombot.service.\n");
     } else {
       err.write(
-        `restart failed: ${r.stderr ?? "unknown"} — run 'systemctl --user restart phantombot' manually.\n`,
+        `restart failed: ${r.stderr ?? "unknown"} — run '${restartCommand()}' manually.\n`,
       );
       // Don't fail the whole command; the binary swap succeeded. The
       // user just needs to restart by hand.
     }
   } else if (!input.force) {
-    out.write(
-      "restart with: systemctl --user restart phantombot\n",
-    );
+    out.write(`restart with: ${restartCommand()}\n`);
   }
 
   return 0;

--- a/src/cli/voice.ts
+++ b/src/cli/voice.ts
@@ -11,7 +11,7 @@ import * as p from "@clack/prompts";
 import { type Config, loadConfig } from "../config.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
 import { defaultEnvFilePath, updateEnvFile } from "../lib/envFile.ts";
-import { defaultServiceControl, type ServiceControl } from "../lib/systemd.ts";
+import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
 import {
   AZURE_EDGE_DEFAULTS,
   AZURE_EDGE_VOICE_OPTIONS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,18 @@
  *
  * Imports the Citty dispatcher and runs it. The dispatcher itself lives in
  * src/cli/index.ts so it can be imported by tests without auto-running.
+ *
+ * Before dispatch, we self-load credentials from `~/.env` and
+ * `~/.config/phantombot/.env` into process.env. On Linux the systemd unit
+ * already sources these via `EnvironmentFile=`, so the lines we'd add are
+ * no-ops (existing values win — see preloadEnvFiles). On macOS launchd
+ * has no equivalent of EnvironmentFile, so this self-load is the only
+ * way credentials reach the running agent.
  */
 
 import { runMain } from "citty";
 import { mainCommand } from "./cli/index.ts";
+import { preloadEnvFiles } from "./lib/envBootstrap.ts";
 
+await preloadEnvFiles();
 runMain(mainCommand);

--- a/src/lib/envBootstrap.ts
+++ b/src/lib/envBootstrap.ts
@@ -1,0 +1,74 @@
+/**
+ * Self-load `~/.env` and `~/.config/phantombot/.env` into process.env at
+ * startup.
+ *
+ * Why: launchd has no equivalent of systemd's `EnvironmentFile=` plist
+ * key, so on macOS phantombot has to source these files itself before
+ * any subcommand reads `process.env.X`. On Linux the systemd unit
+ * already sources both files, so this is a (cheap) no-op there — the
+ * `existing-wins` policy below means anything systemd already set keeps
+ * its value.
+ *
+ * Existing-wins ordering matters:
+ *   - Variables explicitly exported in the parent shell (e.g. `GITHUB_TOKEN=foo phantombot ask …`)
+ *     must win over what's persisted in the file.
+ *   - On Linux, EnvironmentFile= already pre-populates process.env before
+ *     the binary starts, so systemd's values also win — meaning the file
+ *     read here is effectively a fallback for fresh invocations from a
+ *     plain shell.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { defaultEnvFilePath, loadEnvFile } from "./envFile.ts";
+
+/** Files to source, in priority order (later entries override earlier ones in process.env). */
+function envFilesToLoad(): string[] {
+  const userEnv = join(homedir(), ".env");
+  return [userEnv, defaultEnvFilePath()];
+}
+
+export interface PreloadOptions {
+  /** Override the file list — tests use this to point at fixture files. */
+  files?: readonly string[];
+  /** Override the env target — defaults to process.env. Tests inject a mutable map. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Read each .env file in turn and copy missing keys into env. Existing
+ * values are not overwritten. Silent on missing files (a fresh install
+ * has neither .env yet).
+ *
+ * Returns the names of variables we set, so tests can assert on the
+ * effect without intercepting process.env writes.
+ */
+export async function preloadEnvFiles(
+  opts: PreloadOptions = {},
+): Promise<{ loaded: string[] }> {
+  const env = opts.env ?? process.env;
+  const files = opts.files ?? envFilesToLoad();
+  const loaded: string[] = [];
+
+  for (const path of files) {
+    if (!existsSync(path)) continue;
+    let vars: Record<string, string>;
+    try {
+      vars = await loadEnvFile(path);
+    } catch {
+      // A malformed .env shouldn't crash startup. The follow-up `phantombot
+      // env` commands will surface the parse error in a more useful way.
+      continue;
+    }
+    for (const [k, v] of Object.entries(vars)) {
+      if (env[k] === undefined) {
+        env[k] = v;
+        loaded.push(k);
+      }
+    }
+  }
+
+  return { loaded };
+}

--- a/src/lib/githubReleases.ts
+++ b/src/lib/githubReleases.ts
@@ -14,6 +14,14 @@ const DEFAULT_REPO = "phantomyard/phantombot";
 /** What kind of host arch the running phantombot needs an asset for. */
 export type SupportedArch = "x64" | "arm64";
 
+/**
+ * The full release-target tuple — phantombot ships one binary per
+ * (platform, arch) pair, named `phantombot-${tag}-${target}`. Currently
+ * built: linux-x64, linux-arm64, darwin-arm64. No darwin-x64 because no
+ * deploy target uses Intel Mac.
+ */
+export type SupportedTarget = "linux-x64" | "linux-arm64" | "darwin-arm64";
+
 export interface ReleaseAsset {
   name: string;
   url: string;
@@ -39,11 +47,11 @@ export type FindLatestResult =
 
 /**
  * Hit GitHub's `/releases/latest` endpoint, find the binary asset that
- * matches the requested arch + the SHA256SUMS file beside it, and return
- * everything `phantombot update` needs to download and verify.
+ * matches the requested target + the SHA256SUMS file beside it, and
+ * return everything `phantombot update` needs to download and verify.
  */
 export async function findLatestRelease(opts: {
-  arch: SupportedArch;
+  target: SupportedTarget;
   /** Override the upstream repo. Default: env var or DEFAULT_REPO. */
   repo?: string;
   fetchImpl?: typeof fetch;
@@ -106,7 +114,7 @@ export async function findLatestRelease(opts: {
 
   const tag = body.tag_name;
   const version = tag.startsWith("v") ? tag.slice(1) : tag;
-  const wantedBinaryName = `phantombot-${tag}-linux-${opts.arch}`;
+  const wantedBinaryName = `phantombot-${tag}-${opts.target}`;
   const binary = body.assets.find((a) => a.name === wantedBinaryName);
   const checksums = body.assets.find((a) => a.name === "SHA256SUMS");
 
@@ -148,12 +156,35 @@ export async function findLatestRelease(opts: {
  * Map node/bun's process.arch to the suffix the release workflow uses.
  * Returns undefined on architectures we don't ship binaries for, so the
  * CLI can refuse with a clear message instead of trying a missing asset.
+ *
+ * Kept for tests + back-compat. New code should prefer
+ * detectSupportedTarget which also includes the platform.
  */
 export function detectSupportedArch(
   procArch: string = process.arch,
 ): SupportedArch | undefined {
   if (procArch === "x64") return "x64";
   if (procArch === "arm64") return "arm64";
+  return undefined;
+}
+
+/**
+ * Map (process.platform, process.arch) to one of the release-target
+ * tuples we actually ship. Returns undefined for combinations the
+ * release workflow doesn't build (e.g. darwin-x64, linux-ia32, win32-*),
+ * so `phantombot update` can refuse with a clear message instead of
+ * 404-ing on a missing asset.
+ *
+ * Built targets: linux-x64, linux-arm64, darwin-arm64.
+ */
+export function detectSupportedTarget(
+  procPlatform: string = process.platform,
+  procArch: string = process.arch,
+): SupportedTarget | undefined {
+  const arch = detectSupportedArch(procArch);
+  if (!arch) return undefined;
+  if (procPlatform === "linux") return `linux-${arch}` as SupportedTarget;
+  if (procPlatform === "darwin" && arch === "arm64") return "darwin-arm64";
   return undefined;
 }
 

--- a/src/lib/launchd.ts
+++ b/src/lib/launchd.ts
@@ -1,0 +1,514 @@
+/**
+ * launchd unit (plist) generation and install/uninstall logic for
+ * phantombot on macOS.
+ *
+ * Mirrors the shape of `systemd.ts` so the per-platform router in
+ * `platform.ts` can dispatch to either backend with the same surface
+ * area. The `LaunchctlRunner` indirection keeps this testable: tests
+ * inject a fake runner instead of actually invoking `launchctl`.
+ *
+ * Path layout (per-user LaunchAgents — equivalent of systemd --user):
+ *
+ *   ~/Library/LaunchAgents/dev.phantombot.phantombot.plist
+ *   ~/Library/LaunchAgents/dev.phantombot.heartbeat.plist
+ *   ~/Library/LaunchAgents/dev.phantombot.nightly.plist
+ *   ~/Library/LaunchAgents/dev.phantombot.tick.plist
+ *
+ * Logs go to ~/Library/Logs/phantombot/<unit>.{out,err}.log (no journald
+ * on Mac, and `log show` is a poor fit for free-form bot output).
+ *
+ * Note on env files: launchd's `EnvironmentVariables` plist key only
+ * accepts inline static values — it has no equivalent of systemd's
+ * `EnvironmentFile=`. Phantombot self-loads `~/.env` and
+ * `~/.config/phantombot/.env` at startup (see src/index.ts), so the
+ * agent finds credentials in process.env on both platforms without
+ * needing per-plist env entries here.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import type { WriteSink } from "./io.ts";
+
+export const PHANTOMBOT_PLIST_LABEL = "dev.phantombot.phantombot";
+export const HEARTBEAT_PLIST_LABEL = "dev.phantombot.heartbeat";
+export const NIGHTLY_PLIST_LABEL = "dev.phantombot.nightly";
+export const TICK_PLIST_LABEL = "dev.phantombot.tick";
+
+function launchAgentsDir(): string {
+  return join(homedir(), "Library", "LaunchAgents");
+}
+
+function logsDir(): string {
+  return join(homedir(), "Library", "Logs", "phantombot");
+}
+
+export function defaultPlistPath(): string {
+  return join(launchAgentsDir(), `${PHANTOMBOT_PLIST_LABEL}.plist`);
+}
+
+export function heartbeatPlistPath(): string {
+  return join(launchAgentsDir(), `${HEARTBEAT_PLIST_LABEL}.plist`);
+}
+
+export function nightlyPlistPath(): string {
+  return join(launchAgentsDir(), `${NIGHTLY_PLIST_LABEL}.plist`);
+}
+
+export function tickPlistPath(): string {
+  return join(launchAgentsDir(), `${TICK_PLIST_LABEL}.plist`);
+}
+
+/**
+ * XML-escape a value for inclusion in a plist string. Plists are XML, so
+ * `&`, `<`, `>` need entities — the rest survive intact.
+ */
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+const PLIST_HEADER =
+  '<?xml version="1.0" encoding="UTF-8"?>\n' +
+  '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" ' +
+  '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n' +
+  '<plist version="1.0">\n';
+const PLIST_FOOTER = "</plist>\n";
+
+interface BasePlistOptions {
+  label: string;
+  binPath: string;
+  args: readonly string[];
+  /** When true, KeepAlive=true + RunAtLoad=true (long-running daemon). */
+  keepAlive?: boolean;
+  /** Seconds between firings (StartInterval). Mutually exclusive with calendar. */
+  startIntervalSec?: number;
+  /** Calendar firing (e.g. {Hour: 2, Minute: 0}). */
+  startCalendar?: { Hour?: number; Minute?: number; Weekday?: number };
+  /** When true, sets RunAtLoad=true so the unit fires once on load (and again per StartInterval). */
+  runAtLoad?: boolean;
+}
+
+function generatePlist(opts: BasePlistOptions): string {
+  const argv = [opts.binPath, ...opts.args];
+  const argvXml = argv
+    .map((a) => `    <string>${xmlEscape(a)}</string>`)
+    .join("\n");
+
+  const lines: string[] = [];
+  lines.push(PLIST_HEADER + "<dict>");
+  lines.push(`  <key>Label</key>`);
+  lines.push(`  <string>${xmlEscape(opts.label)}</string>`);
+  lines.push(`  <key>ProgramArguments</key>`);
+  lines.push(`  <array>`);
+  lines.push(argvXml);
+  lines.push(`  </array>`);
+
+  if (opts.runAtLoad ?? opts.keepAlive) {
+    lines.push(`  <key>RunAtLoad</key>`);
+    lines.push(`  <true/>`);
+  }
+  if (opts.keepAlive) {
+    // Restart on crash. The dict form lets us be more precise (don't restart
+    // on clean exit), but the boolean form is simpler and matches the
+    // systemd Restart=on-failure semantics closely enough.
+    lines.push(`  <key>KeepAlive</key>`);
+    lines.push(`  <true/>`);
+    lines.push(`  <key>ThrottleInterval</key>`);
+    lines.push(`  <integer>5</integer>`);
+  }
+  if (opts.startIntervalSec !== undefined) {
+    lines.push(`  <key>StartInterval</key>`);
+    lines.push(`  <integer>${opts.startIntervalSec}</integer>`);
+  }
+  if (opts.startCalendar) {
+    lines.push(`  <key>StartCalendarInterval</key>`);
+    lines.push(`  <dict>`);
+    for (const [k, v] of Object.entries(opts.startCalendar)) {
+      lines.push(`    <key>${xmlEscape(k)}</key>`);
+      lines.push(`    <integer>${v}</integer>`);
+    }
+    lines.push(`  </dict>`);
+  }
+
+  // PATH: include ~/.pi/agent/bin and ~/.local/bin so the harness's Bash
+  // tool finds `phantombot` and `pi` when the agent invokes them. Mac
+  // default PATH is narrow (/usr/bin:/bin:/usr/sbin:/sbin), so we have to
+  // be explicit. $HOME interpolation isn't supported in plist values, so
+  // we resolve it eagerly at install time using homedir().
+  const home = homedir();
+  const pathValue = `${home}/.pi/agent/bin:${home}/.local/bin:/opt/homebrew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`;
+  lines.push(`  <key>EnvironmentVariables</key>`);
+  lines.push(`  <dict>`);
+  lines.push(`    <key>PATH</key>`);
+  lines.push(`    <string>${xmlEscape(pathValue)}</string>`);
+  lines.push(`  </dict>`);
+
+  // Logs: ~/Library/Logs/phantombot/<label>.{out,err}.log. Created on demand
+  // by launchd; we just point at them.
+  const logBase = join(logsDir(), opts.label);
+  lines.push(`  <key>StandardOutPath</key>`);
+  lines.push(`  <string>${xmlEscape(logBase + ".out.log")}</string>`);
+  lines.push(`  <key>StandardErrorPath</key>`);
+  lines.push(`  <string>${xmlEscape(logBase + ".err.log")}</string>`);
+
+  // Working dir: the user's home, mirroring how systemd starts a user unit
+  // with HOME-cwd. Some phantombot subcommands resolve relative paths
+  // against cwd, so this matters.
+  lines.push(`  <key>WorkingDirectory</key>`);
+  lines.push(`  <string>${xmlEscape(home)}</string>`);
+
+  lines.push(`</dict>`);
+  lines.push(PLIST_FOOTER);
+  return lines.join("\n") + "\n";
+}
+
+function quoteArg(s: string): string {
+  if (/^[A-Za-z0-9_/.\-]+$/.test(s)) return s;
+  return `"${s.replace(/(["\\$`])/g, "\\$1")}"`;
+}
+// Re-export so tests can verify the encoded ExecStart equivalent if needed.
+export { quoteArg as _quoteArg };
+
+export interface LaunchdUnitParams {
+  binPath: string;
+  args: readonly string[];
+}
+
+/** Generate the always-on phantombot agent plist (Label dev.phantombot.phantombot). */
+export function generatePhantombotPlist(params: LaunchdUnitParams): string {
+  return generatePlist({
+    label: PHANTOMBOT_PLIST_LABEL,
+    binPath: params.binPath,
+    args: params.args,
+    keepAlive: true,
+    runAtLoad: true,
+  });
+}
+
+/** Generate the heartbeat plist — fires every 30 minutes. */
+export function generateHeartbeatPlist(binPath: string): string {
+  return generatePlist({
+    label: HEARTBEAT_PLIST_LABEL,
+    binPath,
+    args: ["heartbeat"],
+    startIntervalSec: 30 * 60,
+  });
+}
+
+/** Generate the nightly plist — fires daily at 02:00. */
+export function generateNightlyPlist(binPath: string): string {
+  return generatePlist({
+    label: NIGHTLY_PLIST_LABEL,
+    binPath,
+    args: ["nightly"],
+    startCalendar: { Hour: 2, Minute: 0 },
+  });
+}
+
+/**
+ * Generate the tick plist — fires every 60 seconds.
+ *
+ * launchd's minimum reliable StartInterval is roughly 10s; 60s matches
+ * the systemd timer cadence exactly so cron-style schedules behave the
+ * same on both platforms.
+ */
+export function generateTickPlist(binPath: string): string {
+  return generatePlist({
+    label: TICK_PLIST_LABEL,
+    binPath,
+    args: ["tick"],
+    startIntervalSec: 60,
+  });
+}
+
+export interface LaunchctlResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface LaunchctlRunner {
+  run(args: readonly string[]): Promise<LaunchctlResult>;
+}
+
+export class BunLaunchctlRunner implements LaunchctlRunner {
+  async run(args: readonly string[]): Promise<LaunchctlResult> {
+    const proc = Bun.spawn(["launchctl", ...args], {
+      env: { ...process.env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { exitCode, stdout, stderr };
+  }
+}
+
+/**
+ * Resolve the gui domain target for the current user. launchd's modern
+ * (10.10+) command surface is domain-scoped: `gui/<uid>` is the user's
+ * graphical session, the closest analogue to systemd --user.
+ *
+ * Tests inject the uid; production reads process.getuid() directly.
+ */
+export function guiDomain(uid?: number): string {
+  const u = uid ?? process.getuid?.();
+  if (u === undefined) {
+    throw new Error("cannot determine current uid for launchd gui domain");
+  }
+  return `gui/${u}`;
+}
+
+export interface InstallLaunchdOptions {
+  binPath: string;
+  /** Path overrides — tests use these to keep writes inside a tmpdir. */
+  plistPath?: string;
+  heartbeatPlistPath?: string;
+  nightlyPlistPath?: string;
+  tickPlistPath?: string;
+  /** Override gui domain (e.g. gui/501). Defaults to gui/<current uid>. */
+  domain?: string;
+  launchctl: LaunchctlRunner;
+  out: WriteSink;
+  err: WriteSink;
+}
+
+/**
+ * Write the four plists, then bootstrap each into the user's gui domain.
+ *
+ * `bootstrap` is the modern install verb (replaces `load`). It both loads
+ * the unit and starts it (for KeepAlive=true) or schedules it (for
+ * StartInterval/StartCalendarInterval). If a unit with the same Label is
+ * already loaded, bootstrap fails with EBUSY — we bootout first to make
+ * the operation idempotent for upgrade scenarios.
+ */
+export async function installPhantombotPlists(
+  opts: InstallLaunchdOptions,
+): Promise<{ installed: boolean }> {
+  const domain = opts.domain ?? guiDomain();
+  const mainPath = opts.plistPath ?? defaultPlistPath();
+  const hbPath = opts.heartbeatPlistPath ?? heartbeatPlistPath();
+  const ngPath = opts.nightlyPlistPath ?? nightlyPlistPath();
+  const tkPath = opts.tickPlistPath ?? tickPlistPath();
+
+  const plists: Array<{ path: string; label: string; body: string }> = [
+    {
+      path: mainPath,
+      label: PHANTOMBOT_PLIST_LABEL,
+      body: generatePhantombotPlist({ binPath: opts.binPath, args: ["run"] }),
+    },
+    {
+      path: hbPath,
+      label: HEARTBEAT_PLIST_LABEL,
+      body: generateHeartbeatPlist(opts.binPath),
+    },
+    {
+      path: ngPath,
+      label: NIGHTLY_PLIST_LABEL,
+      body: generateNightlyPlist(opts.binPath),
+    },
+    {
+      path: tkPath,
+      label: TICK_PLIST_LABEL,
+      body: generateTickPlist(opts.binPath),
+    },
+  ];
+
+  // Make sure the logs dir exists — launchd will refuse to start the
+  // service if StandardOutPath/StandardErrorPath point at a non-existent
+  // directory, and silently truncating the error to journald isn't an
+  // option here.
+  await mkdir(logsDir(), { recursive: true });
+
+  for (const p of plists) {
+    await mkdir(dirname(p.path), { recursive: true });
+    await writeFile(p.path, p.body, "utf8");
+    opts.out.write(`wrote plist: ${p.path}\n`);
+  }
+
+  // Idempotent install: bootout any pre-existing target (best-effort,
+  // don't fail if it isn't loaded), then bootstrap fresh.
+  for (const p of plists) {
+    await opts.launchctl.run(["bootout", `${domain}/${p.label}`]);
+  }
+  for (const p of plists) {
+    const r = await opts.launchctl.run(["bootstrap", domain, p.path]);
+    if (r.exitCode !== 0) {
+      opts.err.write(
+        `launchctl bootstrap ${domain} ${p.path} failed (${r.exitCode}): ${r.stderr.trim() || r.stdout.trim()}\n`,
+      );
+      return { installed: false };
+    }
+  }
+  opts.out.write(
+    `bootstrapped ${PHANTOMBOT_PLIST_LABEL} + heartbeat + nightly + tick into ${domain}\n`,
+  );
+  return { installed: true };
+}
+
+export interface UninstallLaunchdOptions {
+  /** Path overrides — tests use these to keep writes inside a tmpdir. */
+  plistPath?: string;
+  heartbeatPlistPath?: string;
+  nightlyPlistPath?: string;
+  tickPlistPath?: string;
+  domain?: string;
+  launchctl: LaunchctlRunner;
+  out: WriteSink;
+  err: WriteSink;
+}
+
+export async function uninstallPhantombotPlists(
+  opts: UninstallLaunchdOptions,
+): Promise<{ removed: boolean }> {
+  const domain = opts.domain ?? guiDomain();
+  const mainPath = opts.plistPath ?? defaultPlistPath();
+  const hbPath = opts.heartbeatPlistPath ?? heartbeatPlistPath();
+  const ngPath = opts.nightlyPlistPath ?? nightlyPlistPath();
+  const tkPath = opts.tickPlistPath ?? tickPlistPath();
+
+  const labels = [
+    TICK_PLIST_LABEL,
+    NIGHTLY_PLIST_LABEL,
+    HEARTBEAT_PLIST_LABEL,
+    PHANTOMBOT_PLIST_LABEL,
+  ];
+  // bootout each label (best-effort). A missing target returns non-zero
+  // — that's fine, we just want it gone from the domain.
+  for (const label of labels) {
+    const r = await opts.launchctl.run(["bootout", `${domain}/${label}`]);
+    if (r.exitCode !== 0) {
+      opts.out.write(
+        `launchctl bootout ${domain}/${label} returned ${r.exitCode} (continuing)\n`,
+      );
+    }
+  }
+
+  // Main plist gets a "(no plist at …)" log if absent so the user can tell
+  // whether they ever installed; companion plists are silent if absent.
+  if (existsSync(mainPath)) {
+    await unlink(mainPath);
+    opts.out.write(`removed ${mainPath}\n`);
+  } else {
+    opts.out.write(`(no plist at ${mainPath})\n`);
+  }
+  for (const p of [hbPath, ngPath, tkPath]) {
+    if (existsSync(p)) {
+      await unlink(p);
+      opts.out.write(`removed ${p}\n`);
+    }
+  }
+
+  return { removed: true };
+}
+
+export interface LaunchdServiceControl {
+  isActive(): Promise<boolean>;
+  restart(): Promise<{ ok: boolean; stderr?: string }>;
+  rerenderUnitIfStale(): Promise<{ rerendered: boolean; backupPath?: string }>;
+}
+
+/**
+ * Compare the on-disk plist at plistPath against the canonical template
+ * for binPath. If absent or different, write the canonical template and
+ * `launchctl bootout` + `launchctl bootstrap` to reload. Returns whether
+ * a rerender happened and, if it did, the path of any backup written.
+ */
+export async function ensurePlistCurrent(opts: {
+  plistPath: string;
+  binPath: string;
+  domain: string;
+  launchctl: LaunchctlRunner;
+}): Promise<{ rerendered: boolean; backupPath?: string }> {
+  const expected = generatePhantombotPlist({
+    binPath: opts.binPath,
+    args: ["run"],
+  });
+  let current: string | undefined;
+  if (existsSync(opts.plistPath)) {
+    current = await readFile(opts.plistPath, "utf8");
+  }
+  if (current === expected) return { rerendered: false };
+  await mkdir(dirname(opts.plistPath), { recursive: true });
+  let backupPath: string | undefined;
+  if (current !== undefined) {
+    backupPath = `${opts.plistPath}.bak`;
+    await writeFile(backupPath, current, "utf8");
+  }
+  await writeFile(opts.plistPath, expected, "utf8");
+  // Reload so launchd picks up the new plist body.
+  await opts.launchctl.run([
+    "bootout",
+    `${opts.domain}/${PHANTOMBOT_PLIST_LABEL}`,
+  ]);
+  await opts.launchctl.run(["bootstrap", opts.domain, opts.plistPath]);
+  return { rerendered: true, backupPath };
+}
+
+/**
+ * Default LaunchdServiceControl backed by real launchctl. Returns
+ * isActive=false on any error so callers can treat "service unknown" the
+ * same as "not running".
+ */
+export function defaultLaunchdServiceControl(): LaunchdServiceControl {
+  const runner = new BunLaunchctlRunner();
+  return {
+    async isActive() {
+      // `launchctl print gui/<uid>/<label>` returns 0 if loaded.
+      // `launchctl list <label>` is the legacy form — also returns 0 if
+      // loaded but is deprecated. Use print which is reliable on 10.10+.
+      let domain: string;
+      try {
+        domain = guiDomain();
+      } catch {
+        return false;
+      }
+      const r = await runner.run([
+        "print",
+        `${domain}/${PHANTOMBOT_PLIST_LABEL}`,
+      ]);
+      return r.exitCode === 0;
+    },
+    async restart() {
+      let domain: string;
+      try {
+        domain = guiDomain();
+      } catch (e) {
+        return { ok: false, stderr: (e as Error).message };
+      }
+      // `kickstart -k` stops the running instance (if any) and starts a
+      // fresh one — the launchd analogue of `systemctl restart`.
+      const r = await runner.run([
+        "kickstart",
+        "-k",
+        `${domain}/${PHANTOMBOT_PLIST_LABEL}`,
+      ]);
+      return r.exitCode === 0
+        ? { ok: true }
+        : { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
+    },
+    async rerenderUnitIfStale() {
+      const binPath = process.execPath;
+      if (basename(binPath) !== "phantombot") return { rerendered: false };
+      const plistPath = defaultPlistPath();
+      if (!existsSync(plistPath)) return { rerendered: false };
+      let domain: string;
+      try {
+        domain = guiDomain();
+      } catch {
+        return { rerendered: false };
+      }
+      return ensurePlistCurrent({
+        plistPath,
+        binPath,
+        domain,
+        launchctl: runner,
+      });
+    },
+  };
+}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,112 @@
+/**
+ * Cross-platform service-manager router.
+ *
+ * Phantombot ships on Linux (systemd --user) and macOS (launchd, per-user
+ * LaunchAgents). The two backends have different unit-file shapes,
+ * different control verbs, and different log destinations — this module
+ * is the single place where CLI code decides which one to talk to.
+ *
+ * Public surface:
+ *
+ *   defaultServiceControl()       — ServiceControl wired to the host's
+ *                                    backend (used by every TUI that wants
+ *                                    to restart phantombot after a config
+ *                                    change).
+ *   restartCommand()              — copy-pasteable command string for hint
+ *                                    output ("restart with: …").
+ *   statusCommand()               — same, for `status:` lines.
+ *   logsCommand()                 — same, for `view logs:` lines.
+ *   currentPlatform()             — narrowed enum so callers can branch
+ *                                    without touching process.platform
+ *                                    directly.
+ *
+ * The `ServiceControl` interface itself lives in systemd.ts (where it
+ * was originally defined); we re-export it here so platform-aware code
+ * has a single import path.
+ */
+
+import { defaultLaunchdServiceControl } from "./launchd.ts";
+import {
+  defaultSystemdServiceControl,
+  type ServiceControl,
+} from "./systemd.ts";
+
+export type { ServiceControl };
+
+export type Platform = "linux" | "darwin" | "unsupported";
+
+export function currentPlatform(): Platform {
+  if (process.platform === "linux") return "linux";
+  if (process.platform === "darwin") return "darwin";
+  return "unsupported";
+}
+
+/**
+ * ServiceControl wired to the appropriate backend for the host.
+ *
+ * On unsupported platforms (anything other than linux/darwin) we return
+ * a no-op control that says the service is never active and refuses to
+ * restart — phantombot doesn't ship binaries for those platforms anyway,
+ * so the only way to hit this branch is `bun src/index.ts` on Windows
+ * or BSD, where the user is on their own.
+ */
+export function defaultServiceControl(): ServiceControl {
+  switch (currentPlatform()) {
+    case "linux":
+      return defaultSystemdServiceControl();
+    case "darwin":
+      return defaultLaunchdServiceControl();
+    default:
+      return noopServiceControl();
+  }
+}
+
+function noopServiceControl(): ServiceControl {
+  return {
+    async isActive() {
+      return false;
+    },
+    async restart() {
+      return {
+        ok: false,
+        stderr: `phantombot has no service-manager backend on ${process.platform}`,
+      };
+    },
+    async rerenderUnitIfStale() {
+      return { rerendered: false };
+    },
+  };
+}
+
+/** Copy-pasteable command string the user can run to restart phantombot. */
+export function restartCommand(): string {
+  switch (currentPlatform()) {
+    case "darwin":
+      return `launchctl kickstart -k gui/$(id -u)/dev.phantombot.phantombot`;
+    case "linux":
+    default:
+      return "systemctl --user restart phantombot";
+  }
+}
+
+/** Copy-pasteable command string for "show me the service status". */
+export function statusCommand(): string {
+  switch (currentPlatform()) {
+    case "darwin":
+      return `launchctl print gui/$(id -u)/dev.phantombot.phantombot`;
+    case "linux":
+    default:
+      return "systemctl --user status phantombot";
+  }
+}
+
+/** Copy-pasteable command string for "tail the logs". */
+export function logsCommand(): string {
+  switch (currentPlatform()) {
+    case "darwin":
+      return `tail -f ~/Library/Logs/phantombot/dev.phantombot.phantombot.{out,err}.log`;
+    case "linux":
+    default:
+      return "journalctl --user -u phantombot -f";
+  }
+}

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -358,8 +358,12 @@ async function defaultRerenderUnitIfStale(): Promise<{
  * Returns `isActive: false` when systemd isn't reachable (no linger / no
  * runtime dir) so callers can treat "service unknown" the same as
  * "service not running" — they don't need to print a restart hint.
+ *
+ * Most callers want the platform-router `defaultServiceControl` in
+ * `./platform.ts`, which dispatches to this on Linux and to launchd on
+ * macOS. This export stays for direct Linux-only usage and tests.
  */
-export function defaultServiceControl(): ServiceControl {
+export function defaultSystemdServiceControl(): ServiceControl {
   return {
     async isActive() {
       const sysEnv = ensureUserSystemdEnv();

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -177,8 +177,9 @@ Look in this order; don't ask the user for anything that's already
 discoverable:
 
   1. process.env  — already loaded; phantombot sources both \`~/.env\` and
-                    \`~/.config/phantombot/.env\` via systemd EnvironmentFile=,
-                    so most credentials are available without re-reading.
+                    \`~/.config/phantombot/.env\` at startup (systemd
+                    EnvironmentFile= on Linux, self-loaded on macOS), so
+                    most credentials are available without re-reading.
   2. ~/.env       — the agent's general credentials file. The canonical
                     home for things like GITHUB_TOKEN, OPENAI_API_KEY, ssh
                     passphrases.

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -11,6 +11,10 @@ import { join } from "node:path";
 import { runInstall } from "../src/cli/install.ts";
 import { runUninstall } from "../src/cli/uninstall.ts";
 import type {
+  LaunchctlResult,
+  LaunchctlRunner,
+} from "../src/lib/launchd.ts";
+import type {
   SystemctlResult,
   SystemctlRunner,
   UserSystemdEnv,
@@ -19,6 +23,14 @@ import type {
 class FakeSystemctl implements SystemctlRunner {
   calls: string[][] = [];
   async run(args: readonly string[]): Promise<SystemctlResult> {
+    this.calls.push([...args]);
+    return { exitCode: 0, stdout: "", stderr: "" };
+  }
+}
+
+class FakeLaunchctl implements LaunchctlRunner {
+  calls: string[][] = [];
+  async run(args: readonly string[]): Promise<LaunchctlResult> {
     this.calls.push([...args]);
     return { exitCode: 0, stdout: "", stderr: "" };
   }
@@ -81,7 +93,7 @@ const sysEnvMissing = (): UserSystemdEnv => ({
   reason: "/run/user/1003 does not exist — enable linger first: sudo loginctl enable-linger kai",
 });
 
-describe("runInstall", () => {
+describe("runInstall (linux/systemd)", () => {
   test("rejects when bin name isn't 'phantombot'", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
@@ -93,6 +105,7 @@ describe("runInstall", () => {
       out,
       err,
       ensureSystemdEnv: sysEnvReady,
+      platform: "linux",
     });
     expect(code).toBe(2);
     expect(err.text).toContain("compiled binary");
@@ -110,6 +123,7 @@ describe("runInstall", () => {
       out,
       err,
       ensureSystemdEnv: sysEnvMissing,
+      platform: "linux",
     });
     expect(code).toBe(2);
     expect(err.text).toContain("no user-level systemd bus available");
@@ -128,6 +142,7 @@ describe("runInstall", () => {
       out,
       err,
       ensureSystemdEnv: sysEnvAutoSet,
+      platform: "linux",
     });
     expect(code).toBe(0);
     expect(out.text).toContain(
@@ -147,6 +162,7 @@ describe("runInstall", () => {
       out,
       err,
       ensureSystemdEnv: sysEnvReady,
+      platform: "linux",
     });
     expect(code).toBe(0);
     expect(sys.calls.map((a) => a.join(" "))).toEqual([
@@ -160,13 +176,96 @@ describe("runInstall", () => {
       "--user enable phantombot-tick.timer",
       "--user start phantombot-tick.timer",
     ]);
-    expect(out.text).toContain("journalctl --user -u phantombot");
+    // The hint text uses the host's restartCommand/logsCommand, so it'll
+    // be journalctl on linux CI; match loosely.
+    expect(out.text).toContain("view logs:");
+    expect(out.text).toContain("restart:");
     // No auto-set message when env was already set.
     expect(out.text).not.toContain("auto-detected");
   });
 });
 
-describe("runUninstall", () => {
+describe("runInstall (darwin/launchd)", () => {
+  test("happy path writes plists + bootstraps each into the gui domain", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const lc = new FakeLaunchctl();
+    const code = await runInstall({
+      binPath: "/Users/andrew/.local/bin/phantombot",
+      plistPath: join(workdir, "dev.phantombot.phantombot.plist"),
+      heartbeatPlistPath: join(workdir, "dev.phantombot.heartbeat.plist"),
+      nightlyPlistPath: join(workdir, "dev.phantombot.nightly.plist"),
+      tickPlistPath: join(workdir, "dev.phantombot.tick.plist"),
+      domain: "gui/501",
+      launchctl: lc,
+      out,
+      err,
+      platform: "darwin",
+    });
+    expect(code).toBe(0);
+    // bootouts of nothing × 4, then bootstrap each plist × 4. We check the
+    // verb sequence rather than full strings so test stays readable.
+    const verbs = lc.calls.map((c) => c[0]);
+    expect(verbs).toEqual([
+      "bootout",
+      "bootout",
+      "bootout",
+      "bootout",
+      "bootstrap",
+      "bootstrap",
+      "bootstrap",
+      "bootstrap",
+    ]);
+    // bootstraps target the correct domain.
+    for (const c of lc.calls.filter((c) => c[0] === "bootstrap")) {
+      expect(c[1]).toBe("gui/501");
+    }
+  });
+
+  test("doesn't fall through to systemctl on darwin (the bug Andrew hit on his Mac)", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const sys = new FakeSystemctl();
+    const lc = new FakeLaunchctl();
+    const code = await runInstall({
+      binPath: "/Users/andrew/.local/bin/phantombot",
+      plistPath: join(workdir, "dev.phantombot.phantombot.plist"),
+      heartbeatPlistPath: join(workdir, "dev.phantombot.heartbeat.plist"),
+      nightlyPlistPath: join(workdir, "dev.phantombot.nightly.plist"),
+      tickPlistPath: join(workdir, "dev.phantombot.tick.plist"),
+      domain: "gui/501",
+      systemctl: sys,
+      launchctl: lc,
+      out,
+      err,
+      platform: "darwin",
+    });
+    expect(code).toBe(0);
+    // No systemctl calls — the regression test for the original Mac bug.
+    expect(sys.calls).toEqual([]);
+    // No "loginctl" appears anywhere.
+    expect(err.text).not.toContain("loginctl");
+    expect(out.text).not.toContain("loginctl");
+  });
+
+  test("rejects when bin name isn't 'phantombot' regardless of platform", async () => {
+    const err = new CaptureStream();
+    const lc = new FakeLaunchctl();
+    const code = await runInstall({
+      binPath: "/Users/andrew/.local/bin/bun",
+      domain: "gui/501",
+      launchctl: lc,
+      out: new CaptureStream(),
+      err,
+      platform: "darwin",
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("compiled binary");
+    expect(lc.calls).toEqual([]);
+  });
+});
+
+describe("runUninstall (linux/systemd)", () => {
   test("issues stop/disable/daemon-reload regardless of unit existing", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
@@ -177,6 +276,7 @@ describe("runUninstall", () => {
       out,
       err,
       ensureSystemdEnv: sysEnvReady,
+      platform: "linux",
     });
     expect(code).toBe(0);
     expect(sys.calls.map((a) => a.join(" "))).toEqual([
@@ -203,8 +303,35 @@ describe("runUninstall", () => {
       out,
       err,
       ensureSystemdEnv: sysEnvMissing,
+      platform: "linux",
     });
     expect(code).toBe(0);
     expect(err.text).toContain("no user-level systemd bus available");
+  });
+});
+
+describe("runUninstall (darwin/launchd)", () => {
+  test("boots out each label without touching systemctl", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const sys = new FakeSystemctl();
+    const lc = new FakeLaunchctl();
+    const code = await runUninstall({
+      plistPath: join(workdir, "dev.phantombot.phantombot.plist"),
+      heartbeatPlistPath: join(workdir, "dev.phantombot.heartbeat.plist"),
+      nightlyPlistPath: join(workdir, "dev.phantombot.nightly.plist"),
+      tickPlistPath: join(workdir, "dev.phantombot.tick.plist"),
+      domain: "gui/501",
+      systemctl: sys,
+      launchctl: lc,
+      out,
+      err,
+      platform: "darwin",
+    });
+    expect(code).toBe(0);
+    expect(sys.calls).toEqual([]);
+    expect(lc.calls.length).toBe(4);
+    expect(lc.calls.every((c) => c[0] === "bootout")).toBe(true);
+    expect(out.text).toContain("uninstall complete");
   });
 });

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -241,6 +241,90 @@ describe("runUpdate refusals", () => {
     expect(code).toBe(1);
     expect(err.text).toContain("only released for");
   });
+
+  test("darwin-x64 → exit 1 (Intel Mac isn't released)", async () => {
+    const err = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procPlatform: "darwin",
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      out: new CaptureStream(),
+      err,
+      force: true,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("only released for");
+    expect(err.text).toContain("darwin-arm64");
+    expect(err.text).toContain("platform=darwin");
+  });
+});
+
+describe("runUpdate on darwin-arm64", () => {
+  // On Mac, the asset name is `phantombot-vX-darwin-arm64`, not the
+  // hardcoded `linux-${arch}` from before this PR. Verify the right
+  // asset is fetched and the restart hint is launchctl-shaped.
+  const DARWIN_ASSET = "phantombot-v1.0.99-darwin-arm64";
+  const DARWIN_BYTES = Buffer.from("DARWIN_BINARY_VERIFIED");
+  const DARWIN_SHA = createHash("sha256").update(DARWIN_BYTES).digest("hex");
+
+  function darwinFetch(): typeof fetch {
+    const releaseBody = {
+      tag_name: "v1.0.99",
+      body: "test release",
+      assets: [
+        {
+          name: DARWIN_ASSET,
+          browser_download_url: "https://example/" + DARWIN_ASSET,
+          size: DARWIN_BYTES.byteLength,
+        },
+        {
+          name: "phantombot-v1.0.99-linux-x64",
+          browser_download_url: "https://example/linux-x64",
+          size: DARWIN_BYTES.byteLength,
+        },
+        {
+          name: "SHA256SUMS",
+          browser_download_url: "https://example/SHA256SUMS",
+          size: 256,
+        },
+      ],
+    };
+    return (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("api.github.com")) {
+        return new Response(JSON.stringify(releaseBody), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (u.includes("SHA256SUMS")) {
+        return new Response(`${DARWIN_SHA}  ${DARWIN_ASSET}\n`, {
+          status: 200,
+        });
+      }
+      return new Response(DARWIN_BYTES, { status: 200 });
+    }) as unknown as typeof fetch;
+  }
+
+  test("picks the darwin-arm64 asset, not the linux one", async () => {
+    const out = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procPlatform: "darwin",
+      procArch: "arm64",
+      currentVersion: "1.0.42",
+      fetchImpl: darwinFetch(),
+      out,
+      err: new CaptureStream(),
+      force: true,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("phantombot-v1.0.99-darwin-arm64");
+    // Binary on disk is the darwin one.
+    expect((await readFile(binPath)).equals(DARWIN_BYTES)).toBe(true);
+  });
 });
 
 describe("runUpdate happy path with --force --restart", () => {

--- a/tests/lib-envBootstrap.test.ts
+++ b/tests/lib-envBootstrap.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for preloadEnvFiles — the startup hook that gives launchd parity
+ * with systemd's EnvironmentFile=. Existing env values must always win
+ * (so an explicit `FOO=bar phantombot ask …` from the shell beats
+ * whatever's persisted in ~/.env).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { preloadEnvFiles } from "../src/lib/envBootstrap.ts";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-envboot-"));
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("preloadEnvFiles", () => {
+  test("loads keys from a .env file into the env map", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const r = await preloadEnvFiles({ files: [path], env });
+    expect(r.loaded.sort()).toEqual(["BAR", "FOO"]);
+    expect(env.FOO).toBe("hello");
+    expect(env.BAR).toBe("world");
+  });
+
+  test("existing env values win — does NOT overwrite a key already set in env", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=from-file\nBAR=from-file\n", "utf8");
+    const env: NodeJS.ProcessEnv = { FOO: "from-shell" };
+    const r = await preloadEnvFiles({ files: [path], env });
+    // FOO not loaded because the shell already set it.
+    expect(r.loaded).toEqual(["BAR"]);
+    expect(env.FOO).toBe("from-shell");
+    expect(env.BAR).toBe("from-file");
+  });
+
+  test("silent on missing files — fresh install with neither .env yet", async () => {
+    const env: NodeJS.ProcessEnv = {};
+    const r = await preloadEnvFiles({
+      files: [join(workdir, "does-not-exist")],
+      env,
+    });
+    expect(r.loaded).toEqual([]);
+    expect(Object.keys(env)).toEqual([]);
+  });
+
+  test("multi-file: later files don't overwrite earlier ones (existing-wins applies to each file too)", async () => {
+    const a = join(workdir, "a.env");
+    const b = join(workdir, "b.env");
+    await writeFile(a, "FOO=from-a\n", "utf8");
+    await writeFile(b, "FOO=from-b\nBAR=from-b\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    await preloadEnvFiles({ files: [a, b], env });
+    // FOO was set by file a; file b can't overwrite it.
+    expect(env.FOO).toBe("from-a");
+    expect(env.BAR).toBe("from-b");
+  });
+});

--- a/tests/lib-githubReleases.test.ts
+++ b/tests/lib-githubReleases.test.ts
@@ -72,7 +72,7 @@ describe("detectSupportedArch", () => {
 describe("findLatestRelease", () => {
   test("picks the x64 binary + SHA256SUMS, strips leading v from version", async () => {
     const r = await findLatestRelease({
-      arch: "x64",
+      target: "linux-x64",
       fetchImpl: fakeFetch(200, SAMPLE_RELEASE),
     });
     expect(r.ok).toBe(true);
@@ -88,7 +88,7 @@ describe("findLatestRelease", () => {
 
   test("picks the arm64 binary on arm64 host", async () => {
     const r = await findLatestRelease({
-      arch: "arm64",
+      target: "linux-arm64",
       fetchImpl: fakeFetch(200, SAMPLE_RELEASE),
     });
     expect(r.ok).toBe(true);
@@ -102,7 +102,7 @@ describe("findLatestRelease", () => {
       assets: SAMPLE_RELEASE.assets.filter((a) => a.name === "SHA256SUMS"),
     };
     const r = await findLatestRelease({
-      arch: "x64",
+      target: "linux-x64",
       fetchImpl: fakeFetch(200, partial),
     });
     expect(r.ok).toBe(false);
@@ -116,7 +116,7 @@ describe("findLatestRelease", () => {
       assets: SAMPLE_RELEASE.assets.filter((a) => a.name !== "SHA256SUMS"),
     };
     const r = await findLatestRelease({
-      arch: "x64",
+      target: "linux-x64",
       fetchImpl: fakeFetch(200, noChecksums),
     });
     expect(r.ok).toBe(false);
@@ -127,7 +127,7 @@ describe("findLatestRelease", () => {
 
   test("403 → rate limit hint mentioning GITHUB_TOKEN", async () => {
     const r = await findLatestRelease({
-      arch: "x64",
+      target: "linux-x64",
       fetchImpl: fakeFetch(403, { message: "rate limited" }),
     });
     expect(r.ok).toBe(false);
@@ -137,7 +137,7 @@ describe("findLatestRelease", () => {
 
   test("404 → 'no releases found' hint", async () => {
     const r = await findLatestRelease({
-      arch: "x64",
+      target: "linux-x64",
       fetchImpl: fakeFetch(404, { message: "not found" }),
     });
     expect(r.ok).toBe(false);
@@ -155,7 +155,7 @@ describe("findLatestRelease", () => {
         headers: { "content-type": "application/json" },
       });
     }) as unknown as typeof fetch;
-    await findLatestRelease({ arch: "x64", fetchImpl: recordingFetch });
+    await findLatestRelease({ target: "linux-x64", fetchImpl: recordingFetch });
     expect(seenUrl).toContain("fakeorg/fakerepo");
   });
 });

--- a/tests/lib-launchd.test.ts
+++ b/tests/lib-launchd.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for launchd plist generation + install/uninstall logic. Uses a
+ * fake LaunchctlRunner that records every invocation, so we don't need
+ * actual launchctl on the test host (and so these tests pass on Linux CI).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  generateHeartbeatPlist,
+  generateNightlyPlist,
+  generatePhantombotPlist,
+  generateTickPlist,
+  installPhantombotPlists,
+  type LaunchctlResult,
+  type LaunchctlRunner,
+  uninstallPhantombotPlists,
+  PHANTOMBOT_PLIST_LABEL,
+  HEARTBEAT_PLIST_LABEL,
+  NIGHTLY_PLIST_LABEL,
+  TICK_PLIST_LABEL,
+} from "../src/lib/launchd.ts";
+
+class FakeLaunchctl implements LaunchctlRunner {
+  calls: string[][] = [];
+  responses: LaunchctlResult[] = [];
+  async run(args: readonly string[]): Promise<LaunchctlResult> {
+    this.calls.push([...args]);
+    return (
+      this.responses.shift() ?? { exitCode: 0, stdout: "", stderr: "" }
+    );
+  }
+}
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+let workdir: string;
+let mainPath: string;
+let hbPath: string;
+let ngPath: string;
+let tkPath: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-launchd-"));
+  mainPath = join(workdir, `${PHANTOMBOT_PLIST_LABEL}.plist`);
+  hbPath = join(workdir, `${HEARTBEAT_PLIST_LABEL}.plist`);
+  ngPath = join(workdir, `${NIGHTLY_PLIST_LABEL}.plist`);
+  tkPath = join(workdir, `${TICK_PLIST_LABEL}.plist`);
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("generatePhantombotPlist", () => {
+  test("renders a launch-on-boot, keep-alive plist with the bin path as ProgramArguments", () => {
+    const plist = generatePhantombotPlist({
+      binPath: "/Users/andrew/.local/bin/phantombot",
+      args: ["run"],
+    });
+    expect(plist).toContain(`<string>${PHANTOMBOT_PLIST_LABEL}</string>`);
+    expect(plist).toContain(
+      "<string>/Users/andrew/.local/bin/phantombot</string>",
+    );
+    expect(plist).toContain("<string>run</string>");
+    expect(plist).toContain("<key>RunAtLoad</key>");
+    expect(plist).toContain("<key>KeepAlive</key>");
+    expect(plist).toContain("<key>ThrottleInterval</key>");
+    // Always-on units don't get a fire schedule.
+    expect(plist).not.toContain("<key>StartInterval</key>");
+    expect(plist).not.toContain("<key>StartCalendarInterval</key>");
+  });
+
+  test("XML-escapes ampersands and angle brackets in bin path", () => {
+    const plist = generatePhantombotPlist({
+      binPath: "/usr/local/odd&path/<phantombot>",
+      args: ["run"],
+    });
+    expect(plist).toContain(
+      "<string>/usr/local/odd&amp;path/&lt;phantombot&gt;</string>",
+    );
+  });
+
+  test("includes a usable PATH so subprocess agents can find pi/phantombot", () => {
+    const plist = generatePhantombotPlist({
+      binPath: "/Users/andrew/.local/bin/phantombot",
+      args: ["run"],
+    });
+    expect(plist).toContain("<key>PATH</key>");
+    // /opt/homebrew/bin matters on Apple Silicon — that's where bun lives if
+    // installed via brew.
+    expect(plist).toContain("/.local/bin");
+    expect(plist).toContain("/opt/homebrew/bin");
+  });
+
+  test("logs go to ~/Library/Logs/phantombot/<label>.{out,err}.log", () => {
+    const plist = generatePhantombotPlist({
+      binPath: "/Users/andrew/.local/bin/phantombot",
+      args: ["run"],
+    });
+    expect(plist).toContain(
+      `${PHANTOMBOT_PLIST_LABEL}.out.log`,
+    );
+    expect(plist).toContain(
+      `${PHANTOMBOT_PLIST_LABEL}.err.log`,
+    );
+  });
+});
+
+describe("companion plists carry the right schedule", () => {
+  test("heartbeat fires every 30 minutes", () => {
+    const plist = generateHeartbeatPlist("/usr/local/bin/phantombot");
+    expect(plist).toContain(`<string>${HEARTBEAT_PLIST_LABEL}</string>`);
+    expect(plist).toContain("<string>heartbeat</string>");
+    expect(plist).toContain("<key>StartInterval</key>");
+    expect(plist).toContain("<integer>1800</integer>");
+    // No KeepAlive on a periodic oneshot.
+    expect(plist).not.toContain("<key>KeepAlive</key>");
+  });
+
+  test("nightly fires daily at 02:00 (calendar-based)", () => {
+    const plist = generateNightlyPlist("/usr/local/bin/phantombot");
+    expect(plist).toContain(`<string>${NIGHTLY_PLIST_LABEL}</string>`);
+    expect(plist).toContain("<string>nightly</string>");
+    expect(plist).toContain("<key>StartCalendarInterval</key>");
+    expect(plist).toContain("<key>Hour</key>");
+    expect(plist).toContain("<integer>2</integer>");
+    expect(plist).toContain("<key>Minute</key>");
+    expect(plist).toContain("<integer>0</integer>");
+  });
+
+  test("tick fires every 60 seconds", () => {
+    const plist = generateTickPlist("/usr/local/bin/phantombot");
+    expect(plist).toContain(`<string>${TICK_PLIST_LABEL}</string>`);
+    expect(plist).toContain("<string>tick</string>");
+    expect(plist).toContain("<key>StartInterval</key>");
+    expect(plist).toContain("<integer>60</integer>");
+  });
+});
+
+describe("installPhantombotPlists", () => {
+  test("writes all four plists then bootstraps each into the gui domain", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const lc = new FakeLaunchctl();
+    const result = await installPhantombotPlists({
+      binPath: "/Users/andrew/.local/bin/phantombot",
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      launchctl: lc,
+      out,
+      err,
+    });
+    expect(result.installed).toBe(true);
+
+    // All four files exist on disk with sane bodies.
+    for (const path of [mainPath, hbPath, ngPath, tkPath]) {
+      const body = await readFile(path, "utf8");
+      expect(body).toContain('<?xml version="1.0"');
+      expect(body).toContain("<key>Label</key>");
+    }
+
+    // The launchctl call sequence is: bootout(label) × 4 (idempotent
+    // pre-cleanup), then bootstrap(plist) × 4.
+    const sequence = lc.calls.map((c) => c.join(" "));
+    expect(sequence).toEqual([
+      `bootout gui/501/${PHANTOMBOT_PLIST_LABEL}`,
+      `bootout gui/501/${HEARTBEAT_PLIST_LABEL}`,
+      `bootout gui/501/${NIGHTLY_PLIST_LABEL}`,
+      `bootout gui/501/${TICK_PLIST_LABEL}`,
+      `bootstrap gui/501 ${mainPath}`,
+      `bootstrap gui/501 ${hbPath}`,
+      `bootstrap gui/501 ${ngPath}`,
+      `bootstrap gui/501 ${tkPath}`,
+    ]);
+    expect(out.text).toContain("bootstrapped");
+  });
+
+  test("fails install (and reports) when bootstrap returns non-zero", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const lc = new FakeLaunchctl();
+    // 4 bootouts succeed; first bootstrap fails.
+    lc.responses = [
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 5, stdout: "", stderr: "Input/output error" },
+    ];
+    const result = await installPhantombotPlists({
+      binPath: "/Users/andrew/.local/bin/phantombot",
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      launchctl: lc,
+      out,
+      err,
+    });
+    expect(result.installed).toBe(false);
+    expect(err.text).toContain("launchctl bootstrap");
+    expect(err.text).toContain("Input/output error");
+  });
+});
+
+describe("uninstallPhantombotPlists", () => {
+  test("boots out each label then removes the plists from disk", async () => {
+    // Pre-create plists so the uninstall has files to remove.
+    await Bun.write(mainPath, "<plist></plist>");
+    await Bun.write(hbPath, "<plist></plist>");
+    await Bun.write(ngPath, "<plist></plist>");
+    await Bun.write(tkPath, "<plist></plist>");
+
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const lc = new FakeLaunchctl();
+    const result = await uninstallPhantombotPlists({
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      launchctl: lc,
+      out,
+      err,
+    });
+    expect(result.removed).toBe(true);
+
+    expect(lc.calls.map((c) => c.join(" "))).toEqual([
+      `bootout gui/501/${TICK_PLIST_LABEL}`,
+      `bootout gui/501/${NIGHTLY_PLIST_LABEL}`,
+      `bootout gui/501/${HEARTBEAT_PLIST_LABEL}`,
+      `bootout gui/501/${PHANTOMBOT_PLIST_LABEL}`,
+    ]);
+    // All plists removed.
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(mainPath)).toBe(false);
+    expect(existsSync(hbPath)).toBe(false);
+    expect(existsSync(ngPath)).toBe(false);
+    expect(existsSync(tkPath)).toBe(false);
+    expect(out.text).toContain("removed");
+  });
+
+  test("logs '(no plist at …)' for the main plist when nothing was installed", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const lc = new FakeLaunchctl();
+    // Even bootouts of nothing return non-zero — make sure we don't fail.
+    lc.responses = [
+      { exitCode: 1, stdout: "", stderr: "Could not find target" },
+      { exitCode: 1, stdout: "", stderr: "Could not find target" },
+      { exitCode: 1, stdout: "", stderr: "Could not find target" },
+      { exitCode: 1, stdout: "", stderr: "Could not find target" },
+    ];
+    const result = await uninstallPhantombotPlists({
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      launchctl: lc,
+      out,
+      err,
+    });
+    expect(result.removed).toBe(true);
+    expect(out.text).toContain("(no plist at");
+    // bootout failures are logged but don't fail the uninstall.
+    expect(out.text).toContain("returned 1 (continuing)");
+  });
+});

--- a/tests/lib-platform.test.ts
+++ b/tests/lib-platform.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for the platform-router. We can't easily mutate process.platform
+ * mid-test, so the routing functions are read-only on currentPlatform();
+ * what we CAN check is the shape of the returned hint strings (Linux on
+ * the CI box) and that defaultServiceControl() returns a working object
+ * with the right interface.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  currentPlatform,
+  defaultServiceControl,
+  logsCommand,
+  restartCommand,
+  statusCommand,
+} from "../src/lib/platform.ts";
+
+describe("currentPlatform", () => {
+  test("returns linux/darwin/unsupported only", () => {
+    const p = currentPlatform();
+    expect(["linux", "darwin", "unsupported"]).toContain(p);
+  });
+
+  test("matches process.platform when it's one of the supported pair", () => {
+    if (process.platform === "linux") expect(currentPlatform()).toBe("linux");
+    if (process.platform === "darwin") expect(currentPlatform()).toBe("darwin");
+  });
+});
+
+describe("hint commands shape per platform", () => {
+  test("on linux: systemctl/journalctl strings", () => {
+    if (process.platform !== "linux") return; // guard for CI on darwin
+    expect(restartCommand()).toContain("systemctl --user restart phantombot");
+    expect(statusCommand()).toContain("systemctl --user status phantombot");
+    expect(logsCommand()).toContain("journalctl --user -u phantombot");
+  });
+
+  test("on darwin: launchctl strings", () => {
+    if (process.platform !== "darwin") return;
+    expect(restartCommand()).toContain("launchctl kickstart -k");
+    expect(restartCommand()).toContain("dev.phantombot.phantombot");
+    expect(statusCommand()).toContain("launchctl print");
+    expect(logsCommand()).toContain("Library/Logs/phantombot");
+  });
+});
+
+describe("defaultServiceControl", () => {
+  test("returns an object with the ServiceControl interface", () => {
+    const svc = defaultServiceControl();
+    expect(typeof svc.isActive).toBe("function");
+    expect(typeof svc.restart).toBe("function");
+    expect(typeof svc.rerenderUnitIfStale).toBe("function");
+  });
+
+  test("isActive doesn't throw — it returns false when the backend isn't reachable", async () => {
+    const svc = defaultServiceControl();
+    // We don't care what it returns; we care that it doesn't blow up
+    // when no service-manager bus is available (e.g. CI containers).
+    await expect(svc.isActive()).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two Mac install/update bugs Andrew hit:

1. `phantombot install` was hardcoded for systemd, so on Mac it bailed with `no user-level systemd bus available: /run/user/501 does not exist` and suggested `loginctl enable-linger` (which doesn't exist on macOS).
2. `phantombot update`'s asset-name builder always asked for `phantombot-${tag}-linux-${arch}`, so even after a working install the update path would 404 on Mac.

## What changed

- **`src/lib/launchd.ts`** (new) — plist generation + install/uninstall + a `LaunchdServiceControl` that mirrors the systemd one (`launchctl kickstart -k` for restart, `bootstrap`/`bootout` for install/uninstall). Plists land in `~/Library/LaunchAgents/dev.phantombot.{phantombot,heartbeat,nightly,tick}.plist`; logs in `~/Library/Logs/phantombot/`.
- **`src/lib/platform.ts`** (new) — single dispatch point. `defaultServiceControl()`, `restartCommand()`, `statusCommand()`, `logsCommand()` all branch on `process.platform`. CLIs now import from `platform.ts` instead of `systemd.ts` directly.
- **`src/cli/install.ts`** + **`uninstall.ts`** — split into `runInstallLinux` / `runInstallDarwin` (and the uninstall pair). Same bin-name precheck, then per-platform path.
- **`src/lib/githubReleases.ts`** — `findLatestRelease({ target })` replaces `{ arch }`; new `detectSupportedTarget(platform, arch)` returns one of `linux-x64 | linux-arm64 | darwin-arm64`. `phantombot update` on darwin now fetches the right asset.
- **`src/index.ts`** + **`src/lib/envBootstrap.ts`** — self-load `~/.env` and `~/.config/phantombot/.env` at startup. launchd has no `EnvironmentFile=` equivalent, so without this credentials never reach the agent on Mac. Existing-wins ordering preserved, so systemd's pre-loaded values still win on Linux.
- Restart-hint strings (`harness`, `import-persona`, `update`, `run`, `install`) all now route through `restartCommand()` so messages match the host platform.

## What you'll see on Mac after this lands

```
$ phantombot install
wrote plist: /Users/andrew/Library/LaunchAgents/dev.phantombot.phantombot.plist
wrote plist: …/dev.phantombot.heartbeat.plist
wrote plist: …/dev.phantombot.nightly.plist
wrote plist: …/dev.phantombot.tick.plist
bootstrapped dev.phantombot.phantombot + heartbeat + nightly + tick into gui/501

view logs:    tail -f ~/Library/Logs/phantombot/dev.phantombot.phantombot.{out,err}.log
restart:      launchctl kickstart -k gui/$(id -u)/dev.phantombot.phantombot
uninstall:    phantombot uninstall
```

No `loginctl`. No `/run/user/501`.

## Tests

671 pass (up from 645). New: `lib-launchd`, `lib-platform`, `lib-envBootstrap`. Extended: `cli-install` (darwin path + regression test that we don't fall through to systemctl on Mac), `cli-update` (darwin asset-name + Intel-Mac refusal), `lib-githubReleases` (target parameter).

Includes a regression test specifically for the bug Andrew hit:

```ts
test("doesn't fall through to systemctl on darwin (the bug Andrew hit on his Mac)", …)
```

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` — 671 pass, 0 fail
- [x] On the Linux VPS, `phantombot install` still works end-to-end (smoke-tested + restored the live unit afterwards)
- [ ] Andrew test on Mac: `curl -fsSL .../install.sh | sh` then `phantombot install` should produce the launchctl output above
- [ ] Andrew test on Mac: `phantombot update --check` should hit the darwin-arm64 asset (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)