### PR TITLE
chore(tests): scrub real Telegram user ID from lib-tasks fixtures

### DIFF
--- a/tests/lib-tasks.test.ts
+++ b/tests/lib-tasks.test.ts
@@ -423,10 +423,10 @@ describe("TaskStore.silent / createdBy", () => {
       schedule: "0 * * * *",
       prompt: "x",
       now: NOW,
-      createdBy: "telegram:7995070089",
+      createdBy: "telegram:123456789",
     });
     if (!r.ok) throw new Error("setup");
-    expect(r.task.createdBy).toBe("telegram:7995070089");
+    expect(r.task.createdBy).toBe("telegram:123456789");
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #89 — extends the same hygiene fix to a pre-existing test file that wasn't in #89's diff.

`tests/lib-tasks.test.ts:426,429` embedded the literal Telegram user ID `7995070089` (Andrew's actual ID) in `createdBy` fixtures. PR #89 already scrubbed the matching leak in `src/cli/telegram.ts`; this finishes the job in the test file. Replaced with the conventional placeholder `123456789`.

## Scope

No behavior change — `createdBy` is an opaque string the test just round-trips through `TaskStore.add` / `task.createdBy`.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test tests/lib-tasks.test.ts` → 23 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)