### PR TITLE
Reliable, observable memory capture & resumable nightly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,8 @@ phantombot/
 │   │   ├── loader.ts         # accepts BOOT.md / SOUL.md / IDENTITY.md, MEMORY.md, tools.md / AGENTS.md
 │   │   └── builder.ts        # buildSystemPrompt + MEMORY_TOOLS_SECTION + CREDENTIALS_SECTION
 │   ├── memory/
-│   │   └── store.ts          # bun:sqlite turn store (turns table)
+│   │   └── store.ts          # bun:sqlite store: turns table + capture_log table
+│   │                         #   (capture_log backs the 30-turn nudge + doctor)
 │   ├── importer/
 │   │   └── openclaw.ts       # OpenClaw → phantombot persona import
 │   ├── orchestrator/
@@ -81,8 +82,9 @@ phantombot/
 │   │   ├── voice.ts          # phantombot voice (TUI: TTS/STT provider config)
 │   │   ├── telegram.ts       # phantombot telegram (TUI: token + allowed users)
 │   │   ├── harness.ts        # phantombot harness (TUI: chain) + maybePromptRestart helper
-│   │   ├── memory.ts         # phantombot memory (search/get/today/index/list)
-│   │   ├── heartbeat.ts nightly.ts
+│   │   ├── memory.ts         # phantombot memory (search/get/today/index/list/capture)
+│   │   ├── heartbeat.ts nightly.ts  # nightly is 5 checkpointed stages (--resume)
+│   │   ├── doctor.ts         # phantombot doctor (memory health check + nightly auto-repair)
 │   │   ├── embedding.ts      # phantombot embedding (TUI: Gemini config)
 │   │   ├── persona.ts        # phantombot persona (consolidates create / import / restore / switch)
 │   │   ├── create-persona.ts import-persona.ts  # implementation files; no top-level subcommand

--- a/README.md
+++ b/README.md
@@ -174,13 +174,15 @@ mkdir -p ~/.local/bin && cp dist/phantombot ~/.local/bin/
 | `phantombot task list / show <id> / cancel <id>` | Manage tasks |
 | `phantombot tick` | Fire any due tasks (called every minute by `phantombot-tick.timer`) |
 | `phantombot memory today / search / get / list / index` | Read/write the persona's memory + KB |
+| `phantombot memory capture "<text>" --tag <tag>` | Append a tagged line to today's daily file (`decision` / `lesson` / `person` / `commitment`; `--tag` repeatable) and record it in `capture_log` |
 
 ### Periodic maintenance (called by systemd timers, occasionally by hand)
 
 | Command | What it does |
 |---|---|
 | `phantombot heartbeat` | Mechanical 30-min pass (no LLM) |
-| `phantombot nightly` | Cognitive distillation pass (LLM) |
+| `phantombot nightly [--resume]` | Cognitive distillation pass (LLM), checkpointed in five stages; `--resume` continues from `.nightly-progress.json` |
+| `phantombot doctor [--no-repair]` | Memory-subsystem health check; auto-repairs a missed/failed/partial nightly by spawning `nightly --resume` |
 
 ---
 
@@ -335,16 +337,52 @@ Every service has **two `EnvironmentFile=` lines** (`~/.config/phantombot/.env` 
 
 ## Memory
 
-Local SQLite at `~/.local/share/phantombot/memory.sqlite`. Two tables:
+Phantombot's memory has **two layers** that do different jobs. The SQLite layer is short-term machine state; the markdown layer is the durable, human-readable knowledge the agent accumulates over time. Most "where did my memory go?" confusion comes from conflating the two — so they're documented separately below.
+
+### Layer 1 — SQLite (`memory.sqlite`)
+
+Local SQLite at `~/.local/share/phantombot/memory.sqlite`. Three tables:
 
 ```sql
 turns(id, persona, conversation, role, text, created_at)
 tasks(id, persona, description, schedule, prompt, created_at,
       last_run_at, next_run_at, run_count,
       next_review_at, review_count, active)
+capture_log(id, persona, conversation, tags, created_at)
 ```
 
-Each persona × conversation gets its own namespace (`telegram:<chatId>`, `tick:<task-id>`, etc.). FTS5-based hybrid search via `phantombot memory search` (built into bun:sqlite); optional Gemini embeddings if `phantombot embedding` is configured.
+- **`turns`** is a **rolling per-conversation context buffer, not an archive.** Each persona × conversation namespace (`telegram:<chatId>`, `tick:<task-id>`, `system:nightly:<date>`, …) keeps only its most recent turns so the harness has continuity when threading a reply. Older turns are pruned — on a live box the table holds ~100–150 rows even after thousands of turns. Don't treat it as a transcript log; yesterday's chat is already gone.
+- **`tasks`** backs `phantombot task` — the scheduled-task store.
+- **`capture_log`** records every `phantombot memory capture` invocation (one row, tags joined). It is *not* the memory itself — it's the **observability trail** that lets the 30-turn nudge and `phantombot doctor` answer "did capture actually fire today?".
+
+FTS5-based hybrid search via `phantombot memory search` (built into bun:sqlite); optional Gemini embeddings if `phantombot embedding` is configured.
+
+### Layer 2 — markdown (the persona working directory)
+
+The durable memory lives as plain markdown under `~/.local/share/phantombot/personas/<name>/`, and flows through a four-stage pipeline:
+
+```
+  capture             heartbeat (30 min)       nightly (02:00, LLM)
+  ───────             ──────────────────       ────────────────────
+  memory/             promote tagged lines     distill drawers → KB
+  <YYYY-MM-DD>.md ──▶  into the four drawers ──▶ atomic notes, sweep
+  (daily journal)     (mechanical, no LLM)     kb/inbox/, compress
+```
+
+1. **Daily journal** — `memory/<YYYY-MM-DD>.md`. The agent appends tagged lines as things happen via `phantombot memory capture "<text>" --tag <tag>`, which writes `- [tag] text · HH:MMZ` and creates the file on the day's first capture. Valid tags: `decision`, `lesson`, `person`, `commitment`.
+2. **Drawers** — `memory/{decisions,lessons,people,commitments}.md`. The **heartbeat** (mechanical, every 30 min, no LLM) promotes tagged daily-file lines into the matching structured drawer.
+3. **KB** — `kb/`, an Obsidian-shaped vault of atomic notes with frontmatter and `[[wikilinks]]`. The **nightly** (cognitive, LLM-driven) distills the drawers into KB notes and sweeps `kb/inbox/`.
+4. **Persistent memory** — `MEMORY.md`, the always-loaded summary the nightly keeps lean.
+
+`phantombot memory capture` exists so this protocol has the same shape as every other subsystem — a command, a log line, an exit code, a queryable trace — instead of being a prose-only instruction a harness might silently skip.
+
+### The nightly is checkpointed
+
+The nightly runs as **five idempotent stages** — `essence` → `promote` → `kb` → `compress` → `state` — each its own bounded harness turn. After every completed stage phantombot writes `.nightly-progress.json`. If a stage times out, or the box powers off mid-run, the next invocation (`phantombot nightly --resume`, the startup catch-up, or `phantombot doctor`) skips the finished stages and continues. A timeout therefore costs at most one stage, never the whole night. The final result is recorded in `.nightly-state.json` (`last_run`, `last_status`, item counts).
+
+### Health check
+
+`phantombot doctor` reads `.nightly-state.json`, `.nightly-progress.json` and `capture_log`, and reports — then auto-repairs — memory-subsystem problems: a nightly that never ran, errored, or is >24h stale; a partial checkpoint left behind; or a "dry day" (≥20 real user turns with zero captures). When repair is warranted it spawns a detached `phantombot nightly --resume`. The `run` startup catch-up routes through the same logic, so a box powered off overnight self-heals on next boot.
 
 ---
 
@@ -389,7 +427,7 @@ phantombot/
 │   ├── version.ts                 # CI sed-replaces "0.1.0-dev" with "1.0.<PR_NUMBER>"
 │   ├── config.ts state.ts
 │   ├── persona/                   # loader + builder (system-prompt sections)
-│   ├── memory/                    # bun:sqlite turn store
+│   ├── memory/                    # bun:sqlite store (turns + capture_log)
 │   ├── importer/                  # OpenClaw → phantombot persona import
 │   ├── orchestrator/              # turn coordinator + harness fallback chain
 │   ├── channels/telegram.ts       # Telegram adapter (HTTP + long-poll)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,9 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 | `src/state.ts` | Phantombot-managed runtime state (currently just `default_persona`). Lives at `$XDG_DATA_HOME/phantombot/state.json`. | filesystem |
 | `src/persona/loader.ts` | Reads BOOT.md / SOUL.md / IDENTITY.md (required) + MEMORY.md / tools.md / AGENTS.md (optional). | filesystem |
 | `src/persona/builder.ts` | Concatenates persona pieces + (deferred) retrieved memory + invocation context into a system prompt string. | `loader.ts` |
-| `src/memory/store.ts` | bun:sqlite wrapper. `appendTurn`, `recentTurns`, `recentTurnsForDisplay`, `close`. | `bun:sqlite` |
+| `src/memory/store.ts` | bun:sqlite wrapper. `turns` table (`appendTurn`, `recentTurns`, …) + `capture_log` table (`appendCapture`, `lastCaptureAt`, `countCapturesSince`, turn counters for the nudge/doctor). | `bun:sqlite` |
+| `src/lib/nightly.ts` | Nightly stage list, per-stage prompt bodies, `.nightly-progress.json` checkpoint read/write, `pendingNightlyStages`. | filesystem |
+| `src/cli/doctor.ts` | `phantombot doctor`: reads nightly state/progress + `capture_log`, decides if repair is needed, spawns detached `nightly --resume`. | `memory/store`, `lib/nightly` |
 | `src/importer/openclaw.ts` | Walks an OpenClaw agent dir; copies recognized markdown into the personas dir. | filesystem |
 | `src/orchestrator/turn.ts` | `runTurn`: persona → memory → harness chain → persist. The one function every entry point calls. | `loader`, `builder`, `memory`, `fallback` |
 | `src/orchestrator/fallback.ts` | `runWithFallback`: tries each harness in order, advances on recoverable error, terminates on success or terminal error. Pre-spawn skip when `maxPayloadBytes` is too small. | `harnesses/*` |
@@ -72,6 +74,34 @@ phantombot ask "what's on my calendar?"
   → ask.ts: write the harness's final assistant text to stdout, ensure trailing "\n"
   → exit 0 / 1 / 2
 ```
+
+## Memory subsystem
+
+Memory is two layers — see the README `## Memory` section for the operator-facing
+picture. From an architecture standpoint:
+
+- **SQLite (`memory.sqlite`)** is machine state. `turns` is a *rolling* per-conversation
+  context buffer, deliberately pruned — it is not a transcript archive, and nothing
+  should be designed assuming old turns survive. `capture_log` is append-only and
+  exists purely as an observability trail.
+- **Markdown (the persona dir)** is the durable memory: `memory/<date>.md` daily
+  journals → four structured drawers → `kb/` atomic notes → `MEMORY.md`.
+
+Three properties worth knowing when touching this code:
+
+1. **Capture has a CLI** (`phantombot memory capture`). It is the *only* sanctioned
+   write path into the daily journal, so every capture leaves a `capture_log` row.
+   A CLI cannot *force* a harness to capture — it makes a missed capture observable
+   instead of silent.
+2. **The 30-turn nudge is mechanical.** `src/channels/telegram.ts` counts user turns
+   since the last `capture_log` row; at every multiple of `CAPTURE_NUDGE_INTERVAL`
+   (30) it stacks a fixed reminder onto the next system prompt. No LLM decides this.
+3. **The nightly is checkpointed and resumable.** It is decomposed into five
+   idempotent stages (`essence` → `promote` → `kb` → `compress` → `state`), each a
+   bounded harness turn. `.nightly-progress.json` is written after every stage;
+   `--resume` skips completed stages. A stage timeout costs one stage, not the night.
+   `phantombot doctor` (also wired into the `run` startup catch-up) detects a
+   missed/failed/partial nightly and repairs it by spawning a detached `nightly --resume`.
 
 ## Open design questions
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1109,10 +1109,25 @@ async function processChatMessage(
     refreshIndicator();
   };
 
+  // Mechanical capture nudge: every CAPTURE_NUDGE_INTERVAL user turns
+  // without a `memory capture`, append a reminder to the system-prompt
+  // suffix. Only for real `telegram:*` conversations — never tick:/system:.
+  // runTurn appends this incoming message to `turns` only AFTER the turn,
+  // so we count prior user turns + 1 to land the nudge on the Nth turn.
+  const conversationKey = `telegram:${msg.chatId}`;
+  let captureNudge: string | undefined;
+  if (conversationKey.startsWith("telegram:")) {
+    captureNudge = await captureNudgeForTurn(
+      input.memory,
+      input.persona,
+      conversationKey,
+    );
+  }
+
   try {
     for await (const chunk of runTurn({
       persona: input.persona,
-      conversation: `telegram:${msg.chatId}`,
+      conversation: conversationKey,
       userMessage: msg.text,
       agentDir: input.agentDir,
       harnesses,
@@ -1130,9 +1145,17 @@ async function processChatMessage(
       // Living at the channel layer (not in persona files) keeps these
       // rules from leaking into CLI/nightly turns, where verbosity is
       // fine and the user isn't on a phone.
-      systemPromptSuffix: willReplyWithVoice
-        ? `${TELEGRAM_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
-        : TELEGRAM_REPLY_INSTRUCTION,
+      // The mechanical capture nudge (when due) stacks last so it is
+      // the freshest standing instruction the harness sees this turn —
+      // exactly the salience boost weak harnesses need.
+      systemPromptSuffix: [
+        willReplyWithVoice
+          ? `${TELEGRAM_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
+          : TELEGRAM_REPLY_INSTRUCTION,
+        captureNudge,
+      ]
+        .filter(Boolean)
+        .join("\n\n"),
       // Pre-tool narration: ON for text-out (the user sees streamed
       // text as it lands, so a "checking your calendar..." sentence
       // before a tool call usefully fills the silence). OFF for
@@ -1401,6 +1424,68 @@ sentences and ask the user to confirm or adjust:
 Telegram round-trips are slow and tokens aren't free — confirming up
 front beats producing the wrong thing minutes later. For
 straightforward questions, just answer.`;
+
+/**
+ * Mechanical capture nudge — every {@link CAPTURE_NUDGE_INTERVAL} user
+ * turns without a `memory capture`, the dispatch appends this to the
+ * system-prompt suffix. Pure turn counter; no LLM decides whether to
+ * nudge. Counteracts long-context dilution on weak harnesses that
+ * weight standing instructions less.
+ */
+export const CAPTURE_NUDGE_INTERVAL = 30;
+
+export const CAPTURE_NUDGE_TEXT =
+  `${CAPTURE_NUDGE_INTERVAL} turns without a memory capture in this ` +
+  `conversation. If a decision, lesson, person fact or commitment came ` +
+  `up, capture it now with \`phantombot memory capture\`. If nothing is ` +
+  `worth keeping, carry on — no capture is a valid answer.`;
+
+/**
+ * Decide whether to append the capture nudge for this turn.
+ *
+ * Counts `role = 'user'` turns since the last capture in this
+ * (persona, conversation) — so any capture resets the counter for free
+ * and the nudge re-fires at 2x, 3x, … if still dry. State lives entirely
+ * in `memory.sqlite`, shared by the long-running phantombot process and
+ * the short-lived `memory capture` CLI call, so the two stay in sync.
+ *
+ * The current incoming user message is NOT yet persisted to `turns`
+ * (runTurn appends it only after the turn completes), so the effective
+ * turn index is `countUserTurnsSince(...) + 1`. The nudge fires when
+ * that effective index is a positive multiple of `interval` — i.e. on
+ * the 30th, 60th, … dry turn.
+ *
+ * Only meaningful for real `telegram:*` conversations — the caller is
+ * responsible for that gate.
+ */
+export async function captureNudgeForTurn(
+  memory: MemoryStore,
+  persona: string,
+  conversation: string,
+  interval = CAPTURE_NUDGE_INTERVAL,
+): Promise<string | undefined> {
+  try {
+    const since =
+      (await memory.lastCaptureAt(persona, conversation)) ??
+      "1970-01-01T00:00:00.000Z";
+    const priorTurns = await memory.countUserTurnsSince(
+      persona,
+      conversation,
+      since,
+    );
+    // +1 for the current message, not yet written to `turns`.
+    const effectiveTurn = priorTurns + 1;
+    if (effectiveTurn > 0 && effectiveTurn % interval === 0) {
+      return CAPTURE_NUDGE_TEXT;
+    }
+  } catch (e) {
+    // A nudge is a nice-to-have — never let a counter query fail a turn.
+    log.warn("telegram: capture nudge check failed", {
+      error: (e as Error).message,
+    });
+  }
+  return undefined;
+}
 
 /**
  * Voice-only overlay, stacked on top of TELEGRAM_REPLY_INSTRUCTION

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -266,10 +266,12 @@ export default defineCommand({
       type: "string",
       description: "Persona name (default: configured default).",
     },
-    "no-repair": {
+    repair: {
       type: "boolean",
-      description: "Only report; do not spawn a background nightly --resume.",
-      default: false,
+      description:
+        "Spawn a background `nightly --resume` when repair is warranted. " +
+        "Pass --no-repair to only report.",
+      default: true,
     },
     json: {
       type: "boolean",
@@ -280,7 +282,7 @@ export default defineCommand({
   async run({ args }) {
     process.exitCode = await runDoctor({
       persona: args.persona ? String(args.persona) : undefined,
-      repair: !args["no-repair"],
+      repair: args.repair !== false,
       json: Boolean(args.json),
     });
   },

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,287 @@
+/**
+ * `phantombot doctor` — memory-subsystem health check + auto-repair.
+ *
+ * Reads signals that already exist on disk and in `memory.sqlite`:
+ *   - `.nightly-state.json`    — last run timestamp + status
+ *   - `.nightly-progress.json` — an in-flight / partial checkpoint
+ *   - `capture_log`            — was anything captured in the last 24h?
+ *
+ * It answers the three questions the issue author could only guess at:
+ * did the last nightly run, did it succeed, and is capture actually
+ * firing. When the nightly is stale, failed, or left a partial
+ * checkpoint, doctor spawns `phantombot nightly --resume` as a detached
+ * background process — which, thanks to the checkpointed nightly, picks
+ * up exactly where the last run stopped.
+ *
+ * Invoked manually, from the startup catch-up in `run`, and safe to
+ * wire into any mechanical scheduler (it never runs an LLM in-process —
+ * repair is a detached child).
+ */
+
+import { spawn } from "node:child_process";
+import { defineCommand } from "citty";
+import { existsSync } from "node:fs";
+
+import { type Config, loadConfig, personaDir } from "../config.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { log } from "../lib/logger.ts";
+import {
+  CATCHUP_WINDOW_MS,
+  loadNightlyProgress,
+  loadNightlyState,
+  type NightlyProgress,
+  type NightlyState,
+} from "../lib/nightly.ts";
+import { openMemoryStore } from "../memory/store.ts";
+
+/** Window for the capture-health check: a "dry day" is judged over 24h. */
+const CAPTURE_WINDOW_MS = 24 * 60 * 60 * 1000;
+/**
+ * Below this many real user turns in the window we don't flag a dry
+ * day — a genuinely quiet day legitimately has nothing to capture.
+ */
+const DRY_DAY_TURN_THRESHOLD = 20;
+
+export interface DoctorReport {
+  persona: string;
+  nightly: {
+    last_run?: string;
+    last_status?: string;
+    /** Hours since the last run, or null if it never ran. */
+    age_hours: number | null;
+    stale: boolean;
+    /** A partial/in-progress checkpoint, if one is parked on disk. */
+    checkpoint?: {
+      date: string;
+      status: NightlyProgress["status"];
+      completed_stages: string[];
+      last_error?: string;
+    };
+  };
+  capture: {
+    window_hours: number;
+    user_turns: number;
+    captures: number;
+    /** Many user turns, zero captures — capture is likely not firing. */
+    dry_day: boolean;
+  };
+  repair_needed: boolean;
+  repair_reason?: string;
+  repair_triggered: boolean;
+}
+
+export interface RunDoctorInput {
+  config?: Config;
+  persona?: string;
+  /** Spawn `nightly --resume` when repair is warranted. Default true. */
+  repair?: boolean;
+  /** Emit machine-readable JSON instead of the human summary. */
+  json?: boolean;
+  out?: WriteSink;
+  err?: WriteSink;
+  /** Test seam — override the repair spawn. */
+  spawnRepair?: (persona: string) => void;
+}
+
+function decideRepair(
+  state: NightlyState,
+  progress: NightlyProgress | null,
+  ageHours: number | null,
+): { needed: boolean; reason?: string } {
+  if (progress && progress.status !== "complete") {
+    return {
+      needed: true,
+      reason:
+        `partial nightly checkpoint for ${progress.date} ` +
+        `(${progress.completed_stages.length} stage(s) done` +
+        (progress.last_error ? `; last error: ${progress.last_error}` : "") +
+        ")",
+    };
+  }
+  if (!state.last_run || ageHours === null) {
+    return { needed: true, reason: "no record of any nightly run" };
+  }
+  if (state.last_status === "error" || state.last_status === "partial") {
+    return {
+      needed: true,
+      reason: `last nightly status was '${state.last_status}'`,
+    };
+  }
+  if (ageHours * 3_600_000 > CATCHUP_WINDOW_MS) {
+    return {
+      needed: true,
+      reason: `last nightly ran ${Math.round(ageHours)}h ago (>${
+        CATCHUP_WINDOW_MS / 3_600_000
+      }h)`,
+    };
+  }
+  return { needed: false };
+}
+
+/** Spawn a detached `phantombot nightly --resume` that outlives this process. */
+function defaultSpawnRepair(persona: string): void {
+  const entry = process.argv[1] ?? "";
+  const dev = entry.endsWith(".ts") || entry.endsWith(".js");
+  const args = dev
+    ? [entry, "nightly", "--resume", "--persona", persona]
+    : ["nightly", "--resume", "--persona", persona];
+  const child = spawn(process.execPath, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  log.info("doctor: spawned background nightly --resume", { persona });
+}
+
+export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const repair = input.repair ?? true;
+
+  const config = input.config ?? (await loadConfig());
+  const persona = input.persona ?? config.defaultPersona;
+  const dir = personaDir(config, persona);
+  if (!existsSync(dir)) {
+    err.write(`persona '${persona}' not found at ${dir}\n`);
+    return 2;
+  }
+
+  const state = await loadNightlyState(dir);
+  const progress = await loadNightlyProgress(dir);
+
+  const lastRunMs = state.last_run ? Date.parse(state.last_run) : NaN;
+  const ageHours = Number.isNaN(lastRunMs)
+    ? null
+    : (Date.now() - lastRunMs) / 3_600_000;
+
+  // Capture health — compare real user turns vs captures over 24h.
+  const since = new Date(Date.now() - CAPTURE_WINDOW_MS).toISOString();
+  const memory = await openMemoryStore(config.memoryDbPath);
+  let userTurns = 0;
+  let captures = 0;
+  try {
+    userTurns = await memory.countUserTurnsForPersonaSince(
+      persona,
+      "telegram:",
+      since,
+    );
+    captures = await memory.countCapturesSince(persona, since);
+  } finally {
+    await memory.close();
+  }
+  const dryDay = userTurns >= DRY_DAY_TURN_THRESHOLD && captures === 0;
+
+  const { needed, reason } = decideRepair(state, progress, ageHours);
+
+  let repairTriggered = false;
+  if (needed && repair) {
+    (input.spawnRepair ?? defaultSpawnRepair)(persona);
+    repairTriggered = true;
+  }
+
+  const report: DoctorReport = {
+    persona,
+    nightly: {
+      last_run: state.last_run,
+      last_status: state.last_status,
+      age_hours: ageHours === null ? null : Math.round(ageHours * 10) / 10,
+      stale: needed,
+      ...(progress
+        ? {
+            checkpoint: {
+              date: progress.date,
+              status: progress.status,
+              completed_stages: progress.completed_stages,
+              ...(progress.last_error
+                ? { last_error: progress.last_error }
+                : {}),
+            },
+          }
+        : {}),
+    },
+    capture: {
+      window_hours: CAPTURE_WINDOW_MS / 3_600_000,
+      user_turns: userTurns,
+      captures,
+      dry_day: dryDay,
+    },
+    repair_needed: needed,
+    repair_reason: reason,
+    repair_triggered: repairTriggered,
+  };
+
+  if (input.json) {
+    out.write(JSON.stringify(report, null, 2) + "\n");
+    return needed && !repairTriggered ? 1 : 0;
+  }
+
+  // Human summary.
+  const tick = (ok: boolean) => (ok ? "ok" : "WARN");
+  out.write(`phantombot doctor — persona '${persona}'\n`);
+  out.write(
+    `  nightly: ${tick(!needed)} — ` +
+      (state.last_run
+        ? `last run ${state.last_run} (${report.nightly.age_hours}h ago), status '${
+            state.last_status ?? "unknown"
+          }'`
+        : "never run") +
+      "\n",
+  );
+  if (progress) {
+    out.write(
+      `  checkpoint: ${progress.status} for ${progress.date} — ` +
+        `done [${progress.completed_stages.join(", ") || "none"}]` +
+        (progress.last_error ? ` — ${progress.last_error}` : "") +
+        "\n",
+    );
+  }
+  out.write(
+    `  capture: ${tick(!dryDay)} — ${captures} capture(s), ${userTurns} ` +
+      `user turn(s) in the last ${report.capture.window_hours}h` +
+      (dryDay ? " — DRY DAY: turns but no captures" : "") +
+      "\n",
+  );
+  if (needed) {
+    out.write(`  repair: ${reason}\n`);
+    out.write(
+      repairTriggered
+        ? "  → spawned background `nightly --resume`\n"
+        : "  → run `phantombot nightly --resume` to repair\n",
+    );
+  } else {
+    out.write("  repair: not needed\n");
+  }
+
+  return needed && !repairTriggered ? 1 : 0;
+}
+
+export default defineCommand({
+  meta: {
+    name: "doctor",
+    description:
+      "Memory health check — reports nightly/capture status and auto-repairs a stale or partial nightly by resuming it in the background.",
+  },
+  args: {
+    persona: {
+      type: "string",
+      description: "Persona name (default: configured default).",
+    },
+    "no-repair": {
+      type: "boolean",
+      description: "Only report; do not spawn a background nightly --resume.",
+      default: false,
+    },
+    json: {
+      type: "boolean",
+      description: "Emit the report as JSON (for schedulers / scripts).",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    process.exitCode = await runDoctor({
+      persona: args.persona ? String(args.persona) : undefined,
+      repair: !args["no-repair"],
+      json: Boolean(args.json),
+    });
+  },
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,10 +10,11 @@
  *   run             - run the bot in the foreground (Ctrl-C to stop)
  *   ask             - one-shot prompt through the persona + harness chain
  *
- * Dev/debug commands (chat, doctor, history, list-personas, etc.) were
- * removed as part of the v0.1 surface lock. `ask` was reintroduced for
- * external programs that want Robbie's brain as a non-interactive tool
- * (e.g. the Twilio voice-agent's `askRobbie` relay).
+ * Dev/debug commands (chat, history, list-personas, etc.) were removed
+ * as part of the v0.1 surface lock. `ask` was reintroduced for external
+ * programs that want Robbie's brain as a non-interactive tool (e.g. the
+ * Twilio voice-agent's `askRobbie` relay). `doctor` was reintroduced as
+ * the memory-subsystem health check + nightly auto-repair.
  */
 
 import { defineCommand } from "citty";
@@ -30,6 +31,7 @@ import memoryCmd from "./memory.ts";
 import embeddingCmd from "./embedding.ts";
 import heartbeatCmd from "./heartbeat.ts";
 import nightlyCmd from "./nightly.ts";
+import doctorCmd from "./doctor.ts";
 import envCmd from "./env.ts";
 import notifyCmd from "./notify.ts";
 import taskCmd from "./task.ts";
@@ -59,6 +61,7 @@ export const mainCommand = defineCommand({
     notify: notifyCmd,
     heartbeat: heartbeatCmd,
     nightly: nightlyCmd,
+    doctor: doctorCmd,
     task: taskCmd,
     tick: tickCmd,
     update: updateCmd,

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -16,18 +16,23 @@
  *                              unconditionally so the harness can write to it)
  *   phantombot memory index [--rebuild]
  *                              rebuild the FTS5 index (incremental by default)
+ *   phantombot memory capture "<text>" --tag <tag> [--tag <tag> ...]
+ *                              append a tagged line to today's daily file
+ *                              and record the capture in capture_log
  */
 
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { defaultEmbedder, runEmbedJob } from "../lib/embedJob.ts";
 import { geminiEmbed } from "../lib/geminiEmbed.ts";
+import { TAG_TO_DRAWER } from "../lib/heartbeat.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { MemoryIndex, type Scope } from "../lib/memoryIndex.ts";
+import { openMemoryStore } from "../memory/store.ts";
 
 function indexPath(_config: Config, persona: string): string {
   // One index file per persona — easier to rebuild a single persona without
@@ -286,6 +291,98 @@ export async function runMemoryIndex(
   return 0;
 }
 
+export interface RunCaptureInput extends RunMemoryInput {
+  text: string;
+  tags: string[];
+  persona?: string;
+  /** Conversation key the capture belongs to. Default: cli:default. */
+  conversation?: string;
+  /** Override "today" for testing. ISO date YYYY-MM-DD. */
+  date?: string;
+  /** Override "now" for the line timestamp (testing). */
+  now?: Date;
+}
+
+/**
+ * `phantombot memory capture` — append one tagged line per tag to today's
+ * daily file and record the capture in `capture_log`.
+ *
+ * Gives the capture protocol the same observable shape every other
+ * harness-facing tool has: a command, a log line, an exit code. The line
+ * leads with the tag (`- [decision] … · 09:34Z`) so the heartbeat
+ * promotion regex matches and the timestamp lands at the end where it
+ * won't break the `[a-z]+` tag capture.
+ */
+export async function runMemoryCapture(
+  input: RunCaptureInput,
+): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const config = input.config ?? (await loadConfig());
+  const { persona, dir } = resolvePersonaDir(config, input.persona);
+
+  if (!existsSync(dir)) {
+    err.write(`persona '${persona}' not found at ${dir}\n`);
+    return 2;
+  }
+
+  const text = input.text.trim();
+  if (text.length === 0) {
+    err.write("memory capture: empty text\n");
+    return 2;
+  }
+
+  const tags = input.tags.map((t) => t.trim().toLowerCase()).filter(Boolean);
+  if (tags.length === 0) {
+    err.write("memory capture: at least one --tag is required\n");
+    return 2;
+  }
+  for (const tag of tags) {
+    if (!TAG_TO_DRAWER[tag]) {
+      err.write(
+        `memory capture: unknown tag '${tag}'. ` +
+          `Valid tags: ${Object.keys(TAG_TO_DRAWER).sort().join(", ")}\n`,
+      );
+      return 2;
+    }
+  }
+
+  const now = input.now ?? new Date();
+  const date = input.date ?? now.toISOString().slice(0, 10);
+  const memDir = join(dir, "memory");
+  await mkdir(memDir, { recursive: true });
+  const dailyPath = join(memDir, `${date}.md`);
+
+  // Create today's daily file with a one-line header if it doesn't exist.
+  if (!existsSync(dailyPath)) {
+    await Bun.write(dailyPath, `# ${date}\n`);
+  }
+
+  // HH:MMZ — appended at the END of the line so the heartbeat tag regex
+  // (/^\s*-?\s*\[([a-z]+)\]\s+(.+)$/i) still matches.
+  const stamp = `${now.toISOString().slice(11, 16)}Z`;
+  let block = "";
+  for (const tag of tags) {
+    block += `- [${tag}] ${text} · ${stamp}\n`;
+  }
+  await appendFile(dailyPath, block, "utf8");
+
+  // Record the capture so the nudge counter and `doctor` can see it.
+  const conversation = input.conversation ?? "cli:default";
+  const store = await openMemoryStore(config.memoryDbPath);
+  try {
+    await store.appendCapture({ persona, conversation, tags });
+  } finally {
+    await store.close();
+  }
+
+  out.write(
+    `memory capture: tags=${tags.join(",")} conv=${conversation} ` +
+      `persona=${persona} ok\n`,
+  );
+  return 0;
+}
+
 // ---------------------------------------------------------------------------
 // Citty subcommand wiring
 // ---------------------------------------------------------------------------
@@ -373,11 +470,50 @@ const indexCmd = defineCommand({
   },
 });
 
+const captureCmd = defineCommand({
+  meta: {
+    name: "capture",
+    description:
+      "Append a tagged line to today's daily file and record the capture (decision | lesson | person | commitment).",
+  },
+  args: {
+    text: {
+      type: "positional",
+      description: "The thing worth keeping.",
+      required: true,
+    },
+    tag: {
+      type: "string",
+      description:
+        "Tag (decision | lesson | person | commitment). Repeatable for multi-tag.",
+      required: true,
+    },
+    persona: { type: "string", description: "Persona name." },
+    conversation: {
+      type: "string",
+      description: "Conversation key this capture belongs to (default cli:default).",
+    },
+  },
+  async run({ args }) {
+    // citty collapses repeated --tag into a string OR string[]; normalise.
+    const rawTag = args.tag as unknown;
+    const tags = Array.isArray(rawTag)
+      ? rawTag.map(String)
+      : [String(rawTag)];
+    process.exitCode = await runMemoryCapture({
+      text: String(args.text),
+      tags,
+      persona: args.persona ? String(args.persona) : undefined,
+      conversation: args.conversation ? String(args.conversation) : undefined,
+    });
+  },
+});
+
 export default defineCommand({
   meta: {
     name: "memory",
     description:
-      "Memory tools the harness can call from its Bash loop (search, get, list, today, index).",
+      "Memory tools the harness can call from its Bash loop (search, get, list, today, index, capture).",
   },
   subCommands: {
     search: searchCmd,
@@ -385,5 +521,6 @@ export default defineCommand({
     list: listCmd,
     today: todayCmd,
     index: indexCmd,
+    capture: captureCmd,
   },
 });

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -1,17 +1,28 @@
 /**
  * `phantombot nightly` — runs the cognitive distillation pass.
  *
- * Spawns the harness once with the nightly prompt as a system-prompt
- * suffix and the prompt body as the user message. Conversation key is
- * `system:nightly:<YYYY-MM-DD>` so it's isolated from Telegram chats
- * and from any other phantombot conversation namespace.
+ * The pass is CHECKPOINTED: it is decomposed into five idempotent stages
+ * (essence → promote → kb → compress → state), each run as its own
+ * harness turn. After every completed stage phantombot writes
+ * `.nightly-progress.json`. If a stage times out — or the box powers off
+ * mid-run — the next invocation with `--resume` (or the startup catch-up,
+ * or `phantombot doctor`) skips the finished stages and continues. A
+ * timeout therefore costs at most one stage, never the whole night.
  *
- * Schedule: runs daily at 02:00 local via systemd timer (installed
- * by `phantombot install`). Manual invocation works the same.
+ * Conversation key is `system:nightly:<YYYY-MM-DD>` so every stage is
+ * isolated from Telegram chats and shares context across stages.
+ *
+ * If the persona ships a `nightly-prompt.md` override, that custom
+ * prompt is run as a single monolithic turn (no checkpointing) — the
+ * override owns the phase contract, so phantombot can't safely split it.
+ *
+ * Schedule: runs daily at 02:00 local via systemd timer. Manual
+ * invocation works the same.
  */
 
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { ClaudeHarness } from "../harnesses/claude.ts";
@@ -21,19 +32,77 @@ import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import {
   buildNightlyPromptForPersona,
+  buildNightlyStagePrompt,
+  clearNightlyProgress,
+  type NightlyStage,
   nightlyConversationKey,
+  type NightlyProgress,
+  pendingNightlyStages,
+  saveNightlyProgress,
   saveNightlyState,
 } from "../lib/nightly.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
+
+const NIGHTLY_SUFFIX =
+  "You are operating in NIGHTLY MAINTENANCE MODE. " +
+  "Skip pleasantries. Do work, write files, report briefly.";
+
+// Per-stage timeouts. A single stage is far smaller than the old
+// monolithic pass, so the hard cap can be tighter; idle stays at 5 min
+// to tolerate long thinking between tool calls.
+const STAGE_IDLE_TIMEOUT_MS = 5 * 60_000;
+const STAGE_HARD_TIMEOUT_MS = 20 * 60_000;
 
 export interface RunNightlyInput {
   config?: Config;
   persona?: string;
   /** Override "today" — useful for backfill or testing. ISO YYYY-MM-DD. */
   today?: string;
+  /** Resume from `.nightly-progress.json` instead of starting fresh. */
+  resume?: boolean;
   out?: WriteSink;
   err?: WriteSink;
+}
+
+interface TurnResult {
+  finalReply: string;
+  errored?: string;
+  durationMs: number;
+}
+
+/** Run one harness turn for the nightly conversation. */
+async function runNightlyTurn(opts: {
+  persona: string;
+  conversation: string;
+  userMessage: string;
+  agentDir: string;
+  harnesses: Harness[];
+  memory: Awaited<ReturnType<typeof openMemoryStore>>;
+}): Promise<TurnResult> {
+  const startedAt = Date.now();
+  let finalReply = "";
+  let errored: string | undefined;
+  try {
+    for await (const chunk of runTurn({
+      persona: opts.persona,
+      conversation: opts.conversation,
+      userMessage: opts.userMessage,
+      agentDir: opts.agentDir,
+      harnesses: opts.harnesses,
+      memory: opts.memory,
+      idleTimeoutMs: STAGE_IDLE_TIMEOUT_MS,
+      hardTimeoutMs: STAGE_HARD_TIMEOUT_MS,
+      systemPromptSuffix: NIGHTLY_SUFFIX,
+    })) {
+      if (chunk.type === "text") finalReply += chunk.text;
+      if (chunk.type === "done") finalReply = chunk.finalText;
+      if (chunk.type === "error") errored = chunk.error;
+    }
+  } catch (e) {
+    errored = (e as Error).message;
+  }
+  return { finalReply, errored, durationMs: Date.now() - startedAt };
 }
 
 export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
@@ -56,69 +125,135 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
 
   const today = input.today ?? new Date().toISOString().slice(0, 10);
   const conversation = nightlyConversationKey(today);
-  const prompt = await buildNightlyPromptForPersona(dir, persona, today);
-
-  out.write(
-    `nightly: persona='${persona}' date=${today} conversation=${conversation}\n`,
-  );
-
   const memory = await openMemoryStore(config.memoryDbPath);
-  const startedAt = Date.now();
-  let finalReply = "";
-  let errored: string | undefined;
+  const runStartedAt = Date.now();
 
   try {
-    for await (const chunk of runTurn({
-      persona,
-      conversation,
-      userMessage: prompt,
-      agentDir: dir,
-      harnesses,
-      memory,
-      // Nightly tasks chew on long thinking — accept up to 5 minutes of
-      // silence between tool calls before assuming wedged. Hard cap stays
-      // at 30 minutes (matches the original behavior).
-      idleTimeoutMs: 5 * 60_000,
-      hardTimeoutMs: 30 * 60_000,
-      systemPromptSuffix:
-        "You are operating in NIGHTLY MAINTENANCE MODE. " +
-        "Skip pleasantries. Do work, write files, report briefly.",
-    })) {
-      if (chunk.type === "text") finalReply += chunk.text;
-      if (chunk.type === "done") finalReply = chunk.finalText;
-      if (chunk.type === "error") errored = chunk.error;
+    // A persona-provided override owns the whole phase contract; we
+    // can't safely chunk it, so run it as one monolithic turn.
+    if (existsSync(join(dir, "nightly-prompt.md"))) {
+      out.write(
+        `nightly: persona='${persona}' date=${today} conversation=${conversation} (override prompt — monolithic, no checkpointing)\n`,
+      );
+      const prompt = await buildNightlyPromptForPersona(dir, persona, today);
+      const r = await runNightlyTurn({
+        persona,
+        conversation,
+        userMessage: prompt,
+        agentDir: dir,
+        harnesses,
+        memory,
+      });
+      if (r.errored) log.error("nightly: override turn failed", { error: r.errored });
+      await saveNightlyState(dir, {
+        last_run: new Date().toISOString(),
+        last_status: r.errored ? "error" : "ok",
+        ...(r.errored ? { errors: [r.errored] } : {}),
+      });
+      out.write(
+        `nightly ${r.errored ? "FAILED" : "ok"}: ${r.durationMs}ms` +
+          (r.errored ? ` — ${r.errored}` : "") +
+          `\n`,
+      );
+      return r.errored ? 1 : 0;
     }
-  } catch (e) {
-    errored = (e as Error).message;
-    log.error("nightly: turn threw", { error: errored });
+
+    // Checkpointed path: run each pending stage, checkpoint after each.
+    const stages = await pendingNightlyStages(dir, today, input.resume ?? false);
+    const allStages: NightlyStage[] = [
+      "essence",
+      "promote",
+      "kb",
+      "compress",
+      "state",
+    ];
+    const completed = allStages.filter((s) => !stages.includes(s));
+
+    out.write(
+      `nightly: persona='${persona}' date=${today} conversation=${conversation}\n`,
+    );
+    if (stages.length === 0) {
+      out.write("nightly: all stages already complete for today — nothing to do\n");
+      return 0;
+    }
+    if (completed.length > 0) {
+      out.write(
+        `nightly: resuming — ${completed.length} stage(s) already done [${completed.join(", ")}], ${stages.length} remaining\n`,
+      );
+    }
+
+    const progress: NightlyProgress = {
+      date: today,
+      started_at: new Date(runStartedAt).toISOString(),
+      updated_at: new Date().toISOString(),
+      completed_stages: [...completed],
+      status: "in_progress",
+    };
+    await saveNightlyProgress(dir, progress);
+
+    for (const stage of stages) {
+      out.write(`nightly: stage '${stage}' starting\n`);
+      const prompt = buildNightlyStagePrompt(persona, today, stage);
+      const r = await runNightlyTurn({
+        persona,
+        conversation,
+        userMessage: prompt,
+        agentDir: dir,
+        harnesses,
+        memory,
+      });
+
+      if (r.errored) {
+        // Checkpoint stays at the last good stage; status -> partial so
+        // resume / doctor pick up exactly here next time.
+        progress.status = "partial";
+        progress.last_error = `stage '${stage}': ${r.errored}`;
+        progress.updated_at = new Date().toISOString();
+        await saveNightlyProgress(dir, progress);
+        await saveNightlyState(dir, {
+          last_run: new Date().toISOString(),
+          last_status: "partial",
+          errors: [`stage '${stage}': ${r.errored}`],
+        });
+        log.error("nightly: stage failed — checkpoint saved", {
+          persona,
+          date: today,
+          stage,
+          error: r.errored,
+          completed: progress.completed_stages,
+        });
+        out.write(
+          `nightly PARTIAL: stage '${stage}' failed after ${r.durationMs}ms — ${r.errored}\n` +
+            `nightly: ${progress.completed_stages.length}/${allStages.length} stages done; rerun with --resume to continue\n`,
+        );
+        return 1;
+      }
+
+      progress.completed_stages.push(stage);
+      progress.updated_at = new Date().toISOString();
+      await saveNightlyProgress(dir, progress);
+      out.write(`nightly: stage '${stage}' ok (${r.durationMs}ms)\n`);
+    }
+
+    // Every stage done — clear the checkpoint and stamp success.
+    progress.status = "complete";
+    await clearNightlyProgress(dir);
+    await saveNightlyState(dir, {
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const totalMs = Date.now() - runStartedAt;
+    out.write(`nightly ok: ${allStages.length} stages, ${totalMs}ms total\n`);
+    log.info("nightly: complete", {
+      persona,
+      date: today,
+      durationMs: totalMs,
+      stages: allStages.length,
+    });
+    return 0;
   } finally {
     await memory.close();
   }
-
-  const durationMs = Date.now() - startedAt;
-  // If the harness wrote .nightly-state.json itself (per the prompt), great.
-  // We ALSO record a phantombot-side timestamp so we never lose the
-  // last-run anchor even if the harness flubbed phase 5.
-  await saveNightlyState(dir, {
-    last_run: new Date().toISOString(),
-    last_status: errored ? "error" : "ok",
-    ...(errored ? { errors: [errored] } : {}),
-  });
-
-  out.write(
-    `nightly ${errored ? "FAILED" : "ok"}: ` +
-      `${durationMs}ms, ${finalReply.length} reply chars` +
-      (errored ? ` — ${errored}` : "") +
-      `\n`,
-  );
-  log.info("nightly: complete", {
-    persona,
-    date: today,
-    durationMs,
-    replyChars: finalReply.length,
-    ok: !errored,
-  });
-  return errored ? 1 : 0;
 }
 
 function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
@@ -135,7 +270,7 @@ export default defineCommand({
   meta: {
     name: "nightly",
     description:
-      "Run the cognitive distillation pass — promote, KB-feed, compress. Isolated conversation; long-running; manual or via the systemd timer.",
+      "Run the cognitive distillation pass — promote, KB-feed, compress. Checkpointed into resumable stages; isolated conversation; manual or via the systemd timer.",
   },
   args: {
     persona: {
@@ -146,11 +281,18 @@ export default defineCommand({
       type: "string",
       description: "Override today's date (YYYY-MM-DD); useful for backfill.",
     },
+    resume: {
+      type: "boolean",
+      description:
+        "Resume from .nightly-progress.json — skip stages already completed today.",
+      default: false,
+    },
   },
   async run({ args }) {
     process.exitCode = await runNightly({
       persona: args.persona ? String(args.persona) : undefined,
       today: args.date ? String(args.date) : undefined,
+      resume: Boolean(args.resume),
     });
   },
 });

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -17,7 +17,6 @@ import { type Config, loadConfig, personaDir } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
-import { shouldRunCatchupNightly } from "../lib/nightly.ts";
 import { healDefaultPersonaIfBroken } from "../lib/personaDefault.ts";
 import { logsCommand, statusCommand } from "../lib/platform.ts";
 import {
@@ -28,7 +27,7 @@ import {
 import { notifyPostRestartIfPending } from "../lib/updateNotify.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { VERSION } from "../version.ts";
-import { runNightly } from "./nightly.ts";
+import { runDoctor } from "./doctor.ts";
 
 export interface RunInput {
   config?: Config;
@@ -128,21 +127,20 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   );
   out.write("Ctrl-C to stop.\n");
 
-  // Catch-up nightly: if the machine was off during the 02:00 window
-  // and the last run is >24h stale, fire it now in the background.
-  // Don't await — must not slow startup.
-  if (await shouldRunCatchupNightly(agentDir)) {
-    log.info("run: nightly stale, starting background catch-up");
-    runNightly({ config, persona, out, err }).then(
-      (code) => {
-        if (code !== 0) log.warn("run: catch-up nightly exited", { code });
-      },
-      (e: unknown) =>
-        log.error("run: catch-up nightly threw", {
-          error: (e as Error).message,
-        }),
-    );
-  }
+  // Startup catch-up: `doctor` checks for a stale, failed, or partially
+  // checkpointed nightly and, if found, spawns a detached
+  // `nightly --resume` that picks up from the last good stage. This
+  // covers machines powered off during the 02:00 window. Don't await —
+  // doctor's repair is a detached child, so this returns immediately.
+  runDoctor({ config, persona, out, err }).then(
+    (code) => {
+      if (code !== 0) log.info("run: startup doctor flagged an issue", { code });
+    },
+    (e: unknown) =>
+      log.error("run: startup doctor threw", {
+        error: (e as Error).message,
+      }),
+  );
 
   const ac = new AbortController();
   const onSig = () => ac.abort();

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -43,7 +43,13 @@ export interface HeartbeatResult {
   updateCheck?: CheckAndNotifyOnceResult;
 }
 
-const TAG_TO_DRAWER: Record<string, string> = {
+/**
+ * Tag → drawer mapping. Both singular and plural spellings are accepted
+ * so the heartbeat promotion and `phantombot memory capture` agree on
+ * exactly the same vocabulary. Exported so the CLI validates against the
+ * single source of truth.
+ */
+export const TAG_TO_DRAWER: Record<string, string> = {
   decision: "memory/decisions.md",
   decisions: "memory/decisions.md",
   lesson: "memory/lessons.md",

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -26,7 +26,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "./logger.ts";
 
@@ -47,6 +47,112 @@ export function nightlyConversationKey(date: string): string {
 
 export function nightlyStatePath(personaDir: string): string {
   return join(personaDir, "memory", ".nightly-state.json");
+}
+
+// ---------------------------------------------------------------------------
+// Checkpointed nightly — stage model
+// ---------------------------------------------------------------------------
+
+/**
+ * The nightly pass decomposed into idempotent stages. Each stage is one
+ * bounded harness turn; phantombot checkpoints after every completed
+ * stage to `.nightly-progress.json`. A run that times out (or the box
+ * powering off) loses at most the in-flight stage — the next run resumes
+ * from the checkpoint instead of redoing the whole night.
+ *
+ * Order matters: `essence` and `promote` read the daily file, `kb`
+ * synthesises (the long pole), `compress` trims MEMORY.md, `state`
+ * records counts.
+ */
+export type NightlyStage =
+  | "essence"
+  | "promote"
+  | "kb"
+  | "compress"
+  | "state";
+
+export const NIGHTLY_STAGES: readonly NightlyStage[] = [
+  "essence",
+  "promote",
+  "kb",
+  "compress",
+  "state",
+] as const;
+
+export interface NightlyProgress {
+  /** ISO date (YYYY-MM-DD) this checkpoint belongs to. */
+  date: string;
+  started_at: string;
+  updated_at: string;
+  /** Stages finished successfully, in completion order. */
+  completed_stages: NightlyStage[];
+  status: "in_progress" | "partial" | "complete";
+  /** Message from the stage that failed/timed out, if any. */
+  last_error?: string;
+}
+
+export function nightlyProgressPath(personaDir: string): string {
+  return join(personaDir, "memory", ".nightly-progress.json");
+}
+
+/** Read the current checkpoint. Returns null if none exists. */
+export async function loadNightlyProgress(
+  personaDir: string,
+): Promise<NightlyProgress | null> {
+  const p = nightlyProgressPath(personaDir);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(await readFile(p, "utf8")) as NightlyProgress;
+  } catch (e) {
+    log.warn("nightly: progress file unreadable; treating as absent", {
+      error: (e as Error).message,
+    });
+    return null;
+  }
+}
+
+export async function saveNightlyProgress(
+  personaDir: string,
+  progress: NightlyProgress,
+): Promise<void> {
+  await writeFile(
+    nightlyProgressPath(personaDir),
+    JSON.stringify(progress, null, 2) + "\n",
+    "utf8",
+  );
+}
+
+/** Remove the checkpoint — called once all stages complete. */
+export async function clearNightlyProgress(
+  personaDir: string,
+): Promise<void> {
+  const p = nightlyProgressPath(personaDir);
+  if (!existsSync(p)) return;
+  try {
+    await rm(p);
+  } catch (e) {
+    log.warn("nightly: could not clear progress file", {
+      error: (e as Error).message,
+    });
+  }
+}
+
+/**
+ * Given a persona dir and the date being processed, return the stages
+ * still to run. Honors an existing checkpoint ONLY when it belongs to
+ * the same date — a stale checkpoint from a previous day is ignored so
+ * we always start a fresh day clean.
+ */
+export async function pendingNightlyStages(
+  personaDir: string,
+  today: string,
+  resume: boolean,
+): Promise<NightlyStage[]> {
+  if (!resume) return [...NIGHTLY_STAGES];
+  const progress = await loadNightlyProgress(personaDir);
+  if (!progress || progress.date !== today) return [...NIGHTLY_STAGES];
+  const done = new Set(progress.completed_stages);
+  return NIGHTLY_STAGES.filter((s) => !done.has(s));
 }
 
 /**
@@ -189,4 +295,72 @@ PHASE 5 — State report
     errors           (array of strings — anything that went wrong; empty array on full success)
 
 When you're done, your final reply (which won't go anywhere user-facing) should be a brief sentence acknowledging completion. Phantombot will log it.`;
+}
+
+/**
+ * Common preamble for every checkpointed nightly stage — the tools list
+ * and the isolation note, shared by all five stage prompts.
+ */
+function nightlyStagePreamble(personaName: string, today: string): string {
+  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Today is ${today}.
+
+This conversation is ISOLATED (conversation key system:nightly:${today}); nothing you say here will appear in Telegram or any user-facing chat. Speak in summaries, not replies.
+
+You have access to phantombot's memory tools via Bash:
+
+  phantombot memory today                       # path to today's daily file
+  phantombot memory search "<query>"            # FTS5 + (if configured) semantic search
+  phantombot memory get <persona-relative-path> # cat a file
+  phantombot memory list <persona-relative-dir> # ls a dir
+  phantombot memory index --rebuild             # full reindex (FTS + embeddings)
+
+You also have your normal Read / Write / Edit tools — use them on files inside this persona's working directory. The structured drawers are under memory/ and the KB vault under kb/.
+
+This nightly run is CHECKPOINTED: you are executing exactly ONE stage. Do only the stage described below, then stop with a one-line completion note. Do not run other phases — phantombot drives them as separate turns.`;
+}
+
+/** Per-stage instruction body. Mirrors the phases of {@link buildNightlyPrompt}. */
+const NIGHTLY_STAGE_BODY: Record<NightlyStage, (today: string) => string> = {
+  essence: (today) => `STAGE: DAY ESSENCE
+Read today's daily file (memory/${today}.md). If it exists and is non-empty, prepend a 2-3 line "Day essence" section summarising what mattered today. If the file is missing or empty, do nothing and say so.`,
+  promote: (today) => `STAGE: PROMOTE TO DRAWERS
+Re-read the daily file (memory/${today}.md). For each promote-able item the heartbeat has not already filed:
+  - People / relationships   → memory/people.md
+  - Decisions with rationale → memory/decisions.md
+  - Mistakes and learnings   → memory/lessons.md
+  - Deadlines / obligations  → memory/commitments.md
+Append under a "## ${today}" header. Do not duplicate items the heartbeat already promoted.`,
+  kb: () => `STAGE: FEED THE KB
+Re-read today's daily file for durable knowledge (procedures, configs, runbooks, concepts, decisions worth keeping). For each candidate:
+  a) phantombot memory search "<topic>" to check for existing coverage
+  b) If a note already covers the area, open and update it (new case, edge cases, links)
+  c) Otherwise create a new atomic note in the right kb/<category>/ subdir from a kb/templates/ scaffold. Frontmatter required: type, tags, created, updated. Link related notes with [[wikilinks]].
+Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
+Finish with \`phantombot memory index --rebuild\` so new notes get embeddings.`,
+  compress: () => `STAGE: COMPRESS MEMORY.md
+MEMORY.md should stay short (orientation layer only). If it is bloated, move detail into the relevant KB note(s) and leave a short pointer. Clear items from "## Recent" that have now been distilled to a permanent home.`,
+  state: (today) => `STAGE: STATE REPORT
+Write memory/.nightly-state.json (overwrite). Include:
+  last_run         (ISO 8601 timestamp — now)
+  last_status      ("ok" | "partial" | "error")
+  items_promoted   (count of items promoted in the PROMOTE stage)
+  kb_notes_updated (existing-note edits from the KB stage)
+  kb_notes_created (new notes from the KB stage)
+  errors           (array of strings; empty array on full success)
+Use \`phantombot memory get\`/your Read tool to recall counts from this conversation's earlier stages. Phantombot also patches last_run/last_status itself, so an approximate count is fine — date ${today}.`,
+};
+
+/**
+ * Build the user-message for ONE checkpointed nightly stage. Used by the
+ * resumable nightly driver, which runs each stage as a separate harness
+ * turn and checkpoints between them.
+ */
+export function buildNightlyStagePrompt(
+  personaName: string,
+  today: string,
+  stage: NightlyStage,
+): string {
+  return `${nightlyStagePreamble(personaName, today)}
+
+${NIGHTLY_STAGE_BODY[stage](today)}`;
 }

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,8 +1,13 @@
 /**
  * Memory store. SQLite-backed via bun:sqlite (no native compile, no extra deps).
  *
- * Schema is one table:
+ * Schema is two tables:
  *   turns(id, persona, conversation, role, text, created_at)
+ *   capture_log(id, persona, conversation, tags, created_at)
+ *
+ * `capture_log` records every `phantombot memory capture` invocation —
+ * it gives the otherwise-invisible capture protocol a queryable trace
+ * and backs the mechanical "N turns without a capture" nudge.
  *
  * Turns are scoped by (persona, conversation). The conversation key is
  * 'cli:default' for v1 — phantombot is a single-operator CLI tool, so all
@@ -36,6 +41,13 @@ export interface AppendTurnInput {
   text: string;
 }
 
+export interface AppendCaptureInput {
+  persona: string;
+  conversation: string;
+  /** Tags applied to this capture (already validated by the caller). */
+  tags: string[];
+}
+
 export interface MemoryStore {
   /** Persist one turn. Auto-stamps created_at to "now" UTC. */
   appendTurn(turn: AppendTurnInput): Promise<void>;
@@ -49,6 +61,40 @@ export interface MemoryStore {
   recentTurnsForDisplay(persona: string, n: number): Promise<Turn[]>;
   /** Delete all turns for a (persona, conversation) pair. Used by /reset. */
   deleteConversation(persona: string, conversation: string): Promise<number>;
+  /** Record one `memory capture` invocation. Auto-stamps created_at UTC. */
+  appendCapture(input: AppendCaptureInput): Promise<void>;
+  /**
+   * ISO timestamp of the most recent capture in (persona, conversation),
+   * or undefined if this pair has never captured.
+   */
+  lastCaptureAt(
+    persona: string,
+    conversation: string,
+  ): Promise<string | undefined>;
+  /**
+   * Count `role = 'user'` turns in (persona, conversation) with
+   * `created_at > since`. Used by the mechanical capture nudge.
+   */
+  countUserTurnsSince(
+    persona: string,
+    conversation: string,
+    since: string,
+  ): Promise<number>;
+  /**
+   * Count capture_log rows for one persona with `created_at >= since`.
+   * Used by `doctor` to detect a fully dry capture day.
+   */
+  countCapturesSince(persona: string, since: string): Promise<number>;
+  /**
+   * Count `role = 'user'` turns for one persona, across conversations
+   * matching `conversationPrefix` (SQL LIKE-escaped), with
+   * `created_at >= since`. Used by `doctor`'s capture-health check.
+   */
+  countUserTurnsForPersonaSince(
+    persona: string,
+    conversationPrefix: string,
+    since: string,
+  ): Promise<number>;
   /** Close the underlying SQLite connection. Safe to call once; idempotent thereafter. */
   close(): Promise<void>;
 }
@@ -66,6 +112,16 @@ CREATE INDEX IF NOT EXISTS idx_turns_persona_conv_time
   ON turns (persona, conversation, created_at);
 CREATE INDEX IF NOT EXISTS idx_turns_persona_time
   ON turns (persona, created_at);
+
+CREATE TABLE IF NOT EXISTS capture_log (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  persona      TEXT NOT NULL,
+  conversation TEXT NOT NULL,
+  tags         TEXT NOT NULL,
+  created_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_capture_persona_conv_time
+  ON capture_log (persona, conversation, created_at);
 `;
 
 interface RawDisplayRow {
@@ -82,6 +138,10 @@ class SqliteMemoryStore implements MemoryStore {
   private recentStmt;
   private recentDisplayStmt;
   private deleteStmt;
+  private appendCaptureStmt;
+  private lastCaptureStmt;
+  private countTurnsSinceStmt;
+  private countCapturesSinceStmt;
   private closed = false;
 
   constructor(private db: Database) {
@@ -110,6 +170,23 @@ class SqliteMemoryStore implements MemoryStore {
     );
     this.deleteStmt = db.prepare(
       "DELETE FROM turns WHERE persona = ? AND conversation = ?",
+    );
+    this.appendCaptureStmt = db.prepare(
+      "INSERT INTO capture_log (persona, conversation, tags, created_at) VALUES (?, ?, ?, ?)",
+    );
+    this.lastCaptureStmt = db.prepare(
+      `SELECT created_at FROM capture_log
+       WHERE persona = ? AND conversation = ?
+       ORDER BY created_at DESC, id DESC LIMIT 1`,
+    );
+    this.countTurnsSinceStmt = db.prepare(
+      `SELECT COUNT(*) AS n FROM turns
+       WHERE persona = ? AND conversation = ?
+         AND role = 'user' AND created_at > ?`,
+    );
+    this.countCapturesSinceStmt = db.prepare(
+      `SELECT COUNT(*) AS n FROM capture_log
+       WHERE persona = ? AND created_at >= ?`,
     );
   }
 
@@ -144,6 +221,61 @@ class SqliteMemoryStore implements MemoryStore {
       text: r.text,
       createdAt: new Date(r.created_at),
     }));
+  }
+
+  async appendCapture(input: AppendCaptureInput): Promise<void> {
+    this.appendCaptureStmt.run(
+      input.persona,
+      input.conversation,
+      input.tags.join(","),
+      new Date().toISOString(),
+    );
+  }
+
+  async lastCaptureAt(
+    persona: string,
+    conversation: string,
+  ): Promise<string | undefined> {
+    const row = this.lastCaptureStmt.get(persona, conversation) as
+      | { created_at: string }
+      | undefined;
+    return row?.created_at;
+  }
+
+  async countUserTurnsSince(
+    persona: string,
+    conversation: string,
+    since: string,
+  ): Promise<number> {
+    const row = this.countTurnsSinceStmt.get(persona, conversation, since) as {
+      n: number;
+    };
+    return row.n;
+  }
+
+  async countCapturesSince(persona: string, since: string): Promise<number> {
+    const row = this.countCapturesSinceStmt.get(persona, since) as {
+      n: number;
+    };
+    return row.n;
+  }
+
+  async countUserTurnsForPersonaSince(
+    persona: string,
+    conversationPrefix: string,
+    since: string,
+  ): Promise<number> {
+    // Escape LIKE wildcards in the caller-supplied prefix, then anchor it
+    // with a trailing % so `telegram:` matches `telegram:123` etc.
+    const escaped = conversationPrefix.replace(/[\\%_]/g, "\\$&");
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM turns
+         WHERE persona = ? AND role = 'user' AND created_at >= ?
+           AND conversation LIKE ? ESCAPE '\\'`,
+      )
+      .get(persona, since, `${escaped}%`) as { n: number };
+    return row.n;
   }
 
   async close(): Promise<void> {

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -91,6 +91,7 @@ commands you can run from your Bash tool:
   phantombot memory get <persona-relative-path>   # cat a file
   phantombot memory list <persona-relative-dir>   # ls a dir
   phantombot memory index [--rebuild]             # refresh search index
+  phantombot memory capture "<text>" --tag <tag>  # record a tagged note
 
 Layout (relative to your working dir):
 
@@ -110,12 +111,19 @@ Two hard rules — apply on every nontrivial task:
    first. If memory or KB has prior knowledge, use it. Investigate
    from scratch only if neither found anything.
 
-2. CAPTURE AS YOU GO. Decisions / lessons / commitments go in today's
-   daily file (\`phantombot memory today\` returns the path) — tag them
-   with \`[decision]\`, \`[lesson]\`, \`[person]\`, or \`[commitment]\` so
-   the heartbeat (every 30 min) and nightly cycle can promote them
-   to the right drawer. KB-worthy thoughts go in
-   \`kb/inbox/<short-name>.md\`. The nightly cycle files them later.
+2. CAPTURE AS YOU GO. When a decision, lesson, person fact, or
+   commitment comes up, record it with:
+
+     phantombot memory capture "<the thing worth keeping>" --tag <tag>
+
+   where \`<tag>\` is \`decision\`, \`lesson\`, \`person\`, or
+   \`commitment\` (repeat \`--tag\` for more than one). This appends a
+   tagged line to today's daily file so the heartbeat (every 30 min)
+   and nightly cycle promote it to the right drawer — and logs the
+   capture so a missed day is visible rather than silent. KB-worthy
+   thoughts go in \`kb/inbox/<short-name>.md\`; the nightly cycle files
+   them later. If nothing is worth keeping, that's fine — no capture
+   is a valid answer.
 
 The heartbeat is mechanical (no LLM). The nightly is cognitive — that's
 when KB notes get created or updated based on what you captured during

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runDoctor } from "../src/cli/doctor.ts";
+import type { Config } from "../src/config.ts";
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+let workdir: string;
+let config: Config;
+let personaMemoryDir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-doctor-"));
+  personaMemoryDir = join(workdir, "personas", "phantom", "memory");
+  await mkdir(personaMemoryDir, { recursive: true });
+  config = {
+    defaultPersona: "phantom",
+    harnessIdleTimeoutMs: 600_000,
+    harnessHardTimeoutMs: 600_000,
+    personasDir: join(workdir, "personas"),
+    memoryDbPath: join(workdir, "memory.sqlite"),
+    configPath: join(workdir, "config.toml"),
+    harnesses: {
+      chain: ["claude"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1_500_000 },
+      gemini: { bin: "gemini", model: "" },
+    },
+    channels: {},
+    embeddings: { provider: "none" },
+    voice: { provider: "none" },
+  };
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+async function writeState(obj: unknown): Promise<void> {
+  await writeFile(
+    join(personaMemoryDir, ".nightly-state.json"),
+    JSON.stringify(obj),
+    "utf8",
+  );
+}
+async function writeProgress(obj: unknown): Promise<void> {
+  await writeFile(
+    join(personaMemoryDir, ".nightly-progress.json"),
+    JSON.stringify(obj),
+    "utf8",
+  );
+}
+
+describe("runDoctor", () => {
+  test("missing persona → exit 2", async () => {
+    const err = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      persona: "nope",
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("not found");
+  });
+
+  test("no nightly record → repair needed and spawned", async () => {
+    const spawned: string[] = [];
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      spawnRepair: (p) => spawned.push(p),
+    });
+    expect(spawned).toEqual(["phantom"]);
+    expect(out.text).toContain("never run");
+    expect(code).toBe(0); // repair was triggered
+  });
+
+  test("fresh ok nightly → repair not needed", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const spawned: string[] = [];
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      spawnRepair: (p) => spawned.push(p),
+    });
+    expect(spawned).toEqual([]);
+    expect(code).toBe(0);
+    expect(out.text).toContain("repair: not needed");
+  });
+
+  test("stale nightly (>24h) → repair needed", async () => {
+    await writeState({
+      last_run: new Date(Date.now() - 30 * 3_600_000).toISOString(),
+      last_status: "ok",
+    });
+    const spawned: string[] = [];
+    await runDoctor({ config, out: new CaptureStream(), spawnRepair: (p) => spawned.push(p) });
+    expect(spawned).toEqual(["phantom"]);
+  });
+
+  test("partial checkpoint → repair needed, reason names the checkpoint", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "partial",
+    });
+    await writeProgress({
+      date: "2026-05-18",
+      started_at: "x",
+      updated_at: "x",
+      completed_stages: ["essence", "promote"],
+      status: "partial",
+    });
+    const spawned: string[] = [];
+    const out = new CaptureStream();
+    await runDoctor({ config, out, spawnRepair: (p) => spawned.push(p) });
+    expect(spawned).toEqual(["phantom"]);
+    expect(out.text).toContain("checkpoint");
+    expect(out.text).toContain("2026-05-18");
+  });
+
+  test("no-repair mode reports but never spawns; exits 1 when repair needed", async () => {
+    const spawned: string[] = [];
+    const code = await runDoctor({
+      config,
+      repair: false,
+      out: new CaptureStream(),
+      spawnRepair: (p) => spawned.push(p),
+    });
+    expect(spawned).toEqual([]);
+    expect(code).toBe(1);
+  });
+
+  test("json mode emits a parseable report", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({ config, json: true, out, spawnRepair: () => {} });
+    const report = JSON.parse(out.text);
+    expect(report.persona).toBe("phantom");
+    expect(report.repair_needed).toBe(false);
+    expect(report.capture).toBeDefined();
+    expect(report.nightly.last_status).toBe("ok");
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -21,6 +21,7 @@ describe("phantombot CLI dispatcher", () => {
     const names = Object.keys(subs).sort();
     expect(names).toEqual([
       "ask",
+      "doctor",
       "embedding",
       "env",
       "harness",

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -5,10 +5,17 @@ import { join } from "node:path";
 import {
   buildNightlyPrompt,
   buildNightlyPromptForPersona,
+  buildNightlyStagePrompt,
   CATCHUP_WINDOW_MS,
+  clearNightlyProgress,
+  loadNightlyProgress,
   loadNightlyState,
+  NIGHTLY_STAGES,
+  type NightlyProgress,
   nightlyConversationKey,
   nightlyStatePath,
+  pendingNightlyStages,
+  saveNightlyProgress,
   saveNightlyState,
   shouldRunCatchupNightly,
 } from "../src/lib/nightly.ts";
@@ -187,5 +194,103 @@ describe("buildNightlyPromptForPersona — override", () => {
       "2026-05-02",
     );
     expect(built).toBe("Hey robbie, today is 2026-05-02. Do the thing.");
+  });
+});
+
+describe("nightly checkpoint — progress file", () => {
+  test("loadNightlyProgress returns null when no file exists", async () => {
+    expect(await loadNightlyProgress(workdir)).toBeNull();
+  });
+
+  test("save then load round-trips", async () => {
+    const progress: NightlyProgress = {
+      date: "2026-05-18",
+      started_at: "2026-05-18T02:00:00.000Z",
+      updated_at: "2026-05-18T02:03:00.000Z",
+      completed_stages: ["essence", "promote"],
+      status: "in_progress",
+    };
+    await saveNightlyProgress(workdir, progress);
+    expect(await loadNightlyProgress(workdir)).toEqual(progress);
+  });
+
+  test("clearNightlyProgress removes the file", async () => {
+    await saveNightlyProgress(workdir, {
+      date: "2026-05-18",
+      started_at: "x",
+      updated_at: "x",
+      completed_stages: [],
+      status: "in_progress",
+    });
+    await clearNightlyProgress(workdir);
+    expect(await loadNightlyProgress(workdir)).toBeNull();
+  });
+
+  test("clearNightlyProgress is a no-op when there is no file", async () => {
+    await clearNightlyProgress(workdir); // must not throw
+    expect(await loadNightlyProgress(workdir)).toBeNull();
+  });
+});
+
+describe("pendingNightlyStages", () => {
+  test("returns every stage when resume is false", async () => {
+    expect(await pendingNightlyStages(workdir, "2026-05-18", false)).toEqual([
+      ...NIGHTLY_STAGES,
+    ]);
+  });
+
+  test("returns every stage when resume is true but no checkpoint", async () => {
+    expect(await pendingNightlyStages(workdir, "2026-05-18", true)).toEqual([
+      ...NIGHTLY_STAGES,
+    ]);
+  });
+
+  test("skips completed stages when checkpoint matches today", async () => {
+    await saveNightlyProgress(workdir, {
+      date: "2026-05-18",
+      started_at: "x",
+      updated_at: "x",
+      completed_stages: ["essence", "promote"],
+      status: "partial",
+    });
+    expect(await pendingNightlyStages(workdir, "2026-05-18", true)).toEqual([
+      "kb",
+      "compress",
+      "state",
+    ]);
+  });
+
+  test("ignores a stale checkpoint from a different date", async () => {
+    await saveNightlyProgress(workdir, {
+      date: "2026-05-17",
+      started_at: "x",
+      updated_at: "x",
+      completed_stages: ["essence", "promote", "kb"],
+      status: "partial",
+    });
+    expect(await pendingNightlyStages(workdir, "2026-05-18", true)).toEqual([
+      ...NIGHTLY_STAGES,
+    ]);
+  });
+});
+
+describe("buildNightlyStagePrompt", () => {
+  test("embeds persona, date and the isolation/checkpoint notes", () => {
+    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "essence");
+    expect(p).toContain("persona 'robbie'");
+    expect(p).toContain("2026-05-18");
+    expect(p).toContain("CHECKPOINTED");
+    expect(p).toContain("system:nightly:2026-05-18");
+  });
+
+  test("each stage carries its own distinct instruction body", () => {
+    const bodies = NIGHTLY_STAGES.map((s) =>
+      buildNightlyStagePrompt("robbie", "2026-05-18", s),
+    );
+    expect(bodies[0]).toContain("DAY ESSENCE");
+    expect(bodies[1]).toContain("PROMOTE TO DRAWERS");
+    expect(bodies[2]).toContain("FEED THE KB");
+    expect(bodies[3]).toContain("COMPRESS MEMORY.md");
+    expect(bodies[4]).toContain("STATE REPORT");
   });
 });


### PR DESCRIPTION
## Reliable, observable memory capture & a resumable nightly

Closes the diagnosis in #112. Investigation (incl. a three-persona control group on a separate box) found **three stacked failures merged into one "memory is broken" symptom**, not one systemic bug:

1. **Nightly idle-timeout.** The nightly is a deep, monolithic LLM pass. `claude timed out after 300000ms` is the **5-minute idle timeout** (`cli/nightly.ts` — 5 min idle, 30 min hard) firing when the model goes quiet mid-pass. On a box with a real day of chat it dies, so daily files never consolidate into the drawers. *(Corrected from an earlier comment that called it a hard cap — it is the idle cap.)*
2. **Capture never fired on the OpenRouter box** — the missing `today.md`. Capture is the only phantombot subsystem with no CLI: pure prose protocol, no log, no trace. A harness that under-weights standing system instructions can simply skip it, and nothing notices.
3. **Embedding key added mid-day** → `indexed 0`. Setup ordering; self-heals on reindex. Not a code bug.

The control group (Lena/Kai/Jake, v1.1.66) showed healthy nightlies and populated drawers — capture is **not** broken across the board; the reporter hit the specific combination of a busy box + a flaky harness.

### The four changes

**1. `phantombot memory capture` — give capture the same shape as the rest of the project**
`env`, `notify`, `task` all have a command, a log line, an exit code. Capture now does too: a Citty subcommand that appends a tagged, heartbeat-promotable line to today's daily file and records the call in a new `capture_log` table. Converts an *invisible* miss into a *visible, queryable* one. (Honest scope: a CLI cannot *force* a model to capture — that would mean dictating the harness's model.)

**2. Mechanical 30-turn nudge**
The Telegram dispatch counts user turns since the last `capture_log` row; when the effective turn index hits a multiple of 30 it stacks a fresh reminder onto the system-prompt suffix. Pure counter — no LLM decides whether to nudge. Directly counteracts the long-context dilution that broke the OpenRouter box. Gated to real `telegram:*` conversations.

**3. Checkpointed, resumable nightly**
The monolithic pass is decomposed into five idempotent stages (`essence → promote → kb → compress → state`), each its own harness turn. After every completed stage phantombot writes `.nightly-progress.json`. A stage timeout — or a mid-run power-off — costs at most one stage; `nightly --resume` skips the finished stages. Per-stage hard cap drops to 20 min since each stage is far smaller. Persona `nightly-prompt.md` overrides still run monolithic (the override owns the phase contract).

**4. `phantombot doctor` — detect & auto-repair**
Reads signals that already exist — `.nightly-state.json`, `.nightly-progress.json`, `capture_log` — and answers: did the last nightly run, did it succeed, is capture firing. When the nightly is stale/failed/partial it spawns a detached `nightly --resume`. `--no-repair` (report only) and `--json` (for schedulers). The startup catch-up in `run` now routes through doctor, so a *partial* checkpoint is repaired too — not just a fully-missed night.

### What this PR deliberately does NOT do

No transcript-fallback. The `turns` table is a ~120-row rolling per-conversation buffer (verified — IDs run to ~1956, ~1,800 already pruned); it cannot serve as a transcript archive. If write-time capture fails for a whole day and the daily file is empty, the nightly still has nothing to consolidate. We accept this consciously: change #1 makes such a day *visible*, #2 makes it far less likely. A durable transcript log is separate, larger work.

### Tests / verification

- `bun tsc --noEmit` clean; `bun test` — **859 pass, 0 fail**.
- New coverage: checkpoint progress round-trip, `pendingNightlyStages` resume logic, per-stage prompt builders, and `doctor` (no-record / fresh-ok / stale / partial-checkpoint / no-repair / json).
- ARM64 compile verified; `phantombot doctor --help` smoke-tested.

Opening as **draft** for a few-days soak on a high-volume box before merge.
