### PR TITLE
fix(www): wrap install command on mobile, add copy button

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -33,7 +33,10 @@
             <p class="tagline">The harness can do its own tools — let it. Built for minimalist, high-torque agency.</p>
             <div class="cta">
                 <p class="cta-label">Install on Linux (x64/ARM64):</p>
-                <code>curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh</code>
+                <div class="cta-command">
+                    <code>curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh</code>
+                    <button class="copy-button" type="button" aria-label="Copy install command" data-clipboard-text="curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh">Copy</button>
+                </div>
             </div>
         </section>
 
@@ -104,5 +107,26 @@
     <footer>
         <p>&copy; 2026 Phantomyard. Built with Phantombot.</p>
     </footer>
+
+    <script>
+        document.querySelectorAll('.copy-button').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var text = btn.getAttribute('data-clipboard-text') || '';
+                var original = btn.textContent;
+                var done = function (msg) {
+                    btn.textContent = msg;
+                    setTimeout(function () { btn.textContent = original; }, 1500);
+                };
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(text).then(
+                        function () { done('Copied!'); },
+                        function () { done('Press Ctrl+C'); }
+                    );
+                } else {
+                    done('Press Ctrl+C');
+                }
+            });
+        });
+    </script>
 </body>
 </html>

--- a/www/styles.css
+++ b/www/styles.css
@@ -148,6 +148,11 @@ h1 {
     border: 1px solid var(--grid);
 }
 
+/* Copy button is mobile-only — desktop layout stays unchanged. */
+.copy-button {
+    display: none;
+}
+
 .grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -249,6 +254,48 @@ footer {
 @media (max-width: 768px) {
     h1 { font-size: 2.5rem; }
     .crooked { transform: none; }
+
+    .cta-command {
+        position: relative;
+        display: block;
+        width: 100%;
+        max-width: 100%;
+        text-align: left;
+    }
+
+    .cta code {
+        display: block;
+        font-size: 0.85rem;
+        padding: 1rem 1.25rem;
+        padding-right: 4.25rem;
+        word-break: break-all;
+        white-space: pre-wrap;
+        text-align: left;
+    }
+
+    .copy-button {
+        display: inline-block;
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        background: rgba(0, 0, 0, 0.4);
+        color: var(--muted);
+        border: 1px solid var(--grid);
+        border-radius: 4px;
+        padding: 0.3rem 0.6rem;
+        font-family: var(--font-mono);
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        cursor: pointer;
+    }
+
+    .copy-button:hover,
+    .copy-button:focus-visible {
+        color: var(--fg);
+        border-color: var(--muted);
+        outline: none;
+    }
 }
 
 .philosophy {


### PR DESCRIPTION
## Summary
- Hero install command (`curl ... install.sh | sh`) was rendered `display: inline-block` with no wrap rules, so on narrow viewports it overflowed past the right edge and got clipped by `body { overflow-x: hidden }`. Reported by Janko van Deventer.
- On mobile (`max-width: 768px`) the code now wraps as a full-width block (`word-break: break-all` + `white-space: pre-wrap`) and a small **Copy** button appears in the top-right corner.
- Above 768px the copy button is `display: none` and the new `.cta-command` wrapper has no styles of its own, so the existing centred inline-block layout is byte-identical to before. Desktop visuals unchanged.

## Implementation
- `www/index.html` — wrapped the existing `<code>` in `<div class="cta-command">` and added a sibling `<button class="copy-button">`. Tiny inline `<script>` at the bottom of body wires up the click using `navigator.clipboard.writeText` with a `Press Ctrl+C` fallback for non-secure contexts.
- `www/styles.css` — added `.copy-button { display: none }` global default; added a `@media (max-width: 768px)` block that activates the wrapper, switches the code to wrapping block layout, and reveals the copy button.

No new files, no JS framework, no build step changes.

## Test plan
- [ ] DevTools → 360x800 mobile viewport: install command wraps cleanly inside the viewport, no horizontal scroll, copy button visible top-right of the code block.
- [ ] Click copy button on mobile → label flips to `Copied!` for ~1.5s, then back to `Copy`. Pasting yields the full curl command.
- [ ] Browser without clipboard API (or non-HTTPS) → label flips to `Press Ctrl+C` instead of silently failing.
- [ ] Desktop ≥769px: hero install command renders identically to `main` — same width, same centred inline-block, same `crooked` rotation, no copy button visible.
- [ ] iPhone Safari (real device) at 390x844: same wrap behaviour, button is tappable.

## Out of scope
- Showing the copy button on desktop too — Andrew explicitly asked the desktop to be unaffected. Easy follow-up if it's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)