### PR TITLE
feat(www): show copy button on desktop

### DIFF
--- a/www/styles.css
+++ b/www/styles.css
@@ -139,7 +139,7 @@ h1 {
 
 .cta code {
     background: var(--border);
-    padding: 1rem 2rem;
+    padding: 1rem 3.5rem 1rem 2rem;
     border-radius: 4px;
     font-family: var(--font-mono);
     font-size: 1.1rem;
@@ -148,9 +148,33 @@ h1 {
     border: 1px solid var(--grid);
 }
 
-/* Copy button is mobile-only — desktop layout stays unchanged. */
+.cta-command {
+    position: relative;
+    display: inline-block;
+}
+
 .copy-button {
-    display: none;
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: rgba(0, 0, 0, 0.5);
+    color: var(--muted);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.25rem 0.6rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    cursor: pointer;
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.copy-button:hover,
+.copy-button:focus-visible {
+    color: var(--accent);
+    border-color: var(--accent);
+    outline: none;
 }
 
 .grid {


### PR DESCRIPTION
## What

Enables the copy-to-clipboard button on desktop (≥769px), not just mobile.

## How

**CSS-only** — the button was already in the HTML from #97, just hidden with `display: none`.

- `.cta-command` base style: `position: relative; display: inline-block` → keeps the code block centred in the hero
- `.copy-button` base style: absolute-positioned top-right of `.cta-command`, subtle dark background, green accent on hover
- `.cta code` base padding: right side bumped to `3.5rem` so the button has breathing room without overlapping text
- Mobile media query overrides are **unchanged** — block layout, wrapping, and mobile-specific padding all still apply

## Visual

| Breakpoint | Before | After |
|---|---|---|
| Desktop (≥769px) | No copy button | Small "Copy" button top-right of command block, turns green on hover |
| Mobile (≤768px) | Copy button present | Same as before — no change |

## Test plan

1. **Desktop:** open DevTools at ≥769px, confirm "Copy" button appears in hero code block, click it → reads "Copied!", reverts after 1.5s
2. **Mobile:** resize to ≤768px, confirm layout unchanged from #97 — command wraps, button still works
3. **Clipboard:** `navigator.clipboard.writeText` disabled → button shows "Press Ctrl+C" fallback