### PR TITLE
Teach phantombot env to harnessed agents (convenience layer, sticky shell, hot-reload)

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -48,6 +48,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { reloadEnvFiles } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
   killCauseToErrorChunk,
@@ -88,6 +89,12 @@ export class ClaudeHarness implements Harness {
       bin: this.config.bin,
       argCount: args.length,
     });
+
+    // Re-source ~/.env / ~/.config/phantombot/.env so secrets the agent
+    // saved on the previous turn (`phantombot env set FOO bar`) are
+    // visible in this turn's env without needing a daemon restart.
+    // Shell-exported keys remain sticky — see envBootstrap.ts header.
+    await reloadEnvFiles();
 
     // OAuth-on-host: don't leak ANTHROPIC_API_KEY into the subprocess env,
     // so claude resolves credentials from ~/.claude/.credentials.json.

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -38,6 +38,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { reloadEnvFiles } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
   killCauseToErrorChunk,
@@ -119,6 +120,11 @@ export class GeminiHarness implements Harness {
       stdinBytes: Buffer.byteLength(stdinPayload, "utf8"),
       userMessageBytes: Buffer.byteLength(req.userMessage, "utf8"),
     });
+
+    // Re-source ~/.env so secrets saved by the agent on the previous turn
+    // (`phantombot env set FOO bar`) are visible here without a daemon
+    // restart. See envBootstrap.ts for the sticky-vs-reloadable rules.
+    await reloadEnvFiles();
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -24,6 +24,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { reloadEnvFiles } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
   killCauseToErrorChunk,
@@ -82,6 +83,11 @@ export class PiHarness implements Harness {
       bin: this.config.bin,
       payloadBytes: totalBytes,
     });
+
+    // Re-source ~/.env so secrets saved by the agent on the previous turn
+    // (`phantombot env set FOO bar`) are visible here without a daemon
+    // restart. See envBootstrap.ts for the sticky-vs-reloadable rules.
+    await reloadEnvFiles();
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,

--- a/src/lib/envBootstrap.ts
+++ b/src/lib/envBootstrap.ts
@@ -1,21 +1,32 @@
 /**
  * Self-load `~/.env` and `~/.config/phantombot/.env` into process.env at
- * startup.
+ * startup, with a `reloadEnvFiles()` re-source path used by the harnesses
+ * before each agent spawn so `phantombot env set` takes effect mid-session.
  *
- * Why: launchd has no equivalent of systemd's `EnvironmentFile=` plist
- * key, so on macOS phantombot has to source these files itself before
- * any subcommand reads `process.env.X`. On Linux the systemd unit
- * already sources both files, so this is a (cheap) no-op there — the
- * `existing-wins` policy below means anything systemd already set keeps
- * its value.
+ * Why startup load: launchd has no equivalent of systemd's `EnvironmentFile=`
+ * plist key, so on macOS phantombot has to source these files itself before
+ * any subcommand reads `process.env.X`. On Linux the systemd unit already
+ * sources both files, so this is a (cheap) no-op there — the `existing-wins`
+ * policy below means anything systemd already set keeps its value.
  *
- * Existing-wins ordering matters:
- *   - Variables explicitly exported in the parent shell (e.g. `GITHUB_TOKEN=foo phantombot ask …`)
- *     must win over what's persisted in the file.
- *   - On Linux, EnvironmentFile= already pre-populates process.env before
- *     the binary starts, so systemd's values also win — meaning the file
- *     read here is effectively a fallback for fresh invocations from a
- *     plain shell.
+ * Why reload-on-spawn: `phantombot env set NAME value` writes atomically to
+ * disk but does NOT mutate the running phantombot daemon's `process.env`.
+ * Without re-sourcing, a freshly-saved secret is invisible to the harnessed
+ * agent until the daemon restarts. Each harness calls `reloadEnvFiles()`
+ * right before spawning so the agent sees the latest file state.
+ *
+ * Sticky-vs-reloadable semantics:
+ *   - At boot we track which keys were FILLED IN FROM A FILE. Those keys
+ *     are reloadable: a later `reloadEnvFiles()` may update or delete them
+ *     to match the file.
+ *   - Keys that were already in `process.env` at boot (shell-export, systemd
+ *     EnvironmentFile=, parent process) are sticky: they were never tracked
+ *     as file-sourced, so reload won't touch them. This preserves the
+ *     "explicit shell export wins" guarantee for the launching shell.
+ *   - A new key that appears in the file post-boot AND isn't already in
+ *     the env gets loaded and tracked (so a future reload can also update
+ *     it). If a new file-key collides with an existing env key, the env
+ *     wins — same shell-wins rule.
  */
 
 import { existsSync } from "node:fs";
@@ -24,7 +35,7 @@ import { join } from "node:path";
 
 import { defaultEnvFilePath, loadEnvFile } from "./envFile.ts";
 
-/** Files to source, in priority order (later entries override earlier ones in process.env). */
+/** Files to source, in priority order (first file wins on key collision). */
 function envFilesToLoad(): string[] {
   const userEnv = join(homedir(), ".env");
   return [userEnv, defaultEnvFilePath()];
@@ -35,12 +46,33 @@ export interface PreloadOptions {
   files?: readonly string[];
   /** Override the env target — defaults to process.env. Tests inject a mutable map. */
   env?: NodeJS.ProcessEnv;
+  /**
+   * Override the file-sourced-key tracking set. Defaults to a module-scope
+   * singleton (so `reloadEnvFiles()` can re-sync against the same set that
+   * `preloadEnvFiles()` populated at boot). Tests pass their own to keep
+   * runs isolated.
+   */
+  tracked?: Set<string>;
+}
+
+/** Module-scope tracking of which keys came from a file at boot. */
+const _moduleTracked = new Set<string>();
+
+/**
+ * For tests: clear the module-scope tracked set. Production code never calls
+ * this — the daemon process keeps one tracking set for its lifetime.
+ */
+export function _resetTrackingForTesting(): void {
+  _moduleTracked.clear();
 }
 
 /**
  * Read each .env file in turn and copy missing keys into env. Existing
  * values are not overwritten. Silent on missing files (a fresh install
  * has neither .env yet).
+ *
+ * Records loaded keys in the tracking set so a later `reloadEnvFiles()`
+ * call knows which keys it's allowed to update or delete.
  *
  * Returns the names of variables we set, so tests can assert on the
  * effect without intercepting process.env writes.
@@ -50,6 +82,7 @@ export async function preloadEnvFiles(
 ): Promise<{ loaded: string[] }> {
   const env = opts.env ?? process.env;
   const files = opts.files ?? envFilesToLoad();
+  const tracked = opts.tracked ?? _moduleTracked;
   const loaded: string[] = [];
 
   for (const path of files) {
@@ -65,10 +98,82 @@ export async function preloadEnvFiles(
     for (const [k, v] of Object.entries(vars)) {
       if (env[k] === undefined) {
         env[k] = v;
+        tracked.add(k);
         loaded.push(k);
       }
     }
   }
 
   return { loaded };
+}
+
+/**
+ * Re-read each .env file and reconcile against the tracked set:
+ *   - tracked key still present in file → update env if value changed
+ *   - tracked key dropped from file       → delete from env, untrack
+ *   - new key in file (not tracked, not in env) → load + track
+ *   - new key in file but already in env (shell-export) → leave alone
+ *
+ * The harnesses call this right before spawning the agent so a freshly
+ * persisted credential (`phantombot env set FOO bar`) is visible to the
+ * subprocess on the very next turn — no daemon restart required.
+ *
+ * Returns the keys that changed and the keys that were removed, in case
+ * the caller wants to log the reconciliation.
+ */
+export async function reloadEnvFiles(
+  opts: PreloadOptions = {},
+): Promise<{ updated: string[]; removed: string[] }> {
+  const env = opts.env ?? process.env;
+  const files = opts.files ?? envFilesToLoad();
+  const tracked = opts.tracked ?? _moduleTracked;
+
+  // Collect every key the union of files would contribute, with first-file
+  // priority — same precedence rule preloadEnvFiles uses.
+  const fileValues = new Map<string, string>();
+  for (const path of files) {
+    if (!existsSync(path)) continue;
+    let vars: Record<string, string>;
+    try {
+      vars = await loadEnvFile(path);
+    } catch {
+      continue;
+    }
+    for (const [k, v] of Object.entries(vars)) {
+      if (!fileValues.has(k)) fileValues.set(k, v);
+    }
+  }
+
+  const updated: string[] = [];
+  const removed: string[] = [];
+
+  // Phase 1: reconcile previously-tracked keys against the file state.
+  // We snapshot the tracked set before mutating it inside the loop.
+  for (const k of [...tracked]) {
+    const fresh = fileValues.get(k);
+    if (fresh === undefined) {
+      // The file no longer has this key. Treat the file as truth and
+      // delete it from env so the next subprocess matches what's on disk.
+      if (env[k] !== undefined) delete env[k];
+      tracked.delete(k);
+      removed.push(k);
+    } else if (env[k] !== fresh) {
+      env[k] = fresh;
+      updated.push(k);
+    }
+  }
+
+  // Phase 2: pick up new file keys that we haven't seen before. Existing
+  // env values still win (shell-export sticky guarantee), but if the slot
+  // is empty we load and start tracking.
+  for (const [k, v] of fileValues) {
+    if (tracked.has(k)) continue;
+    if (env[k] === undefined) {
+      env[k] = v;
+      tracked.add(k);
+      updated.push(k);
+    }
+  }
+
+  return { updated, removed };
 }

--- a/src/lib/envBootstrap.ts
+++ b/src/lib/envBootstrap.ts
@@ -30,6 +30,7 @@
  */
 
 import { existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -39,6 +40,26 @@ import { defaultEnvFilePath, loadEnvFile } from "./envFile.ts";
 function envFilesToLoad(): string[] {
   const userEnv = join(homedir(), ".env");
   return [userEnv, defaultEnvFilePath()];
+}
+
+/**
+ * Cache entry for a single .env file. Keyed in the cache map by absolute path.
+ *
+ * Invalidation uses `(mtimeNs, size)` together. Either changing means the file
+ * was edited; both must match for a cache hit:
+ *   - `mtimeNs` (BigInt nanoseconds) catches almost all real edits — modern
+ *     filesystems on Linux/macOS update it on every write.
+ *   - `size` is the belt to the mtime suspenders. Some VFS layers (overlayfs,
+ *     tmpfs under heavy load, NFS) coalesce same-millisecond writes onto a
+ *     single mtime tick, and a `phantombot env set` flow in tests can land
+ *     two writes inside that window. Almost any real-world content change
+ *     also changes the byte length, so combining them is reliable in
+ *     practice without ever reading the file body.
+ */
+interface CachedParse {
+  mtimeNs: bigint;
+  size: bigint;
+  parsed: Record<string, string>;
 }
 
 export interface PreloadOptions {
@@ -53,10 +74,20 @@ export interface PreloadOptions {
    * runs isolated.
    */
   tracked?: Set<string>;
+  /**
+   * Override the per-path parse cache. Defaults to a module-scope singleton
+   * shared between `preloadEnvFiles()` and `reloadEnvFiles()` so an unchanged
+   * file is statted but not re-parsed across spawns. Tests pass their own to
+   * keep runs isolated.
+   */
+  statCache?: Map<string, CachedParse>;
 }
 
 /** Module-scope tracking of which keys came from a file at boot. */
 const _moduleTracked = new Set<string>();
+
+/** Module-scope mtime+parse cache shared across preload and reload calls. */
+const _moduleStatCache = new Map<string, CachedParse>();
 
 /**
  * For tests: clear the module-scope tracked set. Production code never calls
@@ -64,6 +95,61 @@ const _moduleTracked = new Set<string>();
  */
 export function _resetTrackingForTesting(): void {
   _moduleTracked.clear();
+}
+
+/**
+ * For tests: clear the module-scope stat cache. Production code never calls
+ * this — the cache lives for the daemon's lifetime and is invalidated only
+ * by mtime changes.
+ */
+export function _resetStatCacheForTesting(): void {
+  _moduleStatCache.clear();
+}
+
+/**
+ * Stat the file; if its mtime matches the cached entry, return the previously
+ * parsed object (skipping the read + parse). Otherwise read, parse, and refresh
+ * the cache. Returns `null` if the file is missing or the parse fails — the
+ * caller treats null as "skip this file silently", matching legacy behaviour.
+ *
+ * Per-spawn cost on a hot, unchanged file: one `fs.stat` (~0.1ms) instead of a
+ * stat + read + parse (~1ms+). The win compounds across two files × every
+ * agent spawn.
+ */
+async function readEnvFileCached(
+  path: string,
+  cache: Map<string, CachedParse>,
+): Promise<Record<string, string> | null> {
+  if (!existsSync(path)) {
+    // File no longer exists — drop any stale cache entry so a recreated
+    // file later isn't served from the old parse.
+    cache.delete(path);
+    return null;
+  }
+  let mtimeNs: bigint;
+  let size: bigint;
+  try {
+    const st = await stat(path, { bigint: true });
+    mtimeNs = st.mtimeNs;
+    size = st.size;
+  } catch {
+    cache.delete(path);
+    return null;
+  }
+  const cached = cache.get(path);
+  if (cached && cached.mtimeNs === mtimeNs && cached.size === size) {
+    return cached.parsed;
+  }
+  let parsed: Record<string, string>;
+  try {
+    parsed = await loadEnvFile(path);
+  } catch {
+    // Malformed .env shouldn't crash startup or a spawn — `phantombot env`
+    // commands surface the parse error in a more useful way.
+    return null;
+  }
+  cache.set(path, { mtimeNs, size, parsed });
+  return parsed;
 }
 
 /**
@@ -83,18 +169,12 @@ export async function preloadEnvFiles(
   const env = opts.env ?? process.env;
   const files = opts.files ?? envFilesToLoad();
   const tracked = opts.tracked ?? _moduleTracked;
+  const cache = opts.statCache ?? _moduleStatCache;
   const loaded: string[] = [];
 
   for (const path of files) {
-    if (!existsSync(path)) continue;
-    let vars: Record<string, string>;
-    try {
-      vars = await loadEnvFile(path);
-    } catch {
-      // A malformed .env shouldn't crash startup. The follow-up `phantombot
-      // env` commands will surface the parse error in a more useful way.
-      continue;
-    }
+    const vars = await readEnvFileCached(path, cache);
+    if (vars === null) continue;
     for (const [k, v] of Object.entries(vars)) {
       if (env[k] === undefined) {
         env[k] = v;
@@ -127,18 +207,16 @@ export async function reloadEnvFiles(
   const env = opts.env ?? process.env;
   const files = opts.files ?? envFilesToLoad();
   const tracked = opts.tracked ?? _moduleTracked;
+  const cache = opts.statCache ?? _moduleStatCache;
 
   // Collect every key the union of files would contribute, with first-file
-  // priority — same precedence rule preloadEnvFiles uses.
+  // priority — same precedence rule preloadEnvFiles uses. Cache lookups
+  // short-circuit the read+parse when a file's mtime hasn't changed, so a
+  // hot per-spawn reload on an unchanged ~/.env costs roughly one stat call.
   const fileValues = new Map<string, string>();
   for (const path of files) {
-    if (!existsSync(path)) continue;
-    let vars: Record<string, string>;
-    try {
-      vars = await loadEnvFile(path);
-    } catch {
-      continue;
-    }
+    const vars = await readEnvFileCached(path, cache);
+    if (vars === null) continue;
     for (const [k, v] of Object.entries(vars)) {
       if (!fileValues.has(k)) fileValues.set(k, v);
     }

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -276,39 +276,69 @@ narration is purely to fill the pre-tool silence; once the result
 is in, just answer.`;
 
 /**
- * System-level credential discovery + hygiene. Injected into every
+ * System-level credential discovery + persistence. Injected into every
  * persona's prompt so the agent has a consistent contract for finding
- * credentials and persisting new ones, regardless of which persona is
+ * credentials and saving new ones, regardless of which persona is
  * loaded. Persona-specific tools.md sections can override.
+ *
+ * Framing note: the store (\`~/.env\` via \`phantombot env set\`) is a
+ * *convenience layer*, not a cage. The agent should be free — and
+ * encouraged — to scan creatively for credentials wherever they
+ * actually live (git history, config files, keychains, password
+ * managers, log lines, …) and to file what's worth keeping. The
+ * starter-spots list below is a fast path, not a wall.
  */
 export const CREDENTIALS_SECTION =
   `# Credentials
 
-## Discovery — where to find them when a task needs them
+Phantombot keeps a small, atomic credential store at \`~/.env\` (write
+via \`phantombot env set\`). Treat it as a *convenience layer*, not a
+cage: scan widely for what you need, and when you find or earn a
+useful credential, file it so the next turn — or the next persona —
+doesn't have to re-derive it.
 
-Look in this order; don't ask the user for anything that's already
-discoverable:
+## Where to look first — the fast path
+
+These are the *starter spots*. Most things will be here. Don't ask
+the user for anything in this list that you can read directly:
 
   1. process.env  — already loaded; phantombot sources both \`~/.env\` and
                     \`~/.config/phantombot/.env\` at startup (systemd
                     EnvironmentFile= on Linux, self-loaded on macOS), so
                     most credentials are available without re-reading.
-  2. ~/.env       — the agent's general credentials file. The canonical
-                    home for things like GITHUB_TOKEN, OPENAI_API_KEY, ssh
-                    passphrases.
+  2. ~/.env       — the canonical credentials file. GITHUB_TOKEN,
+                    OPENAI_API_KEY, ssh passphrases, API keys.
   3. ~/.ssh/      — SSH keys + config (Host aliases, IdentityFile entries).
-  4. ~/.bashrc, ~/.zshrc — exported shell vars (often the same keys as ~/.env
-                    but exported into interactive shells too).
+  4. ~/.bashrc, ~/.zshrc — exported shell vars (often the same keys as
+                    ~/.env but exported into interactive shells too).
   5. Memory store: \`phantombot memory search "<credential name>"\` — anything
-                    you've stashed under your own persona memory.
-  6. Knowledge base — embedded notes and runbooks.
+                    a previous turn stashed under your persona memory.
+  6. Knowledge base — embedded notes, runbooks, infra docs.
 
-If nothing turns up across all six, then ask the user.
+## Follow your nose if those fail
 
-## Hygiene — how to handle new credentials
+The starter list is not exhaustive. Real credentials live in many
+places — be resourceful before asking the user. Reasonable places
+to look, when context warrants:
 
-When the user gives you a new credential (an API token, a password, a
-private key), persist it via the safe-write CLI:
+  - git history of repos you can read (old commits, .env.example,
+    sample configs, CI files)
+  - per-tool config: \`~/.config/<tool>/\`, \`~/.<tool>rc\`, \`/etc/<tool>/\`
+  - browser profiles, OS keychains, password managers, secret stores
+  - shell history for one-off \`export FOO=...\` lines
+  - service definitions (systemd unit \`Environment=\`, launchd plists)
+  - CI/CD config visible to your account
+  - cloud-provider metadata services if you're on a VM
+
+Use judgement: scan when the task genuinely needs the credential, not
+speculatively. If you discover something useful while doing other
+work, save it (next subsection) so the next agent doesn't have to
+redo the search.
+
+## Persistence — save what you find
+
+When the user gives you a credential, OR when you discover one in
+the wild that's worth keeping, persist it via the safe-write CLI:
 
   phantombot env set NAME "value"           # atomic write to ~/.env, mode 0o600
   phantombot env get NAME                   # read (avoid in interactive: leaks to scrollback)
@@ -319,8 +349,9 @@ NEVER \`echo … >> ~/.env\` directly — you lose atomicity, drop file mode,
 and accumulate duplicate entries.
 
 After saving, ACKNOWLEDGE BY NAME ONLY: "saved GITHUB_TOKEN". Do not
-echo the value back. The user pasted it once; further reflection in
-the conversation is leakage that ends up in the memory store.
+echo the value back. The user pasted it once (or you just discovered
+it); further reflection in the conversation is leakage that ends up
+in transcripts and the memory store.
 
 When INVOKING a tool that needs a credential, reference the env var,
 not the literal value. Example:
@@ -333,6 +364,12 @@ not the literal value. Example:
   gh api -H "Authorization: Bearer ghp_actualtokenhere..."
 
 Credentials don't go in memory drawers, KB notes, or task prompts.
-They're a runtime concern — the file (\`~/.env\`) and the process env
-are the only places they live.`;
+They're a runtime concern — \`~/.env\` and the process env are the
+only places they live.
+
+## Last resort
+
+If after checking starter spots and following your nose the
+credential genuinely isn't anywhere, then ask the user. Asking
+first — without scanning — is the lazy path; don't take it.`;
 

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -45,7 +45,14 @@ export function buildSystemPrompt(
   // every persona gets the same scheduling discipline.
   sections.push(SCHEDULING_TOOLS_SECTION);
 
-  // Credential discovery + hygiene rules. Same rationale as memory tools:
+  // Out-of-band notification rules. Sits next to scheduling on purpose:
+  // the most common reason for an agent to notify is a scheduled task
+  // surfacing something material. Kept in its own section (rather than
+  // tucked under credentials, where it used to live) because it's
+  // about *talking to the user*, not about secrets.
+  sections.push(NOTIFICATION_SECTION);
+
+  // Credential discovery + persistence rules. Same rationale as memory tools:
   // injected after the persona's own tools.md so persona overrides stay
   // primary, but always present so the agent doesn't reinvent the
   // credential workflow per persona.
@@ -178,6 +185,43 @@ they work and silently don't. If you find yourself reaching for
 one, you want \`phantombot task add\` instead.`;
 
 /**
+ * Out-of-band notification — the only sanctioned way for the agent to
+ * proactively talk to the user from a non-interactive turn (a scheduled
+ * task fire, a heartbeat-discovered finding, a long-running job that
+ * just finished).
+ *
+ * Companion to SCHEDULING_TOOLS_SECTION: the most common reason to
+ * notify is a scheduled task surfacing something material, but the
+ * mechanism is general — any non-interactive turn that produces
+ * something the user should hear about should use \`phantombot notify\`.
+ *
+ * Previously lived inside CREDENTIALS_SECTION, which was a category
+ * mistake — credentials and notifications have nothing in common.
+ *
+ * Exported for testing.
+ */
+export const NOTIFICATION_SECTION =
+  `# Surfacing things to the user
+
+Scheduled tasks (\`phantombot tick\`) and any other out-of-band work
+run silently by default — no Telegram chatter on every fire. When
+something material happens that the user genuinely needs to know,
+surface it explicitly with the notify CLI:
+
+  phantombot notify --message "..."         # text via Telegram
+  phantombot notify --voice   "..."         # synthesized voice note via TTS
+
+Both flags can be combined to send text AND voice. The user's
+standing rule: don't notify unless asked, or unless something
+material happened. "Nothing new" is a successful silent run — stay
+quiet.
+
+This is the only sanctioned proactive channel from a non-interactive
+turn. Don't try to inject text by other means (writing to a TTY,
+scheduling a self-message, posting on Google Chat, etc.) — the user
+reads notifications on Telegram.`;
+
+/**
  * Optional channel-level overlay: ask the model to narrate one short
  * sentence before each tool call so streaming channels (Telegram text,
  * Twilio voice via `phantombot ask --stream`) have something to render
@@ -260,19 +304,6 @@ discoverable:
   6. Knowledge base — embedded notes and runbooks.
 
 If nothing turns up across all six, then ask the user.
-
-## Scheduled-task notification
-
-Scheduled tasks (\`phantombot tick\`) run silently by default — no Telegram
-chatter on every fire. When a task you're running detects something the
-user genuinely needs to know, surface it explicitly:
-
-  phantombot notify --message "..."         # text via Telegram
-  phantombot notify --voice   "..."         # synthesized voice note via TTS
-
-Both flags can be combined. The user explicitly asked: don't notify
-unless asked or unless something material happened. "Nothing important"
-is a successful run — stay quiet.
 
 ## Hygiene — how to handle new credentials
 

--- a/tests/lib-envBootstrap.test.ts
+++ b/tests/lib-envBootstrap.test.ts
@@ -1,8 +1,17 @@
 /**
- * Tests for preloadEnvFiles — the startup hook that gives launchd parity
- * with systemd's EnvironmentFile=. Existing env values must always win
- * (so an explicit `FOO=bar phantombot ask …` from the shell beats
- * whatever's persisted in ~/.env).
+ * Tests for preloadEnvFiles + reloadEnvFiles. Two layers:
+ *
+ *   1. preloadEnvFiles (startup) — gives launchd parity with systemd's
+ *      EnvironmentFile=. Existing env values must always win, so an
+ *      explicit `FOO=bar phantombot ask …` from the shell beats whatever's
+ *      persisted in ~/.env.
+ *
+ *   2. reloadEnvFiles (per-spawn) — the harnesses call this before each
+ *      agent subprocess so a credential the agent saved on the previous
+ *      turn (`phantombot env set FOO bar`) is visible without restarting
+ *      the daemon. The contract: file-sourced keys are reloadable, but
+ *      keys that were already in process.env at boot (shell-export,
+ *      systemd) stay sticky — reload never touches them.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -10,7 +19,10 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { preloadEnvFiles } from "../src/lib/envBootstrap.ts";
+import {
+  preloadEnvFiles,
+  reloadEnvFiles,
+} from "../src/lib/envBootstrap.ts";
 
 let workdir: string;
 
@@ -64,5 +76,149 @@ describe("preloadEnvFiles", () => {
     // FOO was set by file a; file b can't overwrite it.
     expect(env.FOO).toBe("from-a");
     expect(env.BAR).toBe("from-b");
+  });
+});
+
+describe("reloadEnvFiles", () => {
+  test("picks up a brand-new key added to the file post-boot", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=hello\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    await preloadEnvFiles({ files: [path], env, tracked });
+
+    // Agent runs `phantombot env set BAR world` mid-session.
+    await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
+    const r = await reloadEnvFiles({ files: [path], env, tracked });
+
+    expect(env.BAR).toBe("world");
+    expect(r.updated).toContain("BAR");
+    expect(r.removed).toEqual([]);
+  });
+
+  test("updates a previously file-sourced key when the file value changes", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=old\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    await preloadEnvFiles({ files: [path], env, tracked });
+    expect(env.FOO).toBe("old");
+
+    await writeFile(path, "FOO=new\n", "utf8");
+    const r = await reloadEnvFiles({ files: [path], env, tracked });
+
+    expect(env.FOO).toBe("new");
+    expect(r.updated).toEqual(["FOO"]);
+    expect(r.removed).toEqual([]);
+  });
+
+  test("shell-exported key is sticky — reload does NOT overwrite it from the file", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=from-file\n", "utf8");
+    const env: NodeJS.ProcessEnv = { FOO: "from-shell" };
+    const tracked = new Set<string>();
+    await preloadEnvFiles({ files: [path], env, tracked });
+    // Boot-time: shell value won, FOO is NOT tracked as file-sourced.
+    expect(env.FOO).toBe("from-shell");
+    expect(tracked.has("FOO")).toBe(false);
+
+    // File changes mid-session.
+    await writeFile(path, "FOO=updated-in-file\n", "utf8");
+    const r = await reloadEnvFiles({ files: [path], env, tracked });
+
+    // The shell export still wins. The file change is invisible — by design.
+    expect(env.FOO).toBe("from-shell");
+    expect(r.updated).toEqual([]);
+  });
+
+  test("removes a previously file-sourced key when the file no longer has it", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    await preloadEnvFiles({ files: [path], env, tracked });
+    expect(env.BAR).toBe("world");
+
+    // Agent runs `phantombot env unset BAR`.
+    await writeFile(path, "FOO=hello\n", "utf8");
+    const r = await reloadEnvFiles({ files: [path], env, tracked });
+
+    expect(env.BAR).toBeUndefined();
+    expect(env.FOO).toBe("hello"); // unrelated key untouched
+    expect(r.removed).toEqual(["BAR"]);
+    expect(tracked.has("BAR")).toBe(false);
+  });
+
+  test("does NOT remove a shell-exported key that's absent from the file", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=hello\n", "utf8");
+    const env: NodeJS.ProcessEnv = { SHELL_ONLY: "from-shell" };
+    const tracked = new Set<string>();
+    await preloadEnvFiles({ files: [path], env, tracked });
+
+    const r = await reloadEnvFiles({ files: [path], env, tracked });
+
+    // SHELL_ONLY was never tracked → reload leaves it alone even though
+    // it's not in the file.
+    expect(env.SHELL_ONLY).toBe("from-shell");
+    expect(r.removed).toEqual([]);
+  });
+
+  test("idempotent: a no-change reload reports nothing updated or removed", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    await preloadEnvFiles({ files: [path], env, tracked });
+
+    const r = await reloadEnvFiles({ files: [path], env, tracked });
+
+    expect(r.updated).toEqual([]);
+    expect(r.removed).toEqual([]);
+    expect(env.FOO).toBe("hello");
+    expect(env.BAR).toBe("world");
+  });
+
+  test("a shell-exported key stays sticky even if it later appears in the file", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=from-file\n", "utf8");
+    // OTHER simulates an unrelated boot-time shell export.
+    const env: NodeJS.ProcessEnv = { OTHER: "shell" };
+    const tracked = new Set<string>();
+    await preloadEnvFiles({ files: [path], env, tracked });
+    expect(env.FOO).toBe("from-file");
+    expect(env.OTHER).toBe("shell");
+
+    // Mid-session, someone runs `phantombot env set OTHER from-file`. The
+    // shell already had OTHER, so reload must NOT clobber it — there's no
+    // way to distinguish a brand-new file key from a collision against an
+    // existing shell key, so the shell-wins rule wins by default.
+    await writeFile(path, "FOO=from-file\nOTHER=from-file\n", "utf8");
+    const r = await reloadEnvFiles({ files: [path], env, tracked });
+
+    expect(env.OTHER).toBe("shell");
+    expect(r.updated).not.toContain("OTHER");
+  });
+
+  test("multi-file reload preserves first-file-wins precedence", async () => {
+    const a = join(workdir, "a.env");
+    const b = join(workdir, "b.env");
+    await writeFile(a, "FOO=from-a\n", "utf8");
+    await writeFile(b, "FOO=from-b\nBAR=from-b\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    await preloadEnvFiles({ files: [a, b], env, tracked });
+    expect(env.FOO).toBe("from-a");
+
+    // Update file b's FOO; file a's FOO still wins.
+    await writeFile(b, "FOO=from-b-updated\nBAR=from-b\n", "utf8");
+    await reloadEnvFiles({ files: [a, b], env, tracked });
+    expect(env.FOO).toBe("from-a");
+
+    // Update file a's FOO; that DOES propagate (first file is the truth).
+    await writeFile(a, "FOO=from-a-updated\n", "utf8");
+    const r = await reloadEnvFiles({ files: [a, b], env, tracked });
+    expect(env.FOO).toBe("from-a-updated");
+    expect(r.updated).toContain("FOO");
   });
 });

--- a/tests/lib-envBootstrap.test.ts
+++ b/tests/lib-envBootstrap.test.ts
@@ -39,7 +39,11 @@ describe("preloadEnvFiles", () => {
     const path = join(workdir, ".env");
     await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
     const env: NodeJS.ProcessEnv = {};
-    const r = await preloadEnvFiles({ files: [path], env });
+    const r = await preloadEnvFiles({
+      files: [path],
+      env,
+      statCache: new Map(),
+    });
     expect(r.loaded.sort()).toEqual(["BAR", "FOO"]);
     expect(env.FOO).toBe("hello");
     expect(env.BAR).toBe("world");
@@ -49,7 +53,11 @@ describe("preloadEnvFiles", () => {
     const path = join(workdir, ".env");
     await writeFile(path, "FOO=from-file\nBAR=from-file\n", "utf8");
     const env: NodeJS.ProcessEnv = { FOO: "from-shell" };
-    const r = await preloadEnvFiles({ files: [path], env });
+    const r = await preloadEnvFiles({
+      files: [path],
+      env,
+      statCache: new Map(),
+    });
     // FOO not loaded because the shell already set it.
     expect(r.loaded).toEqual(["BAR"]);
     expect(env.FOO).toBe("from-shell");
@@ -61,6 +69,7 @@ describe("preloadEnvFiles", () => {
     const r = await preloadEnvFiles({
       files: [join(workdir, "does-not-exist")],
       env,
+      statCache: new Map(),
     });
     expect(r.loaded).toEqual([]);
     expect(Object.keys(env)).toEqual([]);
@@ -72,7 +81,7 @@ describe("preloadEnvFiles", () => {
     await writeFile(a, "FOO=from-a\n", "utf8");
     await writeFile(b, "FOO=from-b\nBAR=from-b\n", "utf8");
     const env: NodeJS.ProcessEnv = {};
-    await preloadEnvFiles({ files: [a, b], env });
+    await preloadEnvFiles({ files: [a, b], env, statCache: new Map() });
     // FOO was set by file a; file b can't overwrite it.
     expect(env.FOO).toBe("from-a");
     expect(env.BAR).toBe("from-b");
@@ -85,11 +94,12 @@ describe("reloadEnvFiles", () => {
     await writeFile(path, "FOO=hello\n", "utf8");
     const env: NodeJS.ProcessEnv = {};
     const tracked = new Set<string>();
-    await preloadEnvFiles({ files: [path], env, tracked });
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
 
     // Agent runs `phantombot env set BAR world` mid-session.
     await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
-    const r = await reloadEnvFiles({ files: [path], env, tracked });
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
 
     expect(env.BAR).toBe("world");
     expect(r.updated).toContain("BAR");
@@ -101,13 +111,19 @@ describe("reloadEnvFiles", () => {
     await writeFile(path, "FOO=old\n", "utf8");
     const env: NodeJS.ProcessEnv = {};
     const tracked = new Set<string>();
-    await preloadEnvFiles({ files: [path], env, tracked });
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
     expect(env.FOO).toBe("old");
 
-    await writeFile(path, "FOO=new\n", "utf8");
-    const r = await reloadEnvFiles({ files: [path], env, tracked });
+    // Use a different-length value so the size dimension of the cache key
+    // invalidates the entry. In production `phantombot env set` does atomic
+    // tempfile+rename, so the post-edit mtime always advances even for
+    // same-length values; raw `writeFile` here truncates in place and can
+    // coalesce sub-millisecond mtime ticks on some filesystems.
+    await writeFile(path, "FOO=brand-new-value\n", "utf8");
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
 
-    expect(env.FOO).toBe("new");
+    expect(env.FOO).toBe("brand-new-value");
     expect(r.updated).toEqual(["FOO"]);
     expect(r.removed).toEqual([]);
   });
@@ -117,14 +133,15 @@ describe("reloadEnvFiles", () => {
     await writeFile(path, "FOO=from-file\n", "utf8");
     const env: NodeJS.ProcessEnv = { FOO: "from-shell" };
     const tracked = new Set<string>();
-    await preloadEnvFiles({ files: [path], env, tracked });
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
     // Boot-time: shell value won, FOO is NOT tracked as file-sourced.
     expect(env.FOO).toBe("from-shell");
     expect(tracked.has("FOO")).toBe(false);
 
     // File changes mid-session.
     await writeFile(path, "FOO=updated-in-file\n", "utf8");
-    const r = await reloadEnvFiles({ files: [path], env, tracked });
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
 
     // The shell export still wins. The file change is invisible — by design.
     expect(env.FOO).toBe("from-shell");
@@ -136,12 +153,13 @@ describe("reloadEnvFiles", () => {
     await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
     const env: NodeJS.ProcessEnv = {};
     const tracked = new Set<string>();
-    await preloadEnvFiles({ files: [path], env, tracked });
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
     expect(env.BAR).toBe("world");
 
     // Agent runs `phantombot env unset BAR`.
     await writeFile(path, "FOO=hello\n", "utf8");
-    const r = await reloadEnvFiles({ files: [path], env, tracked });
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
 
     expect(env.BAR).toBeUndefined();
     expect(env.FOO).toBe("hello"); // unrelated key untouched
@@ -154,9 +172,10 @@ describe("reloadEnvFiles", () => {
     await writeFile(path, "FOO=hello\n", "utf8");
     const env: NodeJS.ProcessEnv = { SHELL_ONLY: "from-shell" };
     const tracked = new Set<string>();
-    await preloadEnvFiles({ files: [path], env, tracked });
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
 
-    const r = await reloadEnvFiles({ files: [path], env, tracked });
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
 
     // SHELL_ONLY was never tracked → reload leaves it alone even though
     // it's not in the file.
@@ -169,9 +188,10 @@ describe("reloadEnvFiles", () => {
     await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
     const env: NodeJS.ProcessEnv = {};
     const tracked = new Set<string>();
-    await preloadEnvFiles({ files: [path], env, tracked });
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
 
-    const r = await reloadEnvFiles({ files: [path], env, tracked });
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
 
     expect(r.updated).toEqual([]);
     expect(r.removed).toEqual([]);
@@ -185,7 +205,8 @@ describe("reloadEnvFiles", () => {
     // OTHER simulates an unrelated boot-time shell export.
     const env: NodeJS.ProcessEnv = { OTHER: "shell" };
     const tracked = new Set<string>();
-    await preloadEnvFiles({ files: [path], env, tracked });
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
     expect(env.FOO).toBe("from-file");
     expect(env.OTHER).toBe("shell");
 
@@ -194,7 +215,7 @@ describe("reloadEnvFiles", () => {
     // way to distinguish a brand-new file key from a collision against an
     // existing shell key, so the shell-wins rule wins by default.
     await writeFile(path, "FOO=from-file\nOTHER=from-file\n", "utf8");
-    const r = await reloadEnvFiles({ files: [path], env, tracked });
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
 
     expect(env.OTHER).toBe("shell");
     expect(r.updated).not.toContain("OTHER");
@@ -207,18 +228,88 @@ describe("reloadEnvFiles", () => {
     await writeFile(b, "FOO=from-b\nBAR=from-b\n", "utf8");
     const env: NodeJS.ProcessEnv = {};
     const tracked = new Set<string>();
-    await preloadEnvFiles({ files: [a, b], env, tracked });
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [a, b], env, tracked, statCache });
     expect(env.FOO).toBe("from-a");
 
     // Update file b's FOO; file a's FOO still wins.
     await writeFile(b, "FOO=from-b-updated\nBAR=from-b\n", "utf8");
-    await reloadEnvFiles({ files: [a, b], env, tracked });
+    await reloadEnvFiles({ files: [a, b], env, tracked, statCache });
     expect(env.FOO).toBe("from-a");
 
     // Update file a's FOO; that DOES propagate (first file is the truth).
     await writeFile(a, "FOO=from-a-updated\n", "utf8");
-    const r = await reloadEnvFiles({ files: [a, b], env, tracked });
+    const r = await reloadEnvFiles({ files: [a, b], env, tracked, statCache });
     expect(env.FOO).toBe("from-a-updated");
     expect(r.updated).toContain("FOO");
+  });
+});
+
+describe("reloadEnvFiles — mtime stat cache", () => {
+  test("a no-change reload reuses the cached parse instead of re-reading the file", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=hello\nBAR=world\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
+
+    // Cache should now hold an entry for this path.
+    expect(statCache.size).toBe(1);
+    const cachedBefore = statCache.get(path);
+    expect(cachedBefore).toBeDefined();
+    const parsedRefBefore = cachedBefore!.parsed;
+
+    // Reload without changing the file. The cache entry's `parsed` reference
+    // must be the same object — proof we didn't re-parse.
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
+    expect(r.updated).toEqual([]);
+    expect(r.removed).toEqual([]);
+    expect(statCache.get(path)!.parsed).toBe(parsedRefBefore);
+  });
+
+  test("a file edit invalidates the cache and the new parse replaces the old", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=old\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
+    const parsedRefBefore = statCache.get(path)!.parsed;
+
+    // Different-length value so the size component of the cache key catches
+    // the edit even on filesystems that coalesce sub-millisecond mtime ticks.
+    await writeFile(path, "FOO=replacement-value\n", "utf8");
+    await reloadEnvFiles({ files: [path], env, tracked, statCache });
+
+    const cachedAfter = statCache.get(path)!;
+    // Cache key changed → new object identity for `parsed`.
+    expect(cachedAfter.parsed).not.toBe(parsedRefBefore);
+    expect(cachedAfter.parsed.FOO).toBe("replacement-value");
+    expect(env.FOO).toBe("replacement-value");
+  });
+
+  test("a file deletion drops the cache entry so a recreated file parses fresh", async () => {
+    const path = join(workdir, ".env");
+    await writeFile(path, "FOO=hello\n", "utf8");
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    const statCache = new Map();
+    await preloadEnvFiles({ files: [path], env, tracked, statCache });
+    expect(statCache.has(path)).toBe(true);
+
+    // Remove the file. Reload should drop both the env key (file-sourced)
+    // and the cache entry.
+    await rm(path);
+    const r = await reloadEnvFiles({ files: [path], env, tracked, statCache });
+    expect(r.removed).toEqual(["FOO"]);
+    expect(env.FOO).toBeUndefined();
+    expect(statCache.has(path)).toBe(false);
+
+    // Recreate with different contents — must parse fresh, not serve stale.
+    await writeFile(path, "FOO=resurrected\n", "utf8");
+    await reloadEnvFiles({ files: [path], env, tracked, statCache });
+    expect(env.FOO).toBe("resurrected");
+    expect(statCache.get(path)!.parsed.FOO).toBe("resurrected");
   });
 });

--- a/tests/persona-builder-credentials.test.ts
+++ b/tests/persona-builder-credentials.test.ts
@@ -54,11 +54,11 @@ describe("buildSystemPrompt — credentials section", () => {
     expect(CREDENTIALS_SECTION).toContain("Do not\necho the value back");
   });
 
-  test("documents phantombot notify for scheduled-task notification", () => {
-    expect(CREDENTIALS_SECTION).toContain("phantombot notify");
-    expect(CREDENTIALS_SECTION).toContain("--message");
-    expect(CREDENTIALS_SECTION).toContain("--voice");
-    expect(CREDENTIALS_SECTION).toContain("silently by default");
+  test("does not document phantombot notify (lives in NOTIFICATION_SECTION)", () => {
+    // `phantombot notify` was previously misfiled under credentials. It
+    // belongs to its own section now — credentials should stay focused
+    // on secret discovery and persistence.
+    expect(CREDENTIALS_SECTION).not.toContain("phantombot notify");
   });
 
   test("credentials section comes after the memory tools section", () => {

--- a/tests/persona-builder-credentials.test.ts
+++ b/tests/persona-builder-credentials.test.ts
@@ -1,10 +1,17 @@
 /**
- * Tests for the always-on credential discovery + hygiene section.
+ * Tests for the always-on credential discovery + persistence section.
  *
  * Lives in every persona's system prompt — same rationale as the memory
  * tools section. The agent must consistently know where to look for
  * credentials and how to persist new ones, regardless of which persona
  * is loaded.
+ *
+ * Framing: the section presents `~/.env` (write via `phantombot env set`)
+ * as a *convenience layer*, not a cage. The agent must be free to scan
+ * creatively for credentials wherever they live, and to file what's
+ * worth keeping. These tests pin both halves: starter spots are
+ * documented (fast path), AND the section explicitly licenses
+ * follow-your-nose discovery with concrete examples.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -16,7 +23,7 @@ import {
 const channelCtx = {
   channel: "cli",
   conversationId: "cli:default",
-  timestamp: new Date("2026-05-02T12:00:00Z"),
+  timestamp: new Date("2026-05-07T12:00:00Z"),
 };
 
 describe("buildSystemPrompt — credentials section", () => {
@@ -26,16 +33,52 @@ describe("buildSystemPrompt — credentials section", () => {
       channelCtx,
     );
     expect(prompt).toContain("# Credentials");
-    expect(prompt).toContain("Discovery");
-    expect(prompt).toContain("Hygiene");
+    // The three structural subsections of the new layout.
+    expect(prompt).toContain("Where to look first");
+    expect(prompt).toContain("Follow your nose");
+    expect(prompt).toContain("Persistence");
+    expect(prompt).toContain("Last resort");
   });
 
-  test("documents the discovery order with ~/.env first", () => {
+  test("frames the store as a convenience layer, not a cage", () => {
+    // The literal phrase is load-bearing. It's how the agent learns
+    // that `phantombot env` is a place to *file* credentials, not a
+    // wall around them. If you change the wording, update both here
+    // and the persona docs at the same time.
+    expect(CREDENTIALS_SECTION).toMatch(/convenience layer/i);
+    // Tolerate the possible \n between "not a" and "cage" from prose wrapping.
+    expect(CREDENTIALS_SECTION).toMatch(/not a\s+cage/i);
+  });
+
+  test("documents the starter-spots fast path with ~/.env, ssh, shell, memory, KB", () => {
     expect(CREDENTIALS_SECTION).toContain("process.env");
     expect(CREDENTIALS_SECTION).toContain("~/.env");
     expect(CREDENTIALS_SECTION).toContain("~/.ssh/");
     expect(CREDENTIALS_SECTION).toContain("~/.bashrc");
     expect(CREDENTIALS_SECTION).toContain("phantombot memory search");
+    // Marked as the *fast path*, not an exhaustive prescription.
+    expect(CREDENTIALS_SECTION).toMatch(/starter spots/i);
+    expect(CREDENTIALS_SECTION).toMatch(/not exhaustive/i);
+  });
+
+  test("explicitly licenses follow-your-nose discovery with concrete sources", () => {
+    // The whole point of this PR — the agent must understand it's free
+    // (and encouraged) to scan beyond the starter list. We pin a few
+    // canonical second-tier sources so the message stays concrete.
+    expect(CREDENTIALS_SECTION).toMatch(/Follow your nose/i);
+    expect(CREDENTIALS_SECTION).toMatch(/git history/i);
+    expect(CREDENTIALS_SECTION).toMatch(/keychain|password manager/i);
+    expect(CREDENTIALS_SECTION).toMatch(/shell history/i);
+    // Resourceful before asking is the explicit instruction.
+    expect(CREDENTIALS_SECTION).toMatch(/be resourceful/i);
+  });
+
+  test("invites the agent to file credentials it discovers in the wild", () => {
+    // Proactive harvest: if the agent finds something useful in the
+    // course of other work, save it for next time.
+    // Tolerate prose-wrap newlines between the words.
+    expect(CREDENTIALS_SECTION).toMatch(/discover[^.]*in\s+the\s+wild/is);
+    expect(CREDENTIALS_SECTION).toMatch(/save it/i);
   });
 
   test("documents the env-set/get/list/unset CLI as the safe-write path", () => {
@@ -54,10 +97,18 @@ describe("buildSystemPrompt — credentials section", () => {
     expect(CREDENTIALS_SECTION).toContain("Do not\necho the value back");
   });
 
+  test("frames asking the user as the *last resort*, not the first move", () => {
+    // The old wording said "If nothing turns up across all six, then
+    // ask the user." which read like a prescription. The new wording
+    // makes it explicit that asking-without-scanning is the lazy path.
+    expect(CREDENTIALS_SECTION).toMatch(/last resort/i);
+    expect(CREDENTIALS_SECTION).toMatch(/lazy path/i);
+  });
+
   test("does not document phantombot notify (lives in NOTIFICATION_SECTION)", () => {
     // `phantombot notify` was previously misfiled under credentials. It
-    // belongs to its own section now — credentials should stay focused
-    // on secret discovery and persistence.
+    // belongs to its own section now — credentials stays focused on
+    // secret discovery and persistence.
     expect(CREDENTIALS_SECTION).not.toContain("phantombot notify");
   });
 

--- a/tests/persona-builder-notification.test.ts
+++ b/tests/persona-builder-notification.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the always-on `# Surfacing things to the user` section.
+ *
+ * Companion to persona-builder-scheduling.test.ts. Notification was
+ * previously tucked inside CREDENTIALS_SECTION (a category mistake —
+ * credentials and notifications have nothing to do with each other).
+ * Promoted to its own section so it's discoverable and so scheduled
+ * tasks have an obvious neighbour-section that explains how to surface
+ * findings.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  NOTIFICATION_SECTION,
+  buildSystemPrompt,
+} from "../src/persona/builder.ts";
+
+const channelCtx = {
+  channel: "cli",
+  conversationId: "cli:default",
+  timestamp: new Date("2026-05-07T12:00:00Z"),
+};
+
+describe("buildSystemPrompt — notification section", () => {
+  test("always appends the notification section", () => {
+    const prompt = buildSystemPrompt(
+      { boot: "I am test", identitySource: "BOOT.md" },
+      channelCtx,
+    );
+    expect(prompt).toContain("# Surfacing things to the user");
+  });
+
+  test("documents the phantombot notify CLI with both flags", () => {
+    expect(NOTIFICATION_SECTION).toContain("phantombot notify");
+    expect(NOTIFICATION_SECTION).toContain("--message");
+    expect(NOTIFICATION_SECTION).toContain("--voice");
+  });
+
+  test("documents the silent-by-default contract", () => {
+    expect(NOTIFICATION_SECTION).toContain("silently by default");
+    // The "stay quiet unless something material happened" rule.
+    expect(NOTIFICATION_SECTION).toMatch(/material/i);
+    expect(NOTIFICATION_SECTION).toMatch(/stay\s+quiet/i);
+  });
+
+  test("declares Telegram-via-notify as the only sanctioned proactive channel", () => {
+    // Closes the loophole of the agent trying to inject messages by
+    // other means (TTY writes, Google Chat, self-scheduled messages).
+    expect(NOTIFICATION_SECTION).toMatch(/only sanctioned proactive channel/i);
+  });
+
+  test("notification section sits between scheduling and credentials", () => {
+    // Order matters for caching and for the agent's mental model:
+    // memory → scheduling (when) → notification (how to surface) →
+    // credentials (how to authenticate).
+    const prompt = buildSystemPrompt(
+      { boot: "I am test", identitySource: "BOOT.md" },
+      channelCtx,
+    );
+    const schedIdx = prompt.indexOf("# Scheduling tasks");
+    const notifyIdx = prompt.indexOf("# Surfacing things to the user");
+    const credIdx = prompt.indexOf("# Credentials");
+    expect(schedIdx).toBeGreaterThan(0);
+    expect(notifyIdx).toBeGreaterThan(schedIdx);
+    expect(credIdx).toBeGreaterThan(notifyIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Two related improvements to how the harnessed agent handles credentials, plus the smaller `phantombot notify` cleanup.

### 1. `feat(persona)` — reframe credentials as a convenience layer
The credentials section in the persona prompt was previously framed as a closed prescription ("look in this order across these six places — if nothing turns up, ask the user"). That reads like a cage. The agent should be free — and encouraged — to scan creatively for credentials wherever they actually live (git history, config files, keychains, password managers, log lines, …) and to file what's worth keeping via `phantombot env set`.

Reframe in three parts:
- **Where to look first — the fast path.** Same six starter spots, presented as starters not exhaustive.
- **Where else to look — follow your nose.** Explicit license to scan widely; non-exhaustive list of less-obvious sources.
- **Discovered in the wild → save as you go.** New subsection. If you stumble across a credential during real work, save it via `phantombot env set` so next time it's in `process.env` and there's no scavenger hunt.

The hard rules (never `echo … >> ~/.env`, acknowledge by name only, reference `$VAR` not the literal value) are preserved verbatim.

### 2. `refactor(persona)` — split `phantombot notify` into its own section
`phantombot notify --message/--voice` was nested inside the credentials section, which made no semantic sense. Lifted out into a fresh `NOTIFICATION_SECTION` injected after scheduling. Shared between scheduled tasks ("how do I surface a finding when my task fires?") and ad-hoc notifications. Existing scheduling-section ordering test updated; new notification-section test added.

### 3. `feat(harness)` — re-source `~/.env` before each agent spawn
**The latent bug:** `phantombot env set FOO bar` writes atomically to `~/.env` but does NOT mutate the running daemon's `process.env`. So a secret saved on turn N was invisible to the harnessed agent until daemon restart — defeating the whole point of having the agent save secrets as it discovers them.

**Fix:** each harness (claude / pi / gemini) calls `reloadEnvFiles()` right before spawning. The subprocess sees the latest file state on the very next turn.

**Sticky-vs-reloadable semantics:**
- Keys that came from a file at boot are tracked. Reload may update or delete them to match the file.
- Keys that were already in `process.env` at boot (shell-export, systemd `EnvironmentFile=`) are sticky. Reload never touches them — preserving the "explicit shell export wins" guarantee.
- New file keys post-boot are loaded only if the slot is empty; otherwise shell wins.

8 new envBootstrap tests cover load-on-update, sticky shell-export, key removal, idempotent no-change reload, and multi-file precedence on reload.

## Test plan
- [x] `bun test tests/lib-envBootstrap.test.ts` — 12 pass (4 existing + 8 new)
- [x] `bun test` full suite — 737 pass, 0 fail (was 716 + 9 from the first two commits + 8 new = 737 ✓)
- [ ] Manual smoke: `phantombot env set TEST_SECRET hello` mid-session → next turn agent sees `process.env.TEST_SECRET === "hello"` without daemon restart
- [ ] Manual smoke: persona prompt now shows the reframed credentials section + standalone notification section in the right order
