### PR TITLE
docs: link to pi.dev and fix "Inflection Pi" misattribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Giving the harness a Soul. The harness can do its own tools — let it. A personality-first chat agent for Telegram, built for minimalist, high-torque agency.
 
-Phantombot extends **Inflection Pi** onto Telegram — and uses **Claude Code** or **Google Gemini CLI** as drop-in alternatives or fallbacks when Pi isn't the right fit. **Pi is the recommended primary; Claude and Gemini are first-class but think of them as backup, not the default.** The harness runs its own tool loop; phantombot does identity, memory, channel, scheduling, and self-update.
+Phantombot extends **[Pi](https://pi.dev)** — the terminal-based coding agent from Earendil Works — onto Telegram, and uses **Claude Code** or **Google Gemini CLI** as drop-in alternatives or fallbacks when Pi isn't the right fit. **Pi is the recommended primary; Claude and Gemini are first-class but think of them as backup, not the default.** The harness runs its own tool loop; phantombot does identity, memory, channel, scheduling, and self-update.
+
+Grab Pi from <https://pi.dev> — `curl -fsSL https://pi.dev/install.sh | sh` — before configuring phantombot.
 
 ---
 
@@ -52,7 +54,7 @@ Phantombot doesn't bundle an AI model — it delegates to one you already have i
 
 **You must install and authenticate at least one harness yourself before `phantombot harness` will work:**
 
-- **Pi** *(recommended primary)* — install `pi` from Inflection, then run `pi` once to authenticate.
+- **Pi** *(recommended primary)* — get it from [pi.dev](https://pi.dev) with `curl -fsSL https://pi.dev/install.sh | sh`, then run `pi` once to authenticate.
 - **Claude Code** — `npm install -g @anthropic-ai/claude-code`, then `claude /login` for OAuth.
 - **Gemini CLI** — install Google's Gemini CLI, then `gemini` and follow the `/auth` flow (or set `GEMINI_API_KEY` in `~/.env`).
 
@@ -102,7 +104,7 @@ Updates download to `${binPath}.update.tmp`, SHA256-verify, atomically rename ov
 ## Prerequisites
 
 - **At least one harness** installed and authenticated as the user that will run phantombot:
-  - **Inflection Pi** *(recommended primary)* — `pi` configured per its own setup
+  - **[Pi](https://pi.dev)** *(recommended primary)* — install via `curl -fsSL https://pi.dev/install.sh | sh`, then `pi` configured per its own setup
   - **Claude Code** — `claude /login` (OAuth on host; phantombot filters `ANTHROPIC_API_KEY` so OAuth is the path)
   - **Google Gemini CLI** — `gemini` then OAuth via the in-app `/auth`, OR set `GEMINI_API_KEY` in `~/.env`
 - A Telegram bot token from [@BotFather](https://t.me/BotFather)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. All model + tool work delegates to a CLI harness (Claude Code primary, Inflection Pi fallback). Phantombot's job is identity + memory + harness fallback.
+Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. All model + tool work delegates to a CLI harness (Claude Code primary, [Pi](https://pi.dev) fallback). Phantombot's job is identity + memory + harness fallback.
 
 ## What phantombot does
 

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -1,5 +1,5 @@
 /**
- * Inflection Pi harness.
+ * Pi harness (https://pi.dev — Pi Coding Agent from Earendil Works).
  *
  * Spawns `pi --print --mode json` with the system prompt as a flag and the
  * full rendered payload (history + new message) as the LAST positional

--- a/www/index.html
+++ b/www/index.html
@@ -17,6 +17,7 @@
                 <span>Phantombot</span>
             </div>
             <div class="links">
+                <a href="https://pi.dev">Pi</a>
                 <a href="https://github.com/phantomyard/phantombot">GitHub</a>
                 <a href="https://phantomops.app">PhantomOps</a>
             </div>
@@ -37,6 +38,7 @@
                     <code>curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh</code>
                     <button class="copy-button" type="button" aria-label="Copy install command" data-clipboard-text="curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh">Copy</button>
                 </div>
+                <p class="cta-note">Phantombot delegates to a harness — grab <a href="https://pi.dev">Pi</a> first: <code>curl -fsSL https://pi.dev/install.sh | sh</code></p>
             </div>
         </section>
 
@@ -63,7 +65,7 @@
             <div class="grid">
                 <div class="card">
                     <h3>Pi-Native</h3>
-                    <p>Built for the Pi aesthetic. Minimalist, single-binary, and focused on the essence of agency. Claude and Gemini serve as high-fidelity fallbacks.</p>
+                    <p>Built around <a href="https://pi.dev">Pi</a> — the terminal-based coding agent from Earendil Works. Minimalist, single-binary, and focused on the essence of agency. Claude and Gemini serve as high-fidelity fallbacks.</p>
                 </div>
                 <div class="card">
                     <h3>Atomic Updates</h3>

--- a/www/styles.css
+++ b/www/styles.css
@@ -153,6 +153,27 @@ h1 {
     display: inline-block;
 }
 
+.cta-note {
+    margin-top: 1.2rem;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--muted);
+    max-width: 720px;
+}
+
+.cta-note code {
+    background: var(--border);
+    padding: 0.1rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.85rem;
+    color: var(--fg);
+}
+
+.cta-note a {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
 .copy-button {
     position: absolute;
     top: 0.5rem;


### PR DESCRIPTION
## Summary
- Replace every "Inflection Pi" reference with a link to **[pi.dev](https://pi.dev)** — the harness is Earendil Works' terminal-based Pi Coding Agent, not the Inflection AI chatbot.
- Surface the official one-liner installer `curl -fsSL https://pi.dev/install.sh | sh` in the README intro, Quick start, and Prerequisites.
- Add a **Pi** link to the website top nav, a Pi install hint under the hero CTA, and rewrite the **Pi-Native** card to credit pi.dev / Earendil Works. New `.cta-note` style added for the hero hint.
- Fix the same misattribution in `docs/architecture.md` and the JSDoc header of `src/harnesses/pi.ts` (no runtime change — comment only).

## Files touched
- `README.md` — intro paragraph + new install hint, Quick start bullet, Prerequisites bullet
- `www/index.html` — nav link, hero CTA note, Pi-Native card copy
- `www/styles.css` — new `.cta-note` (+ nested `code` / `a`) rules
- `docs/architecture.md` — Goal sentence
- `src/harnesses/pi.ts` — JSDoc header only

## Test plan
- [ ] Visual check of the rendered README on GitHub — links land on pi.dev, install snippets render as inline code
- [ ] Open `www/index.html` locally — confirm new nav link, hero note, and Pi-Native card render correctly on desktop + mobile widths
- [ ] Confirm no source/behavioural change: only a JSDoc comment in `src/harnesses/pi.ts` was edited, so existing tests and build remain green

🤖 Authored by Robbie on Andrew's behalf