### PR TITLE
feat: startup catch-up nightly for ephemeral machines

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -16,6 +16,8 @@ import {
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import type { WriteSink } from "../lib/io.ts";
+import { log } from "../lib/logger.ts";
+import { shouldRunCatchupNightly } from "../lib/nightly.ts";
 import { logsCommand, statusCommand } from "../lib/platform.ts";
 import {
   acquireRunLock,
@@ -23,6 +25,7 @@ import {
   isLockHandle,
 } from "../lib/runLock.ts";
 import { openMemoryStore } from "../memory/store.ts";
+import { runNightly } from "./nightly.ts";
 
 export interface RunInput {
   config?: Config;
@@ -88,6 +91,22 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     }\n`,
   );
   out.write("Ctrl-C to stop.\n");
+
+  // Catch-up nightly: if the machine was off during the 02:00 window
+  // and the last run is >24h stale, fire it now in the background.
+  // Don't await — must not slow startup.
+  if (await shouldRunCatchupNightly(agentDir)) {
+    log.info("run: nightly stale, starting background catch-up");
+    runNightly({ config, persona, out, err }).then(
+      (code) => {
+        if (code !== 0) log.warn("run: catch-up nightly exited", { code });
+      },
+      (e: unknown) =>
+        log.error("run: catch-up nightly threw", {
+          error: (e as Error).message,
+        }),
+    );
+  }
 
   const ac = new AbortController();
   const onSig = () => ac.abort();

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -49,6 +49,30 @@ export function nightlyStatePath(personaDir: string): string {
   return join(personaDir, "memory", ".nightly-state.json");
 }
 
+/**
+ * Catch-up window: if the last nightly run was more than this many
+ * milliseconds ago, a startup catch-up is warranted. Default: 24 hours.
+ */
+export const CATCHUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Should a catch-up nightly run at startup?
+ *
+ * Returns `true` when the persona has no record of a previous nightly
+ * run OR the last run was more than {@link CATCHUP_WINDOW_MS} ago.
+ * Designed for users who shut down their machine overnight and miss
+ * the 02:00 scheduled run.
+ */
+export async function shouldRunCatchupNightly(
+  personaDir: string,
+): Promise<boolean> {
+  const state = await loadNightlyState(personaDir);
+  if (!state.last_run) return true;
+  const lastRun = Date.parse(state.last_run);
+  if (Number.isNaN(lastRun)) return true;
+  return Date.now() - lastRun > CATCHUP_WINDOW_MS;
+}
+
 /** Read the previous nightly state. Returns {} if no prior run. */
 export async function loadNightlyState(
   personaDir: string,

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -5,10 +5,12 @@ import { join } from "node:path";
 import {
   buildNightlyPrompt,
   buildNightlyPromptForPersona,
+  CATCHUP_WINDOW_MS,
   loadNightlyState,
   nightlyConversationKey,
   nightlyStatePath,
   saveNightlyState,
+  shouldRunCatchupNightly,
 } from "../src/lib/nightly.ts";
 
 let workdir: string;
@@ -107,6 +109,47 @@ describe("buildNightlyPrompt", () => {
     expect(p).toContain("phantombot memory search");
     expect(p).toContain("phantombot memory get");
     expect(p).toContain("phantombot memory index --rebuild");
+  });
+});
+
+describe("shouldRunCatchupNightly", () => {
+  test("returns true when no state file exists", async () => {
+    expect(await shouldRunCatchupNightly(workdir)).toBe(true);
+  });
+
+  test("returns true when last_run is more than 24h ago", async () => {
+    const old = new Date(Date.now() - CATCHUP_WINDOW_MS - 60_000);
+    await saveNightlyState(workdir, {
+      last_run: old.toISOString(),
+    });
+    expect(await shouldRunCatchupNightly(workdir)).toBe(true);
+  });
+
+  test("returns false when last_run is within the last 24h", async () => {
+    const recent = new Date(Date.now() - 60_000); // 1 minute ago
+    await saveNightlyState(workdir, {
+      last_run: recent.toISOString(),
+    });
+    expect(await shouldRunCatchupNightly(workdir)).toBe(false);
+  });
+
+  test("returns true when last_run is unparseable", async () => {
+    // Write malformed last_run directly (bypass saveNightlyState which uses Date.toISOString)
+    await writeFile(
+      nightlyStatePath(workdir),
+      JSON.stringify({ last_run: "not-a-date" }, null, 2) + "\n",
+      "utf8",
+    );
+    expect(await shouldRunCatchupNightly(workdir)).toBe(true);
+  });
+
+  test("returns false exactly at the window boundary", async () => {
+    const atBoundary = new Date(Date.now() - CATCHUP_WINDOW_MS);
+    await saveNightlyState(workdir, {
+      last_run: atBoundary.toISOString(),
+    });
+    // Exactly at boundary: still within window (strictly greater than)
+    expect(await shouldRunCatchupNightly(workdir)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

Users who shut down their PC at end of day miss the 02:00 scheduled nightly run. On restart the next morning, memory never gets promoted, KB notes don't get created, and the pipeline described in AGENTS.md silently breaks.

## Solution

At `phantombot run` startup, check if the last nightly run is more than 24 hours stale (or never ran). If so, fire a catch-up nightly in the background — no await, zero impact on startup time.

### Changes

- **`src/lib/nightly.ts`** — new `shouldRunCatchupNightly(personaDir)` + `CATCHUP_WINDOW_MS` constant (24h)
- **`src/cli/run.ts`** — imports `runNightly` and `shouldRunCatchupNightly`; fires background catch-up if stale
- **`tests/lib-nightly.test.ts`** — 5 test cases: no state, stale, recent, unparseable, boundary

### Design decisions

- Uses strict `>` on the 24h boundary so a nightly that ran at exactly 24h ago is still current
- If `last_run` is unparseable, treats it as stale (safe default)
- Errors in the background catch-up are logged but never bubble to the user
- Reuses existing `runNightly()` and `loadNightlyState()` — no new harness or state paths