### PR TITLE
feat: teach + enforce phantombot task over harness-native schedulers

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -209,10 +209,54 @@ export class ClaudeHarness implements Harness {
     if (this.config.fallbackModel) {
       args.push("--fallback-model", this.config.fallbackModel);
     }
+    // Per-invocation settings injection. Layers additively on top of the user's
+    // own ~/.claude/settings.json — we don't touch that file, so an operator
+    // running `claude` directly on this host (e.g. for emergency repairs) is
+    // unaffected. See PHANTOMBOT_INJECTED_CLAUDE_SETTINGS for the policy.
+    args.push("--settings", JSON.stringify(PHANTOMBOT_INJECTED_CLAUDE_SETTINGS));
     args.push("--system-prompt", systemPrompt);
     return args;
   }
 }
+
+/**
+ * Settings injected into every `claude --print` invocation via `--settings`.
+ *
+ * The Claude Code harness ships a small set of "deferred" tools the model can
+ * call from inside a session — including `CronCreate` / `CronDelete` /
+ * `CronList`, an in-memory single-session scheduler. They're session-bound:
+ * dies with the subprocess, invisible to `phantombot task list`, no audit
+ * trail, no persistence across phantombot restarts.
+ *
+ * That makes them a foot-gun for our use case. A persona ("matt") asked for a
+ * recurring check called CronCreate — the schedule lived ~5 seconds (until
+ * the --print subprocess exited) and the user had no way to verify. The
+ * positive fix is the SCHEDULING_TOOLS_SECTION in persona/builder.ts which
+ * teaches the model to use `phantombot task` instead. THIS deny-list is the
+ * backstop: even if the model reaches for CronCreate in a moment of weakness,
+ * the harness refuses.
+ *
+ * We deliberately deny only the three scheduler tools. Bash, Read, Edit,
+ * WebFetch, and the rest of the Claude Code surface remain available — we're
+ * not crippling the harness, just removing the one footgun that has zero
+ * legitimate use given `phantombot task` exists.
+ *
+ * Layering: --settings is additive on top of ~/.claude/settings.json. The
+ * operator's own user settings are NOT modified by phantombot, so running
+ * `claude` directly outside phantombot (emergency repairs, dev work) is
+ * unaffected by this injection.
+ *
+ * Exported for testing and so the doc-string above is greppable.
+ */
+export const PHANTOMBOT_INJECTED_CLAUDE_SETTINGS = {
+  permissions: {
+    deny: [
+      "CronCreate",
+      "CronDelete",
+      "CronList",
+    ],
+  },
+} as const;
 
 /**
  * Strip ANTHROPIC_API_KEY from the inherited env so the subprocess uses

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -38,6 +38,13 @@ export function buildSystemPrompt(
   // commands exist and that it should use them.
   sections.push(MEMORY_TOOLS_SECTION);
 
+  // Always-on scheduling rules. The Claude Code harness ships native
+  // CronCreate/Delete/List tools that are session-bound and invisible
+  // to the user — we want the agent to reach for `phantombot task`
+  // instead. Injected even when the persona has its own tools.md so
+  // every persona gets the same scheduling discipline.
+  sections.push(SCHEDULING_TOOLS_SECTION);
+
   // Credential discovery + hygiene rules. Same rationale as memory tools:
   // injected after the persona's own tools.md so persona overrides stay
   // primary, but always present so the agent doesn't reinvent the
@@ -107,6 +114,68 @@ The heartbeat is mechanical (no LLM). The nightly is cognitive — that's
 when KB notes get created or updated based on what you captured during
 the day. Don't try to do nightly's job mid-conversation; just capture
 well and the nightly cycle handles synthesis.`;
+
+/**
+ * Scheduling — always use `phantombot task`, never harness-native
+ * scheduler tools. Same shape as MEMORY_TOOLS_SECTION: present a
+ * contract, list the relevant subcommands, then a hard rule.
+ *
+ * Background: the Claude Code harness exposes a deferred toolset
+ * including `CronCreate` / `CronDelete` / `CronList` — an in-memory,
+ * single-session scheduler that dies with the subprocess. A persona
+ * called CronCreate once and the user had no way to know nothing was
+ * actually scheduled (no DB row, no audit trail, no fire log). We
+ * mitigate at two layers:
+ *
+ *   1. THIS section, taught into every persona's context. Positive
+ *      pattern: "use phantombot task, here's why."
+ *   2. A claude.ts --settings injection that adds CronCreate/Delete/
+ *      List to permissions.deny. The model can't reach the tool even
+ *      if it tried. See PHANTOMBOT_INJECTED_CLAUDE_SETTINGS.
+ *
+ * Pi and Gemini have no native scheduler tools, so they only need
+ * this section — there's nothing to deny in those harnesses.
+ *
+ * Exported for testing.
+ */
+export const SCHEDULING_TOOLS_SECTION =
+  `# Scheduling tasks
+
+For anything that should run on a schedule — a check every N
+minutes, a daily reminder, a one-off "wake me in 10 minutes" —
+always use \`phantombot task\`. It writes to a SQLite store the
+user can inspect with \`phantombot task list\`, every fire is logged
+to \`task_runs\`, and tasks survive phantombot restarts.
+
+  phantombot task add "<prompt>" --in 10m              # one-off, fires once in 10 min
+  phantombot task add "<prompt>" --at "2026-05-06T18:00:00+02:00"
+                                                       # one-off at ISO time
+  phantombot task add "<prompt>" --every 30m --until "..."
+                                                       # recurring, requires expiry
+  phantombot task add "<prompt>" --every 1h --count 24 # recurring, fixed run count
+  phantombot task add "<prompt>" --every 5m  --for 2h  # recurring, duration
+  phantombot task list                                  # active tasks
+  phantombot task log <id>                              # fire history for a task
+  phantombot task rm <id>                               # delete a task
+  phantombot task selftest                              # 60-second end-to-end check
+
+Recurring tasks REQUIRE an expiry (--until / --count / --for) —
+without one the CLI exits non-zero and prints an error. Default
+maximum is 90 days; use \`--force-long-running\` only with the
+user's explicit permission.
+
+When you call \`task add\`, the CLI echoes \`task <id> scheduled at
+<local-time>\`. Repeat that line verbatim in your reply to the
+user — it's the proof-of-creation contract. No id in your reply
+means no schedule was made, full stop.
+
+DO NOT use harness-native scheduler tools (\`CronCreate\`,
+\`CronDelete\`, \`CronList\`, or any equivalent under another
+harness). They are session-bound — the schedule dies the moment
+the subprocess exits, the user can't see it in
+\`phantombot task list\`, and there's no fire log. They look like
+they work and silently don't. If you find yourself reaching for
+one, you want \`phantombot task add\` instead.`;
 
 /**
  * Optional channel-level overlay: ask the model to narrate one short

--- a/tests/fixtures/fake-claude.sh
+++ b/tests/fixtures/fake-claude.sh
@@ -10,6 +10,8 @@
 #   error    — emit a stderr line, exit 1
 #   notfound — exit 127 (terminal, simulates "command not found")
 #   hang     — sleep forever (used for the timeout test)
+#   argv     — emit argv as a single assistant text event (so the test can
+#              inspect what flags the harness passed), then exit 0
 
 mode="${FAKE_CLAUDE_MODE:-normal}"
 
@@ -36,6 +38,18 @@ case "$mode" in
     # the actual blocking process. Without exec, bash absorbs SIGTERM and
     # the orphaned sleep keeps stdout open, leaking the timeout into a hang.
     exec sleep 3600
+    ;;
+  argv)
+    # Emit our argv as a single assistant text event so the test can verify
+    # which flags the harness passed (e.g. --settings + the deny-list JSON).
+    # jq isn't guaranteed to be available on the target hosts, so build the
+    # JSON by hand and escape characters that would break stream-json: \, ".
+    payload="$*"
+    payload="${payload//\\/\\\\}"
+    payload="${payload//\"/\\\"}"
+    printf '%s\n' "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"${payload}\"}]}}"
+    printf '%s\n' '{"type":"result"}'
+    exit 0
     ;;
   *)
     echo "fake-claude.sh: unknown FAKE_CLAUDE_MODE=$mode" >&2

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
 import {
   ClaudeHarness,
+  PHANTOMBOT_INJECTED_CLAUDE_SETTINGS,
   filterAuthEnv,
   parseStreamJson,
   renderStdinPayload,
@@ -266,6 +267,51 @@ describe("ClaudeHarness.invoke (subprocess)", () => {
       recoverable: true,
       error: expect.stringContaining("timed out"),
     });
+  });
+});
+
+describe("PHANTOMBOT_INJECTED_CLAUDE_SETTINGS", () => {
+  test("denies the three harness-native scheduler tools and only those", () => {
+    const denied = PHANTOMBOT_INJECTED_CLAUDE_SETTINGS.permissions.deny;
+    expect(denied).toContain("CronCreate");
+    expect(denied).toContain("CronDelete");
+    expect(denied).toContain("CronList");
+    // We're not crippling the harness — this list is intentionally narrow.
+    expect(denied).toHaveLength(3);
+  });
+
+  test("serializes to valid JSON for --settings flag", () => {
+    const json = JSON.stringify(PHANTOMBOT_INJECTED_CLAUDE_SETTINGS);
+    const round = JSON.parse(json);
+    expect(round.permissions.deny).toEqual([
+      "CronCreate",
+      "CronDelete",
+      "CronList",
+    ]);
+  });
+});
+
+describe("ClaudeHarness subprocess invocation passes injected settings", () => {
+  test("--settings JSON appears in argv received by claude subprocess", async () => {
+    // fake-claude.sh in 'argv' mode (added below) prints argv to stdout
+    // as a stream-json text event so we can inspect what it received.
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness({
+      bin: FAKE_CLAUDE,
+      model: "test",
+      fallbackModel: "",
+    });
+    const chunks = await collect(h.invoke(newRequest()));
+    const texts = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    // --settings should be present and immediately followed by JSON
+    // containing the deny list.
+    expect(texts).toContain("--settings");
+    expect(texts).toContain("CronCreate");
+    expect(texts).toContain("CronDelete");
+    expect(texts).toContain("CronList");
   });
 });
 

--- a/tests/persona-builder-scheduling.test.ts
+++ b/tests/persona-builder-scheduling.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the always-on Scheduling tools section in buildSystemPrompt.
+ *
+ * Companion to persona-builder-memory-tools.test.ts. The scheduling
+ * section is the positive half of the CronCreate fix — it teaches every
+ * persona to use `phantombot task` and explicitly forbids the
+ * harness-native scheduler tools. The negative half (a deny-list passed
+ * to claude --settings) is exercised in harnesses-claude.test.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  SCHEDULING_TOOLS_SECTION,
+  buildSystemPrompt,
+} from "../src/persona/builder.ts";
+
+const channelCtx = {
+  channel: "cli",
+  conversationId: "cli:default",
+  timestamp: new Date("2026-05-06T12:00:00Z"),
+};
+
+describe("buildSystemPrompt — scheduling tools section", () => {
+  test("always appends the scheduling tools section", () => {
+    const prompt = buildSystemPrompt(
+      { boot: "I am test", identitySource: "BOOT.md" },
+      channelCtx,
+    );
+    expect(prompt).toContain("# Scheduling tasks");
+    expect(prompt).toContain("phantombot task add");
+    expect(prompt).toContain("phantombot task list");
+    expect(prompt).toContain("phantombot task selftest");
+  });
+
+  test("explicitly forbids harness-native scheduler tools by name", () => {
+    expect(SCHEDULING_TOOLS_SECTION).toContain("CronCreate");
+    expect(SCHEDULING_TOOLS_SECTION).toContain("CronDelete");
+    expect(SCHEDULING_TOOLS_SECTION).toContain("CronList");
+    // The instruction itself, not just the names.
+    expect(SCHEDULING_TOOLS_SECTION).toMatch(/DO NOT use/);
+  });
+
+  test("documents the recurring-requires-expiry contract", () => {
+    expect(SCHEDULING_TOOLS_SECTION).toContain("--until");
+    expect(SCHEDULING_TOOLS_SECTION).toContain("--count");
+    expect(SCHEDULING_TOOLS_SECTION).toContain("--for");
+    expect(SCHEDULING_TOOLS_SECTION).toMatch(/REQUIRE.*expiry/i);
+  });
+
+  test("documents the proof-of-creation echo contract", () => {
+    // The CLI echoes "task <id> scheduled at ..." — the persona must
+    // repeat that verbatim. This is the audit trail that defeats
+    // hallucinated schedules.
+    expect(SCHEDULING_TOOLS_SECTION).toContain("scheduled at");
+    expect(SCHEDULING_TOOLS_SECTION).toMatch(/proof[- ]of[- ]creation/);
+  });
+
+  test("scheduling section comes after persona-supplied tools.md", () => {
+    const prompt = buildSystemPrompt(
+      {
+        boot: "I am test",
+        identitySource: "BOOT.md",
+        tools: "Use the kettle in the kitchen.",
+        toolsSource: "tools.md",
+      },
+      channelCtx,
+    );
+    const ti = prompt.indexOf("# Tools available to you");
+    const si = prompt.indexOf("# Scheduling tasks");
+    expect(ti).toBeGreaterThan(0);
+    expect(si).toBeGreaterThan(ti);
+  });
+
+  test("scheduling section sits between memory and credentials sections", () => {
+    // Order matters for caching: stable persona/memory/tools first, then
+    // the system-level injections in a deterministic order.
+    const prompt = buildSystemPrompt(
+      { boot: "I am test", identitySource: "BOOT.md" },
+      channelCtx,
+    );
+    const memoryIdx = prompt.indexOf("# Memory tools");
+    const schedIdx = prompt.indexOf("# Scheduling tasks");
+    const credIdx = prompt.indexOf("# Credentials");
+    expect(memoryIdx).toBeGreaterThan(0);
+    expect(schedIdx).toBeGreaterThan(memoryIdx);
+    expect(credIdx).toBeGreaterThan(schedIdx);
+  });
+});


### PR DESCRIPTION
## Why

Matt called `CronCreate` and the user had no way to know nothing was actually scheduled. The Claude Code harness ships deferred tools — `CronCreate` / `CronDelete` / `CronList` — that are session-bound, die with the subprocess, and have zero audit trail. They look like they work and silently don't. PR #87 made `phantombot task` reliable; this PR teaches every persona to use it, and stops Claude Code from reaching the footgun even if tempted.

## What

Two-layer fix:

**1. Positive pattern (all harnesses)** — `src/persona/builder.ts` adds `SCHEDULING_TOOLS_SECTION`, injected into every persona's system prompt right after `MEMORY_TOOLS_SECTION`. It documents the `phantombot task` surface (`--in` / `--at` / `--every` with required expiry, `list` / `log` / `rm` / `selftest`), the proof-of-creation echo contract from PR #87, and explicitly forbids harness-native schedulers by name.

Pi and Gemini have no native scheduler tools, but the same doc still applies — single source of truth.

**2. Deny-list backstop (Claude Code only)** — `src/harnesses/claude.ts` injects `PHANTOMBOT_INJECTED_CLAUDE_SETTINGS` via `--settings <json>` on every `claude --print` invocation:

```json
{ "permissions": { "deny": ["CronCreate", "CronDelete", "CronList"] } }
```

The `--settings` flag layers additively on top of the user's own `~/.claude/settings.json`, which we deliberately **leave untouched**. An operator running `claude` directly outside phantombot (emergency repairs, dev work, daily-driver on a Mac) is unaffected. The deny-list is narrow: Bash / Read / Edit / WebFetch / etc. remain available — we're not crippling the harness, just removing the one footgun.

## Why both layers

- Doc-only would still leave Claude Code able to call CronCreate in a moment of weakness.
- Deny-list-only would leave Pi/Gemini agents (and future harnesses) ungoverned, and offers no positive guidance — "use this instead".

Together: the doc teaches the right pattern across all harnesses; the deny-list catches the failure case on Claude Code.

## Tests

- `tests/persona-builder-scheduling.test.ts` (new, 6 tests): section presence, deny-list naming, recurring-requires-expiry, proof-of-creation echo, ordering after persona tools.md, ordering between memory and credentials sections.
- `tests/harnesses-claude.test.ts` (+3 tests): `PHANTOMBOT_INJECTED_CLAUDE_SETTINGS` shape, JSON serializability, end-to-end argv-inspection via a new `argv` mode in `tests/fixtures/fake-claude.sh`.

All 716 existing tests pass alongside the 9 new ones; typecheck green.

## Live test — Lena

Deployed to Lena (kw-openclaw) and verified the actual loaded system prompt:

```
=== SECTION CHECK ===
FOUND scheduling section
deny-list NAMED in prompt
PROHIBITION CLAUSE present
=== ORDER ===
Memory @ 10726
Scheduling @ 12842
Credentials @ 14865
```

Lena's harness chain is `pi → gemini` so the `--settings` injection doesn't fire for her live, but the unit test in `harnesses-claude.test.ts` proves argv contains the deny-list when claude IS invoked. The persona-level prohibition reaches her either way.

## Test plan

- [x] All tests pass on linux-x64 (kw-openclaw)
- [x] Typecheck green
- [x] Deployed to Lena, system prompt verified end-to-end
- [ ] CI green on push
- [ ] Lena + Kai review

🤖 Generated with [Claude Code](https://claude.com/claude-code)