### PR TITLE
feat(task): make expiry optional, add fire-time hygiene footer

### DIFF
--- a/src/cli/task.ts
+++ b/src/cli/task.ts
@@ -12,8 +12,12 @@
  *
  * One-off vs recurring:
  *   - One-off (default): --in 10m or --at "2026-05-07 09:00"
- *   - Recurring: --every 1h --until <date> or --count <N> or --for <dur>
- *   - Recurring WITHOUT an expiry is an error.
+ *   - Recurring: --every 1h (optionally --until <date> / --count <N> / --for <dur>)
+ *   - Recurring WITHOUT an expiry runs forever. The agent is asked at every
+ *     fire whether the task is still useful and is expected to cancel it
+ *     (`phantombot task cancel <id>`) when not — see the hygiene footer in
+ *     src/cli/tick.ts. Expiries remain available for tasks with a known
+ *     end (e.g. "ping me every hour for the next 8 hours").
  */
 
 import { defineCommand } from "citty";
@@ -106,14 +110,10 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
       if (!everyParsed.ok) { err.write(`${everyParsed.error}\n`); return 2; }
       schedule = everyParsed.cron;
 
-      // Require an expiry.
-      if (!input.until && !input.count && !input.relFor) {
-        err.write(
-          "recurring tasks require --until <date>, --count <N>, or --for <duration>.\n" +
-          "  No task runs forever. Add an expiry.\n",
-        );
-        return 2;
-      }
+      // Expiry is optional. If none is set, the task runs forever and the
+      // agent is asked at every fire (via the hygiene footer in tick.ts)
+      // whether it's still useful. Expiries are still useful for tasks
+      // with a known end — they short-circuit the self-policing dance.
 
       // Parse expiry.
       if (input.until) {
@@ -183,6 +183,8 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
     }
 
     // Mandatory echo — agent contract requires repeating this to user.
+    const hasExpiry =
+      t.expiresAt !== undefined || t.maxRuns !== undefined;
     out.write(
       `task ${t.id} scheduled\n` +
       `  description: ${t.description}\n` +
@@ -190,7 +192,11 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
       (t.oneOff
         ? `  type:        one-off\n`
         : `  schedule:    ${t.schedule}\n  expiry:      ${describeExpiry(t)}\n`) +
-      (t.silent ? `  silent:      yes\n` : ""),
+      (t.silent ? `  silent:      yes\n` : "") +
+      (!t.oneOff && !hasExpiry
+        ? `  hygiene:     no expiry — every fire will ask if it's still needed.\n` +
+          `               cancel with: phantombot task cancel ${t.id}\n`
+        : ""),
     );
     return 0;
   } finally {
@@ -202,7 +208,7 @@ function describeExpiry(t: Task): string {
   const parts: string[] = [];
   if (t.expiresAt) parts.push(`until ${formatLocal(t.expiresAt)}`);
   if (t.maxRuns !== undefined) parts.push(`${t.maxRuns} runs`);
-  return parts.join(" or ") || "none set";
+  return parts.join(" or ") || "none (runs forever — agent self-polices)";
 }
 
 /**
@@ -431,7 +437,7 @@ export default defineCommand({
       meta: {
         name: "add",
         description:
-          "Add a task. One-off by default (--in 10m or --at <time>). Recurring with --every requires --until, --count, or --for.",
+          "Add a task. One-off by default (--in 10m or --at <time>). Recurring with --every (e.g. --every 1h) runs forever unless you add --until, --count, or --for. The agent is asked at every fire whether the task is still needed.",
       },
       args: {
         prompt: {
@@ -467,17 +473,17 @@ export default defineCommand({
         until: {
           type: "string",
           required: false,
-          description: "Expiry date for recurring tasks (ISO 8601).",
+          description: "Optional expiry date for recurring tasks (ISO 8601). Without one, the task runs forever and self-polices at each fire.",
         },
         count: {
           type: "string",
           required: false,
-          description: "Max number of runs for recurring tasks.",
+          description: "Optional max number of runs for recurring tasks.",
         },
         for: {
           type: "string",
           required: false,
-          description: "Expiry duration for recurring tasks (e.g. 30d).",
+          description: "Optional expiry duration for recurring tasks (e.g. 30d).",
         },
         silent: {
           type: "boolean",

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -108,7 +108,9 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
 
     for (const task of due) {
       const isReview = task.nextReviewAt.getTime() <= now.getTime();
-      const promptText = isReview ? buildReviewPrompt(task) : task.prompt;
+      const promptText = isReview
+        ? buildReviewPrompt(task)
+        : appendHygieneFooter(task);
       const conversation = isReview
         ? `tick:${task.id}:review`
         : `tick:${task.id}`;
@@ -216,6 +218,37 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
     if (!input.memory) await memory.close();
     lock.release();
   }
+}
+
+/**
+ * Soft self-policing nudge appended to the prompt of every recurring,
+ * forever-running fire (i.e. recurring tasks with no expiry set).
+ *
+ * Recurring tasks with an explicit expiry (--until/--count/--for) skip
+ * this — the user has already set an end. One-offs skip it — they
+ * delete themselves. Reviews skip it — `buildReviewPrompt` does its
+ * own thing.
+ *
+ * The nudge is short, factual, and ends with the exact cancel command.
+ * The aim is that even a small model notices the line and acts on it
+ * when the task is genuinely no longer useful, without us having to
+ * hard-stop everything that doesn't have a calendar end-date.
+ *
+ * Exported for testing.
+ */
+export function appendHygieneFooter(task: Task): string {
+  if (task.oneOff) return task.prompt;
+  const hasExpiry = task.expiresAt !== undefined || task.maxRuns !== undefined;
+  if (hasExpiry) return task.prompt;
+  return (
+    task.prompt +
+    `\n\n---\n` +
+    `Task hygiene: this is recurring task #${task.id} ("${task.description}"), ` +
+    `schedule \`${task.schedule}\`, has fired ${task.runCount} time(s) so far, no expiry set.\n` +
+    `After completing the work above, briefly ask yourself: is this task still useful? ` +
+    `If not, run \`phantombot task cancel ${task.id}\` to retire it. ` +
+    `If yes, ignore this footer and continue.`
+  );
 }
 
 /**

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -154,27 +154,57 @@ always use \`phantombot task\`. It writes to a SQLite store the
 user can inspect with \`phantombot task list\`, every fire is logged
 to \`task_runs\`, and tasks survive phantombot restarts.
 
-  phantombot task add "<prompt>" --in 10m              # one-off, fires once in 10 min
-  phantombot task add "<prompt>" --at "2026-05-06T18:00:00+02:00"
-                                                       # one-off at ISO time
-  phantombot task add "<prompt>" --every 30m --until "..."
-                                                       # recurring, requires expiry
-  phantombot task add "<prompt>" --every 1h --count 24 # recurring, fixed run count
-  phantombot task add "<prompt>" --every 5m  --for 2h  # recurring, duration
-  phantombot task list                                  # active tasks
-  phantombot task log <id>                              # fire history for a task
-  phantombot task rm <id>                               # delete a task
-  phantombot task selftest                              # 60-second end-to-end check
+The signature is always two positionals — \`<prompt>\` (what to do
+when it fires) followed by \`<description>\` (a short human label
+shown by \`task list\`). Both are required. Then exactly one
+scheduling flag:
 
-Recurring tasks REQUIRE an expiry (--until / --count / --for) —
-without one the CLI exits non-zero and prints an error. Default
-maximum is 90 days; use \`--force-long-running\` only with the
-user's explicit permission.
+  # One-off (fires once, then deletes itself)
+  phantombot task add "<prompt>" "<description>" --in 10m
+  phantombot task add "<prompt>" "<description>" --at "2026-05-06T18:00:00+02:00"
 
-When you call \`task add\`, the CLI echoes \`task <id> scheduled at
-<local-time>\`. Repeat that line verbatim in your reply to the
-user — it's the proof-of-creation contract. No id in your reply
-means no schedule was made, full stop.
+  # Recurring (no expiry — runs forever; you'll be asked at every
+  # fire whether it's still useful, see "Task hygiene" below)
+  phantombot task add "<prompt>" "<description>" --every 1h
+  phantombot task add "<prompt>" "<description>" --every 30m
+
+  # Recurring with an expiry (optional — use when you already know
+  # when the task should stop)
+  phantombot task add "<prompt>" "<description>" --every 30m --until "2026-06-01T00:00:00Z"
+  phantombot task add "<prompt>" "<description>" --every 1h --count 24
+  phantombot task add "<prompt>" "<description>" --every 5m  --for 2h
+
+  # Inspect / cancel
+  phantombot task list                                 # active tasks
+  phantombot task log <id>                             # fire history for one task
+  phantombot task cancel <id>                          # deactivate a task
+  phantombot task selftest                             # 60-second end-to-end check
+
+Cron syntax check: \`--every\` accepts a duration (\`30m\`, \`1h\`,
+\`2d\`, \`1w\`); the CLI compiles it to a cron expression. Bad
+durations and bad cron exit non-zero with a clear error — if you
+see \`task <id> scheduled\` you got a real schedule, otherwise read
+the error and fix the invocation. Don't proceed without an id.
+
+Task hygiene — important: recurring tasks WITHOUT an expiry run
+until you cancel them. Phantombot does NOT enforce an expiry; you
+do, by self-policing. At every fire of a forever-recurring task
+you'll see a short footer reminding you which task this is, how
+many times it has fired, and the exact \`phantombot task cancel <id>\`
+command. After completing the actual work, take a beat: is this
+task still useful? If not, cancel it. If yes, ignore the footer
+and continue. This is how the system stays clean.
+
+When you call \`task add\`, the CLI echoes:
+
+  task <id> scheduled
+    description: ...
+    fires at:    ...
+
+Repeat the first line (\`task <id> scheduled\` plus the local
+fires-at time) verbatim in your reply to the user — it's the
+proof-of-creation contract. No id in your reply means no schedule
+was made, full stop.
 
 DO NOT use harness-native scheduler tools (\`CronCreate\`,
 \`CronDelete\`, \`CronList\`, or any equivalent under another

--- a/tests/cli-task.test.ts
+++ b/tests/cli-task.test.ts
@@ -84,6 +84,74 @@ describe("runTaskAdd", () => {
     expect(code).toBe(2);
     expect(err.text).toContain("bad cron");
   });
+
+  test("--every WITHOUT an expiry succeeds (forever-recurring)", async () => {
+    // Used to require --until/--count/--for; expiry is now optional.
+    // The agent self-polices via the hygiene footer at fire time.
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runTaskAdd({
+      config,
+      store,
+      every: "1h",
+      prompt: "check email",
+      description: "hourly email",
+      out,
+      err,
+    });
+    expect(code).toBe(0);
+    expect(err.text).toBe("");
+    expect(out.text).toContain("task 1 scheduled");
+    // Echo surfaces the hygiene contract so the agent + user know
+    // what they signed up for.
+    expect(out.text).toContain("hygiene:");
+    expect(out.text).toContain("phantombot task cancel 1");
+    // Stored row reflects no expiry.
+    const t = store.get(1)!;
+    expect(t.expiresAt).toBeUndefined();
+    expect(t.maxRuns).toBeUndefined();
+    expect(t.oneOff).toBe(false);
+  });
+
+  test("--every with --count records maxRuns and skips the hygiene line", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runTaskAdd({
+      config,
+      store,
+      every: "1h",
+      count: 24,
+      prompt: "x",
+      description: "capped",
+      out,
+      err,
+    });
+    expect(code).toBe(0);
+    expect(err.text).toBe("");
+    expect(out.text).toContain("task 1 scheduled");
+    // No hygiene line — user already set an end (24 runs).
+    expect(out.text).not.toContain("hygiene:");
+    expect(out.text).toContain("24 runs");
+    expect(store.get(1)!.maxRuns).toBe(24);
+  });
+
+  test("--every with --until records expiresAt", async () => {
+    const out = new CaptureStream();
+    const code = await runTaskAdd({
+      config,
+      store,
+      every: "1h",
+      until: "2026-06-01T00:00:00Z",
+      prompt: "x",
+      description: "until-bound",
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).not.toContain("hygiene:");
+    const t = store.get(1)!;
+    expect(t.expiresAt?.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
 });
 
 describe("runTaskList", () => {

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -95,6 +95,7 @@ describe("runTick — normal task fire", () => {
       description: "hourly check",
       schedule: "0 * * * *",
       prompt: "do the thing",
+      // Forever-recurring (no expiry) — fires get the hygiene footer.
       now: new Date("2026-05-02T09:30:00Z"),
     });
     if (!created.ok) throw new Error("setup");
@@ -113,11 +114,67 @@ describe("runTick — normal task fire", () => {
     });
     expect(code).toBe(0);
     expect(harness.invocations).toBe(1);
-    expect(harness.lastUserMessage).toBe("do the thing");
+    // The original prompt is still there...
+    expect(harness.lastUserMessage).toContain("do the thing");
+    // ...followed by the hygiene footer because there's no expiry.
+    expect(harness.lastUserMessage).toContain("Task hygiene");
+    expect(harness.lastUserMessage).toContain(
+      `phantombot task cancel ${created.id}`,
+    );
     // After recordRun, next_run_at moved to 11:00.
     const t = store.get(created.id)!;
     expect(t.runCount).toBe(1);
     expect(t.nextRunAt.toISOString()).toBe("2026-05-02T11:00:00.000Z");
+  });
+
+  test("recurring task WITH an expiry skips the hygiene footer", async () => {
+    const created = store.add({
+      persona: "phantom",
+      description: "hourly check, capped",
+      schedule: "0 * * * *",
+      prompt: "do the thing",
+      expiresAt: new Date("2026-05-09T00:00:00Z"),
+      now: new Date("2026-05-02T09:30:00Z"),
+    });
+    if (!created.ok) throw new Error("setup");
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "result" },
+    ]);
+    await runTick({
+      config,
+      taskStore: store,
+      memory,
+      harnesses: [harness],
+      lockPath,
+      now: new Date("2026-05-02T10:00:00Z"),
+    });
+    // No footer when the user has already set an end-date.
+    expect(harness.lastUserMessage).toBe("do the thing");
+  });
+
+  test("one-off task skips the hygiene footer (it's self-deleting)", async () => {
+    const created = store.add({
+      persona: "phantom",
+      description: "wake me up",
+      schedule: "",
+      prompt: "do the thing",
+      oneOff: true,
+      nextRunAt: new Date("2026-05-02T10:00:00Z"),
+      now: new Date("2026-05-02T09:30:00Z"),
+    });
+    if (!created.ok) throw new Error("setup");
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "result" },
+    ]);
+    await runTick({
+      config,
+      taskStore: store,
+      memory,
+      harnesses: [harness],
+      lockPath,
+      now: new Date("2026-05-02T10:00:00Z"),
+    });
+    expect(harness.lastUserMessage).toBe("do the thing");
   });
 });
 

--- a/tests/persona-builder-scheduling.test.ts
+++ b/tests/persona-builder-scheduling.test.ts
@@ -40,18 +40,36 @@ describe("buildSystemPrompt — scheduling tools section", () => {
     expect(SCHEDULING_TOOLS_SECTION).toMatch(/DO NOT use/);
   });
 
-  test("documents the recurring-requires-expiry contract", () => {
+  test("documents optional expiry flags for recurring tasks", () => {
     expect(SCHEDULING_TOOLS_SECTION).toContain("--until");
     expect(SCHEDULING_TOOLS_SECTION).toContain("--count");
     expect(SCHEDULING_TOOLS_SECTION).toContain("--for");
-    expect(SCHEDULING_TOOLS_SECTION).toMatch(/REQUIRE.*expiry/i);
+    // The new contract: expiry is OPTIONAL, not REQUIRED. The agent
+    // self-polices via the hygiene footer instead of being blocked
+    // at scheduling time.
+    expect(SCHEDULING_TOOLS_SECTION).toMatch(/optional|without an expiry|self-polic/i);
+  });
+
+  test("documents the agent self-policing hygiene contract", () => {
+    // Forever-recurring tasks (no --until/--count/--for) get a footer
+    // appended to every fire that asks the agent whether the task is
+    // still useful and provides the exact cancel command.
+    expect(SCHEDULING_TOOLS_SECTION).toMatch(/Task hygiene/);
+    expect(SCHEDULING_TOOLS_SECTION).toContain("phantombot task cancel");
+  });
+
+  test("documents the two-positional signature (prompt + description)", () => {
+    // Old docs only showed `phantombot task add "<prompt>" --in 10m` which
+    // failed at the CLI because <description> is also required. The new
+    // examples must show both positionals.
+    expect(SCHEDULING_TOOLS_SECTION).toContain('"<prompt>" "<description>"');
   });
 
   test("documents the proof-of-creation echo contract", () => {
-    // The CLI echoes "task <id> scheduled at ..." — the persona must
-    // repeat that verbatim. This is the audit trail that defeats
-    // hallucinated schedules.
-    expect(SCHEDULING_TOOLS_SECTION).toContain("scheduled at");
+    // The CLI echoes "task <id> scheduled" — the persona must repeat
+    // that verbatim. This is the audit trail that defeats hallucinated
+    // schedules.
+    expect(SCHEDULING_TOOLS_SECTION).toMatch(/task <id> scheduled/);
     expect(SCHEDULING_TOOLS_SECTION).toMatch(/proof[- ]of[- ]creation/);
   });
 


### PR DESCRIPTION
## Summary
- Recurring `--every` tasks no longer require `--until`/`--count`/`--for`. They're optional and useful when you already know the end-date; otherwise the task runs forever.
- For forever-recurring tasks, the tick runner appends a short hygiene footer to every fire — names the task, run count, exact `phantombot task cancel <id>` command. The agent self-polices instead of being blocked at scheduling time.
- Fixed `SCHEDULING_TOOLS_SECTION` in the persona system prompt: examples now include the required `<description>` positional (previous examples literally didn't run), document optional expiry, and document the hygiene contract.

## Why
Old behavior was `phantombot task add "x" "x" --every 1h` → exit 2, "recurring tasks require --until / --count / --for". That's a hard stop in front of the most common agent use case ("watch this every N minutes"). On top of that the system-prompt examples missing `<description>` meant every agent's first attempt failed at the CLI before they hit the expiry guard at all.

New contract:
- Recurring + expiry → behaves as before.
- Recurring without expiry → runs forever, but every fire ends with a footer asking the agent if it's still needed. The agent owns hygiene; the system makes it impossible to forget which task is firing.
- One-offs and reviews skip the footer (they have their own end conditions).
- The `task add` echo surfaces the hygiene contract upfront when no expiry is set, so both the agent and the user see what they signed up for.

## Files
- `src/cli/task.ts` — drop the require-expiry guard, mark flags optional in citty meta + help text, surface the hygiene line in the echo when no expiry is set.
- `src/cli/tick.ts` — new `appendHygieneFooter(task)` invoked for non-review fires; skips one-offs and recurring-with-expiry.
- `src/persona/builder.ts` — rewrite `SCHEDULING_TOOLS_SECTION` to fix the `<description>` positional, document optional expiry, and explain the hygiene footer.
- Tests: `tests/cli-task.test.ts` (+3), `tests/cli-tick.test.ts` (+2), `tests/persona-builder-scheduling.test.ts` (updated contract).

## Test plan
- [x] `bun test` — 747 pass, 0 fail (1 pre-existing skip)
- [x] `bun run typecheck` — clean
- [ ] Manual smoke test on Robbie's box after merge: `phantombot task add "x" "smoke" --every 1m` (no expiry), wait one tick, confirm footer appears in logs, run `phantombot task cancel <id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)