### PR TITLE
ci(release): tag releases by github.run_number, not PR number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,21 @@
 name: Release on PR merge
 
 # Fires for every PR merged into main. Cuts a GitHub Release tagged
-# v1.0.<PR_NUMBER> with two cross-compiled binaries (x64-baseline + arm64)
-# and a SHA256SUMS file. `phantombot update` reads this feed.
+# v1.0.<RUN_NUMBER> with cross-compiled binaries (linux x64-baseline +
+# arm64, darwin x64 + arm64) and a SHA256SUMS file. `phantombot update`
+# reads this feed.
+#
+# Why github.run_number and not the PR number: PR numbers can regress
+# if a later-numbered PR is merged before an earlier-numbered one
+# (e.g. PR #50 lands while #49 is still in review, then #49 lands and
+# would produce v1.0.49 *after* v1.0.50). `phantombot update` does string
+# equality on the latest release tag, but humans reading "version went
+# backwards" get confused, and any future ordering heuristic breaks.
+# github.run_number is a per-workflow monotonic counter — it only ever
+# goes up, and every value points to exactly one Actions run, so we can
+# pivot from a deployed binary to the build that produced it in one click.
+# The originating PR number is preserved in the release title and notes
+# so the audit trail (which PR shipped what) is still intact.
 #
 # Why every PR (not manual tags): the user runs `phantombot update --force
 # --restart` from cron and wants always-fresh binaries. If a PR shouldn't
@@ -54,9 +67,14 @@ jobs:
       - name: Compute version + bake into src/version.ts
         id: version
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # RUN_NUMBER is the per-workflow monotonic counter (never
+          # regresses). PR_NUMBER is kept around purely for the audit
+          # trail in the release title and notes — it is no longer part
+          # of the version string itself. See the file header comment
+          # for the why.
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
-          VERSION="1.0.${PR_NUMBER}"
+          VERSION="1.0.${RUN_NUMBER}"
           TAG="v${VERSION}"
           # Replace only the literal placeholder so the doc comment in
           # src/version.ts (and any future sibling const) survives. The
@@ -126,9 +144,17 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
         run: |
           cat > release-notes.md <<EOF
-          Automated release for PR #${PR_NUMBER}: ${PR_TITLE}
+          Automated release from workflow run #${RUN_NUMBER} (run id ${RUN_ID}).
+          Originating PR: #${PR_NUMBER} — ${PR_TITLE}
+
+          Build run: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}
+          Pull request: ${SERVER_URL}/${REPO}/pull/${PR_NUMBER}
 
           Binaries:
           - phantombot-${TAG}-linux-x64 — x86-64, baseline (no AVX2 required)
@@ -152,14 +178,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # --target pins the git tag to the merge commit we built from.
           # Without it, a second PR landing mid-workflow would shift the
           # tag onto the wrong sha (binaries would still be correct, but
           # `git checkout v1.0.N` would lie about what code is in there).
+          # Release title carries the PR number so the GitHub Releases UI
+          # surfaces the originating PR without having to open the notes.
           gh release create "$TAG" \
             --target "${{ github.event.pull_request.merge_commit_sha }}" \
-            --title "$TAG" \
+            --title "$TAG (PR #${PR_NUMBER})" \
             --notes-file release-notes.md \
             "dist/phantombot-${TAG}-linux-x64" \
             "dist/phantombot-${TAG}-linux-arm64" \

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,18 +2,29 @@
  * The single source of truth for phantombot's version string.
  *
  * Local development always reports the `-dev` suffix. CI replaces the
- * literal `0.1.0-dev` below with `1.0.<PR_NUMBER>` (sed, not full-file
+ * literal `0.1.0-dev` below with `1.0.<RUN_NUMBER>` (sed, not full-file
  * overwrite — see .github/workflows/release.yml) before
  * `bun build --compile`, so the released binary prints its real version.
  *
- * **Versioning scheme is intentionally NOT semver.** `1.0.<PR_NUMBER>`
- * uses the GitHub PR number as the patch component because every merged
- * PR auto-releases. There is no path to bumping major or minor without
- * breaking the scheme, and PR-numbered patches are not ordered by
- * semantic impact (1.0.42 is a "patch" of 1.0.41 only by coincidence).
- * Don't bolt semver-aware logic onto `phantombot update` (e.g. "this
- * is a major upgrade, read the release notes first") — the version
- * string can't carry that information here.
+ * **Versioning scheme is intentionally NOT semver.** `1.0.<RUN_NUMBER>`
+ * uses the GitHub Actions per-workflow `run_number` as the patch
+ * component because every merged PR auto-releases. `run_number` is a
+ * monotonic counter scoped to the release workflow — it only ever
+ * increases, so the latest release is always the one with the highest
+ * number, and every binary maps 1:1 to exactly one Actions run.
+ *
+ * We deliberately moved off `<PR_NUMBER>` because PR numbers can
+ * regress (PR #50 lands before PR #49) and were producing confusing
+ * "version went backwards" semantics. The originating PR number is
+ * still preserved in the release title and notes for audit purposes —
+ * it's just not in the version string.
+ *
+ * There is no path to bumping major or minor without breaking the
+ * scheme, and run-numbered patches are not ordered by semantic impact
+ * (1.0.42 is a "patch" of 1.0.41 only by coincidence). Don't bolt
+ * semver-aware logic onto `phantombot update` (e.g. "this is a major
+ * upgrade, read the release notes first") — the version string can't
+ * carry that information here.
  *
  * **Contract for the placeholder**: the literal `"0.1.0-dev"` below
  * must round-trip exactly. The CI sed substitution targets that string;


### PR DESCRIPTION
## Problem

The release workflow currently tags every merged-PR release as `v1.0.<PR_NUMBER>`. That number can regress: if PR #50 merges while PR #49 is still in review, then #49 lands afterwards, we ship `v1.0.49` *after* `v1.0.50` and the release listing looks like the version went backwards. It's noisy in the UI and any future ordering logic in `phantombot update` would break on it.

## Fix

Switch the patch component of the version to `github.run_number` — the per-workflow monotonic counter. It only ever increases, and every value maps 1:1 to exactly one Actions run, so a deployed binary points back to its build in one click.

## Audit trail preserved

The originating PR number is still surfaced everywhere a human would look:

- **Release title:** `v1.0.123 (PR #45)` — visible in the GitHub Releases UI without having to expand.
- **Release notes:** explicit PR number + title, plus direct links to both the PR and the Actions run that produced the binaries.

## Safety

`phantombot update` does string equality on the latest release tag (see `src/lib/githubReleases.ts` and `src/cli/update.ts`). Nothing semver-aware exists, so swapping the patch component is purely a name change — no client-side logic needs to come along.

## Files

- `.github/workflows/release.yml` — switched `VERSION` source from `github.event.pull_request.number` to `github.run_number`, added `RUN_ID` / repo / server-url envs into the notes-writing step, added PR number to the release title.
- `src/version.ts` — updated the file header comment to document the new scheme + why we moved off PR-number patches.

## How to verify after merge

1. Watch the workflow for this PR's merge — the resulting tag should be `v1.0.<some run_number>`, *not* `v1.0.<this PR number>`.
2. Open the release in the GitHub UI — title shows `(PR #<this PR number>)`, notes link to the run.
3. `phantombot update --check` on a deployed agent should see the new release as available (string equality, not semver).

---

_Drafted by Robbie (Claude Code) on Andrew's instruction._