### PR TITLE
fix(install): use script(1) pty on macOS to dodge Bun kqueue/dev/tty bug

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -214,14 +214,37 @@ if [ -n "${PHANTOMBOT_SKIP_TUI:-}" ]; then
 fi
 
 # If stdin or stdout is not a TTY (e.g. when this script was piped from
-# `curl … | sh`), reattach all three streams to /dev/tty before exec'ing
-# the wizard. @clack/prompts checks `process.stdout.isTTY` to enable its
-# interactive renderer; redirecting only stdin would leave the spinner
-# and prompt output rendering against a pipe and degrade the UI.
+# `curl … | sh`), reattach to /dev/tty before exec'ing the wizard.
+#
+# Linux: redirect all three streams to /dev/tty directly. Bun's epoll-based
+#   io_uring accepts /dev/tty as an event source, so node:tty WriteStream
+#   wraps it without complaint.
+#
+# macOS: Bun's kqueue rejects /dev/tty registration with EINVAL (it's a
+#   character device, not a pollable kqueue source), which crashes
+#   node:tty's WriteStream with "invalid argument, kqueue". Workaround:
+#   use BSD `script -q /dev/null` to allocate a real pseudo-terminal pair
+#   for the child. The child sees a normal pty (/dev/ttysNN), which kqueue
+#   handles fine, and clack's TTY detection lights up.
 if [ ! -t 0 ] || [ ! -t 1 ]; then
   if [ -e /dev/tty ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
     printf '\nphantombot: not a TTY (script was piped). Launching interactive setup via /dev/tty.\n\n'
-    exec "$INSTALL_DIR/phantombot" init </dev/tty >/dev/tty 2>&1
+    if [ "$platform" = "darwin" ]; then
+      if command -v script >/dev/null 2>&1; then
+        # BSD script: `script [-q] file [command ...]` — /dev/null discards
+        # the typescript log; </dev/tty hands the user's terminal to script
+        # so it can drive the child pty.
+        exec script -q /dev/null "$INSTALL_DIR/phantombot" init </dev/tty
+      else
+        # script(1) ships with macOS by default, but bail gracefully if absent.
+        printf 'phantombot: script(1) not found; cannot allocate a pty.\n'
+        printf 'next, run this in your terminal to finish setup:\n'
+        printf '  phantombot init\n\n'
+        exit 0
+      fi
+    else
+      exec "$INSTALL_DIR/phantombot" init </dev/tty >/dev/tty 2>&1
+    fi
   else
     printf '\nnext, run this to finish setup:\n'
     printf '  phantombot init\n\n'


### PR DESCRIPTION
## Problem

On macOS, the `curl | sh` install path crashed with:

```
error: EINVAL: invalid argument, kqueue
      at WriteStream (internal:fs/streams:244:58)
      at new WriteStream (node:tty:42:36)
```

Root cause: Bun on macOS uses kqueue for I/O polling, and kqueue rejects `/dev/tty` opened as a regular fd. Linux Bun is unaffected because epoll is happy with `/dev/tty`.

The previous fix redirected stdin/stdout/stderr to `/dev/tty` so `@clack/prompts` would see a TTY when run via `curl | sh`. That works on Linux but explodes on macOS the moment Bun tries to wrap stdout in a `node:tty` WriteStream.

## Fix

On macOS only, wrap the re-exec in `script -q /dev/null phantombot init`. `script(1)` allocates a real pseudo-terminal for the child, so Bun sees a genuine pty (no kqueue/dev/tty mismatch) and clack renders normally. Linux path is untouched.

## Verified on macOS (Andrew, MacBook Pro arm64)

```
curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/fix/macos-init-pty/install.sh | sh
```

Full wizard ran end-to-end: harness chain, persona, Telegram (cancelled — left existing), launchd install (4 plists bootstrapped into gui/501). Final "All done!" reached. Linux curl-pipe path unchanged and previously-confirmed working.

## Scope

One file (`install.sh`), one branch (the macOS arm in the curl-pipe re-exec). No binary rebuild needed.