### PR TITLE
chore(init): say "on PATH" instead of "configured" for probe results

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -106,7 +106,7 @@ export default defineCommand({
     const config = await loadConfig();
 
     const spinner = p.spinner();
-    spinner.start("Probing installed AI harnesses to find a configured one...");
+    spinner.start("Probing installed AI harnesses to find ones on PATH...");
 
     // Check which ones are on PATH. Reused below by `runHarness` so we don't
     // walk PATH twice during the same wizard.
@@ -123,12 +123,12 @@ export default defineCommand({
 
     spinner.stop("Probe complete.");
 
-    const configured = Object.entries(probeResults)
+    const onPath = Object.entries(probeResults)
       .filter(([, isReady]) => isReady)
       .map(([id]) => id);
 
-    if (configured.length > 0) {
-      p.note("Found configured AI harnesses: " + configured.join(", "), "Probe result");
+    if (onPath.length > 0) {
+      p.note("Found AI harnesses on PATH: " + onPath.join(", "), "Probe result");
     } else {
       p.note(
         "No AI harness responded to '--version'.\n" +
@@ -209,13 +209,13 @@ export default defineCommand({
         process.exitCode = installCode;
         return;
       }
-      if (configured.length === 0) {
-        p.outro("All done! Your Phantombot is running, but it has no configured harness.\nOnce you install and configure a harness (like gemini or claude), run `phantombot harness` to wire it up.");
+      if (onPath.length === 0) {
+        p.outro("All done! Your Phantombot is running, but no AI harness was found on PATH.\nOnce you install and configure a harness (like gemini or claude), run `phantombot harness` to wire it up.");
       } else {
         p.outro("All done! Your Phantombot is now running and ready to chat.");
       }
     } else {
-      if (configured.length === 0) {
+      if (onPath.length === 0) {
         p.outro("Setup complete! Start your bot anytime with `phantombot run`.\nRemember to run `phantombot harness` after you configure an AI harness.");
       } else {
         p.outro("Setup complete! Start your bot anytime with `phantombot run`.");


### PR DESCRIPTION
## Summary

Follow-up to #89 — addresses @kaieriksen's wording nit on `src/cli/init.ts:126`.

The probe runs `<bin> --version`, which only confirms the binary is on PATH and callable; it doesn't tell us whether the harness has valid API keys configured. The user-visible language was implying the stronger property.

- Renamed local `configured` → `onPath`
- Spinner: `"...find a configured one..."` → `"...find ones on PATH..."`
- Found note: `"Found configured AI harnesses: ..."` → `"Found AI harnesses on PATH: ..."`
- Empty-state outro: `"...has no configured harness."` → `"...no AI harness was found on PATH."`

## Scope

Pure wording / variable rename. No behavior change. No new tests needed; existing 720/721 still green.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` → 720 pass / 1 skip / 0 fail
- [ ] Manual `phantombot init` run shows the new strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)