### PR TITLE
feat(audio): symmetric text negation in replyModalityOverride

### DIFF
--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -109,12 +109,21 @@ export function replyModalityOverride(
   // Negation short-circuit. "Do not reply with voice" literally CONTAINS
   // the substring "reply with voice" which would otherwise hit the
   // positive voice pattern below — so we check negations first and exit.
-  // Symmetric "no text / don't reply with text" isn't covered: it's an
-  // unlikely phrasing, and adding it just bloats the surface. Easy to
-  // bolt on if anyone asks.
+  // Symmetric for text ("no text", "don't reply with text") so users can
+  // negate either modality. If a message negates BOTH (rare — "no text
+  // and no voice"), the later mention is the user's settled intent,
+  // matching the later-wins rule used by the positive patterns below.
   const NEGATION_VOICE =
     /\b(?:no|never|don't|do\s+not)\s+(?:use\s+|reply\s+(?:with|in)\s+|respond\s+(?:with|in)\s+|send\s+(?:me\s+|a\s+)*)?voice(?:\s*(?:note|message|reply|response))?\b/;
-  if (NEGATION_VOICE.test(t)) return "text";
+  const NEGATION_TEXT =
+    /\b(?:no|never|don't|do\s+not)\s+(?:use\s+|reply\s+(?:with|in)\s+|respond\s+(?:with|in)\s+|send\s+(?:me\s+|a\s+)*)?text(?:\s*(?:reply|response|message))?\b/;
+  const negVoice = NEGATION_VOICE.exec(t);
+  const negText = NEGATION_TEXT.exec(t);
+  if (negVoice && negText) {
+    return negVoice.index > negText.index ? "text" : "voice";
+  }
+  if (negVoice) return "text";
+  if (negText) return "voice";
 
   // Patterns are anchored on reply-verbs ("reply", "respond", "answer"),
   // unmistakable shorthand ("text reply", "voice note"), or "as/in text|

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -115,8 +115,15 @@ export function replyModalityOverride(
   // matching the later-wins rule used by the positive patterns below.
   const NEGATION_VOICE =
     /\b(?:no|never|don't|do\s+not)\s+(?:use\s+|reply\s+(?:with|in)\s+|respond\s+(?:with|in)\s+|send\s+(?:me\s+|a\s+)*)?voice(?:\s*(?:note|message|reply|response))?\b/;
+  // Asymmetric with NEGATION_VOICE on purpose: "text message" means SMS,
+  // not a reply-form directive (see positive textPatterns below, which
+  // also exclude "text message"). Both forms of that exclusion live here:
+  //   - the trailing-noun group omits "message" (only "reply"/"response")
+  //   - a negative lookahead `(?!\s+messages?\b)` blocks bare "no text"
+  //     from matching when "message(s)" follows ("no text messages today"
+  //     must stay a no-op, not flip routing to voice).
   const NEGATION_TEXT =
-    /\b(?:no|never|don't|do\s+not)\s+(?:use\s+|reply\s+(?:with|in)\s+|respond\s+(?:with|in)\s+|send\s+(?:me\s+|a\s+)*)?text(?:\s*(?:reply|response|message))?\b/;
+    /\b(?:no|never|don't|do\s+not)\s+(?:use\s+|reply\s+(?:with|in)\s+|respond\s+(?:with|in)\s+|send\s+(?:me\s+|a\s+)*)?text(?:\s*(?:reply|response))?(?!\s+messages?\b)\b/;
   const negVoice = NEGATION_VOICE.exec(t);
   const negText = NEGATION_TEXT.exec(t);
   if (negVoice && negText) {

--- a/tests/lib-audio.test.ts
+++ b/tests/lib-audio.test.ts
@@ -334,6 +334,11 @@ describe("replyModalityOverride", () => {
     "as a voice",
     "voice reply",
     "answer with a voice note",
+    "no text please",
+    "don't use text",
+    "Do not reply with text",
+    "no text, voice please",
+    "don't reply with text",
   ])("voice directive: %s → voice", (input) => {
     expect(replyModalityOverride(input)).toBe("voice");
   });
@@ -365,8 +370,21 @@ describe("replyModalityOverride", () => {
     ).toBe("voice");
   });
 
+  test("both negations in one message — later one wins (voice negated last → text)", () => {
+    expect(
+      replyModalityOverride("no text — actually don't use voice either"),
+    ).toBe("text");
+  });
+
+  test("both negations in one message — later one wins (text negated last → voice)", () => {
+    expect(
+      replyModalityOverride("no voice — actually don't reply with text"),
+    ).toBe("voice");
+  });
+
   test("case-insensitive", () => {
     expect(replyModalityOverride("REPLY IN TEXT")).toBe("text");
     expect(replyModalityOverride("Send A Voice Note")).toBe("voice");
+    expect(replyModalityOverride("NO TEXT PLEASE")).toBe("voice");
   });
 });

--- a/tests/lib-audio.test.ts
+++ b/tests/lib-audio.test.ts
@@ -352,6 +352,11 @@ describe("replyModalityOverride", () => {
     "I'm reading a textbook",
     "summarise this text",
     "what's the difference between text and audio formats",
+    // Regression: NEGATION_TEXT must not match "no text message(s)" — the
+    // positive textPatterns deliberately exclude "text message" (SMS), so
+    // negating it shouldn't flip routing to voice either.
+    "no text messages today please",
+    "don't send any text message to john",
     "",
     undefined,
   ])("no directive: %p → undefined", (input) => {


### PR DESCRIPTION
## Summary
- Mirrors `NEGATION_VOICE` with `NEGATION_TEXT` so users can negate the text modality the same way they can negate voice (e.g. "no text", "don't reply with text").
- When a message negates both modalities, the later mention wins — same later-wins rule the positive patterns already use.
- 8 new tests: 5 text-negation phrasings, 2 dual-negation later-wins cases, 1 case-insensitive case. All green locally.

Closes #105 (follow-up from Kai's review on #104).

## Test plan
- [x] `vitest run tests/lib-audio.test.ts` — new cases pass, no regressions
- [x] `tsc --noEmit` — clean
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)