### PR TITLE
feat: /update command + heartbeat notify + post-restart confirmation

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -20,10 +20,13 @@
  *     so the LLM can interpret it (some personas use `/remember`, etc.).
  */
 
+import type { Config } from "../config.ts";
 import type { Harness } from "../harnesses/types.ts";
 import { formatElapsedSeconds, truncateLine } from "../lib/format.ts";
 import { log } from "../lib/logger.ts";
+import { runUpdateFlow } from "../lib/updateNotify.ts";
 import type { MemoryStore } from "../memory/store.ts";
+import { VERSION } from "../version.ts";
 
 export interface ActiveTurnHandle {
   controller: AbortController;
@@ -55,11 +58,28 @@ export interface SlashCommandContext {
   startedAt: number;
   /** Currently running turn for this chat, if any. /stop aborts it. */
   activeTurn?: ActiveTurnHandle;
+  /**
+   * Full loaded config — currently used only by /update so it can hand
+   * the telegram channel + chatId to runUpdateFlow. Optional so existing
+   * tests can leave it out for commands that don't need it. The channel
+   * adapter always provides it in production.
+   */
+  config?: Config;
 }
 
 export interface SlashCommandResult {
   /** Reply text to send back to the user. Always non-empty for handled commands. */
   reply: string;
+  /**
+   * Optional callback the channel layer awaits AFTER sending `reply`.
+   *
+   * Used by /update: the binary swap completes, we send the user
+   * "installed vX.Y.Z, restarting…", and THEN trigger the systemctl
+   * restart that SIGTERMs us. If we ran the restart synchronously
+   * before returning, sendMessage would race the SIGTERM and the user
+   * would never see the heads-up.
+   */
+  afterSend?: () => Promise<void>;
 }
 
 const HELP =
@@ -68,6 +88,7 @@ const HELP =
   `/reset    — clear this chat's history\n` +
   `/status   — show harness, uptime, context usage\n` +
   `/harness  — list or switch the active harness (e.g. /harness pi)\n` +
+  `/update   — install the latest phantombot release if newer than this build\n` +
   `/help     — this list`;
 
 /**
@@ -100,11 +121,48 @@ export async function handleSlashCommand(
       return await handleStatus(ctx);
     case "/harness":
       return await handleHarness(arg, ctx);
+    case "/update":
+      return await handleUpdate(ctx);
     case "/help":
       return { reply: HELP };
     default:
       return null;
   }
+}
+
+/**
+ * /update — idempotent self-update.
+ *
+ * Three outcomes the user sees:
+ *   1. "already on vX.Y.Z — nothing to do" (we're current)
+ *   2. "installed vX.Y.Z (was vA.B.C). Restarting now…" then, post-restart,
+ *      a separate "✅ Updated to vX.Y.Z" / "⚠️ Update didn't take" message
+ *   3. an error string explaining why the check or install failed
+ *
+ * The restart is fired via `afterSend` so the channel layer sends the
+ * heads-up message FIRST, then SIGTERMs us — without afterSend, the
+ * `systemctl restart` would race the sendMessage call.
+ */
+async function handleUpdate(
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  if (!ctx.config) {
+    // Defensive — production channel always provides this. If a future
+    // caller forgets, fail loud rather than silently no-op.
+    return {
+      reply: "update unavailable: channel didn't pass config to the dispatcher",
+    };
+  }
+  log.info("commands: /update invoked", {
+    chatId: ctx.chatId,
+    currentVersion: VERSION,
+  });
+  const r = await runUpdateFlow({
+    config: ctx.config,
+    currentVersion: VERSION,
+    chatId: ctx.chatId,
+  });
+  return { reply: r.reply, afterSend: r.restart };
 }
 
 function handleStop(ctx: SlashCommandContext): SlashCommandResult {

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -723,6 +723,7 @@ export async function runTelegramServer(
             harnesses,
             startedAt: serverStartedAt,
             activeTurn: activeTurns.get(msg.chatId),
+            config: input.config,
           });
           if (result) {
             try {
@@ -732,6 +733,20 @@ export async function runTelegramServer(
                 error: (e as Error).message,
                 chatId: msg.chatId,
               });
+            }
+            // afterSend runs strictly after sendMessage so heads-up
+            // text lands before any side-effect that could kill us
+            // (used by /update to trigger systemctl restart). Swallow
+            // and log so a failure here can't crash the poll loop.
+            if (result.afterSend) {
+              try {
+                await result.afterSend();
+              } catch (e) {
+                log.error("telegram: slash afterSend failed", {
+                  error: (e as Error).message,
+                  chatId: msg.chatId,
+                });
+              }
             }
             continue;
           }

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { runHeartbeat } from "../lib/heartbeat.ts";
 import type { WriteSink } from "../lib/io.ts";
+import { VERSION } from "../version.ts";
 
 function indexPath(persona: string): string {
   return join(
@@ -46,11 +47,22 @@ export async function runHeartbeatCli(
   const r = await runHeartbeat({
     personaDir: dir,
     indexPath: indexPath(persona),
+    // Pass config + version so the heartbeat can hit GitHub for new
+    // releases and dispatch a one-time Telegram notification when a
+    // newer version is out. See src/lib/updateNotify.ts.
+    config,
+    currentVersion: VERSION,
   });
+  const updateLine =
+    r.updateCheck?.status === "notified"
+      ? `, notified update ${r.updateCheck.latestVersion}`
+      : r.updateCheck?.status === "release_check_failed"
+        ? `, update-check failed (${r.updateCheck.error})`
+        : "";
   out.write(
     `heartbeat ok: promoted ${r.promoted.length}, ` +
       `stale ${r.staleRecent.length}, ` +
-      `indexed ${r.indexedFiles}\n`,
+      `indexed ${r.indexedFiles}${updateLine}\n`,
   );
   return 0;
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -24,7 +24,9 @@ import {
   defaultLockPath,
   isLockHandle,
 } from "../lib/runLock.ts";
+import { notifyPostRestartIfPending } from "../lib/updateNotify.ts";
 import { openMemoryStore } from "../memory/store.ts";
+import { VERSION } from "../version.ts";
 import { runNightly } from "./nightly.ts";
 
 export interface RunInput {
@@ -81,6 +83,31 @@ export async function runRun(input: RunInput = {}): Promise<number> {
 
   const memory = await openMemoryStore(config.memoryDbPath);
   const transport = new HttpTelegramTransport(tg.token);
+
+  // Post-restart check: if `/update` wrote a pending-update marker before
+  // we got SIGTERMed, surface the result to the chat that triggered it.
+  // Runs once at startup; if no marker exists this is a quick no-op stat.
+  // Logged + swallowed so a notify-send failure can't keep us out of the
+  // poll loop — startup must always succeed.
+  try {
+    const r = await notifyPostRestartIfPending({
+      config,
+      currentVersion: VERSION,
+      transport,
+    });
+    if (r.status === "success_notified" || r.status === "failure_notified") {
+      log.info("run: post-restart notify", {
+        status: r.status,
+        targetTag: r.marker?.targetTag,
+        previousVersion: r.marker?.previousVersion,
+        currentVersion: VERSION,
+      });
+    }
+  } catch (e) {
+    log.warn("run: post-restart notify threw", {
+      error: (e as Error).message,
+    });
+  }
 
   out.write(
     `phantombot — persona '${persona}', harnesses ${config.harnesses.chain.join(" → ")}\n`,

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -20,8 +20,15 @@
 import { existsSync } from "node:fs";
 import { appendFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
+
+import type { TelegramTransport } from "../channels/telegram.ts";
+import type { Config } from "../config.ts";
 import { log } from "./logger.ts";
 import { MemoryIndex } from "./memoryIndex.ts";
+import {
+  checkAndNotifyOnce,
+  type CheckAndNotifyOnceResult,
+} from "./updateNotify.ts";
 
 export interface HeartbeatResult {
   promoted: { drawer: string; line: string }[];
@@ -29,6 +36,11 @@ export interface HeartbeatResult {
   indexedFiles: number;
   /** When the heartbeat ran. */
   ranAt: Date;
+  /**
+   * Result of the optional update check. Undefined when the heartbeat
+   * wasn't given a config (e.g. tests that skip the network path).
+   */
+  updateCheck?: CheckAndNotifyOnceResult;
 }
 
 const TAG_TO_DRAWER: Record<string, string> = {
@@ -54,6 +66,25 @@ export interface RunHeartbeatInput {
   index?: MemoryIndex;
   /** Path to the FTS index file (used only if index isn't passed). */
   indexPath?: string;
+  /**
+   * Loaded config — required to enable the once-per-version update
+   * notification. When omitted the heartbeat skips the GitHub check
+   * entirely. The CLI entry point passes this; tests can omit it to
+   * keep the network out of the path.
+   */
+  config?: Config;
+  /**
+   * Currently running phantombot version. Compared against GitHub's
+   * latest release to decide whether to notify. Defaults to the
+   * VERSION constant via the CLI; tests inject a known value.
+   */
+  currentVersion?: string;
+  /** Override fetch for the GitHub release check (test seam). */
+  fetchImpl?: typeof fetch;
+  /** Override transport for the notify send (test seam). */
+  transport?: TelegramTransport;
+  /** Override the dedup-cache path (test seam). */
+  lastNotifiedPath?: string;
 }
 
 export async function runHeartbeat(
@@ -84,7 +115,37 @@ export async function runHeartbeat(
     });
   }
 
-  return { promoted, staleRecent, indexedFiles, ranAt: now };
+  // Update check — guarded by config + currentVersion so tests that
+  // pre-date the wiring stay opt-out. Errors here never bubble up
+  // (checkAndNotifyOnce catches everything internally and returns a
+  // status); a transient GitHub blip mustn't fail the whole heartbeat.
+  let updateCheck: CheckAndNotifyOnceResult | undefined;
+  if (input.config && input.currentVersion) {
+    try {
+      updateCheck = await checkAndNotifyOnce({
+        config: input.config,
+        currentVersion: input.currentVersion,
+        fetchImpl: input.fetchImpl,
+        transport: input.transport,
+        lastNotifiedPath: input.lastNotifiedPath,
+      });
+      if (updateCheck.status === "notified") {
+        log.info("heartbeat: notified update available", {
+          version: updateCheck.latestVersion,
+          recipients: updateCheck.notifiedRecipients,
+        });
+      }
+    } catch (e) {
+      // checkAndNotifyOnce shouldn't throw — but if it does, log and
+      // keep going. The heartbeat's primary job is the local
+      // promotions/staleness/index work; the update notify is a bonus.
+      log.warn("heartbeat: update check threw unexpectedly", {
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  return { promoted, staleRecent, indexedFiles, ranAt: now, updateCheck };
 }
 
 /** Scan today's daily file for [tag] lines; append to matching drawer. */

--- a/src/lib/updateNotify.ts
+++ b/src/lib/updateNotify.ts
@@ -1,0 +1,536 @@
+/**
+ * Update lifecycle: pending-update marker + once-per-version notifications.
+ *
+ * Two concerns, one file:
+ *
+ *   1. Pending-update marker. The `/update` slash command writes
+ *      ~/.config/phantombot/.pending-update.json BEFORE triggering the
+ *      restart. On startup, `phantombot run` reads it and notifies Telegram
+ *      whether the version that came up matches the target. The marker is
+ *      the proof-of-life for "the new binary is up and answering" — without
+ *      it the in-process `/update` handler can only say "restarting..."
+ *      because by the time the new binary is live the old one is gone.
+ *
+ *   2. Heartbeat update check. The 30-minute heartbeat hits GitHub for the
+ *      latest release; if newer than current, sends ONE Telegram message
+ *      pointing the user at `/update`. Deduped via
+ *      ~/.config/phantombot/.last-update-notified so a user who's
+ *      seen-but-not-yet-installed v1.0.99 isn't pinged every half hour.
+ *
+ * Both files live next to the existing phantombot config so they survive
+ * binary swaps cleanly and don't pollute the user's $HOME.
+ *
+ * Test surface: every function takes an optional path override and most
+ * accept a fetch / transport / runUpdate stub. The compose functions
+ * (`runUpdateFlow`, `checkAndNotifyOnce`, `notifyPostRestartIfPending`)
+ * are the things tests exercise end-to-end.
+ */
+
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import {
+  HttpTelegramTransport,
+  type TelegramTransport,
+} from "../channels/telegram.ts";
+import { type Config, xdgConfigHome } from "../config.ts";
+import { runUpdate } from "../cli/update.ts";
+import {
+  detectSupportedTarget,
+  findLatestRelease,
+} from "./githubReleases.ts";
+import { log } from "./logger.ts";
+import {
+  defaultServiceControl,
+  type ServiceControl,
+} from "./platform.ts";
+
+/* -------------------------------------------------------------------------- *
+ * Marker + dedup file paths
+ * -------------------------------------------------------------------------- */
+
+export function pendingUpdatePath(): string {
+  return join(xdgConfigHome(), "phantombot", ".pending-update.json");
+}
+
+export function lastNotifiedPath(): string {
+  return join(xdgConfigHome(), "phantombot", ".last-update-notified");
+}
+
+/* -------------------------------------------------------------------------- *
+ * Pending-update marker
+ * -------------------------------------------------------------------------- */
+
+export interface PendingUpdate {
+  /** Version we expect to be running after the restart, no `v` prefix. */
+  targetVersion: string;
+  /** Tag string (with `v`), e.g. "v1.0.99". Used to render notifications. */
+  targetTag: string;
+  /**
+   * Telegram chat to notify on success. Set when the update was triggered
+   * by an explicit `/update`. May be undefined for future programmatic
+   * triggers (e.g. an unattended cron auto-update) — in that case the
+   * post-restart notify falls back to broadcasting to allowed_user_ids.
+   */
+  chatId?: number;
+  /**
+   * Version we were on before the update. Stored so we can render
+   * "v1.0.42 → v1.0.99" on success and distinguish a real upgrade from
+   * a "we were already current" no-op.
+   */
+  previousVersion: string;
+  /** ISO timestamp the marker was written. Used to flag stale markers. */
+  writtenAt: string;
+}
+
+/** Atomic write so a crash mid-write can't leave a half-parsed marker. */
+export async function writePendingUpdate(
+  p: PendingUpdate,
+  path: string = pendingUpdatePath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, JSON.stringify(p, null, 2), "utf8");
+  await rename(tmp, path);
+}
+
+/** Returns undefined if the marker doesn't exist or is unparseable. */
+export async function readPendingUpdate(
+  path: string = pendingUpdatePath(),
+): Promise<PendingUpdate | undefined> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    log.warn("updateNotify: failed to read pending-update marker", {
+      error: (e as Error).message,
+      path,
+    });
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(text) as Partial<PendingUpdate>;
+    if (
+      typeof parsed?.targetVersion !== "string" ||
+      typeof parsed?.targetTag !== "string" ||
+      typeof parsed?.previousVersion !== "string" ||
+      typeof parsed?.writtenAt !== "string"
+    ) {
+      log.warn("updateNotify: pending-update marker missing required fields", {
+        path,
+      });
+      return undefined;
+    }
+    return parsed as PendingUpdate;
+  } catch (e) {
+    log.warn("updateNotify: pending-update marker is unparseable JSON", {
+      error: (e as Error).message,
+      path,
+    });
+    return undefined;
+  }
+}
+
+export async function clearPendingUpdate(
+  path: string = pendingUpdatePath(),
+): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      log.warn("updateNotify: failed to clear pending-update marker", {
+        error: (e as Error).message,
+        path,
+      });
+    }
+  }
+}
+
+/* -------------------------------------------------------------------------- *
+ * Last-notified dedup file
+ * -------------------------------------------------------------------------- */
+
+export async function readLastNotified(
+  path: string = lastNotifiedPath(),
+): Promise<string | undefined> {
+  try {
+    const text = (await readFile(path, "utf8")).trim();
+    return text.length > 0 ? text : undefined;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    log.warn("updateNotify: failed to read last-notified", {
+      error: (e as Error).message,
+      path,
+    });
+    return undefined;
+  }
+}
+
+export async function writeLastNotified(
+  version: string,
+  path: string = lastNotifiedPath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, version, "utf8");
+  await rename(tmp, path);
+}
+
+/* -------------------------------------------------------------------------- *
+ * Compose: /update slash-command flow
+ * -------------------------------------------------------------------------- */
+
+export interface RunUpdateFlowInput {
+  config: Config;
+  currentVersion: string;
+  /**
+   * Chat that issued the `/update`. Persisted into the marker so the
+   * post-restart notify lands in the same DM the request came from.
+   */
+  chatId: number;
+  fetchImpl?: typeof fetch;
+  serviceControl?: ServiceControl;
+  /** Test seam — defaults to the real `runUpdate` CLI handler. */
+  runUpdateImpl?: typeof runUpdate;
+  /** Override marker path (test seam). */
+  pendingPath?: string;
+  /** Override lastNotified path (test seam). */
+  lastNotifiedPath?: string;
+  /**
+   * Override the per-platform target detection. Tests override this so
+   * "fake host" runs of /update don't have to live on supported hardware.
+   */
+  procPlatform?: string;
+  procArch?: string;
+}
+
+export interface UpdateFlowResult {
+  /** What to tell the user via Telegram before any restart. */
+  reply: string;
+  /**
+   * Set when the flow staged a successful binary swap. The slash handler
+   * MUST send `reply` to the user first, THEN call `restart()` — calling
+   * it synchronously from inside the handler would race the sendMessage
+   * (systemctl restart SIGTERMs us mid-await).
+   *
+   * The function returns a promise that resolves after `systemctl restart`
+   * exits, but the current process is being terminated by that very call,
+   * so the resolution is academic.
+   */
+  restart?: () => Promise<void>;
+}
+
+/**
+ * The /update command's core. Idempotent — if we're already on latest,
+ * it returns a "no-op" reply without touching the filesystem. Otherwise
+ * it writes the marker, runs the in-process binary swap, and hands back
+ * a `restart()` callback for the channel layer to invoke after the
+ * reply has been sent.
+ *
+ * Why does this take chatId? So the post-restart success message lands in
+ * the same DM the request came from, not broadcast to every allowed_user_id.
+ */
+export async function runUpdateFlow(
+  input: RunUpdateFlowInput,
+): Promise<UpdateFlowResult> {
+  const procPlatform = input.procPlatform ?? process.platform;
+  const procArch = input.procArch ?? process.arch;
+  const target = detectSupportedTarget(procPlatform, procArch);
+  if (!target) {
+    return {
+      reply:
+        `can't self-update on this host: phantombot only ships binaries ` +
+        `for linux-x64, linux-arm64, and darwin-arm64 ` +
+        `(this machine reports platform=${procPlatform} arch=${procArch})`,
+    };
+  }
+
+  // 1. Ask GitHub what's latest. Reuse the same client `update --check`
+  //    uses so the version comparison agrees byte-for-byte.
+  const r = await findLatestRelease({
+    target,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!r.ok) {
+    return { reply: `couldn't check for updates: ${r.error}` };
+  }
+  const release = r.release;
+
+  // 2. Idempotent no-op: already current.
+  if (release.version === input.currentVersion) {
+    return { reply: `already on ${release.tag} — nothing to do` };
+  }
+
+  // 3. Write the marker BEFORE touching the binary. If something between
+  //    here and `svc.restart()` goes wrong, we want the marker on disk so
+  //    a manual restart still surfaces the result to the user. If the
+  //    swap then fails (4), we clear the marker — see below.
+  await writePendingUpdate(
+    {
+      targetVersion: release.version,
+      targetTag: release.tag,
+      chatId: input.chatId,
+      previousVersion: input.currentVersion,
+      writtenAt: new Date().toISOString(),
+    },
+    input.pendingPath,
+  );
+
+  // 4. Run the in-process update — downloads, sha256-verifies, swaps the
+  //    binary atomically. We pass restart=false because we want to send
+  //    the reply BEFORE the restart kills us. The channel layer calls
+  //    the returned restart() callback after sendMessage lands.
+  const updateImpl = input.runUpdateImpl ?? runUpdate;
+  const exitCode = await updateImpl({
+    force: true,
+    restart: false,
+    fetchImpl: input.fetchImpl,
+    currentVersion: input.currentVersion,
+    serviceControl: input.serviceControl,
+    procPlatform: input.procPlatform,
+    procArch: input.procArch,
+  });
+  if (exitCode !== 0) {
+    await clearPendingUpdate(input.pendingPath);
+    return {
+      reply:
+        `update to ${release.tag} failed during download/install (exit ${exitCode}). ` +
+        `Check phantombot logs.`,
+    };
+  }
+
+  // 5. Refresh the dedup cache so the heartbeat doesn't immediately
+  //    re-notify the user "v1.0.99 available" while we're mid-restart.
+  await writeLastNotified(release.version, input.lastNotifiedPath).catch(
+    (e: unknown) => {
+      log.warn("updateNotify: failed to write last-notified", {
+        error: (e as Error).message,
+      });
+    },
+  );
+
+  // 6. Hand the restart trigger back to the caller. They'll send the
+  //    reply first, then invoke restart(). Capture the resolved
+  //    serviceControl so the restart uses the same backend the rest of
+  //    the flow used (matters for tests that inject a stub).
+  const svc = input.serviceControl ?? defaultServiceControl();
+  const restart = async (): Promise<void> => {
+    const r = await svc.restart();
+    if (!r.ok) {
+      log.error("updateNotify: restart failed after binary swap", {
+        stderr: r.stderr,
+      });
+      // Restart failed — the marker stays so a manual restart will
+      // still surface the result. No notify here; the marker fallback
+      // handles it.
+    }
+  };
+
+  return {
+    reply:
+      `installed ${release.tag} (was ${input.currentVersion}). ` +
+      `Restarting now to load the new binary…`,
+    restart,
+  };
+}
+
+/* -------------------------------------------------------------------------- *
+ * Compose: heartbeat check + once-per-version notify
+ * -------------------------------------------------------------------------- */
+
+export interface CheckAndNotifyOnceInput {
+  config: Config;
+  currentVersion: string;
+  fetchImpl?: typeof fetch;
+  transport?: TelegramTransport;
+  lastNotifiedPath?: string;
+  procPlatform?: string;
+  procArch?: string;
+}
+
+export interface CheckAndNotifyOnceResult {
+  /** "no_telegram" | "no_target" | "release_check_failed" | "already_current"
+   *  | "already_notified" | "no_allowed_users" | "notified" */
+  status:
+    | "no_telegram"
+    | "no_target"
+    | "release_check_failed"
+    | "already_current"
+    | "already_notified"
+    | "no_allowed_users"
+    | "notified";
+  latestVersion?: string;
+  notifiedRecipients?: number;
+  error?: string;
+}
+
+/**
+ * Heartbeat-time update check. Idempotent: if the latest GitHub release
+ * matches what we last notified about, this is a no-op — even across
+ * restarts, because the last-notified version is on disk.
+ *
+ * Failure modes are all logged and returned as a status string; we don't
+ * throw, because a transient network blip mustn't take the heartbeat down.
+ */
+export async function checkAndNotifyOnce(
+  input: CheckAndNotifyOnceInput,
+): Promise<CheckAndNotifyOnceResult> {
+  const tg = input.config.channels.telegram;
+  if (!tg) return { status: "no_telegram" };
+
+  const procPlatform = input.procPlatform ?? process.platform;
+  const procArch = input.procArch ?? process.arch;
+  const target = detectSupportedTarget(procPlatform, procArch);
+  if (!target) return { status: "no_target" };
+
+  const r = await findLatestRelease({
+    target,
+    fetchImpl: input.fetchImpl,
+  });
+  if (!r.ok) {
+    log.warn("updateNotify: heartbeat release-check failed", {
+      error: r.error,
+    });
+    return { status: "release_check_failed", error: r.error };
+  }
+  const release = r.release;
+
+  if (release.version === input.currentVersion) {
+    return { status: "already_current", latestVersion: release.version };
+  }
+
+  const lastNotified = await readLastNotified(input.lastNotifiedPath);
+  if (lastNotified === release.version) {
+    return { status: "already_notified", latestVersion: release.version };
+  }
+
+  if (tg.allowedUserIds.length === 0) {
+    log.warn(
+      "updateNotify: telegram has no allowed_user_ids; refusing to broadcast",
+    );
+    return { status: "no_allowed_users", latestVersion: release.version };
+  }
+
+  const transport = input.transport ?? new HttpTelegramTransport(tg.token);
+  const message =
+    `📦 phantombot ${release.tag} is available ` +
+    `(you're on ${input.currentVersion}).\n\n` +
+    `Send /update to install it.`;
+
+  let sent = 0;
+  for (const chatId of tg.allowedUserIds) {
+    try {
+      await transport.sendMessage(chatId, message);
+      sent++;
+    } catch (e) {
+      log.warn("updateNotify: heartbeat notify send failed", {
+        chatId,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Write the dedup marker even if some sends failed — otherwise a
+  // partial-broadcast user gets re-notified forever. Better one missed
+  // user than one re-pinged user.
+  await writeLastNotified(release.version, input.lastNotifiedPath);
+
+  log.info("updateNotify: heartbeat notified update available", {
+    latestVersion: release.version,
+    recipients: sent,
+  });
+
+  return {
+    status: "notified",
+    latestVersion: release.version,
+    notifiedRecipients: sent,
+  };
+}
+
+/* -------------------------------------------------------------------------- *
+ * Compose: post-restart confirmation on startup
+ * -------------------------------------------------------------------------- */
+
+export interface NotifyPostRestartInput {
+  config: Config;
+  currentVersion: string;
+  transport?: TelegramTransport;
+  pendingPath?: string;
+}
+
+export interface NotifyPostRestartResult {
+  /** "no_marker" | "success_notified" | "failure_notified" | "no_telegram" */
+  status:
+    | "no_marker"
+    | "success_notified"
+    | "failure_notified"
+    | "no_telegram";
+  marker?: PendingUpdate;
+}
+
+/**
+ * Read the pending-update marker (if any), notify Telegram with the
+ * appropriate success/failure message, and delete the marker.
+ *
+ * Cases:
+ *   - no marker            → no-op, status "no_marker"
+ *   - marker matches       → "✅ Updated to vX.Y.Z" then delete marker
+ *   - marker doesn't match → "⚠️ Update to vX.Y.Z failed, still on vA.B.C"
+ *                            then delete marker (don't keep retrying — if
+ *                            the user wants to try again they /update)
+ *
+ * Recipient: marker.chatId if set, otherwise broadcasts to all
+ * allowedUserIds (same fan-out as `phantombot notify`).
+ */
+export async function notifyPostRestartIfPending(
+  input: NotifyPostRestartInput,
+): Promise<NotifyPostRestartResult> {
+  const marker = await readPendingUpdate(input.pendingPath);
+  if (!marker) return { status: "no_marker" };
+
+  const tg = input.config.channels.telegram;
+  if (!tg) {
+    // Marker exists but Telegram isn't configured — just clear it. No
+    // way to notify; the user will see the version change on their next
+    // CLI call.
+    log.info(
+      "updateNotify: pending-update marker present but telegram not configured; clearing without notify",
+      { targetTag: marker.targetTag },
+    );
+    await clearPendingUpdate(input.pendingPath);
+    return { status: "no_telegram", marker };
+  }
+
+  const transport = input.transport ?? new HttpTelegramTransport(tg.token);
+
+  const success = marker.targetVersion === input.currentVersion;
+  const message = success
+    ? `✅ Updated to ${marker.targetTag} (was v${marker.previousVersion}). Back online.`
+    : `⚠️ Update to ${marker.targetTag} didn't take — still on v${input.currentVersion}. ` +
+      `Check phantombot logs and try /update again.`;
+
+  // Recipient rule: explicit chatId from the marker wins; fall back to
+  // broadcasting to allowed_user_ids when the marker came from a non-
+  // chat path (e.g. heartbeat-triggered, future feature).
+  const recipients =
+    typeof marker.chatId === "number" ? [marker.chatId] : tg.allowedUserIds;
+
+  for (const chatId of recipients) {
+    try {
+      await transport.sendMessage(chatId, message);
+    } catch (e) {
+      log.warn("updateNotify: post-restart notify send failed", {
+        chatId,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  await clearPendingUpdate(input.pendingPath);
+
+  return {
+    status: success ? "success_notified" : "failure_notified",
+    marker,
+  };
+}

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -337,7 +337,79 @@ describe("/help", () => {
     expect(r!.reply).toContain("/reset");
     expect(r!.reply).toContain("/status");
     expect(r!.reply).toContain("/harness");
+    expect(r!.reply).toContain("/update");
     expect(r!.reply).toContain("/help");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /update
+// ---------------------------------------------------------------------------
+//
+// The happy path (update flow, marker write, restart callback) is tested
+// exhaustively in tests/lib-updateNotify.test.ts where the fetch + runUpdate
+// seams are mocked. Here we just verify the dispatcher wires through and
+// fails loud when config wasn't plumbed.
+describe("/update", () => {
+  test("recognized as a slash command (not null)", async () => {
+    // Plumb a config so the handler reaches runUpdateFlow and a non-null
+    // result comes back. With procPlatform=win32 the flow short-circuits
+    // to "can't self-update", so we don't have to mock fetch here — and
+    // we get to verify the dispatcher routed the call correctly.
+    // Construct a minimal config inline rather than importing baseConfig.
+    const minimalConfig = {
+      defaultPersona: "phantom",
+      harnessIdleTimeoutMs: 1000,
+      harnessHardTimeoutMs: 1000,
+      personasDir: "/tmp",
+      memoryDbPath: ":memory:",
+      configPath: "/tmp/c.toml",
+      harnesses: {
+        chain: ["claude"],
+        claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+        pi: { bin: "pi", maxPayloadBytes: 1 },
+        gemini: { bin: "gemini", model: "" },
+      },
+      channels: {
+        telegram: {
+          token: "fake-token",
+          pollTimeoutS: 30,
+          allowedUserIds: [42],
+        },
+      },
+      embeddings: { provider: "none" as const },
+      voice: { provider: "none" as const },
+    };
+    // We can't mock procPlatform from outside runUpdateFlow because the
+    // dispatcher doesn't accept seams. Instead, swap process.platform
+    // briefly so the flow exits early at the platform check — far before
+    // any network call. (Bun preserves the property descriptor; restore
+    // in finally.)
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      const r = await handleSlashCommand(
+        "/update",
+        ctx({ config: minimalConfig }),
+      );
+      expect(r).not.toBeNull();
+      expect(r!.reply).toContain("can't self-update");
+      expect(r!.reply).toContain("platform=win32");
+      // No restart callback when the flow short-circuits at the platform
+      // check (nothing was installed, nothing to restart).
+      expect(r!.afterSend).toBeUndefined();
+    } finally {
+      Object.defineProperty(process, "platform", { value: origPlatform });
+    }
+  });
+
+  test("missing config in context → loud refusal rather than silent no-op", async () => {
+    // Production always plumbs config. This is the defensive branch for
+    // a future caller that forgets — fail visibly, don't pretend we ran.
+    const r = await handleSlashCommand("/update", ctx());
+    expect(r).not.toBeNull();
+    expect(r!.reply).toContain("update unavailable");
+    expect(r!.afterSend).toBeUndefined();
   });
 });
 

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -240,7 +240,15 @@ describe("runHeartbeat update check hook", () => {
     };
     return (async (url: string | URL | Request) => {
       const u = String(url);
-      if (u.includes("api.github.com")) {
+      // Strict hostname check — substring matching can be bypassed
+      // by hostile URLs like `evil.com/api.github.com`.
+      let host = "";
+      try {
+        host = new URL(u).hostname;
+      } catch {
+        host = "";
+      }
+      if (host === "api.github.com") {
         return new Response(JSON.stringify(body), {
           status: 200,
           headers: { "content-type": "application/json" },

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -187,6 +187,156 @@ describe("runHeartbeat (integration)", () => {
     expect(r.promoted).toHaveLength(1);
     expect(r.staleRecent).toHaveLength(1);
     expect(r.indexedFiles).toBeGreaterThan(0);
+    // Without config/currentVersion, the update check is skipped.
+    expect(r.updateCheck).toBeUndefined();
     ix.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runHeartbeat — update-check hook
+// ---------------------------------------------------------------------------
+
+describe("runHeartbeat update check hook", () => {
+  // Minimal config shape for the heartbeat — we only need telegram for the
+  // notify-once flow to reach the send step.
+  function configWithTelegram() {
+    return {
+      defaultPersona: "phantom",
+      harnessIdleTimeoutMs: 1000,
+      harnessHardTimeoutMs: 1000,
+      personasDir: "/tmp",
+      memoryDbPath: ":memory:",
+      configPath: "/tmp/c.toml",
+      harnesses: {
+        chain: ["claude"],
+        claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+        pi: { bin: "pi", maxPayloadBytes: 1 },
+        gemini: { bin: "gemini", model: "" },
+      },
+      channels: {
+        telegram: {
+          token: "fake-token",
+          pollTimeoutS: 30,
+          allowedUserIds: [42],
+        },
+      },
+      embeddings: { provider: "none" as const },
+      voice: { provider: "none" as const },
+    };
+  }
+
+  // Minimal Telegram release fixture matching the linux-x64 asset
+  // expected by checkAndNotifyOnce running on a Linux x64 host.
+  function releaseFetch(tag: string): typeof fetch {
+    const ASSET = `phantombot-${tag}-linux-x64`;
+    const body = {
+      tag_name: tag,
+      body: "test",
+      assets: [
+        { name: ASSET, browser_download_url: "x", size: 1 },
+        { name: "SHA256SUMS", browser_download_url: "x", size: 1 },
+      ],
+    };
+    return (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("api.github.com")) {
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+  }
+
+  test("with config + newer release → fires the update notification", async () => {
+    // Skip the update check on non-linux-x64 hosts (the test would still
+    // run on linux-arm64 if the fixture's asset name doesn't match).
+    if (process.platform !== "linux" || process.arch !== "x64") {
+      return;
+    }
+    let sent = 0;
+    const transport = {
+      async sendMessage() {
+        sent++;
+      },
+      // Stubs to satisfy the TelegramTransport interface — none of these
+      // are reached on the notify path used here.
+      async getUpdates() {
+        return { updates: [], nextOffset: 0 };
+      },
+      async sendTyping() {},
+      async sendRecording() {},
+      async sendVoice() {},
+      async downloadFile() {
+        return { data: Buffer.alloc(0), mime: "" };
+      },
+    };
+    const lastNotifiedPath = join(workdir, "last-notified");
+    const r = await runHeartbeat({
+      personaDir,
+      today: "2026-05-02",
+      now: new Date("2026-05-02T10:00:00Z"),
+      config: configWithTelegram(),
+      currentVersion: "1.0.42",
+      fetchImpl: releaseFetch("v1.0.99"),
+      transport,
+      lastNotifiedPath,
+    });
+    expect(r.updateCheck?.status).toBe("notified");
+    expect(r.updateCheck?.latestVersion).toBe("1.0.99");
+    expect(sent).toBe(1);
+  });
+
+  test("with config but already on latest → status already_current, no send", async () => {
+    if (process.platform !== "linux" || process.arch !== "x64") return;
+    let sent = 0;
+    const transport = {
+      async sendMessage() {
+        sent++;
+      },
+      async getUpdates() {
+        return { updates: [], nextOffset: 0 };
+      },
+      async sendTyping() {},
+      async sendRecording() {},
+      async sendVoice() {},
+      async downloadFile() {
+        return { data: Buffer.alloc(0), mime: "" };
+      },
+    };
+    const r = await runHeartbeat({
+      personaDir,
+      today: "2026-05-02",
+      now: new Date("2026-05-02T10:00:00Z"),
+      config: configWithTelegram(),
+      currentVersion: "1.0.99",
+      fetchImpl: releaseFetch("v1.0.99"),
+      transport,
+      lastNotifiedPath: join(workdir, "last-notified"),
+    });
+    expect(r.updateCheck?.status).toBe("already_current");
+    expect(sent).toBe(0);
+  });
+
+  test("github error in update check doesn't fail the heartbeat", async () => {
+    const failingFetch = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as unknown as typeof fetch;
+    const r = await runHeartbeat({
+      personaDir,
+      today: "2026-05-02",
+      now: new Date("2026-05-02T10:00:00Z"),
+      config: configWithTelegram(),
+      currentVersion: "1.0.42",
+      fetchImpl: failingFetch,
+      lastNotifiedPath: join(workdir, "last-notified"),
+    });
+    // The heartbeat itself succeeded — promotions/staleness/index work
+    // happened. The update-check result records the failure but doesn't
+    // bubble it up.
+    expect(r.updateCheck?.status).toBe("release_check_failed");
+    expect(r.ranAt).toBeDefined();
   });
 });

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -144,12 +144,23 @@ describe("shouldRunCatchupNightly", () => {
   });
 
   test("returns false exactly at the window boundary", async () => {
-    const atBoundary = new Date(Date.now() - CATCHUP_WINDOW_MS);
-    await saveNightlyState(workdir, {
-      last_run: atBoundary.toISOString(),
-    });
-    // Exactly at boundary: still within window (strictly greater than)
-    expect(await shouldRunCatchupNightly(workdir)).toBe(false);
+    // Pin Date.now() so the boundary check is deterministic — without this,
+    // elapsed time between the two Date.now() calls (here vs inside
+    // shouldRunCatchupNightly) pushes `now - lastRun` past CATCHUP_WINDOW_MS
+    // and the strict `>` comparison flips true.
+    const fixedNow = Date.now();
+    const origNow = Date.now;
+    Date.now = () => fixedNow;
+    try {
+      const atBoundary = new Date(fixedNow - CATCHUP_WINDOW_MS);
+      await saveNightlyState(workdir, {
+        last_run: atBoundary.toISOString(),
+      });
+      // Exactly at boundary: still within window (strictly greater than)
+      expect(await shouldRunCatchupNightly(workdir)).toBe(false);
+    } finally {
+      Date.now = origNow;
+    }
   });
 });
 

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -109,13 +109,24 @@ function fakeReleaseFetch(opts: {
   };
   return (async (url: string | URL | Request) => {
     const u = String(url);
-    if (u.includes("api.github.com")) {
+    // Strict hostname check — substring matching can be bypassed
+    // by hostile URLs like `evil.com/api.github.com`.
+    let host = "";
+    let path = "";
+    try {
+      const parsed = new URL(u);
+      host = parsed.hostname;
+      path = parsed.pathname;
+    } catch {
+      // leave host/path empty so we fall through to the binary case
+    }
+    if (host === "api.github.com") {
       return new Response(
         typeof body === "string" ? body : JSON.stringify(body),
         { status, headers: { "content-type": "application/json" } },
       );
     }
-    if (u.includes("SHA256SUMS")) {
+    if (path.endsWith("SHA256SUMS")) {
       return new Response(`${NEW_SHA}  ${ASSET}\n`, { status: 200 });
     }
     return new Response(NEW_BYTES, { status: 200 });

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -1,0 +1,691 @@
+/**
+ * Tests for src/lib/updateNotify.ts — marker I/O, lastNotified dedup, and
+ * the three compose functions (runUpdateFlow, checkAndNotifyOnce,
+ * notifyPostRestartIfPending).
+ *
+ * Network is mocked via fetchImpl. Telegram is mocked via FakeTransport.
+ * runUpdate (the binary-swapping CLI) is mocked via the runUpdateImpl
+ * test seam so the test runner never touches process.execPath.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type {
+  TelegramMessage,
+  TelegramTransport,
+} from "../src/channels/telegram.ts";
+import type { Config } from "../src/config.ts";
+import type { ServiceControl } from "../src/lib/systemd.ts";
+import {
+  checkAndNotifyOnce,
+  clearPendingUpdate,
+  notifyPostRestartIfPending,
+  readLastNotified,
+  readPendingUpdate,
+  runUpdateFlow,
+  writeLastNotified,
+  writePendingUpdate,
+} from "../src/lib/updateNotify.ts";
+
+let workdir: string;
+let pendingPath: string;
+let lastNotifiedPathLocal: string;
+
+class FakeTransport implements TelegramTransport {
+  sent: Array<{ chatId: number; text: string }> = [];
+  sendMessageImpl?: (chatId: number, text: string) => Promise<void>;
+  async getUpdates(): Promise<{
+    updates: TelegramMessage[];
+    nextOffset: number;
+  }> {
+    return { updates: [], nextOffset: 0 };
+  }
+  async sendMessage(chatId: number, text: string): Promise<void> {
+    if (this.sendMessageImpl) await this.sendMessageImpl(chatId, text);
+    this.sent.push({ chatId, text });
+  }
+  async sendTyping(): Promise<void> {}
+  async sendRecording(): Promise<void> {}
+  async sendVoice(): Promise<void> {}
+  async downloadFile(): Promise<{ data: Buffer; mime: string }> {
+    return { data: Buffer.alloc(0), mime: "" };
+  }
+}
+
+function baseConfig(): Config {
+  return {
+    defaultPersona: "phantom",
+    harnessIdleTimeoutMs: 1000,
+    harnessHardTimeoutMs: 1000,
+    personasDir: "/tmp",
+    memoryDbPath: ":memory:",
+    configPath: "/tmp/c.toml",
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1 },
+      gemini: { bin: "gemini", model: "" },
+    },
+    channels: {
+      telegram: {
+        token: "fake-token",
+        pollTimeoutS: 30,
+        allowedUserIds: [42, 99],
+      },
+    },
+    embeddings: { provider: "none" },
+    voice: { provider: "none" },
+  };
+}
+
+const ASSET = "phantombot-v1.0.99-linux-x64";
+const NEW_BYTES = Buffer.from("NEW_BINARY_VERIFIED");
+const NEW_SHA = createHash("sha256").update(NEW_BYTES).digest("hex");
+
+function fakeReleaseFetch(opts: {
+  status?: number;
+  releaseBody?: unknown;
+} = {}): typeof fetch {
+  const status = opts.status ?? 200;
+  const body = opts.releaseBody ?? {
+    tag_name: "v1.0.99",
+    body: "test release",
+    assets: [
+      {
+        name: ASSET,
+        browser_download_url: "https://example/" + ASSET,
+        size: NEW_BYTES.byteLength,
+      },
+      {
+        name: "SHA256SUMS",
+        browser_download_url: "https://example/SHA256SUMS",
+        size: 256,
+      },
+    ],
+  };
+  return (async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.includes("api.github.com")) {
+      return new Response(
+        typeof body === "string" ? body : JSON.stringify(body),
+        { status, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (u.includes("SHA256SUMS")) {
+      return new Response(`${NEW_SHA}  ${ASSET}\n`, { status: 200 });
+    }
+    return new Response(NEW_BYTES, { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+function fakeRunUpdate(exitCode: number) {
+  return async (): Promise<number> => exitCode;
+}
+
+function fakeSvc(opts: { restartOk?: boolean } = {}): {
+  calls: string[];
+  svc: ServiceControl;
+} {
+  const calls: string[] = [];
+  return {
+    calls,
+    svc: {
+      async isActive() {
+        calls.push("isActive");
+        return true;
+      },
+      async restart() {
+        calls.push("restart");
+        return opts.restartOk === false
+          ? { ok: false, stderr: "fake fail" }
+          : { ok: true };
+      },
+      async rerenderUnitIfStale() {
+        return { rerendered: false };
+      },
+    },
+  };
+}
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-updateNotify-"));
+  pendingPath = join(workdir, ".pending-update.json");
+  lastNotifiedPathLocal = join(workdir, ".last-update-notified");
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Marker file I/O
+// ---------------------------------------------------------------------------
+
+describe("pending-update marker", () => {
+  test("write/read round-trip preserves all fields", async () => {
+    const marker = {
+      targetVersion: "1.0.99",
+      targetTag: "v1.0.99",
+      chatId: 42,
+      previousVersion: "1.0.42",
+      writtenAt: "2026-05-11T09:00:00.000Z",
+    };
+    await writePendingUpdate(marker, pendingPath);
+    const read = await readPendingUpdate(pendingPath);
+    expect(read).toEqual(marker);
+  });
+
+  test("readPendingUpdate returns undefined when missing", async () => {
+    const r = await readPendingUpdate(join(workdir, "nonexistent.json"));
+    expect(r).toBeUndefined();
+  });
+
+  test("readPendingUpdate returns undefined on malformed JSON", async () => {
+    await writeFile(pendingPath, "{not json", "utf8");
+    const r = await readPendingUpdate(pendingPath);
+    expect(r).toBeUndefined();
+  });
+
+  test("readPendingUpdate rejects markers missing required fields", async () => {
+    await writeFile(
+      pendingPath,
+      JSON.stringify({ targetVersion: "1.0.99" }),
+      "utf8",
+    );
+    const r = await readPendingUpdate(pendingPath);
+    expect(r).toBeUndefined();
+  });
+
+  test("clearPendingUpdate is idempotent (no-op when absent)", async () => {
+    // Should not throw even with no marker.
+    await clearPendingUpdate(pendingPath);
+    // Now write one and clear it.
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        previousVersion: "1.0.42",
+        writtenAt: "2026-05-11T00:00:00Z",
+      },
+      pendingPath,
+    );
+    await clearPendingUpdate(pendingPath);
+    const r = await readPendingUpdate(pendingPath);
+    expect(r).toBeUndefined();
+  });
+
+  test("chatId is optional in the marker", async () => {
+    const marker = {
+      targetVersion: "1.0.99",
+      targetTag: "v1.0.99",
+      previousVersion: "1.0.42",
+      writtenAt: "2026-05-11T00:00:00Z",
+    };
+    await writePendingUpdate(marker, pendingPath);
+    const read = await readPendingUpdate(pendingPath);
+    expect(read?.chatId).toBeUndefined();
+    expect(read?.targetTag).toBe("v1.0.99");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Last-notified dedup file
+// ---------------------------------------------------------------------------
+
+describe("last-notified dedup", () => {
+  test("write/read round-trip", async () => {
+    await writeLastNotified("1.0.99", lastNotifiedPathLocal);
+    const r = await readLastNotified(lastNotifiedPathLocal);
+    expect(r).toBe("1.0.99");
+  });
+
+  test("returns undefined when missing", async () => {
+    const r = await readLastNotified(join(workdir, "absent"));
+    expect(r).toBeUndefined();
+  });
+
+  test("trims whitespace on read", async () => {
+    await writeFile(lastNotifiedPathLocal, "  1.0.99  \n", "utf8");
+    const r = await readLastNotified(lastNotifiedPathLocal);
+    expect(r).toBe("1.0.99");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runUpdateFlow (/update slash command)
+// ---------------------------------------------------------------------------
+
+describe("runUpdateFlow", () => {
+  test("already on latest → 'nothing to do', no marker written, no restart", async () => {
+    const { calls, svc } = fakeSvc();
+    const r = await runUpdateFlow({
+      config: baseConfig(),
+      currentVersion: "1.0.99",
+      chatId: 42,
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      runUpdateImpl: fakeRunUpdate(0),
+      pendingPath,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.reply).toContain("already on v1.0.99");
+    expect(r.restart).toBeUndefined();
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+    expect(calls).not.toContain("restart");
+  });
+
+  test("update available → writes marker, swaps binary, returns restart() callback", async () => {
+    const { calls, svc } = fakeSvc();
+    let runUpdateCalledWith: unknown;
+    const r = await runUpdateFlow({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      chatId: 42,
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      runUpdateImpl: async (i) => {
+        runUpdateCalledWith = i;
+        return 0;
+      },
+      pendingPath,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.reply).toContain("installed v1.0.99");
+    expect(r.reply).toContain("was 1.0.42");
+    expect(r.restart).toBeDefined();
+    // Marker was written.
+    const marker = await readPendingUpdate(pendingPath);
+    expect(marker?.targetVersion).toBe("1.0.99");
+    expect(marker?.targetTag).toBe("v1.0.99");
+    expect(marker?.chatId).toBe(42);
+    expect(marker?.previousVersion).toBe("1.0.42");
+    // runUpdate was invoked with force:true, restart:false (we control
+    // the restart ourselves so it can fire AFTER the reply lands).
+    expect((runUpdateCalledWith as { force: boolean }).force).toBe(true);
+    expect((runUpdateCalledWith as { restart: boolean }).restart).toBe(false);
+    // Last-notified bumped so heartbeat doesn't re-spam mid-restart.
+    expect(await readLastNotified(lastNotifiedPathLocal)).toBe("1.0.99");
+    // restart() not called yet — caller's responsibility, post-sendMessage.
+    expect(calls).not.toContain("restart");
+    // Invoke it and verify it routes to the injected ServiceControl.
+    await r.restart!();
+    expect(calls).toContain("restart");
+  });
+
+  test("update available but runUpdate exits non-zero → marker cleared, error reply", async () => {
+    const r = await runUpdateFlow({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      chatId: 42,
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: fakeSvc().svc,
+      runUpdateImpl: fakeRunUpdate(1),
+      pendingPath,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.reply).toContain("failed");
+    expect(r.reply).toContain("exit 1");
+    expect(r.restart).toBeUndefined();
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+  });
+
+  test("release-check failure → returns error reply, no marker, no swap", async () => {
+    const failingFetch = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as unknown as typeof fetch;
+    let runUpdateCalled = false;
+    const r = await runUpdateFlow({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      chatId: 42,
+      fetchImpl: failingFetch,
+      runUpdateImpl: async () => {
+        runUpdateCalled = true;
+        return 0;
+      },
+      pendingPath,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.reply).toContain("couldn't check");
+    expect(r.restart).toBeUndefined();
+    expect(runUpdateCalled).toBe(false);
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+  });
+
+  test("unsupported platform → explicit refusal, no swap", async () => {
+    let runUpdateCalled = false;
+    const r = await runUpdateFlow({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      chatId: 42,
+      fetchImpl: fakeReleaseFetch(),
+      runUpdateImpl: async () => {
+        runUpdateCalled = true;
+        return 0;
+      },
+      pendingPath,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "win32",
+      procArch: "x64",
+    });
+    expect(r.reply).toContain("can't self-update");
+    expect(r.reply).toContain("platform=win32");
+    expect(r.restart).toBeUndefined();
+    expect(runUpdateCalled).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkAndNotifyOnce (heartbeat hook)
+// ---------------------------------------------------------------------------
+
+describe("checkAndNotifyOnce", () => {
+  test("update available + nothing previously notified → sends one message per recipient, writes dedup", async () => {
+    const transport = new FakeTransport();
+    const r = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("notified");
+    expect(r.latestVersion).toBe("1.0.99");
+    expect(r.notifiedRecipients).toBe(2);
+    expect(transport.sent.length).toBe(2);
+    expect(transport.sent[0]!.text).toContain("v1.0.99");
+    expect(transport.sent[0]!.text).toContain("/update");
+    expect(await readLastNotified(lastNotifiedPathLocal)).toBe("1.0.99");
+  });
+
+  test("already_current → no sends, no dedup write", async () => {
+    const transport = new FakeTransport();
+    const r = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.99",
+      fetchImpl: fakeReleaseFetch(),
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("already_current");
+    expect(transport.sent.length).toBe(0);
+    expect(await readLastNotified(lastNotifiedPathLocal)).toBeUndefined();
+  });
+
+  test("already_notified → no sends (dedup wins)", async () => {
+    await writeLastNotified("1.0.99", lastNotifiedPathLocal);
+    const transport = new FakeTransport();
+    const r = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("already_notified");
+    expect(transport.sent.length).toBe(0);
+  });
+
+  test("idempotent across two consecutive heartbeats", async () => {
+    const transport = new FakeTransport();
+    const input = {
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    };
+    const first = await checkAndNotifyOnce(input);
+    expect(first.status).toBe("notified");
+    expect(transport.sent.length).toBe(2);
+    const second = await checkAndNotifyOnce(input);
+    expect(second.status).toBe("already_notified");
+    expect(transport.sent.length).toBe(2); // unchanged
+  });
+
+  test("no telegram configured → status no_telegram, no calls to fetch", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram = undefined;
+    let fetched = false;
+    const noFetch = (async () => {
+      fetched = true;
+      throw new Error("should not have fetched");
+    }) as unknown as typeof fetch;
+    const r = await checkAndNotifyOnce({
+      config: cfg,
+      currentVersion: "1.0.42",
+      fetchImpl: noFetch,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("no_telegram");
+    expect(fetched).toBe(false);
+  });
+
+  test("unsupported platform → status no_target", async () => {
+    const r = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      transport: new FakeTransport(),
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "win32",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("no_target");
+  });
+
+  test("github error → status release_check_failed, no notify, no dedup change", async () => {
+    const failingFetch = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as unknown as typeof fetch;
+    const transport = new FakeTransport();
+    const r = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      fetchImpl: failingFetch,
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("release_check_failed");
+    expect(transport.sent.length).toBe(0);
+    expect(await readLastNotified(lastNotifiedPathLocal)).toBeUndefined();
+  });
+
+  test("empty allowed_user_ids → status no_allowed_users, refuses to broadcast", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram!.allowedUserIds = [];
+    const transport = new FakeTransport();
+    const r = await checkAndNotifyOnce({
+      config: cfg,
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("no_allowed_users");
+    expect(transport.sent.length).toBe(0);
+  });
+
+  test("dedup writes even on partial send failure (better one missed than one re-pinged)", async () => {
+    const transport = new FakeTransport();
+    transport.sendMessageImpl = async (chatId) => {
+      if (chatId === 99) throw new Error("rate limited");
+    };
+    const r = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("notified");
+    expect(r.notifiedRecipients).toBe(1); // only chatId 42 succeeded
+    expect(await readLastNotified(lastNotifiedPathLocal)).toBe("1.0.99");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// notifyPostRestartIfPending (run.ts startup hook)
+// ---------------------------------------------------------------------------
+
+describe("notifyPostRestartIfPending", () => {
+  test("no marker → no-op, no notify", async () => {
+    const transport = new FakeTransport();
+    const r = await notifyPostRestartIfPending({
+      config: baseConfig(),
+      currentVersion: "1.0.99",
+      transport,
+      pendingPath,
+    });
+    expect(r.status).toBe("no_marker");
+    expect(transport.sent.length).toBe(0);
+  });
+
+  test("marker matches current version → success notify to marker.chatId only, marker cleared", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        chatId: 42,
+        previousVersion: "1.0.42",
+        writtenAt: "2026-05-11T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakeTransport();
+    const r = await notifyPostRestartIfPending({
+      config: baseConfig(),
+      currentVersion: "1.0.99",
+      transport,
+      pendingPath,
+    });
+    expect(r.status).toBe("success_notified");
+    // Only sent to chatId 42 (from marker), NOT broadcast to allowedUserIds.
+    expect(transport.sent.length).toBe(1);
+    expect(transport.sent[0]!.chatId).toBe(42);
+    expect(transport.sent[0]!.text).toContain("✅");
+    expect(transport.sent[0]!.text).toContain("v1.0.99");
+    expect(transport.sent[0]!.text).toContain("v1.0.42");
+    // Marker gone.
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+  });
+
+  test("marker doesn't match current version → failure notify, marker cleared", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        chatId: 42,
+        previousVersion: "1.0.42",
+        writtenAt: "2026-05-11T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakeTransport();
+    const r = await notifyPostRestartIfPending({
+      config: baseConfig(),
+      currentVersion: "1.0.42", // didn't take
+      transport,
+      pendingPath,
+    });
+    expect(r.status).toBe("failure_notified");
+    expect(transport.sent[0]!.text).toContain("⚠️");
+    expect(transport.sent[0]!.text).toContain("didn't take");
+    expect(transport.sent[0]!.text).toContain("v1.0.99");
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+  });
+
+  test("marker without chatId → broadcasts to allowed_user_ids", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        previousVersion: "1.0.42",
+        writtenAt: "2026-05-11T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakeTransport();
+    const r = await notifyPostRestartIfPending({
+      config: baseConfig(),
+      currentVersion: "1.0.99",
+      transport,
+      pendingPath,
+    });
+    expect(r.status).toBe("success_notified");
+    // No chatId in marker → broadcast to BOTH allowed users.
+    expect(transport.sent.map((s) => s.chatId).sort()).toEqual([42, 99]);
+  });
+
+  test("no telegram configured → clears marker without notify, returns status no_telegram", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram = undefined;
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        chatId: 42,
+        previousVersion: "1.0.42",
+        writtenAt: "2026-05-11T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakeTransport();
+    const r = await notifyPostRestartIfPending({
+      config: cfg,
+      currentVersion: "1.0.99",
+      transport,
+      pendingPath,
+    });
+    expect(r.status).toBe("no_telegram");
+    expect(transport.sent.length).toBe(0);
+    // Marker must be cleared so we don't re-process it forever.
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+  });
+
+  test("malformed marker → treated as no_marker, file left alone", async () => {
+    await writeFile(pendingPath, "{not json", "utf8");
+    const transport = new FakeTransport();
+    const r = await notifyPostRestartIfPending({
+      config: baseConfig(),
+      currentVersion: "1.0.99",
+      transport,
+      pendingPath,
+    });
+    expect(r.status).toBe("no_marker");
+    expect(transport.sent.length).toBe(0);
+    // Garbage file still on disk — operator can inspect / remove manually.
+    const stillThere = await readFile(pendingPath, "utf8").catch(
+      () => "missing",
+    );
+    expect(stillThere).toContain("{not json");
+  });
+});


### PR DESCRIPTION
## Summary

Three pieces that wire phantombot's update lifecycle end-to-end:

1. **`/update` Telegram slash command.** Idempotent — "already on vX.Y.Z" when current; otherwise atomically swaps the binary and triggers restart via a new `afterSend` callback (so the heads-up message lands before SIGTERM hits).
2. **Heartbeat update check.** Every 30 min the heartbeat hits GitHub releases. If newer than current, sends ONE Telegram message pointing at `/update`. Deduped via `~/.config/phantombot/.last-update-notified` so a stuck-on-old-version user isn't pinged every half hour.
3. **Post-restart confirmation.** `/update` writes `~/.config/phantombot/.pending-update.json` BEFORE the restart. On startup, `phantombot run` reads it, compares target vs. running version, and notifies `✅ Updated to vX.Y.Z` or `⚠️ didn't take`. Marker deleted either way.

This is the only way to truthfully report a completed update — the in-process handler can only say "restarting…" because by the time the new binary is live, the old process is gone.

New module `src/lib/updateNotify.ts` holds marker I/O, dedup-cache I/O, and three compose functions (`runUpdateFlow`, `checkAndNotifyOnce`, `notifyPostRestartIfPending`). Every compose function takes `fetch` / `transport` / `runUpdate` test seams.

## Files changed

- **New** `src/lib/updateNotify.ts` — marker file + dedup file helpers, three compose functions.
- **New** `tests/lib-updateNotify.test.ts` (29 cases) — marker round-trip, dedup write/read, every status branch of all three compose functions.
- `src/channels/commands.ts` — `/update` case; `config` field added to `SlashCommandContext`; `afterSend` field added to `SlashCommandResult`.
- `src/channels/telegram.ts` — plumbs `config` into the dispatcher; awaits `result.afterSend` after `sendMessage`.
- `src/lib/heartbeat.ts` — optional `config` / `currentVersion` / `fetchImpl` / `transport` inputs; calls `checkAndNotifyOnce` when wired.
- `src/cli/heartbeat.ts` — passes config + `VERSION` to `runHeartbeat`.
- `src/cli/run.ts` — calls `notifyPostRestartIfPending` once at startup.
- `tests/channels-commands.test.ts` — `/update` routes correctly; defensive branch when config wasn't plumbed; `/help` mentions `/update`.
- `tests/lib-heartbeat.test.ts` — heartbeat triggers + skips update check; release-check failure doesn't break the heartbeat.

## Test plan

- [x] `bun test` — 786 pass, 0 fail across the full suite
- [x] `bun tsc --noEmit` — clean
- [x] `bun run build:arm64` — clean compile + smoke `phantombot --help`
- [ ] Manual on prod VPS once merged: tag a release, watch heartbeat fire the notify, send `/update` from Telegram, confirm the `✅` lands from the new binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)