### PR TITLE
feat: add descriptive subtitle to hero section

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -29,6 +29,7 @@
                 <img src="assets/img/logo.png" alt="Phantombot Logo">
             </div>
             <h1>Phantombot. Giving the harness a Soul.</h1>
+            <p class="subtitle">Personal AI agents that live on your hardware.</p>
             <p class="tagline">The harness can do its own tools — let it. Built for minimalist, high-torque agency.</p>
             <div class="cta">
                 <p class="cta-label">Install on Linux (x64/ARM64):</p>

--- a/www/styles.css
+++ b/www/styles.css
@@ -111,6 +111,14 @@ h1 {
     letter-spacing: -2px;
 }
 
+.subtitle {
+    font-family: var(--font-sans);
+    font-size: 1.25rem;
+    color: #bbbbbb;
+    max-width: 600px;
+    margin-bottom: 0.5rem;
+}
+
 .tagline {
     font-family: var(--font-serif);
     font-style: italic;


### PR DESCRIPTION
Adds `Personal AI agents that live on your hardware.` between the H1 and tagline on the hero section.

Before: landing on the site, you see "Giving the harness a Soul" but nothing tells you what the product actually is.

After: the subtitle answers "what is this?" in six words, right under the H1, without distracting from the brand poetry or the simplicity story.

**Changes:**
- `www/index.html`: insert `<p class="subtitle">` between H1 and tagline
- `www/styles.css`: add `.subtitle` styling (sans-serif, 1.25rem, slightly muted)