### PR TITLE
fix(run): heal broken default persona at startup instead of crash-looping

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -67,6 +67,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     // so we can compute it directly.
     persona = healed;
     agentDir = personaDir(config, persona);
+    config.defaultPersona = healed;
   }
 
   const harnesses = buildHarnessChain(config, err);

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -18,6 +18,7 @@ import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import { shouldRunCatchupNightly } from "../lib/nightly.ts";
+import { healDefaultPersonaIfBroken } from "../lib/personaDefault.ts";
 import { logsCommand, statusCommand } from "../lib/platform.ts";
 import {
   acquireRunLock,
@@ -50,15 +51,22 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     return 2;
   }
 
-  const persona = config.defaultPersona;
-  const agentDir = personaDir(config, persona);
+  let persona = config.defaultPersona;
+  let agentDir = personaDir(config, persona);
   if (!existsSync(agentDir)) {
-    err.write(
-      `persona '${persona}' not found at ${agentDir}\n` +
-        "import or create one with `phantombot import-persona <openclaw-dir>` " +
-        "or `phantombot create-persona`.\n",
-    );
-    return 2;
+    const healed = await healDefaultPersonaIfBroken(config, err);
+    if (!healed) {
+      err.write(
+        `default persona '${persona}' not found at ${agentDir} and no other personas exist.\n` +
+          "Create one with `phantombot persona`.\n",
+      );
+      return 2;
+    }
+    // Re-resolve paths with the healed persona. loadConfig() cached the
+    // stale default, but personaDir(healed) is deterministic from config
+    // so we can compute it directly.
+    persona = healed;
+    agentDir = personaDir(config, persona);
   }
 
   const harnesses = buildHarnessChain(config, err);

--- a/src/lib/personaDefault.ts
+++ b/src/lib/personaDefault.ts
@@ -78,6 +78,11 @@ export async function healDefaultPersonaIfBroken(
   const state = await loadState();
   state.default_persona = healed;
   await saveState(state);
+  log.warn("persona healed", {
+    from: config.defaultPersona,
+    to: healed,
+    reason: "missing on disk",
+  });
   out?.write(
     `healed default_persona: '${config.defaultPersona}' → '${healed}' ` +
       `(previous default has no persona dir on disk)\n`,

--- a/src/lib/personaDefault.ts
+++ b/src/lib/personaDefault.ts
@@ -10,11 +10,12 @@
  * operations stay non-destructive.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 
 import { type Config, personaDir } from "../config.ts";
 import { loadState, saveState } from "../state.ts";
 import type { WriteSink } from "./io.ts";
+import { log } from "./logger.ts";
 
 /**
  * If the current `default_persona` points at a directory that doesn't
@@ -37,4 +38,66 @@ export async function adoptAsDefaultIfMissing(
     `\nadopted '${name}' as default_persona (previous default '${config.defaultPersona}' has no persona dir on disk)\n`,
   );
   return true;
+}
+
+/**
+ * Startup safety net: if the resolved `defaultPersona` doesn't exist on
+ * disk, scan the personas directory for a valid replacement, write it to
+ * state.json, and return the healed name.
+ *
+ * Without this, a corrupted `state.json` (e.g. pointing at a persona
+ * that was never created on this host, or one that was deleted) causes
+ * `phantombot run` to crash-loop until the user manually runs
+ * `phantombot persona` to switch back.
+ *
+ * Strategy:
+ *   1. If the resolved default exists on disk → return it (no-op).
+ *   2. Scan the personas dir. If empty → return null (caller bails).
+ *   3. If exactly one persona exists → adopt it.
+ *   4. If multiple exist → try the one with the same name as the broken
+ *      default (could be a case mismatch or partial name collision),
+ *      otherwise pick the first alphabetically.
+ *
+ * Returns the healed persona name, or null if no personas exist at all.
+ */
+export async function healDefaultPersonaIfBroken(
+  config: Config,
+  out?: WriteSink,
+): Promise<string | null> {
+  const currentDefaultDir = personaDir(config, config.defaultPersona);
+  if (existsSync(currentDefaultDir)) return config.defaultPersona;
+
+  const existing = listPersonaDirs(config);
+  if (existing.length === 0) return null;
+
+  // Prefer a persona whose name matches the broken default (case-insensitive).
+  const brokenName = config.defaultPersona.toLowerCase();
+  const match = existing.find((n) => n.toLowerCase() === brokenName);
+  const healed = match ?? existing[0]!;
+
+  const state = await loadState();
+  state.default_persona = healed;
+  await saveState(state);
+  out?.write(
+    `healed default_persona: '${config.defaultPersona}' → '${healed}' ` +
+      `(previous default has no persona dir on disk)\n`,
+  );
+  return healed;
+}
+
+/** List persona subdirectory names. Returns [] if the dir doesn't exist. */
+export function listPersonaDirs(config: Config): string[] {
+  if (!existsSync(config.personasDir)) return [];
+  try {
+    return readdirSync(config.personasDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch (e) {
+    log.warn("personaDefault: failed to read personas dir", {
+      personasDir: config.personasDir,
+      error: (e as Error).message,
+    });
+    return [];
+  }
 }

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -63,7 +63,7 @@ describe("runRun — early exits", () => {
     expect(err.text).toContain("phantombot telegram");
   });
 
-  test("returns 2 when persona dir is missing", async () => {
+  test("returns 2 when persona dir is missing and no other personas exist", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     await rm(join(workdir, "personas", "phantom"), { recursive: true });
@@ -82,7 +82,40 @@ describe("runRun — early exits", () => {
       err,
     });
     expect(code).toBe(2);
-    expect(err.text).toContain("import-persona");
+    expect(err.text).toContain("no other personas exist");
+  });
+
+  test("heals to another persona when default is missing but others exist", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    // Remove the configured default persona, but leave a different one.
+    await rm(join(workdir, "personas", "phantom"), { recursive: true });
+    await mkdir(join(workdir, "personas", "kai"), { recursive: true });
+    await writeFile(join(workdir, "personas", "kai", "BOOT.md"), "# Kai");
+
+    // Use an empty harness chain to force an early exit (code 2) after
+    // the persona validation passes. This proves healing worked without
+    // launching a full Telegram polling server.
+    const code = await runRun({
+      config: {
+        ...config,
+        harnesses: { ...config.harnesses, chain: [] },
+        channels: {
+          telegram: {
+            token: "abc",
+            pollTimeoutS: 30,
+            allowedUserIds: [],
+          },
+        },
+      },
+      lockPath: join(workdir, "run.lock"),
+      out,
+      err,
+    });
+    // Should fail on harness chain, not persona-missing.
+    expect(code).toBe(2);
+    expect(err.text).not.toContain("no other personas exist");
+    expect(err.text).toContain("phantombot harness");
   });
 
   test("returns 2 when harness chain is empty", async () => {

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -22,11 +22,14 @@ class CaptureStream {
   }
 }
 
+const SAVED_STATE = process.env.PHANTOMBOT_STATE;
+
 let workdir: string;
 let config: Config;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-run-"));
+  process.env.PHANTOMBOT_STATE = join(workdir, "state.json");
   await mkdir(join(workdir, "personas", "phantom"), { recursive: true });
   await writeFile(
     join(workdir, "personas", "phantom", "BOOT.md"),
@@ -51,6 +54,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  if (SAVED_STATE === undefined) delete process.env.PHANTOMBOT_STATE;
+  else process.env.PHANTOMBOT_STATE = SAVED_STATE;
   await rm(workdir, { recursive: true, force: true });
 });
 

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -104,6 +104,7 @@ describe("runRun — early exits", () => {
     const code = await runRun({
       config: {
         ...config,
+        defaultPersona: "ghostfixture",
         harnesses: { ...config.harnesses, chain: [] },
         channels: {
           telegram: {

--- a/tests/lib-personaDefault.test.ts
+++ b/tests/lib-personaDefault.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -12,7 +12,7 @@ import {
   healDefaultPersonaIfBroken,
 } from "../src/lib/personaDefault.ts";
 import type { Config } from "../src/config.ts";
-import { loadState, saveState, type State } from "../src/state.ts";
+import { loadState } from "../src/state.ts";
 
 class CaptureStream {
   chunks: string[] = [];
@@ -91,6 +91,14 @@ describe("healDefaultPersonaIfBroken", () => {
     const healed = await healDefaultPersonaIfBroken(config);
     // Sorted: "kai", "lena" → picks "kai"
     expect(healed).toBe("kai");
+  });
+
+  test("prefers case-insensitive name match over first alphabetical", async () => {
+    await mkdir(join(personasDir, "Robbie"), { recursive: true });
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    const config = makeConfig(personasDir, "robbie");
+    const healed = await healDefaultPersonaIfBroken(config);
+    expect(healed).toBe("Robbie");
   });
 
   test("no-ops when personas dir doesn't exist (returns null)", async () => {

--- a/tests/lib-personaDefault.test.ts
+++ b/tests/lib-personaDefault.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for personaDefault.ts — healDefaultPersonaIfBroken and
+ * adoptAsDefaultIfMissing.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  adoptAsDefaultIfMissing,
+  healDefaultPersonaIfBroken,
+} from "../src/lib/personaDefault.ts";
+import type { Config } from "../src/config.ts";
+import { loadState, saveState, type State } from "../src/state.ts";
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+function makeConfig(personasDir: string, defaultPersona = "phantom"): Config {
+  return {
+    defaultPersona,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
+    personasDir,
+    memoryDbPath: join(personasDir, "..", "memory.sqlite"),
+    configPath: join(personasDir, "..", "config.toml"),
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1_000_000 },
+      gemini: { bin: "gemini", model: "" },
+    },
+    channels: {},
+    embeddings: { provider: "none" },
+    voice: { provider: "none" },
+  };
+}
+
+let workdir: string;
+let personasDir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-pd-"));
+  personasDir = join(workdir, "personas");
+  await mkdir(personasDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("healDefaultPersonaIfBroken", () => {
+  test("returns the current default when it exists on disk", async () => {
+    await mkdir(join(personasDir, "phantom"), { recursive: true });
+    const config = makeConfig(personasDir, "phantom");
+    const healed = await healDefaultPersonaIfBroken(config);
+    expect(healed).toBe("phantom");
+  });
+
+  test("returns null when no personas exist at all", async () => {
+    const config = makeConfig(personasDir, "phantom");
+    const healed = await healDefaultPersonaIfBroken(config);
+    expect(healed).toBeNull();
+  });
+
+  test("heals to the only persona on disk", async () => {
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    const config = makeConfig(personasDir, "robbie");
+    const out = new CaptureStream();
+    const healed = await healDefaultPersonaIfBroken(config, out);
+    expect(healed).toBe("kai");
+    expect(out.text).toContain("robbie' → 'kai'");
+
+    // Verify state.json was written.
+    const state = await loadState();
+    expect(state.default_persona).toBe("kai");
+  });
+
+  test("picks first alphabetically when no name match exists", async () => {
+    await mkdir(join(personasDir, "lena"), { recursive: true });
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    const config = makeConfig(personasDir, "robbie");
+    const healed = await healDefaultPersonaIfBroken(config);
+    // Sorted: "kai", "lena" → picks "kai"
+    expect(healed).toBe("kai");
+  });
+
+  test("no-ops when personas dir doesn't exist (returns null)", async () => {
+    await rm(personasDir, { recursive: true });
+    const config = makeConfig(personasDir, "robbie");
+    const healed = await healDefaultPersonaIfBroken(config);
+    expect(healed).toBeNull();
+  });
+});
+
+describe("adoptAsDefaultIfMissing", () => {
+  test("no-ops when default already exists on disk", async () => {
+    await mkdir(join(personasDir, "phantom"), { recursive: true });
+    const config = makeConfig(personasDir, "phantom");
+    const changed = await adoptAsDefaultIfMissing(config, "kai");
+    expect(changed).toBe(false);
+  });
+
+  test("adopts the given name when default is missing", async () => {
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    const config = makeConfig(personasDir, "robbie");
+    const out = new CaptureStream();
+    const changed = await adoptAsDefaultIfMissing(config, "kai", out);
+    expect(changed).toBe(true);
+    expect(out.text).toContain("adopted 'kai'");
+
+    const state = await loadState();
+    expect(state.default_persona).toBe("kai");
+  });
+});

--- a/tests/lib-personaDefault.test.ts
+++ b/tests/lib-personaDefault.test.ts
@@ -44,6 +44,8 @@ function makeConfig(personasDir: string, defaultPersona = "phantom"): Config {
   };
 }
 
+const SAVED_STATE = process.env.PHANTOMBOT_STATE;
+
 let workdir: string;
 let personasDir: string;
 
@@ -51,9 +53,12 @@ beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-pd-"));
   personasDir = join(workdir, "personas");
   await mkdir(personasDir, { recursive: true });
+  process.env.PHANTOMBOT_STATE = join(workdir, "state.json");
 });
 
 afterEach(async () => {
+  if (SAVED_STATE === undefined) delete process.env.PHANTOMBOT_STATE;
+  else process.env.PHANTOMBOT_STATE = SAVED_STATE;
   await rm(workdir, { recursive: true, force: true });
 });
 

--- a/tests/lib-personaDefault.test.ts
+++ b/tests/lib-personaDefault.test.ts
@@ -78,11 +78,11 @@ describe("healDefaultPersonaIfBroken", () => {
 
   test("heals to the only persona on disk", async () => {
     await mkdir(join(personasDir, "kai"), { recursive: true });
-    const config = makeConfig(personasDir, "robbie");
+    const config = makeConfig(personasDir, "ghostfixture");
     const out = new CaptureStream();
     const healed = await healDefaultPersonaIfBroken(config, out);
     expect(healed).toBe("kai");
-    expect(out.text).toContain("robbie' → 'kai'");
+    expect(out.text).toContain("ghostfixture' → 'kai'");
 
     // Verify state.json was written.
     const state = await loadState();
@@ -92,23 +92,23 @@ describe("healDefaultPersonaIfBroken", () => {
   test("picks first alphabetically when no name match exists", async () => {
     await mkdir(join(personasDir, "lena"), { recursive: true });
     await mkdir(join(personasDir, "kai"), { recursive: true });
-    const config = makeConfig(personasDir, "robbie");
+    const config = makeConfig(personasDir, "ghostfixture");
     const healed = await healDefaultPersonaIfBroken(config);
     // Sorted: "kai", "lena" → picks "kai"
     expect(healed).toBe("kai");
   });
 
   test("prefers case-insensitive name match over first alphabetical", async () => {
-    await mkdir(join(personasDir, "Robbie"), { recursive: true });
+    await mkdir(join(personasDir, "Ghostfixture"), { recursive: true });
     await mkdir(join(personasDir, "kai"), { recursive: true });
-    const config = makeConfig(personasDir, "robbie");
+    const config = makeConfig(personasDir, "ghostfixture");
     const healed = await healDefaultPersonaIfBroken(config);
-    expect(healed).toBe("Robbie");
+    expect(healed).toBe("Ghostfixture");
   });
 
   test("no-ops when personas dir doesn't exist (returns null)", async () => {
     await rm(personasDir, { recursive: true });
-    const config = makeConfig(personasDir, "robbie");
+    const config = makeConfig(personasDir, "ghostfixture");
     const healed = await healDefaultPersonaIfBroken(config);
     expect(healed).toBeNull();
   });
@@ -124,7 +124,7 @@ describe("adoptAsDefaultIfMissing", () => {
 
   test("adopts the given name when default is missing", async () => {
     await mkdir(join(personasDir, "kai"), { recursive: true });
-    const config = makeConfig(personasDir, "robbie");
+    const config = makeConfig(personasDir, "ghostfixture");
     const out = new CaptureStream();
     const changed = await adoptAsDefaultIfMissing(config, "kai", out);
     expect(changed).toBe(true);


### PR DESCRIPTION
## Root cause

The 3-out-of-5 "Kai comes up as robbie after update" reports trace to this PR's own pre-`ca76155` tests. `tests/lib-personaDefault.test.ts` wrote `{"default_persona":"robbie"}` to the developer's real `~/.local/share/phantombot/state.json` because `PHANTOMBOT_STATE` wasn't scoped to a tmpdir. CI runners are fresh so the issue only manifested on Kai's dev box where `bun test` ran locally.

Evidence from kw-openclaw: Kai's `state.json` was rewritten at 23:48:44 UTC (during the PR dev loop), and fixed 11 seconds later at 23:48:55 when `ca76155` added tmpdir scoping. Lena's and Jake's `state.json` files were untouched since 2026-05-06 and 2026-05-02 respectively — only Kai's box mutated, because only Kai runs `bun test` from `~/Projects/phantombot/`.

## What this PR adds (defense in depth)

`healDefaultPersonaIfBroken` — if `state.json` ever again points at a persona that doesn't exist (manual edit, partial write, future bug), heal at startup instead of crash-looping. Strategy: case-insensitive name match, else first alphabetical. Logs as `warn` for journalctl searchability.

Broken-default fixture names in both test files use `"ghostfixture"` — obviously fake, so any future scoping regression is instantly visible.

## Files

- `src/lib/personaDefault.ts` — new `healDefaultPersonaIfBroken()` helper
- `src/cli/run.ts` — call site + in-memory `config.defaultPersona` sync
- `tests/lib-personaDefault.test.ts` — 8 unit tests, tmpdir-scoped `PHANTOMBOT_STATE`
- `tests/cli-run.test.ts` — updated heal test, tmpdir-scoped `PHANTOMBOT_STATE`