### PR TITLE
fix: change persona wizard placeholder from robbie to phantom

### DIFF
--- a/src/cli/create-persona.ts
+++ b/src/cli/create-persona.ts
@@ -134,7 +134,7 @@ export async function runCreatePersona(input: RunInput = {}): Promise<number> {
 
   const name = await p.text({
     message: "Persona name (lowercase letters, digits, '-', '_')",
-    placeholder: "robbie",
+    placeholder: "phantom",
     validate: (v) => {
       if (!v || v.length === 0) return "name is required";
       if (!/^[a-z0-9_-]+$/.test(v))


### PR DESCRIPTION
Single-line change: the persona creation wizard prompt used `robbie` as the default placeholder name. Since Robbie is Andrew's personal AI, this was leading new users to create agents named robbie rather than choosing their own name.

Changes `placeholder: "robbie"` → `placeholder: "phantom"` in `src/cli/create-persona.ts`.

The project is called **phantombot** — `phantom` is a natural, project-aligned neutral default.