### PR TITLE
Website: remove Pi link from top navbar

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -17,7 +17,6 @@
                 <span>Phantombot</span>
             </div>
             <div class="links">
-                <a href="https://pi.dev">Pi</a>
                 <a href="https://github.com/phantomyard/phantombot">GitHub</a>
                 <a href="https://phantomops.app">PhantomOps</a>
             </div>


### PR DESCRIPTION
Removes the **Pi** link from the top navbar in `www/index.html`.

Scoped down per Andrew (2026-05-19): hero tagline and the "Agency by Design" heading are left as-is for now — PhantomOps stays in the navbar too. Only the Pi navbar link is removed.

One file, 1 deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)