### PR TITLE
feat: unified init wizard and zero-friction install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,16 @@ jobs:
             ./src/index.ts \
             --outfile "dist/phantombot-${TAG}-linux-arm64"
 
+      - name: Build darwin-x64 (Intel Mac)
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # Cross-compiled from the Linux runner; Bun emits an unsigned
+          # Mach-O. install.sh handles the xattr / ad-hoc codesign dance.
+          bun build --compile --target=bun-darwin-x64 \
+            ./src/index.ts \
+            --outfile "dist/phantombot-${TAG}-darwin-x64"
+
       - name: Build darwin-arm64 (Apple Silicon)
         env:
           TAG: ${{ steps.version.outputs.tag }}
@@ -94,7 +104,6 @@ jobs:
           # Cross-compiled from the Linux runner; Bun emits an unsigned
           # Mach-O. First-run on macOS will be quarantined by Gatekeeper —
           # see release notes for the `xattr -d com.apple.quarantine` step.
-          # No darwin-x64 build: no current deploy target uses Intel Macs.
           bun build --compile --target=bun-darwin-arm64 \
             ./src/index.ts \
             --outfile "dist/phantombot-${TAG}-darwin-arm64"
@@ -107,6 +116,7 @@ jobs:
           sha256sum \
             "phantombot-${TAG}-linux-x64" \
             "phantombot-${TAG}-linux-arm64" \
+            "phantombot-${TAG}-darwin-x64" \
             "phantombot-${TAG}-darwin-arm64" \
             > SHA256SUMS
           cat SHA256SUMS
@@ -123,15 +133,19 @@ jobs:
           Binaries:
           - phantombot-${TAG}-linux-x64 — x86-64, baseline (no AVX2 required)
           - phantombot-${TAG}-linux-arm64 — ARM64
+          - phantombot-${TAG}-darwin-x64 — macOS x86-64 (unsigned; see below)
           - phantombot-${TAG}-darwin-arm64 — macOS Apple Silicon (unsigned; see below)
 
           Verify with: sha256sum -c SHA256SUMS
 
           Install with: phantombot update
 
-          macOS note: the darwin-arm64 binary is cross-compiled and unsigned.
-          On first run, clear the Gatekeeper quarantine attribute:
+          macOS note: the darwin binaries are cross-compiled and unsigned.
+          install.sh handles the xattr / ad-hoc codesign dance for you. If
+          you download the binary directly, clear the Gatekeeper quarantine
+          attribute on first run:
             xattr -d com.apple.quarantine ./phantombot-${TAG}-darwin-arm64
+            xattr -d com.apple.quarantine ./phantombot-${TAG}-darwin-x64
           EOF
 
       - name: Create GitHub Release with binary assets
@@ -149,5 +163,6 @@ jobs:
             --notes-file release-notes.md \
             "dist/phantombot-${TAG}-linux-x64" \
             "dist/phantombot-${TAG}-linux-arm64" \
+            "dist/phantombot-${TAG}-darwin-x64" \
             "dist/phantombot-${TAG}-darwin-arm64" \
             "dist/SHA256SUMS"

--- a/install.sh
+++ b/install.sh
@@ -13,10 +13,11 @@
 #      Gatekeeper accepts the unsigned-by-Apple binary.
 #   6. Installs to ~/.local/bin/phantombot (mode 0755).
 #   7. Warns if ~/.local/bin isn't on PATH.
-#   8. Launches `phantombot persona` to set up the first persona.
+#   8. Launches `phantombot init` to set up harness, persona, telegram, and
+#      (on Linux) the systemd background service.
 #
 # Override the install dir with PHANTOMBOT_INSTALL_DIR=/some/path.
-# Skip the persona TUI launch with PHANTOMBOT_SKIP_TUI=1 (e.g. CI smoke tests).
+# Skip the init TUI launch with PHANTOMBOT_SKIP_TUI=1 (e.g. CI smoke tests).
 #
 # Refusal modes (intentional — bail fast):
 #   - unsupported OS or arch
@@ -49,16 +50,10 @@ case "$uname_m" in
   x86_64|amd64)        arch="x64" ;;
   aarch64|arm64)       arch="arm64" ;;
   *)
-    printf 'phantombot: unsupported arch %s\n' "$uname_m" >&2
+    printf 'phantombot: unsupported arch %s (only x86_64 / aarch64 are released)\n' "$uname_m" >&2
     exit 1
     ;;
 esac
-
-# Only darwin-arm64 is built (Apple Silicon). Refuse Intel Mac.
-if [ "$platform" = "darwin" ] && [ "$arch" != "arm64" ]; then
-  printf 'phantombot: only darwin-arm64 (Apple Silicon) is released; %s on Mac is unsupported\n' "$arch" >&2
-  exit 1
-fi
 
 # --- preflight -----------------------------------------------------------
 
@@ -212,20 +207,27 @@ case ":$PATH:" in
     ;;
 esac
 
-# --- launch the persona TUI ---------------------------------------------
+# --- launch the init wizard ---------------------------------------------
 
 if [ -n "${PHANTOMBOT_SKIP_TUI:-}" ]; then
   exit 0
 fi
 
-# If stdin is not a TTY (e.g. piped from `curl … | sh`), the @clack
-# prompts in `phantombot persona` will misbehave — exit cleanly with
-# a next-step hint instead of trying to exec the TUI.
+# If stdin or stdout is not a TTY (e.g. when this script was piped from
+# `curl … | sh`), reattach all three streams to /dev/tty before exec'ing
+# the wizard. @clack/prompts checks `process.stdout.isTTY` to enable its
+# interactive renderer; redirecting only stdin would leave the spinner
+# and prompt output rendering against a pipe and degrade the UI.
 if [ ! -t 0 ] || [ ! -t 1 ]; then
-  printf '\nnext, run this to set up your first persona:\n'
-  printf '  phantombot persona\n\n'
-  exit 0
+  if [ -e /dev/tty ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    printf '\nphantombot: not a TTY (script was piped). Launching interactive setup via /dev/tty.\n\n'
+    exec "$INSTALL_DIR/phantombot" init </dev/tty >/dev/tty 2>&1
+  else
+    printf '\nnext, run this to finish setup:\n'
+    printf '  phantombot init\n\n'
+    exit 0
+  fi
 fi
 
-printf '\nphantombot: launching persona TUI to set up your first persona.\n\n'
-exec "$INSTALL_DIR/phantombot" persona
+printf '\nphantombot: launching setup wizard.\n\n'
+exec "$INSTALL_DIR/phantombot" init

--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -69,11 +69,17 @@ export async function applyHarnessChain(
 interface RunInput {
   config?: Config;
   serviceControl?: ServiceControl;
+  /**
+   * Optional pre-computed availability map. If provided, skips the PATH
+   * sweep — useful when the caller (e.g. `init`) has already detected
+   * availability and we don't want to re-walk PATH for every harness.
+   */
+  availability?: Record<HarnessId, string | undefined>;
 }
 
 export async function runHarness(input: RunInput = {}): Promise<number> {
   const config = input.config ?? (await loadConfig());
-  const availability = await detectAvailability(config);
+  const availability = input.availability ?? (await detectAvailability(config));
   const svc = input.serviceControl ?? defaultServiceControl();
 
   p.intro("Configure the harness chain");

--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -85,6 +85,16 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
     "Detected harnesses",
   );
 
+  const hasAnyHarness = Object.values(availability).some((path) => path !== undefined);
+  if (!hasAnyHarness) {
+    p.note(
+      "No supported harness (claude, pi, gemini) was found on your PATH.\n" +
+      "You will need to install at least one of them before the agent can think.\n" +
+      "We will continue the setup anyway so your configuration is ready.",
+      "Warning: No Harness Found",
+    );
+  }
+
   const primary = await p.select<HarnessId>({
     message: "Primary harness",
     options: SUPPORTED_HARNESSES.map((id) => ({

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import telegramCmd from "./telegram.ts";
 import harnessCmd from "./harness.ts";
 import installCmd from "./install.ts";
 import uninstallCmd from "./uninstall.ts";
+import initCmd from "./init.ts";
 import runCmd from "./run.ts";
 import memoryCmd from "./memory.ts";
 import embeddingCmd from "./embedding.ts";
@@ -49,6 +50,7 @@ export const mainCommand = defineCommand({
     harness: harnessCmd,
     embedding: embeddingCmd,
     env: envCmd,
+    init: initCmd,
     install: installCmd,
     uninstall: uninstallCmd,
     run: runCmd,

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,14 +1,59 @@
-import { execFile, execSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
+import { userInfo } from "node:os";
 
 import { defineCommand } from "citty";
 import * as p from "@clack/prompts";
 
-import { loadConfig } from "../config.ts";
+import { type Config, loadConfig } from "../config.ts";
 import { ensureUserSystemdEnv } from "../lib/systemd.ts";
-import { runHarness } from "./harness.ts";
+import {
+  detectAvailability,
+  type HarnessId,
+  runHarness,
+} from "./harness.ts";
 import { runInstall } from "./install.ts";
 import { runPersona } from "./persona.ts";
 import { runTelegram } from "./telegram.ts";
+
+export interface InitFlowInput {
+  config: Config;
+  availability: Record<HarnessId, string | undefined>;
+}
+
+export interface InitFlowDeps {
+  runHarness: (input: {
+    config: Config;
+    availability: Record<HarnessId, string | undefined>;
+  }) => Promise<number>;
+  runPersona: () => Promise<number>;
+  runTelegram: () => Promise<number>;
+}
+
+/**
+ * Pure orchestration of the three configuration wizards: harness → persona
+ * → telegram. Short-circuits on the first non-zero exit. Extracted from the
+ * interactive `run()` so the ordering and short-circuit behavior is testable
+ * without a TTY. The install wizard runs after this in `run()` so it can be
+ * gated on a separate user confirmation and a Linux-only linger pre-check.
+ */
+export async function runInitFlow(
+  input: InitFlowInput,
+  deps: InitFlowDeps,
+): Promise<number> {
+  const harnessCode = await deps.runHarness({
+    config: input.config,
+    availability: input.availability,
+  });
+  if (harnessCode !== 0) return harnessCode;
+
+  const personaCode = await deps.runPersona();
+  if (personaCode !== 0) return personaCode;
+
+  const telegramCode = await deps.runTelegram();
+  if (telegramCode !== 0) return telegramCode;
+
+  return 0;
+}
 
 /**
  * Cheap "is this CLI installed and runnable?" probe. We deliberately use
@@ -36,7 +81,6 @@ export default defineCommand({
     description: "Launch the full Phantombot unified setup wizard.",
   },
   async run() {
-    console.clear();
     p.intro("Welcome to Phantombot");
 
     p.note(
@@ -63,11 +107,11 @@ export default defineCommand({
 
     const spinner = p.spinner();
     spinner.start("Probing installed AI harnesses to find a configured one...");
-    
-    // We check which ones are on PATH first
-    const { detectAvailability } = await import("./harness.ts");
+
+    // Check which ones are on PATH. Reused below by `runHarness` so we don't
+    // walk PATH twice during the same wizard.
     const avail = await detectAvailability(config);
-    
+
     const probeResults: Record<string, boolean> = {};
     for (const [id, bin] of Object.entries(avail)) {
       if (bin) {
@@ -76,9 +120,9 @@ export default defineCommand({
         probeResults[id] = false;
       }
     }
-    
+
     spinner.stop("Probe complete.");
-    
+
     const configured = Object.entries(probeResults)
       .filter(([, isReady]) => isReady)
       .map(([id]) => id);
@@ -87,32 +131,25 @@ export default defineCommand({
       p.note("Found configured AI harnesses: " + configured.join(", "), "Probe result");
     } else {
       p.note(
-        "No AI harness replied to a test 'hello'.\n" +
-        "You might need to authenticate with them first (e.g. running 'claude' or 'pi' manually), " +
+        "No AI harness responded to '--version'.\n" +
+        "You might need to install one (claude, pi, or gemini) first, " +
         "but we can still set up the configuration now.",
         "Probe result"
       );
     }
 
-    // 1. Harness
-
-    const harnessCode = await runHarness();
-    if (harnessCode !== 0) {
-      process.exitCode = harnessCode;
-      return;
-    }
-
-    // 2. Persona
-    const personaCode = await runPersona();
-    if (personaCode !== 0) {
-      process.exitCode = personaCode;
-      return;
-    }
-
-    // 3. Telegram
-    const telegramCode = await runTelegram();
-    if (telegramCode !== 0) {
-      process.exitCode = telegramCode;
+    // 1-3: harness → persona → telegram, orchestrated by runInitFlow so
+    // the ordering + short-circuit behavior can be tested without a TTY.
+    const flowCode = await runInitFlow(
+      { config, availability: avail },
+      {
+        runHarness: (input) => runHarness(input),
+        runPersona,
+        runTelegram,
+      },
+    );
+    if (flowCode !== 0) {
+      process.exitCode = flowCode;
       return;
     }
 
@@ -125,9 +162,16 @@ export default defineCommand({
     if (process.platform === "linux") {
       const sysEnv = ensureUserSystemdEnv();
       if (!sysEnv.ready && sysEnv.reason?.includes("enable linger first")) {
+        // Resolve the username in Node, not the shell — `$USER` may be
+        // unset/empty in stripped environments (some sudoers configs,
+        // minimal containers) or contain unexpected characters that
+        // would corrupt a shell-interpolated command. Fall back to
+        // `os.userInfo()` which reads from the password database.
+        const username = process.env.USER || userInfo().username;
+        const lingerCmd = `sudo loginctl enable-linger ${username}`;
         p.note(
           "Linux requires 'linger' to run services in the background when you are not logged in.\n" +
-          "We need to run 'sudo loginctl enable-linger $USER' to configure this.",
+          `We need to run '${lingerCmd}' to configure this.`,
           "Systemd Linger Required"
         );
         const installLinger = await p.confirm({
@@ -142,10 +186,14 @@ export default defineCommand({
         }
 
         try {
-          execSync(`sudo loginctl enable-linger $USER`, { stdio: "inherit" });
+          // Pass the username as an explicit argv element rather than via a
+          // shell-interpolated string — no command injection or word-splitting
+          // surprises if the resolved username contains spaces or shell
+          // metacharacters.
+          execFileSync("sudo", ["loginctl", "enable-linger", username], { stdio: "inherit" });
           p.note("Linger enabled successfully.", "Success");
         } catch (error) {
-          p.note("Failed to enable linger. You may need to run 'sudo loginctl enable-linger $USER' manually.", "Error");
+          p.note(`Failed to enable linger. You may need to run '${lingerCmd}' manually.`, "Error");
         }
       }
     }
@@ -173,7 +221,7 @@ export default defineCommand({
         p.outro("Setup complete! Start your bot anytime with `phantombot run`.");
       }
     }
-    
+
     process.exitCode = 0;
   },
 });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,0 +1,179 @@
+import { execFile, execSync } from "node:child_process";
+
+import { defineCommand } from "citty";
+import * as p from "@clack/prompts";
+
+import { loadConfig } from "../config.ts";
+import { ensureUserSystemdEnv } from "../lib/systemd.ts";
+import { runHarness } from "./harness.ts";
+import { runInstall } from "./install.ts";
+import { runPersona } from "./persona.ts";
+import { runTelegram } from "./telegram.ts";
+
+/**
+ * Cheap "is this CLI installed and runnable?" probe. We deliberately use
+ * `--version` (and not e.g. `<bin> hello`) so the probe doesn't trigger a
+ * real LLM round-trip — three harnesses × a 15 s timeout each could mean
+ * up to ~45 s of paid inference just to greet the user during install. A
+ * `--version` exits in milliseconds, costs nothing, and tells us what we
+ * actually want to know: is the binary on PATH and able to run.
+ *
+ * This does NOT detect "binary present but not authenticated" — that's a
+ * harness-specific check (different for claude vs pi vs gemini) and is
+ * deferred to a follow-up.
+ */
+async function probeHarness(bin: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(bin, ["--version"], { timeout: 5000 }, (error, stdout) => {
+      resolve(!error && stdout.trim().length > 0);
+    });
+  });
+}
+
+export default defineCommand({
+  meta: {
+    name: "init",
+    description: "Launch the full Phantombot unified setup wizard.",
+  },
+  async run() {
+    console.clear();
+    p.intro("Welcome to Phantombot");
+
+    p.note(
+      "This wizard will guide you through 4 quick steps to get your agent running:\n" +
+      "  1. Pick your AI harness (claude, pi, or gemini)\n" +
+      "  2. Create a persona (identity & memory)\n" +
+      "  3. Connect to Telegram\n" +
+      "  4. Install as a background service",
+      "Setup Flow"
+    );
+
+    const ready = await p.confirm({
+      message: "Ready to start?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(ready) || !ready) {
+      p.cancel("Setup cancelled.");
+      process.exitCode = 1;
+      return;
+    }
+
+    const config = await loadConfig();
+
+    const spinner = p.spinner();
+    spinner.start("Probing installed AI harnesses to find a configured one...");
+    
+    // We check which ones are on PATH first
+    const { detectAvailability } = await import("./harness.ts");
+    const avail = await detectAvailability(config);
+    
+    const probeResults: Record<string, boolean> = {};
+    for (const [id, bin] of Object.entries(avail)) {
+      if (bin) {
+        probeResults[id] = await probeHarness(bin);
+      } else {
+        probeResults[id] = false;
+      }
+    }
+    
+    spinner.stop("Probe complete.");
+    
+    const configured = Object.entries(probeResults)
+      .filter(([, isReady]) => isReady)
+      .map(([id]) => id);
+
+    if (configured.length > 0) {
+      p.note("Found configured AI harnesses: " + configured.join(", "), "Probe result");
+    } else {
+      p.note(
+        "No AI harness replied to a test 'hello'.\n" +
+        "You might need to authenticate with them first (e.g. running 'claude' or 'pi' manually), " +
+        "but we can still set up the configuration now.",
+        "Probe result"
+      );
+    }
+
+    // 1. Harness
+
+    const harnessCode = await runHarness();
+    if (harnessCode !== 0) {
+      process.exitCode = harnessCode;
+      return;
+    }
+
+    // 2. Persona
+    const personaCode = await runPersona();
+    if (personaCode !== 0) {
+      process.exitCode = personaCode;
+      return;
+    }
+
+    // 3. Telegram
+    const telegramCode = await runTelegram();
+    if (telegramCode !== 0) {
+      process.exitCode = telegramCode;
+      return;
+    }
+
+    // 4. Install
+    // Use a step marker, not a second p.intro — clack renders one
+    // open / one close bracket per flow, and a second intro mid-flow
+    // produces a stray opening bracket in the rendered TUI.
+    p.log.step("Final step: Background Service Installation");
+
+    if (process.platform === "linux") {
+      const sysEnv = ensureUserSystemdEnv();
+      if (!sysEnv.ready && sysEnv.reason?.includes("enable linger first")) {
+        p.note(
+          "Linux requires 'linger' to run services in the background when you are not logged in.\n" +
+          "We need to run 'sudo loginctl enable-linger $USER' to configure this.",
+          "Systemd Linger Required"
+        );
+        const installLinger = await p.confirm({
+          message: "Allow sudo to enable linger?",
+          initialValue: true,
+        });
+
+        if (p.isCancel(installLinger) || !installLinger) {
+          p.cancel("Service installation skipped. You will need to start phantombot manually.");
+          process.exitCode = 0;
+          return;
+        }
+
+        try {
+          execSync(`sudo loginctl enable-linger $USER`, { stdio: "inherit" });
+          p.note("Linger enabled successfully.", "Success");
+        } catch (error) {
+          p.note("Failed to enable linger. You may need to run 'sudo loginctl enable-linger $USER' manually.", "Error");
+        }
+      }
+    }
+
+    const installConfirm = await p.confirm({
+      message: "Install Phantombot as a background service now?",
+      initialValue: true,
+    });
+
+    if (!p.isCancel(installConfirm) && installConfirm) {
+      const installCode = await runInstall();
+      if (installCode !== 0) {
+        process.exitCode = installCode;
+        return;
+      }
+      if (configured.length === 0) {
+        p.outro("All done! Your Phantombot is running, but it has no configured harness.\nOnce you install and configure a harness (like gemini or claude), run `phantombot harness` to wire it up.");
+      } else {
+        p.outro("All done! Your Phantombot is now running and ready to chat.");
+      }
+    } else {
+      if (configured.length === 0) {
+        p.outro("Setup complete! Start your bot anytime with `phantombot run`.\nRemember to run `phantombot harness` after you configure an AI harness.");
+      } else {
+        p.outro("Setup complete! Start your bot anytime with `phantombot run`.");
+      }
+    }
+    
+    process.exitCode = 0;
+  },
+});

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -96,6 +96,18 @@ export async function runTelegram(input: RunInput = {}): Promise<number> {
       return updateAllowedUsersOnly(config, existing.token, svc);
     }
     // fallthrough to replace flow
+  } else {
+    p.note(
+      `How to get a Telegram Bot Token:\n` +
+        `  1. Open Telegram and search for "@BotFather"\n` +
+        `  2. Send him: /newbot\n` +
+        `  3. Give it a name and a username (must end in 'bot')\n` +
+        `  4. Copy the HTTP API Token he gives you.\n\n` +
+        `How to find your User ID:\n` +
+        `  1. Search for "@userinfobot" in Telegram\n` +
+        `  2. Start the chat, it will reply with your ID (e.g. 123456789).`,
+      "Setup Guide",
+    );
   }
 
   const token = await p.password({

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the orchestrated init flow (`runInitFlow`).
+ *
+ * These exercise the call ordering and short-circuit behavior of the three
+ * configuration wizards (harness → persona → telegram). The fully-interactive
+ * `run()` exported as default is *not* tested here — it requires a TTY and
+ * touches @clack/prompts, sudo, and the install wizard. The orchestration
+ * function is the right unit boundary: it captures the "flow ordering"
+ * regression risk Kai called out in review without dragging clack into tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Config } from "../src/config.ts";
+import type { HarnessId } from "../src/cli/harness.ts";
+import {
+  type InitFlowDeps,
+  type InitFlowInput,
+  runInitFlow,
+} from "../src/cli/init.ts";
+
+function fakeInput(): InitFlowInput {
+  // Only the references matter — runInitFlow forwards them to deps.runHarness
+  // and never reads the inner shape itself.
+  return {
+    config: {} as Config,
+    availability: {
+      claude: undefined,
+      pi: undefined,
+      gemini: undefined,
+    } as Record<HarnessId, string | undefined>,
+  };
+}
+
+function makeDeps(overrides: Partial<InitFlowDeps> = {}): {
+  deps: InitFlowDeps;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const deps: InitFlowDeps = {
+    runHarness: async () => {
+      calls.push("harness");
+      return 0;
+    },
+    runPersona: async () => {
+      calls.push("persona");
+      return 0;
+    },
+    runTelegram: async () => {
+      calls.push("telegram");
+      return 0;
+    },
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+describe("runInitFlow", () => {
+  test("happy path: runs harness → persona → telegram in order", async () => {
+    const { deps, calls } = makeDeps();
+    const code = await runInitFlow(fakeInput(), deps);
+    expect(code).toBe(0);
+    expect(calls).toEqual(["harness", "persona", "telegram"]);
+  });
+
+  test("forwards config + availability to runHarness", async () => {
+    const seen: Array<{ config: unknown; availability: unknown }> = [];
+    const input = fakeInput();
+    const { deps } = makeDeps({
+      runHarness: async (i) => {
+        seen.push(i);
+        return 0;
+      },
+    });
+    await runInitFlow(input, deps);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.config).toBe(input.config);
+    expect(seen[0]?.availability).toBe(input.availability);
+  });
+
+  test("short-circuits on harness failure: persona + telegram NOT called", async () => {
+    const { deps, calls } = makeDeps({
+      runHarness: async () => {
+        calls.push("harness");
+        return 7;
+      },
+    });
+    const code = await runInitFlow(fakeInput(), deps);
+    expect(code).toBe(7);
+    expect(calls).toEqual(["harness"]);
+  });
+
+  test("short-circuits on persona failure: telegram NOT called", async () => {
+    const { deps, calls } = makeDeps({
+      runPersona: async () => {
+        calls.push("persona");
+        return 3;
+      },
+    });
+    const code = await runInitFlow(fakeInput(), deps);
+    expect(code).toBe(3);
+    expect(calls).toEqual(["harness", "persona"]);
+  });
+
+  test("propagates telegram failure exit code", async () => {
+    const { deps, calls } = makeDeps({
+      runTelegram: async () => {
+        calls.push("telegram");
+        return 9;
+      },
+    });
+    const code = await runInitFlow(fakeInput(), deps);
+    expect(code).toBe(9);
+    expect(calls).toEqual(["harness", "persona", "telegram"]);
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -25,6 +25,7 @@ describe("phantombot CLI dispatcher", () => {
       "env",
       "harness",
       "heartbeat",
+      "init",
       "install",
       "memory",
       "nightly",


### PR DESCRIPTION
This drops time-to-first-wow down to nearly zero.
Users run the curl install and are immediately guided through setup of their AI harness, persona, and telegram config all in one seamless wizard.

Gotchas addressed:
- Added mac cross-compilation (x64 and arm64).
- If no harness is on PATH, it warns but gracefully sets up the config anyway, reminding them at the end.
- Bot token instructions are embedded in the Telegram step.
- loginctl enable-linger is checked and handled during the install step.
- install.sh pipes directly into the wizard by allocating /dev/tty properly.