### PR TITLE
www: extend install label to cover macOS

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -32,7 +32,7 @@
             <p class="subtitle">Personal AI agents that live on your hardware.</p>
             <p class="tagline">The harness can do its own tools — let it. Built for minimalist, high-torque agency.</p>
             <div class="cta">
-                <p class="cta-label">Install on Linux (x64/ARM64):</p>
+                <p class="cta-label">Install on Linux or macOS (x64/ARM64):</p>
                 <div class="cta-command">
                     <code>curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh</code>
                     <button class="copy-button" type="button" aria-label="Copy install command" data-clipboard-text="curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh">Copy</button>


### PR DESCRIPTION
## Summary
- Update the hero install label from `Install on Linux (x64/ARM64):` to `Install on Linux or macOS (x64/ARM64):` so macOS users (Intel + Apple Silicon) know they're covered.
- The installer already auto-detects all four supported targets (Linux x64, Linux ARM64, macOS x64, macOS ARM64) — this just brings the label into line with reality.
- No CSS changes; the wrap rules from #97 still handle the slightly longer string on narrow viewports.

## Test plan
- [ ] Visual check at desktop width (≥769px): label reads `Install on Linux or macOS (x64/ARM64):`, command stays on one line, copy button still in place.
- [ ] Visual check at 360px: label and command both wrap cleanly, no horizontal scroll.
- [ ] Diff is one line in `www/index.html`; no other files touched.