### PR TITLE
release.yml: bump minor to v1.1.<run_number> to escape PR-era tag collisions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release on PR merge
 
 # Fires for every PR merged into main. Cuts a GitHub Release tagged
-# v1.0.<RUN_NUMBER> with cross-compiled binaries (linux x64-baseline +
+# v1.1.<RUN_NUMBER> with cross-compiled binaries (linux x64-baseline +
 # arm64, darwin x64 + arm64) and a SHA256SUMS file. `phantombot update`
 # reads this feed.
 #
@@ -16,6 +16,17 @@ name: Release on PR merge
 # pivot from a deployed binary to the build that produced it in one click.
 # The originating PR number is preserved in the release title and notes
 # so the audit trail (which PR shipped what) is still intact.
+#
+# Why the minor bump from 1.0 → 1.1: the first run under run_number-based
+# tagging would have been v1.0.64, which collided with the old PR-numbered
+# v1.0.64 (from PR #64 back in early May 2026) and made `gh release create`
+# fail with "tag already exists". The PR-numbered era went up to ~v1.0.109,
+# so any run_number under ~110 would have collided. Bumping minor to 1.1
+# gives us a clean namespace with no overlap, while the run_number itself
+# keeps its meaning (it's still the per-workflow counter, just one minor
+# slot higher). Don't bump minor again on the next collision risk —
+# there isn't one; run_number only grows from here and 1.1.<N> can run
+# to infinity.
 #
 # Why every PR (not manual tags): the user runs `phantombot update --force
 # --restart` from cron and wants always-fresh binaries. If a PR shouldn't
@@ -74,7 +85,7 @@ jobs:
           # for the why.
           RUN_NUMBER: ${{ github.run_number }}
         run: |
-          VERSION="1.0.${RUN_NUMBER}"
+          VERSION="1.1.${RUN_NUMBER}"
           TAG="v${VERSION}"
           # Replace only the literal placeholder so the doc comment in
           # src/version.ts (and any future sibling const) survives. The

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,11 +2,11 @@
  * The single source of truth for phantombot's version string.
  *
  * Local development always reports the `-dev` suffix. CI replaces the
- * literal `0.1.0-dev` below with `1.0.<RUN_NUMBER>` (sed, not full-file
+ * literal `0.1.0-dev` below with `1.1.<RUN_NUMBER>` (sed, not full-file
  * overwrite — see .github/workflows/release.yml) before
  * `bun build --compile`, so the released binary prints its real version.
  *
- * **Versioning scheme is intentionally NOT semver.** `1.0.<RUN_NUMBER>`
+ * **Versioning scheme is intentionally NOT semver.** `1.1.<RUN_NUMBER>`
  * uses the GitHub Actions per-workflow `run_number` as the patch
  * component because every merged PR auto-releases. `run_number` is a
  * monotonic counter scoped to the release workflow — it only ever
@@ -19,9 +19,15 @@
  * still preserved in the release title and notes for audit purposes —
  * it's just not in the version string.
  *
+ * Why `1.1.<N>` and not `1.0.<N>`: the first run-numbered release
+ * (run_number=64) collided with the old PR-numbered v1.0.64 tag,
+ * so we bumped minor once to escape the overlap with the PR-era
+ * tags (which went up to ~v1.0.109). Don't bump again — run_number
+ * only grows from here, so v1.1.<N> is safe to infinity.
+ *
  * There is no path to bumping major or minor without breaking the
  * scheme, and run-numbered patches are not ordered by semantic impact
- * (1.0.42 is a "patch" of 1.0.41 only by coincidence). Don't bolt
+ * (1.1.42 is a "patch" of 1.1.41 only by coincidence). Don't bolt
  * semver-aware logic onto `phantombot update` (e.g. "this is a major
  * upgrade, read the release notes first") — the version string can't
  * carry that information here.


### PR DESCRIPTION
## What

Bumps the release tag scheme from `v1.0.<run_number>` to `v1.1.<run_number>`.

## Why

The first run under the new run_number-based tagging (PR #110's own merge) failed with:

```
release not found
GraphQL: Tag "v1.0.64" already exists (createRef)
```

That tag already exists because PR #64 (back on 2026-05-03, under the old PR-numbered scheme) shipped as `v1.0.64`. The PR-era tags run all the way up to ~`v1.0.109`, so any `run_number` under ~110 would have collided the same way.

## Fix

Bump the minor once: `v1.0.<N>` → `v1.1.<N>`. The PR-era tags all live in `v1.0.x`, so `v1.1.x` is a fresh namespace. `run_number` only grows from here (currently 64), so this is a one-time fix — `v1.1.<N>` is safe forever and there's no foreseeable collision risk.

The run_number itself keeps its full meaning: still a per-workflow monotonic counter, still 1:1 with an Actions run, still preserves the originating PR number in the release title and notes.

## Files

- `.github/workflows/release.yml` — `VERSION="1.0.${RUN_NUMBER}"` → `VERSION="1.1.${RUN_NUMBER}"` + comment block explaining the bump
- `src/version.ts` — updated docstring to match (placeholder literal `0.1.0-dev` and the sed pattern are unchanged)
- Tests use generic `v1.0.x` fixtures (exercising the mechanism, not the scheme), so no test changes needed.

## Test plan

- [ ] PR build is green (typecheck + tests)
- [ ] On merge, the release workflow produces `v1.1.<run_number>` (probably `v1.1.65` or `v1.1.66`) without a tag collision
- [ ] `phantombot update` on the Hetzner VPS picks up the new tag and installs cleanly