### PR TITLE
fix(update,doctor): self-heal systemd units after binary swap

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -51,6 +51,13 @@ import {
   tickServicePath,
   tickTimerPath,
 } from "../lib/systemd.ts";
+import {
+  HEARTBEAT_STALE_MINUTES,
+  loadHeartbeatLastFired,
+  loadTickLastFired,
+  TICK_STALE_MINUTES,
+  type TimerLastFired,
+} from "../lib/timerHealth.ts";
 import { openMemoryStore } from "../memory/store.ts";
 
 /** Window for the capture-health check: a "dry day" is judged over 24h. */
@@ -96,6 +103,29 @@ export interface DoctorReport {
     /** True when we re-rendered or re-armed at least one thing. */
     repaired: boolean;
   };
+  /**
+   * Heartbeat + tick "last fired" markers. Catches the long-uptime
+   * failure mode where systemd reports timers as active but they're
+   * not actually firing (bus drop, host suspend, runaway lockfile).
+   * `stale` = age exceeds the per-timer threshold, OR no marker
+   * exists at all. Undefined entries (e.g. `tick.last_fired` missing)
+   * still flag stale=true so a freshly-installed-but-never-fired
+   * timer is visible.
+   */
+  timers?: {
+    heartbeat: {
+      last_fired?: string;
+      age_minutes?: number;
+      stale: boolean;
+      threshold_minutes: number;
+    };
+    tick: {
+      last_fired?: string;
+      age_minutes?: number;
+      stale: boolean;
+      threshold_minutes: number;
+    };
+  };
   repair_needed: boolean;
   repair_reason?: string;
   repair_triggered: boolean;
@@ -122,6 +152,15 @@ export interface RunDoctorInput {
   checkSystemd?:
     | false
     | (() => Promise<DoctorReport["systemd"] | undefined>);
+  /**
+   * Test seam for the timer-fired marker check. Pass `false` to skip
+   * (used by tests that don't care about staleness). Pass a function
+   * to substitute fake marker reads. In production this is undefined
+   * and doctor reads the real marker files from XDG_STATE_HOME.
+   */
+  checkTimers?:
+    | false
+    | (() => Promise<DoctorReport["timers"] | undefined>);
 }
 
 function decideRepair(
@@ -232,6 +271,20 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     }
   }
 
+  // Timer "last fired" check — catches the long-uptime failure mode
+  // where systemd thinks a timer is active but it hasn't fired in
+  // hours. is-active says "active", LastTriggerUSec says "n/a", and
+  // the only ground-truth signal is what tick + heartbeat actually
+  // wrote to disk the last time they ran.
+  let timersReport: DoctorReport["timers"] | undefined;
+  if (input.checkTimers !== false) {
+    if (input.checkTimers) {
+      timersReport = await input.checkTimers();
+    } else {
+      timersReport = computeTimersReport();
+    }
+  }
+
   const report: DoctorReport = {
     persona,
     nightly: {
@@ -259,6 +312,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       dry_day: dryDay,
     },
     ...(systemdReport ? { systemd: systemdReport } : {}),
+    ...(timersReport ? { timers: timersReport } : {}),
     repair_needed: needed,
     repair_reason: reason,
     repair_triggered: repairTriggered,
@@ -330,12 +384,45 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     }
   }
 
+  if (timersReport) {
+    const renderTimer = (
+      label: string,
+      t: NonNullable<DoctorReport["timers"]>["heartbeat"],
+    ): void => {
+      out.write(`  ${label}: ${tick(!t.stale)} — `);
+      if (t.last_fired === undefined) {
+        out.write(
+          `never recorded (threshold ${t.threshold_minutes}m) — ` +
+            "timer may not be installed or has not fired since the marker was added\n",
+        );
+      } else {
+        out.write(
+          `last fired ${t.last_fired} (${t.age_minutes}m ago, ` +
+            `threshold ${t.threshold_minutes}m)` +
+            (t.stale ? " — STALE\n" : "\n"),
+        );
+      }
+    };
+    renderTimer("heartbeat", timersReport.heartbeat);
+    renderTimer("tick", timersReport.tick);
+  }
+
   const systemdBroken =
     !!systemdReport &&
     !systemdReport.repaired &&
     (systemdReport.missing_unit_files.length > 0 ||
       systemdReport.inactive_timers.length > 0);
-  const exitCode = needed && !repairTriggered ? 1 : systemdBroken ? 1 : 0;
+  const timersBroken =
+    !!timersReport &&
+    (timersReport.heartbeat.stale || timersReport.tick.stale);
+  const exitCode =
+    needed && !repairTriggered
+      ? 1
+      : systemdBroken
+        ? 1
+        : timersBroken
+          ? 1
+          : 0;
   return exitCode;
 }
 
@@ -390,6 +477,42 @@ async function defaultCheckSystemd(
     missing_unit_files: missing,
     inactive_timers: inactive,
     repaired,
+  };
+}
+
+/**
+ * Build the timers report from the on-disk marker files. A missing
+ * marker still flags stale=true — that's the "fresh install, hasn't
+ * fired yet" case AND the "marker was deleted somehow" case, both of
+ * which the operator should see.
+ *
+ * Returns undefined when we're not running as the real phantombot
+ * binary (e.g. `bun test`, `bun run` during development). Mirrors the
+ * same gate `defaultCheckSystemd` uses so the check stays inert in
+ * dev contexts and tests don't need to clean up marker files.
+ */
+function computeTimersReport(): DoctorReport["timers"] | undefined {
+  if (basename(process.execPath) !== "phantombot") return undefined;
+  const now = new Date();
+  const heartbeat = loadHeartbeatLastFired(now);
+  const tickFired = loadTickLastFired(now);
+  return {
+    heartbeat: timerSection(heartbeat, HEARTBEAT_STALE_MINUTES),
+    tick: timerSection(tickFired, TICK_STALE_MINUTES),
+  };
+}
+
+function timerSection(
+  m: TimerLastFired,
+  thresholdMinutes: number,
+): NonNullable<DoctorReport["timers"]>["heartbeat"] {
+  const stale =
+    m.ageMinutes === undefined ? true : m.ageMinutes > thresholdMinutes;
+  return {
+    ...(m.iso !== undefined ? { last_fired: m.iso } : {}),
+    ...(m.ageMinutes !== undefined ? { age_minutes: m.ageMinutes } : {}),
+    stale,
+    threshold_minutes: thresholdMinutes,
   };
 }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -21,6 +21,7 @@
 import { spawn } from "node:child_process";
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
+import { basename } from "node:path";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import type { WriteSink } from "../lib/io.ts";
@@ -32,6 +33,24 @@ import {
   type NightlyProgress,
   type NightlyState,
 } from "../lib/nightly.ts";
+import { currentPlatform } from "../lib/platform.ts";
+import {
+  BunSystemctlRunner,
+  buildSystemctlEnv,
+  defaultUnitPath,
+  ensureSystemdUnitsCurrent,
+  ensureUserSystemdEnv,
+  HEARTBEAT_TIMER_NAME,
+  heartbeatServicePath,
+  heartbeatTimerPath,
+  NIGHTLY_TIMER_NAME,
+  nightlyServicePath,
+  nightlyTimerPath,
+  type SystemctlRunner,
+  TICK_TIMER_NAME,
+  tickServicePath,
+  tickTimerPath,
+} from "../lib/systemd.ts";
 import { openMemoryStore } from "../memory/store.ts";
 
 /** Window for the capture-health check: a "dry day" is judged over 24h. */
@@ -65,6 +84,18 @@ export interface DoctorReport {
     /** Many user turns, zero captures — capture is likely not firing. */
     dry_day: boolean;
   };
+  /**
+   * Linux-only — undefined on macOS and dev hosts without a user-systemd
+   * bus. When present, lists which unit files are missing from disk and
+   * which timers are not active right now. A healthy box reports empty
+   * arrays for both.
+   */
+  systemd?: {
+    missing_unit_files: string[];
+    inactive_timers: string[];
+    /** True when we re-rendered or re-armed at least one thing. */
+    repaired: boolean;
+  };
   repair_needed: boolean;
   repair_reason?: string;
   repair_triggered: boolean;
@@ -81,6 +112,16 @@ export interface RunDoctorInput {
   err?: WriteSink;
   /** Test seam — override the repair spawn. */
   spawnRepair?: (persona: string) => void;
+  /**
+   * Test seam for the systemd check. Pass `false` to skip the check
+   * (the default outside Linux). Pass a function to substitute a fake
+   * — the function receives the binary path doctor would use and
+   * returns a SystemctlRunner snapshot to inspect. In production this
+   * is undefined and doctor uses the real systemctl.
+   */
+  checkSystemd?:
+    | false
+    | (() => Promise<DoctorReport["systemd"] | undefined>);
 }
 
 function decideRepair(
@@ -179,6 +220,18 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     repairTriggered = true;
   }
 
+  // systemd health (Linux only) — catches the broken-symlink class of
+  // bug where timers look enabled but never fire. Skipped on macOS,
+  // skipped in tests via checkSystemd: false.
+  let systemdReport: DoctorReport["systemd"] | undefined;
+  if (input.checkSystemd !== false) {
+    if (input.checkSystemd) {
+      systemdReport = await input.checkSystemd();
+    } else if (currentPlatform() === "linux") {
+      systemdReport = await defaultCheckSystemd(repair);
+    }
+  }
+
   const report: DoctorReport = {
     persona,
     nightly: {
@@ -205,6 +258,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       captures,
       dry_day: dryDay,
     },
+    ...(systemdReport ? { systemd: systemdReport } : {}),
     repair_needed: needed,
     repair_reason: reason,
     repair_triggered: repairTriggered,
@@ -252,7 +306,108 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     out.write("  repair: not needed\n");
   }
 
-  return needed && !repairTriggered ? 1 : 0;
+  if (systemdReport) {
+    const sdOk =
+      systemdReport.missing_unit_files.length === 0 &&
+      systemdReport.inactive_timers.length === 0;
+    out.write(`  systemd: ${tick(sdOk)} — `);
+    if (sdOk) {
+      out.write("all unit files present, all timers active\n");
+    } else {
+      const bits: string[] = [];
+      if (systemdReport.missing_unit_files.length > 0) {
+        bits.push(`missing: ${systemdReport.missing_unit_files.join(", ")}`);
+      }
+      if (systemdReport.inactive_timers.length > 0) {
+        bits.push(`inactive: ${systemdReport.inactive_timers.join(", ")}`);
+      }
+      out.write(bits.join("; ") + "\n");
+      out.write(
+        systemdReport.repaired
+          ? "  → re-rendered units and re-armed timers (no restart needed)\n"
+          : "  → run `phantombot install` to repair\n",
+      );
+    }
+  }
+
+  const systemdBroken =
+    !!systemdReport &&
+    !systemdReport.repaired &&
+    (systemdReport.missing_unit_files.length > 0 ||
+      systemdReport.inactive_timers.length > 0);
+  const exitCode = needed && !repairTriggered ? 1 : systemdBroken ? 1 : 0;
+  return exitCode;
+}
+
+/**
+ * Production wiring for the systemd-health check. Returns undefined on
+ * hosts where the user-systemd bus isn't reachable (no linger, or
+ * running from a SSH session without DBUS) — doctor just stays silent
+ * about systemd in that case rather than printing a misleading WARN.
+ *
+ * When `repair` is true, missing unit files or inactive timers are
+ * fixed in-place via ensureSystemdUnitsCurrent. The report's `repaired`
+ * flag tells callers whether the issues were healed or still need
+ * attention. Read-only mode (`--no-repair`) just inspects and reports.
+ */
+async function defaultCheckSystemd(
+  repair: boolean,
+): Promise<DoctorReport["systemd"] | undefined> {
+  const sysEnv = ensureUserSystemdEnv();
+  if (!sysEnv.ready) return undefined;
+  const binPath = process.execPath;
+  if (basename(binPath) !== "phantombot") return undefined;
+  const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
+  const expectedFiles: Array<{ path: string; name: string }> = [
+    { path: defaultUnitPath(), name: basename(defaultUnitPath()) },
+    {
+      path: heartbeatServicePath(),
+      name: basename(heartbeatServicePath()),
+    },
+    { path: heartbeatTimerPath(), name: basename(heartbeatTimerPath()) },
+    { path: nightlyServicePath(), name: basename(nightlyServicePath()) },
+    { path: nightlyTimerPath(), name: basename(nightlyTimerPath()) },
+    { path: tickServicePath(), name: basename(tickServicePath()) },
+    { path: tickTimerPath(), name: basename(tickTimerPath()) },
+  ];
+  const missing = expectedFiles
+    .filter((f) => !existsSync(f.path))
+    .map((f) => f.name);
+  const inactive = await listInactiveTimers(systemctl);
+  let repaired = false;
+  if (repair && (missing.length > 0 || inactive.length > 0)) {
+    try {
+      const heal = await ensureSystemdUnitsCurrent({ binPath, systemctl });
+      repaired =
+        heal.rewrote.length > 0 || heal.repairedTimers.length > 0;
+    } catch (e) {
+      log.warn("doctor: systemd heal failed", {
+        error: (e as Error).message,
+      });
+    }
+  }
+  return {
+    missing_unit_files: missing,
+    inactive_timers: inactive,
+    repaired,
+  };
+}
+
+async function listInactiveTimers(
+  systemctl: SystemctlRunner,
+): Promise<string[]> {
+  const out: string[] = [];
+  for (const t of [
+    HEARTBEAT_TIMER_NAME,
+    NIGHTLY_TIMER_NAME,
+    TICK_TIMER_NAME,
+  ]) {
+    const r = await systemctl.run(["--user", "is-active", t]);
+    if (r.exitCode !== 0 || r.stdout.trim() !== "active") {
+      out.push(t);
+    }
+  }
+  return out;
 }
 
 export default defineCommand({

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -7,11 +7,20 @@
 
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { runHeartbeat } from "../lib/heartbeat.ts";
 import type { WriteSink } from "../lib/io.ts";
+import { log } from "../lib/logger.ts";
+import { currentPlatform } from "../lib/platform.ts";
+import {
+  BunSystemctlRunner,
+  buildSystemctlEnv,
+  ensureSystemdUnitsCurrent,
+  ensureUserSystemdEnv,
+} from "../lib/systemd.ts";
+import { recordHeartbeatFired } from "../lib/timerHealth.ts";
 import { VERSION } from "../version.ts";
 
 function indexPath(persona: string): string {
@@ -28,6 +37,15 @@ export interface RunHeartbeatCliInput {
   persona?: string;
   out?: WriteSink;
   err?: WriteSink;
+  /**
+   * Test seam for the in-process systemd self-heal. Pass `false` to
+   * skip (the production default off Linux, and what tests use to keep
+   * real systemctl out of the path). Pass a function to substitute a
+   * fake that performs the heal and returns whatever the call should
+   * have logged. Production passes undefined → we probe for a user
+   * systemd bus and only run if available.
+   */
+  healSystemd?: false | (() => Promise<void>);
 }
 
 export async function runHeartbeatCli(
@@ -53,6 +71,31 @@ export async function runHeartbeatCli(
     config,
     currentVersion: VERSION,
   });
+
+  // Self-heal systemd units on the heartbeat's regular cadence. This
+  // is the long-uptime cure for the broken-symlink class of bug — a
+  // box that never restarts still gets a re-check every 30 minutes,
+  // and any drift is fixed in-place without operator action. Wrapped
+  // in try/catch so a transient systemctl failure doesn't break the
+  // primary heartbeat work.
+  if (input.healSystemd !== false) {
+    try {
+      if (input.healSystemd) {
+        await input.healSystemd();
+      } else {
+        await defaultHealSystemd();
+      }
+    } catch (e) {
+      log.warn("heartbeat: systemd self-heal threw unexpectedly", {
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Record the fire AFTER the primary work succeeded. Doctor uses
+  // this marker's mtime to flag a dead heartbeat timer.
+  await recordHeartbeatFired();
+
   const updateLine =
     r.updateCheck?.status === "notified"
       ? `, notified update ${r.updateCheck.latestVersion}`
@@ -65,6 +108,28 @@ export async function runHeartbeatCli(
       `indexed ${r.indexedFiles}${updateLine}\n`,
   );
   return 0;
+}
+
+/**
+ * Production self-heal: idempotently ensure all phantombot systemd
+ * units are present and timers are armed. Silent on healthy boxes,
+ * logs a notice on repair. Skips on macOS and on Linux hosts where
+ * the user-systemd bus isn't reachable (e.g. SSH without lingering).
+ */
+async function defaultHealSystemd(): Promise<void> {
+  if (currentPlatform() !== "linux") return;
+  const binPath = process.execPath;
+  if (basename(binPath) !== "phantombot") return;
+  const sysEnv = ensureUserSystemdEnv();
+  if (!sysEnv.ready) return;
+  const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
+  const r = await ensureSystemdUnitsCurrent({ binPath, systemctl });
+  if (r.rewrote.length > 0 || r.repairedTimers.length > 0) {
+    log.info("heartbeat: healed systemd units", {
+      rewrote: r.rewrote,
+      repairedTimers: r.repairedTimers,
+    });
+  }
 }
 
 export default defineCommand({

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -37,6 +37,7 @@ import {
   isLockHandle,
 } from "../lib/runLock.ts";
 import { openTaskStore, type Task, type TaskStore } from "../lib/tasks.ts";
+import { recordTickFired } from "../lib/timerHealth.ts";
 import { openMemoryStore, type MemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
 
@@ -65,6 +66,12 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
   const err = input.err ?? process.stderr;
   const config = input.config ?? (await loadConfig());
   const now = input.now ?? new Date();
+
+  // Record that the tick timer fired — even if the body exits early
+  // because the lock is held. Doctor uses this marker's mtime to flag
+  // a dead tick timer; the signal we want is "the timer fires," not
+  // "tick did meaningful work."
+  await recordTickFired();
 
   const lockPath = input.lockPath ?? defaultTickLockPath();
   const lock = acquireRunLock(lockPath);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -35,6 +35,13 @@ import {
   restartCommand,
   type ServiceControl,
 } from "../lib/platform.ts";
+import {
+  BunSystemctlRunner,
+  buildSystemctlEnv,
+  ensureSystemdUnitsCurrent,
+  ensureUserSystemdEnv,
+  type EnsureUnitsCurrentResult,
+} from "../lib/systemd.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { VERSION } from "../version.ts";
 
@@ -63,6 +70,16 @@ export interface RunUpdateInput {
   /** Inject confirm to bypass @clack's TTY-only prompt in tests. */
   confirmInstall?: (release: LatestRelease) => Promise<boolean>;
   confirmRestart?: () => Promise<boolean>;
+  /**
+   * Test seam — override the post-swap "re-stitch systemd units" step.
+   * Pass `false` to skip entirely (the common case for tests that don't
+   * care about the heal pass). Pass a function to substitute a fake. In
+   * production this is undefined and runUpdate uses the real systemd
+   * runner via `defaultHealUnits`.
+   */
+  healSystemdUnits?:
+    | false
+    | ((binPath: string) => Promise<EnsureUnitsCurrentResult | null>);
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -170,6 +187,43 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
   }
   out.write(`installed ${release.tag} at ${binPath}.\n`);
 
+  // 7.5. Re-stitch systemd unit files so the new binary's templates land
+  // on disk and any timer whose enabled/active state has rotted gets
+  // re-armed. Without this step a previous bad update can leave broken
+  // symlinks in ~/.config/systemd/user/timers.target.wants/ that
+  // silently strand all scheduled tasks — the runs=0 bug we shipped in
+  // 2026-05. Idempotent: nothing changes when units already match.
+  // Non-fatal on failure: the binary swap is the critical step, and
+  // `phantombot install` is still available as a manual fallback.
+  if (input.healSystemdUnits !== false && procPlatform === "linux") {
+    try {
+      const heal = input.healSystemdUnits
+        ? await input.healSystemdUnits(binPath)
+        : await defaultHealUnits(binPath);
+      if (heal) {
+        if (heal.rewrote.length > 0) {
+          out.write(
+            `re-rendered systemd units: ${heal.rewrote.join(", ")}\n`,
+          );
+        }
+        if (heal.repairedTimers.length > 0) {
+          out.write(
+            `re-armed timers: ${heal.repairedTimers.join(", ")}\n`,
+          );
+        }
+        if (heal.rewrote.length === 0 && heal.repairedTimers.length === 0) {
+          out.write("systemd units already current.\n");
+        }
+      }
+    } catch (e) {
+      err.write(
+        `warning: could not re-stitch systemd units: ${(e as Error).message} — ` +
+          `run 'phantombot install' manually if scheduled tasks stop firing.\n`,
+      );
+      // Non-fatal — fall through to restart handling.
+    }
+  }
+
   // 8. Restart handling. The running phantombot process keeps its
   // in-memory binary, so restart is needed to actually load the new bits.
   const svc = input.serviceControl ?? defaultServiceControl();
@@ -197,6 +251,20 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
   }
 
   return 0;
+}
+
+/**
+ * Production wiring for the post-swap "heal units" step. Returns null
+ * when the user-systemd bus isn't reachable (no linger, dev workstation,
+ * etc.) — the update succeeded, we just have nothing to repair.
+ */
+async function defaultHealUnits(
+  binPath: string,
+): Promise<EnsureUnitsCurrentResult | null> {
+  const sysEnv = ensureUserSystemdEnv();
+  if (!sysEnv.ready) return null;
+  const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
+  return ensureSystemdUnitsCurrent({ binPath, systemctl });
 }
 
 async function defaultConfirmInstall(

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -416,6 +416,145 @@ export function defaultSystemdServiceControl(): ServiceControl {
   };
 }
 
+/**
+ * Surgical re-render of all six phantombot systemd unit files, plus a
+ * re-enable / re-start of any timer that isn't currently active.
+ *
+ * This is the post-update healer: a `phantombot update` swaps the
+ * binary, then calls this to make sure the on-disk unit files still
+ * match the new version's templates AND that the timers are actually
+ * armed. Without it, a release that renames or moves a unit (or that
+ * lands on a host whose `~/.config/systemd/user/timers.target.wants/`
+ * symlinks have rotted from a previous bad update) leaves the user
+ * with timers that look enabled but never fire — exactly the bug that
+ * stranded ~2 days of scheduled tasks on hz-phantombot in 2026-05.
+ *
+ * Pure on the inputs: caller picks the paths and the systemctl
+ * runner. Tests inject a FakeSystemctl and a tmpdir; production calls
+ * this with real ones via `runHealSystemdUnits` below.
+ *
+ * Idempotent: writing the same content is a no-op; an already-enabled
+ * + active timer is left alone. Only changes get logged.
+ */
+export interface EnsureUnitsCurrentOptions {
+  binPath: string;
+  unitPath?: string;
+  heartbeatServicePath?: string;
+  heartbeatTimerPath?: string;
+  nightlyServicePath?: string;
+  nightlyTimerPath?: string;
+  tickServicePath?: string;
+  tickTimerPath?: string;
+  systemctl: SystemctlRunner;
+}
+
+export interface EnsureUnitsCurrentResult {
+  /** Basenames of unit files that were (re)written. Empty = nothing changed. */
+  rewrote: string[];
+  /** Backups created for any unit file whose previous content differed. */
+  backups: string[];
+  /** Timer unit names that were re-enabled and/or restarted to repair them. */
+  repairedTimers: string[];
+}
+
+export async function ensureSystemdUnitsCurrent(
+  opts: EnsureUnitsCurrentOptions,
+): Promise<EnsureUnitsCurrentResult> {
+  const targets: Array<{
+    path: string;
+    content: string;
+    unit: string;
+    isTimer: boolean;
+  }> = [
+    {
+      path: opts.unitPath ?? defaultUnitPath(),
+      content: generateSystemdUnit({ binPath: opts.binPath, args: ["run"] }),
+      unit: PHANTOMBOT_UNIT_NAME,
+      isTimer: false,
+    },
+    {
+      path: opts.heartbeatServicePath ?? heartbeatServicePath(),
+      content: generateHeartbeatService(opts.binPath),
+      unit: HEARTBEAT_SERVICE_NAME,
+      isTimer: false,
+    },
+    {
+      path: opts.heartbeatTimerPath ?? heartbeatTimerPath(),
+      content: generateHeartbeatTimer(),
+      unit: HEARTBEAT_TIMER_NAME,
+      isTimer: true,
+    },
+    {
+      path: opts.nightlyServicePath ?? nightlyServicePath(),
+      content: generateNightlyService(opts.binPath),
+      unit: NIGHTLY_SERVICE_NAME,
+      isTimer: false,
+    },
+    {
+      path: opts.nightlyTimerPath ?? nightlyTimerPath(),
+      content: generateNightlyTimer(),
+      unit: NIGHTLY_TIMER_NAME,
+      isTimer: true,
+    },
+    {
+      path: opts.tickServicePath ?? tickServicePath(),
+      content: generateTickService(opts.binPath),
+      unit: TICK_SERVICE_NAME,
+      isTimer: false,
+    },
+    {
+      path: opts.tickTimerPath ?? tickTimerPath(),
+      content: generateTickTimer(),
+      unit: TICK_TIMER_NAME,
+      isTimer: true,
+    },
+  ];
+
+  const rewrote: string[] = [];
+  const backups: string[] = [];
+  for (const t of targets) {
+    let current: string | undefined;
+    if (existsSync(t.path)) {
+      current = await readFile(t.path, "utf8");
+    }
+    if (current === t.content) continue;
+    await mkdir(dirname(t.path), { recursive: true });
+    if (current !== undefined) {
+      const bak = `${t.path}.bak`;
+      await writeFile(bak, current, "utf8");
+      backups.push(bak);
+    }
+    await writeFile(t.path, t.content, "utf8");
+    rewrote.push(basename(t.path));
+  }
+  if (rewrote.length > 0) {
+    await opts.systemctl.run(["--user", "daemon-reload"]);
+  }
+
+  // For each timer, verify it is enabled AND active. is-enabled exits 0 +
+  // prints "enabled" when good; is-active exits 0 + prints "active" when
+  // armed. Anything else means the timer isn't actually running and we
+  // need to enable --now to repair it. Cheap to recheck — systemctl is
+  // local IPC and these calls take ~ms.
+  const repairedTimers: string[] = [];
+  for (const t of targets) {
+    if (!t.isTimer) continue;
+    const enabled = await opts.systemctl.run([
+      "--user",
+      "is-enabled",
+      t.unit,
+    ]);
+    const active = await opts.systemctl.run(["--user", "is-active", t.unit]);
+    const isEnabled = enabled.exitCode === 0 && enabled.stdout.trim() === "enabled";
+    const isActive = active.exitCode === 0 && active.stdout.trim() === "active";
+    if (isEnabled && isActive) continue;
+    await opts.systemctl.run(["--user", "enable", "--now", t.unit]);
+    repairedTimers.push(t.unit);
+  }
+
+  return { rewrote, backups, repairedTimers };
+}
+
 export interface InstallOptions {
   binPath: string;
   unitPath: string;

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -417,6 +417,96 @@ export function defaultSystemdServiceControl(): ServiceControl {
 }
 
 /**
+ * One canonical entry for each of the 7 phantombot systemd unit
+ * files (1 main service + 3 oneshot service/timer pairs).
+ *
+ * Centralised so `installPhantombotUnit` and `ensureSystemdUnitsCurrent`
+ * can't drift: changing a template here updates both. Was inlined twice
+ * before, which review flagged as a maintenance hazard.
+ */
+export interface PhantombotUnitTarget {
+  /** Absolute on-disk path of the unit file. */
+  path: string;
+  /** Rendered unit body. */
+  content: string;
+  /** systemd unit name (e.g. "phantombot-tick.timer"). */
+  unit: string;
+  /** True for `.timer` units; false for `.service` units. */
+  isTimer: boolean;
+}
+
+/**
+ * Optional per-unit path overrides. Production callers leave these
+ * empty and pick up the XDG defaults; tests override to keep writes
+ * inside a tmpdir.
+ */
+export interface PhantombotUnitPathOverrides {
+  unitPath?: string;
+  heartbeatServicePath?: string;
+  heartbeatTimerPath?: string;
+  nightlyServicePath?: string;
+  nightlyTimerPath?: string;
+  tickServicePath?: string;
+  tickTimerPath?: string;
+}
+
+/**
+ * Render the canonical (path, content, unit, isTimer) tuples for every
+ * phantombot unit file. Single source of truth shared by
+ * `installPhantombotUnit` (writes them fresh) and
+ * `ensureSystemdUnitsCurrent` (re-writes any that drifted).
+ */
+export function phantombotUnitTargets(
+  binPath: string,
+  overrides: PhantombotUnitPathOverrides = {},
+): PhantombotUnitTarget[] {
+  return [
+    {
+      path: overrides.unitPath ?? defaultUnitPath(),
+      content: generateSystemdUnit({ binPath, args: ["run"] }),
+      unit: PHANTOMBOT_UNIT_NAME,
+      isTimer: false,
+    },
+    {
+      path: overrides.heartbeatServicePath ?? heartbeatServicePath(),
+      content: generateHeartbeatService(binPath),
+      unit: HEARTBEAT_SERVICE_NAME,
+      isTimer: false,
+    },
+    {
+      path: overrides.heartbeatTimerPath ?? heartbeatTimerPath(),
+      content: generateHeartbeatTimer(),
+      unit: HEARTBEAT_TIMER_NAME,
+      isTimer: true,
+    },
+    {
+      path: overrides.nightlyServicePath ?? nightlyServicePath(),
+      content: generateNightlyService(binPath),
+      unit: NIGHTLY_SERVICE_NAME,
+      isTimer: false,
+    },
+    {
+      path: overrides.nightlyTimerPath ?? nightlyTimerPath(),
+      content: generateNightlyTimer(),
+      unit: NIGHTLY_TIMER_NAME,
+      isTimer: true,
+    },
+    {
+      path: overrides.tickServicePath ?? tickServicePath(),
+      content: generateTickService(binPath),
+      unit: TICK_SERVICE_NAME,
+      isTimer: false,
+    },
+    {
+      path: overrides.tickTimerPath ?? tickTimerPath(),
+      content: generateTickTimer(),
+      unit: TICK_TIMER_NAME,
+      isTimer: true,
+    },
+  ];
+}
+
+/**
  * Surgical re-render of all six phantombot systemd unit files, plus a
  * re-enable / re-start of any timer that isn't currently active.
  *
@@ -436,15 +526,8 @@ export function defaultSystemdServiceControl(): ServiceControl {
  * Idempotent: writing the same content is a no-op; an already-enabled
  * + active timer is left alone. Only changes get logged.
  */
-export interface EnsureUnitsCurrentOptions {
+export interface EnsureUnitsCurrentOptions extends PhantombotUnitPathOverrides {
   binPath: string;
-  unitPath?: string;
-  heartbeatServicePath?: string;
-  heartbeatTimerPath?: string;
-  nightlyServicePath?: string;
-  nightlyTimerPath?: string;
-  tickServicePath?: string;
-  tickTimerPath?: string;
   systemctl: SystemctlRunner;
 }
 
@@ -460,55 +543,7 @@ export interface EnsureUnitsCurrentResult {
 export async function ensureSystemdUnitsCurrent(
   opts: EnsureUnitsCurrentOptions,
 ): Promise<EnsureUnitsCurrentResult> {
-  const targets: Array<{
-    path: string;
-    content: string;
-    unit: string;
-    isTimer: boolean;
-  }> = [
-    {
-      path: opts.unitPath ?? defaultUnitPath(),
-      content: generateSystemdUnit({ binPath: opts.binPath, args: ["run"] }),
-      unit: PHANTOMBOT_UNIT_NAME,
-      isTimer: false,
-    },
-    {
-      path: opts.heartbeatServicePath ?? heartbeatServicePath(),
-      content: generateHeartbeatService(opts.binPath),
-      unit: HEARTBEAT_SERVICE_NAME,
-      isTimer: false,
-    },
-    {
-      path: opts.heartbeatTimerPath ?? heartbeatTimerPath(),
-      content: generateHeartbeatTimer(),
-      unit: HEARTBEAT_TIMER_NAME,
-      isTimer: true,
-    },
-    {
-      path: opts.nightlyServicePath ?? nightlyServicePath(),
-      content: generateNightlyService(opts.binPath),
-      unit: NIGHTLY_SERVICE_NAME,
-      isTimer: false,
-    },
-    {
-      path: opts.nightlyTimerPath ?? nightlyTimerPath(),
-      content: generateNightlyTimer(),
-      unit: NIGHTLY_TIMER_NAME,
-      isTimer: true,
-    },
-    {
-      path: opts.tickServicePath ?? tickServicePath(),
-      content: generateTickService(opts.binPath),
-      unit: TICK_SERVICE_NAME,
-      isTimer: false,
-    },
-    {
-      path: opts.tickTimerPath ?? tickTimerPath(),
-      content: generateTickTimer(),
-      unit: TICK_TIMER_NAME,
-      isTimer: true,
-    },
-  ];
+  const targets = phantombotUnitTargets(opts.binPath, opts);
 
   const rewrote: string[] = [];
   const backups: string[] = [];
@@ -579,37 +614,15 @@ export interface InstallOptions {
 export async function installPhantombotUnit(
   opts: InstallOptions,
 ): Promise<{ installed: boolean }> {
-  const unit = generateSystemdUnit({ binPath: opts.binPath, args: ["run"] });
-  await mkdir(dirname(opts.unitPath), { recursive: true });
-  await writeFile(opts.unitPath, unit, "utf8");
-  opts.out.write(`wrote unit file: ${opts.unitPath}\n`);
-
-  // Heartbeat service + timer
-  const hbService = opts.heartbeatServicePath ?? heartbeatServicePath();
-  const hbTimer = opts.heartbeatTimerPath ?? heartbeatTimerPath();
-  await mkdir(dirname(hbService), { recursive: true });
-  await mkdir(dirname(hbTimer), { recursive: true });
-  await writeFile(hbService, generateHeartbeatService(opts.binPath), "utf8");
-  await writeFile(hbTimer, generateHeartbeatTimer(), "utf8");
-  opts.out.write(`wrote heartbeat units: ${hbService} + ${hbTimer}\n`);
-
-  // Nightly service + timer
-  const ngService = opts.nightlyServicePath ?? nightlyServicePath();
-  const ngTimer = opts.nightlyTimerPath ?? nightlyTimerPath();
-  await mkdir(dirname(ngService), { recursive: true });
-  await mkdir(dirname(ngTimer), { recursive: true });
-  await writeFile(ngService, generateNightlyService(opts.binPath), "utf8");
-  await writeFile(ngTimer, generateNightlyTimer(), "utf8");
-  opts.out.write(`wrote nightly units: ${ngService} + ${ngTimer}\n`);
-
-  // Tick service + timer
-  const tkService = opts.tickServicePath ?? tickServicePath();
-  const tkTimer = opts.tickTimerPath ?? tickTimerPath();
-  await mkdir(dirname(tkService), { recursive: true });
-  await mkdir(dirname(tkTimer), { recursive: true });
-  await writeFile(tkService, generateTickService(opts.binPath), "utf8");
-  await writeFile(tkTimer, generateTickTimer(), "utf8");
-  opts.out.write(`wrote tick units: ${tkService} + ${tkTimer}\n`);
+  // Single source of truth for path + body of every unit file. Shared
+  // with `ensureSystemdUnitsCurrent` so a template change in one place
+  // can't get out of sync with the other.
+  const targets = phantombotUnitTargets(opts.binPath, opts);
+  for (const t of targets) {
+    await mkdir(dirname(t.path), { recursive: true });
+    await writeFile(t.path, t.content, "utf8");
+    opts.out.write(`wrote ${t.unit}: ${t.path}\n`);
+  }
 
   for (const args of [
     ["--user", "daemon-reload"],

--- a/src/lib/timerHealth.ts
+++ b/src/lib/timerHealth.ts
@@ -58,6 +58,15 @@ function parseMarker(text: string): MarkerPayload | undefined {
  * Record that the named timer just fired. Best-effort: any write
  * failure is logged and swallowed — we never want a disk hiccup in
  * the marker to break the actual heartbeat/tick work.
+ *
+ * The ISO timestamp comes from `new Date().toISOString()`, i.e.
+ * wall-clock time. A backward NTP step between two fires would make
+ * the recorded age look briefly negative (clamped to 0 by
+ * `loadLastFired`) or smaller than the real elapsed time. Fine here
+ * because the staleness bars are coarse: heartbeat 120m, tick 5m. If
+ * tighter age thresholding becomes important, switch to a monotonic
+ * clock (`process.hrtime.bigint()` snapshotted at process start) for
+ * the age delta and keep the wall-clock ISO only for forensic logs.
  */
 async function recordFired(path: string): Promise<void> {
   try {

--- a/src/lib/timerHealth.ts
+++ b/src/lib/timerHealth.ts
@@ -1,0 +1,156 @@
+/**
+ * Timer fire-marker bookkeeping for heartbeat + tick.
+ *
+ * Why this exists: when phantombot's user-systemd timers go silent
+ * (broken symlinks after an update, bus going away, host being
+ * suspended for days), the only signal is "stuff didn't run." Doctor
+ * needs a positive on-disk indicator that says "heartbeat last ran at
+ * T" / "tick last ran at T" so a >threshold age can be flagged.
+ *
+ * We write one cheap, atomic marker file per timer in XDG_STATE_HOME.
+ * No JSON parsing on read — we just stat() the mtime — but the file
+ * also contains the ISO timestamp + a "runs=" counter for forensic
+ * tail -F use. Marker files are TIMER-scoped (not persona-scoped) on
+ * purpose: heartbeat may eventually run multi-persona, and tick has
+ * no persona at all. We're tracking the timer's heartbeat, not any
+ * one persona's memory.
+ *
+ * Staleness thresholds are passed in by callers (doctor picks them)
+ * rather than hard-coded here, because the heartbeat-firing-every-30m
+ * vs tick-firing-every-minute cadence means they need different bars.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { xdgStateHome } from "../config.ts";
+import { log } from "./logger.ts";
+
+export function heartbeatMarkerPath(): string {
+  return join(xdgStateHome(), "phantombot", "heartbeat.last-fired");
+}
+
+export function tickMarkerPath(): string {
+  return join(xdgStateHome(), "phantombot", "tick.last-fired");
+}
+
+interface MarkerPayload {
+  iso: string;
+  runs: number;
+}
+
+function parseMarker(text: string): MarkerPayload | undefined {
+  const lines = text.split("\n").filter((l) => l.length > 0);
+  if (lines.length === 0) return undefined;
+  // Format: "ISO=2026-05-20T07:30:00.000Z runs=42"
+  const head = lines[lines.length - 1]!;
+  const isoMatch = /ISO=(\S+)/.exec(head);
+  const runsMatch = /runs=(\d+)/.exec(head);
+  if (!isoMatch) return undefined;
+  const iso = isoMatch[1]!;
+  if (Number.isNaN(Date.parse(iso))) return undefined;
+  const runs = runsMatch ? Number(runsMatch[1]) : 0;
+  return { iso, runs };
+}
+
+/**
+ * Record that the named timer just fired. Best-effort: any write
+ * failure is logged and swallowed — we never want a disk hiccup in
+ * the marker to break the actual heartbeat/tick work.
+ */
+async function recordFired(path: string): Promise<void> {
+  try {
+    let runs = 0;
+    if (existsSync(path)) {
+      try {
+        const prev = parseMarker(readFileSync(path, "utf8"));
+        if (prev) runs = prev.runs;
+      } catch {
+        // Corrupt marker — reset counter, keep going.
+      }
+    }
+    const next: MarkerPayload = {
+      iso: new Date().toISOString(),
+      runs: runs + 1,
+    };
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(
+      path,
+      `ISO=${next.iso} runs=${next.runs}\n`,
+      "utf8",
+    );
+  } catch (e) {
+    log.warn("timerHealth: failed to record fire", {
+      path,
+      error: (e as Error).message,
+    });
+  }
+}
+
+export function recordHeartbeatFired(): Promise<void> {
+  return recordFired(heartbeatMarkerPath());
+}
+
+export function recordTickFired(): Promise<void> {
+  return recordFired(tickMarkerPath());
+}
+
+export interface TimerLastFired {
+  /** ISO timestamp of the last recorded fire, or undefined if no marker. */
+  iso?: string;
+  /** Whole-number minutes since the last fire, or undefined if none. */
+  ageMinutes?: number;
+  /** Total fires recorded (rough — resets on marker corruption). */
+  runs?: number;
+}
+
+function loadLastFired(path: string, now: Date): TimerLastFired {
+  if (!existsSync(path)) return {};
+  try {
+    // Cheap path: stat mtime. We still parse the body so the JSON
+    // report carries the explicit ISO (which doesn't drift if someone
+    // touches the file).
+    const text = readFileSync(path, "utf8");
+    const parsed = parseMarker(text);
+    if (parsed) {
+      const t = Date.parse(parsed.iso);
+      const ageMs = now.getTime() - t;
+      return {
+        iso: parsed.iso,
+        ageMinutes: Math.max(0, Math.round(ageMs / 60_000)),
+        runs: parsed.runs,
+      };
+    }
+    // Fall back to mtime if the body is unreadable.
+    const mt = statSync(path).mtime;
+    return {
+      iso: mt.toISOString(),
+      ageMinutes: Math.max(0, Math.round((now.getTime() - mt.getTime()) / 60_000)),
+    };
+  } catch (e) {
+    log.warn("timerHealth: failed to read marker", {
+      path,
+      error: (e as Error).message,
+    });
+    return {};
+  }
+}
+
+export function loadHeartbeatLastFired(now: Date = new Date()): TimerLastFired {
+  return loadLastFired(heartbeatMarkerPath(), now);
+}
+
+export function loadTickLastFired(now: Date = new Date()): TimerLastFired {
+  return loadLastFired(tickMarkerPath(), now);
+}
+
+/**
+ * Default staleness bars used by doctor. Heartbeat fires every 30m,
+ * so a 2h bar tolerates 3 missed fires before yelling. Tick fires
+ * every minute, so a 5m bar tolerates 4 missed fires. Both are
+ * deliberately loose — we want a "this timer is dead" signal, not a
+ * "this timer was 30 seconds late" signal.
+ */
+export const HEARTBEAT_STALE_MINUTES = 120;
+export const TICK_STALE_MINUTES = 5;

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -270,3 +270,147 @@ describe("runDoctor systemd health check", () => {
     });
   });
 });
+
+describe("runDoctor timer-fired staleness check", () => {
+  // Driven by the checkTimers test seam so we don't read real marker
+  // files. Catches the long-uptime failure mode where the timer is
+  // "active" but hasn't actually fired in hours (bus drop, host
+  // suspend, etc.) — the only signal is what tick + heartbeat wrote
+  // to disk on their last successful fire.
+
+  test("fresh heartbeat + tick markers pass with exit 0", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkTimers: async () => ({
+        heartbeat: {
+          last_fired: "2026-05-20T08:55:00.000Z",
+          age_minutes: 2,
+          stale: false,
+          threshold_minutes: 120,
+        },
+        tick: {
+          last_fired: "2026-05-20T08:57:30.000Z",
+          age_minutes: 0,
+          stale: false,
+          threshold_minutes: 5,
+        },
+      }),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("heartbeat: ok");
+    expect(out.text).toContain("tick: ok");
+    expect(out.text).toContain("2m ago");
+  });
+
+  test("stale heartbeat → WARN + exit 1", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkTimers: async () => ({
+        heartbeat: {
+          last_fired: "2026-05-20T05:00:00.000Z",
+          age_minutes: 240,
+          stale: true,
+          threshold_minutes: 120,
+        },
+        tick: {
+          last_fired: "2026-05-20T08:57:30.000Z",
+          age_minutes: 0,
+          stale: false,
+          threshold_minutes: 5,
+        },
+      }),
+    });
+    expect(code).toBe(1);
+    expect(out.text).toContain("heartbeat: WARN");
+    expect(out.text).toContain("240m ago");
+    expect(out.text).toContain("STALE");
+    expect(out.text).toContain("tick: ok");
+  });
+
+  test("missing marker → reported as never recorded + stale", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkTimers: async () => ({
+        heartbeat: {
+          stale: true,
+          threshold_minutes: 120,
+        },
+        tick: {
+          last_fired: "2026-05-20T08:57:30.000Z",
+          age_minutes: 0,
+          stale: false,
+          threshold_minutes: 5,
+        },
+      }),
+    });
+    expect(code).toBe(1);
+    expect(out.text).toContain("heartbeat: WARN — never recorded");
+  });
+
+  test("checkTimers=false omits the timer sections entirely", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({
+      config,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+    });
+    expect(out.text).not.toContain("heartbeat:");
+    expect(out.text).not.toContain("tick:");
+  });
+
+  test("json mode emits the timers block when checked", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({
+      config,
+      json: true,
+      out,
+      checkSystemd: false,
+      checkTimers: async () => ({
+        heartbeat: {
+          last_fired: "2026-05-20T08:55:00.000Z",
+          age_minutes: 2,
+          stale: false,
+          threshold_minutes: 120,
+        },
+        tick: {
+          last_fired: "2026-05-20T08:57:30.000Z",
+          age_minutes: 0,
+          stale: false,
+          threshold_minutes: 5,
+        },
+      }),
+    });
+    const report = JSON.parse(out.text);
+    expect(report.timers.heartbeat.age_minutes).toBe(2);
+    expect(report.timers.tick.age_minutes).toBe(0);
+    expect(report.timers.heartbeat.stale).toBe(false);
+    expect(report.timers.tick.stale).toBe(false);
+  });
+});

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -161,3 +161,112 @@ describe("runDoctor", () => {
     expect(report.nightly.last_status).toBe("ok");
   });
 });
+
+describe("runDoctor systemd health check", () => {
+  // Driven by the checkSystemd test seam so we don't depend on real
+  // systemctl. The new check catches the broken-symlink class of bug
+  // where timers look enabled but never fire — exactly the failure that
+  // stranded all scheduled tasks on hz-phantombot in May 2026.
+
+  test("reports a healthy systemd subsystem in the human summary", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: async () => ({
+        missing_unit_files: [],
+        inactive_timers: [],
+        repaired: false,
+      }),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain(
+      "systemd: ok — all unit files present, all timers active",
+    );
+  });
+
+  test("reports missing unit files and inactive timers", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: async () => ({
+        missing_unit_files: ["phantombot-tick.timer"],
+        inactive_timers: ["phantombot-tick.timer"],
+        repaired: false,
+      }),
+    });
+    // Nightly is healthy, but systemd has unrepaired damage → exit 1.
+    expect(code).toBe(1);
+    expect(out.text).toContain("systemd: WARN");
+    expect(out.text).toContain("missing: phantombot-tick.timer");
+    expect(out.text).toContain("inactive: phantombot-tick.timer");
+    expect(out.text).toContain("run `phantombot install` to repair");
+  });
+
+  test("repaired=true tells the user no manual action is needed", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: async () => ({
+        missing_unit_files: ["phantombot-tick.timer"],
+        inactive_timers: [],
+        repaired: true,
+      }),
+    });
+    // Damage was healed → exit 0, message tells user it's fixed.
+    expect(code).toBe(0);
+    expect(out.text).toContain("re-rendered units and re-armed timers");
+  });
+
+  test("checkSystemd=false omits the systemd section entirely", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({
+      config,
+      out,
+      checkSystemd: false,
+    });
+    expect(out.text).not.toContain("systemd:");
+  });
+
+  test("json mode includes the systemd block when checked", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({
+      config,
+      json: true,
+      out,
+      checkSystemd: async () => ({
+        missing_unit_files: [],
+        inactive_timers: ["phantombot-tick.timer"],
+        repaired: false,
+      }),
+    });
+    const report = JSON.parse(out.text);
+    expect(report.systemd).toEqual({
+      missing_unit_files: [],
+      inactive_timers: ["phantombot-tick.timer"],
+      repaired: false,
+    });
+  });
+});

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runHeartbeatCli } from "../src/cli/heartbeat.ts";
 import type { Config } from "../src/config.ts";
+import { heartbeatMarkerPath } from "../src/lib/timerHealth.ts";
 
 class CaptureStream {
   chunks: string[] = [];
@@ -28,6 +30,9 @@ beforeEach(async () => {
     recursive: true,
   });
   process.env.XDG_DATA_HOME = workdir;
+  // Redirect the timer-fired marker path so heartbeat writes into the
+  // test workdir, not the developer's real ~/.local/state/.
+  process.env.XDG_STATE_HOME = workdir;
   config = {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
@@ -81,5 +86,49 @@ describe("runHeartbeatCli", () => {
     });
     expect(code).toBe(2);
     expect(err.text).toContain("not found");
+  });
+
+  test("happy path records a fire-marker for the doctor staleness check", async () => {
+    await writeFile(
+      join(workdir, "personas", "phantom", "memory", "decisions.md"),
+      "# Decisions\n",
+    );
+    const code = await runHeartbeatCli({
+      config,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      // Skip the real systemd self-heal — we're testing the marker write.
+      healSystemd: false,
+    });
+    expect(code).toBe(0);
+    expect(existsSync(heartbeatMarkerPath())).toBe(true);
+  });
+
+  test("healSystemd seam runs after the heartbeat body", async () => {
+    let healCalled = false;
+    await runHeartbeatCli({
+      config,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      healSystemd: async () => {
+        healCalled = true;
+      },
+    });
+    expect(healCalled).toBe(true);
+  });
+
+  test("healSystemd throwing does not break the heartbeat", async () => {
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: async () => {
+        throw new Error("systemctl exploded");
+      },
+    });
+    // Primary work still completes and exit is 0; the heal failure is logged but swallowed.
+    expect(code).toBe(0);
+    expect(out.text).toContain("heartbeat ok");
   });
 });

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -37,6 +37,9 @@ let lockPath: string;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-tick-"));
+  // Redirect the timer-fired marker path so runTick writes into the
+  // test workdir, not the developer's real ~/.local/state/.
+  process.env.XDG_STATE_HOME = workdir;
   store = await openTaskStore(join(workdir, "tasks.sqlite"));
   memory = await openMemoryStore(join(workdir, "memory.sqlite"));
   lockPath = join(workdir, "tick.lock");
@@ -85,6 +88,24 @@ describe("runTick — no-op cases", () => {
     });
     expect(code).toBe(0);
     expect(harness.invocations).toBe(0);
+  });
+
+  test("even a no-due-tasks tick records a fire-marker", async () => {
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "unused" },
+    ]);
+    await runTick({
+      config,
+      taskStore: store,
+      memory,
+      harnesses: [harness],
+      lockPath,
+      now: new Date("2026-05-02T09:00:00Z"),
+    });
+    // Use a deferred import so we read XDG_STATE_HOME at call time.
+    const { tickMarkerPath } = await import("../src/lib/timerHealth.ts");
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(tickMarkerPath())).toBe(true);
   });
 });
 

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -46,6 +46,23 @@ const ASSET = "phantombot-v1.0.99-linux-x64";
 const NEW_BYTES = Buffer.from("NEW_BINARY_VERIFIED");
 const NEW_SHA = createHash("sha256").update(NEW_BYTES).digest("hex");
 
+/**
+ * Exact hostname match — `URL.hostname` returns the parsed host with no
+ * userinfo / port noise, so an attacker-shaped URL like
+ * `https://api.github.com.evil.example/...` is correctly rejected, and
+ * `https://evil.example/?u=api.github.com` likewise. Earlier
+ * substring-based `u.includes("api.github.com")` tripped CodeQL
+ * "incomplete URL substring sanitization"; this is the precise form.
+ * Invalid URLs are simply non-matches rather than throwing.
+ */
+function isGitHubApiUrl(u: string): boolean {
+  try {
+    return new URL(u).hostname === "api.github.com";
+  } catch {
+    return false;
+  }
+}
+
 function fakeReleaseFetch(opts: {
   releaseStatus?: number;
   releaseBody?: unknown;
@@ -79,7 +96,7 @@ function fakeReleaseFetch(opts: {
     opts.checksumsText ?? `${NEW_SHA}  ${ASSET}\n`;
   return (async (url: string | URL | Request) => {
     const u = String(url);
-    if (u.includes("api.github.com")) {
+    if (isGitHubApiUrl(u)) {
       return new Response(
         typeof releaseBody === "string"
           ? releaseBody
@@ -293,7 +310,7 @@ describe("runUpdate on darwin-arm64", () => {
     };
     return (async (url: string | URL | Request) => {
       const u = String(url);
-      if (u.includes("api.github.com")) {
+      if (isGitHubApiUrl(u)) {
         return new Response(JSON.stringify(releaseBody), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -501,7 +518,7 @@ describe("runUpdate post-swap systemd heal", () => {
       .digest("hex");
     const fetchImpl = (async (url: string | URL | Request) => {
       const u = String(url);
-      if (u.includes("api.github.com")) {
+      if (isGitHubApiUrl(u)) {
         return new Response(
           JSON.stringify({
             tag_name: "v1.0.99",

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -319,6 +319,7 @@ describe("runUpdate on darwin-arm64", () => {
       out,
       err: new CaptureStream(),
       force: true,
+      healSystemdUnits: false,
     });
     expect(code).toBe(0);
     expect(out.text).toContain("phantombot-v1.0.99-darwin-arm64");
@@ -341,6 +342,7 @@ describe("runUpdate happy path with --force --restart", () => {
       err: new CaptureStream(),
       force: true,
       restart: true,
+      healSystemdUnits: false,
     });
     expect(code).toBe(0);
     // New binary swapped in.
@@ -371,6 +373,7 @@ describe("runUpdate happy path with --force --restart", () => {
       err: new CaptureStream(),
       force: true,
       // restart NOT set
+      healSystemdUnits: false,
     });
     expect(code).toBe(0);
     expect(calls).not.toContain("restart");
@@ -392,6 +395,7 @@ describe("runUpdate happy path with --force --restart", () => {
       err,
       force: true,
       restart: true,
+      healSystemdUnits: false,
     });
     // Exit 0 — the install succeeded; restart is best-effort.
     expect(code).toBe(0);
@@ -399,6 +403,150 @@ describe("runUpdate happy path with --force --restart", () => {
     expect(err.text).toContain("manually");
     // Binary still got swapped.
     expect((await readFile(binPath)).equals(NEW_BYTES)).toBe(true);
+  });
+});
+
+describe("runUpdate post-swap systemd heal", () => {
+  // The bug being fixed: a successful binary swap used to leave systemd
+  // unit files exactly as the previous version installed them, which
+  // meant a previous bad update that left broken symlinks in
+  // ~/.config/systemd/user/timers.target.wants/ would silently strand
+  // every scheduled task forever. The heal step calls
+  // ensureSystemdUnitsCurrent after the swap so the next minute's tick
+  // is actually armed.
+
+  test("calls healSystemdUnits with the swapped binPath on linux", async () => {
+    const called: string[] = [];
+    const out = new CaptureStream();
+    const { svc } = makeSvc({ active: false });
+    const code = await runUpdate({
+      binPath,
+      procPlatform: "linux",
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      out,
+      err: new CaptureStream(),
+      force: true,
+      healSystemdUnits: async (bin) => {
+        called.push(bin);
+        return { rewrote: [], backups: [], repairedTimers: [] };
+      },
+    });
+    expect(code).toBe(0);
+    expect(called).toEqual([binPath]);
+    expect(out.text).toContain("systemd units already current");
+  });
+
+  test("reports rewritten units and re-armed timers", async () => {
+    const out = new CaptureStream();
+    const { svc } = makeSvc({ active: false });
+    const code = await runUpdate({
+      binPath,
+      procPlatform: "linux",
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      out,
+      err: new CaptureStream(),
+      force: true,
+      healSystemdUnits: async () => ({
+        rewrote: ["phantombot-tick.timer", "phantombot.service"],
+        backups: [],
+        repairedTimers: ["phantombot-tick.timer"],
+      }),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("re-rendered systemd units: phantombot-tick.timer, phantombot.service");
+    expect(out.text).toContain("re-armed timers: phantombot-tick.timer");
+  });
+
+  test("heal failure is non-fatal: binary swap still succeeds, warning logged", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const { svc } = makeSvc({ active: false });
+    const code = await runUpdate({
+      binPath,
+      procPlatform: "linux",
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: svc,
+      out,
+      err,
+      force: true,
+      healSystemdUnits: async () => {
+        throw new Error("dbus is missing");
+      },
+    });
+    // Exit 0 — the install succeeded; heal is best-effort. Matches the
+    // restart-failure contract (binary swap is the critical operation).
+    expect(code).toBe(0);
+    expect(err.text).toContain("could not re-stitch systemd units");
+    expect(err.text).toContain("dbus is missing");
+    // Binary was still swapped.
+    expect((await readFile(binPath)).equals(NEW_BYTES)).toBe(true);
+  });
+
+  test("skipped entirely on darwin (launchd, not systemd)", async () => {
+    // Darwin doesn't have systemd; the heal step would just panic. The
+    // implementation guards with `procPlatform === "linux"`. Use a
+    // darwin-shaped release feed via the existing darwin fixture.
+    const DARWIN_ASSET = "phantombot-v1.0.99-darwin-arm64";
+    const DARWIN_BYTES = Buffer.from("DARWIN_BINARY_VERIFIED");
+    const DARWIN_SHA = createHash("sha256")
+      .update(DARWIN_BYTES)
+      .digest("hex");
+    const fetchImpl = (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("api.github.com")) {
+        return new Response(
+          JSON.stringify({
+            tag_name: "v1.0.99",
+            body: "",
+            assets: [
+              {
+                name: DARWIN_ASSET,
+                browser_download_url: "https://example/" + DARWIN_ASSET,
+                size: DARWIN_BYTES.byteLength,
+              },
+              {
+                name: "SHA256SUMS",
+                browser_download_url: "https://example/SHA256SUMS",
+                size: 256,
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (u.includes("SHA256SUMS")) {
+        return new Response(`${DARWIN_SHA}  ${DARWIN_ASSET}\n`, {
+          status: 200,
+        });
+      }
+      return new Response(DARWIN_BYTES, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    let healCalled = false;
+    const code = await runUpdate({
+      binPath,
+      procPlatform: "darwin",
+      procArch: "arm64",
+      currentVersion: "1.0.42",
+      fetchImpl,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      force: true,
+      healSystemdUnits: async () => {
+        healCalled = true;
+        return null;
+      },
+    });
+    expect(code).toBe(0);
+    expect(healCalled).toBe(false);
   });
 });
 
@@ -436,6 +584,7 @@ describe("runUpdate confirm injection", () => {
       err: new CaptureStream(),
       confirmInstall: async () => true,
       confirmRestart: async () => false,
+      healSystemdUnits: false,
     });
     expect(code).toBe(0);
     expect(calls).not.toContain("restart");

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -163,7 +163,8 @@ describe("installPhantombotUnit", () => {
       ["--user", "enable", "phantombot-tick.timer"],
       ["--user", "start", "phantombot-tick.timer"],
     ]);
-    expect(out.text).toContain("wrote unit file");
+    expect(out.text).toContain("wrote phantombot.service");
+    expect(out.text).toContain("wrote phantombot-tick.timer");
     expect(out.text).toContain("enabled and started");
   });
 

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildSystemctlEnv,
+  ensureSystemdUnitsCurrent,
   ensureUnitCurrent,
   ensureUserSystemdEnv,
   generateSystemdUnit,
@@ -185,6 +186,195 @@ describe("installPhantombotUnit", () => {
     expect(err.text).toContain("systemctl --user daemon-reload failed");
     // Did NOT proceed to enable / start.
     expect(sys.calls).toHaveLength(1);
+  });
+});
+
+describe("ensureSystemdUnitsCurrent", () => {
+  // Drive every test through the tmpdir paths so we never touch the real
+  // ~/.config/systemd/user/ on the test runner. Same pattern as the
+  // installPhantombotUnit tests above.
+  function paths() {
+    return {
+      unitPath,
+      heartbeatServicePath: hbServicePath,
+      heartbeatTimerPath: hbTimerPath,
+      nightlyServicePath: ngServicePath,
+      nightlyTimerPath: ngTimerPath,
+      tickServicePath,
+      tickTimerPath,
+    };
+  }
+
+  function isEnabledActive(): SystemctlResult {
+    return { exitCode: 0, stdout: "enabled\n", stderr: "" };
+  }
+  function isActiveActive(): SystemctlResult {
+    return { exitCode: 0, stdout: "active\n", stderr: "" };
+  }
+
+  test("nothing to do when all units already match and timers are active", async () => {
+    // Pre-populate every unit file with the canonical template.
+    const bin = "/usr/local/bin/phantombot";
+    await writeFile(
+      unitPath,
+      generateSystemdUnit({ binPath: bin, args: ["run"] }),
+      "utf8",
+    );
+    const sys = new FakeSystemctl();
+    // Need the heartbeat/nightly/tick canonical contents too. Easier:
+    // ask the helper to write them first, then run again and assert it
+    // does nothing the second time.
+    await ensureSystemdUnitsCurrent({ binPath: bin, ...paths(), systemctl: sys });
+    sys.calls = [];
+    // Second call: everything already current, timers report enabled+active.
+    sys.responses = [
+      isEnabledActive(),
+      isActiveActive(),
+      isEnabledActive(),
+      isActiveActive(),
+      isEnabledActive(),
+      isActiveActive(),
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+    });
+    expect(r.rewrote).toEqual([]);
+    expect(r.backups).toEqual([]);
+    expect(r.repairedTimers).toEqual([]);
+    // No daemon-reload, no enable, no start — only the 6 inspect calls
+    // (is-enabled + is-active for each of the 3 timers).
+    expect(sys.calls).toEqual([
+      ["--user", "is-enabled", "phantombot-heartbeat.timer"],
+      ["--user", "is-active", "phantombot-heartbeat.timer"],
+      ["--user", "is-enabled", "phantombot-nightly.timer"],
+      ["--user", "is-active", "phantombot-nightly.timer"],
+      ["--user", "is-enabled", "phantombot-tick.timer"],
+      ["--user", "is-active", "phantombot-tick.timer"],
+    ]);
+  });
+
+  test("rewrites every missing unit file, runs daemon-reload once, enables timers", async () => {
+    const sys = new FakeSystemctl();
+    // Workdir is empty; every target file is missing. After running:
+    // daemon-reload + for each of 3 timers we'll see is-enabled
+    // returning "disabled" (exit 1) + enable --now.
+    sys.responses = [
+      // daemon-reload after rewrite
+      { exitCode: 0, stdout: "", stderr: "" },
+      // heartbeat: is-enabled, is-active, enable --now
+      { exitCode: 1, stdout: "disabled\n", stderr: "" },
+      { exitCode: 3, stdout: "inactive\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      // nightly
+      { exitCode: 1, stdout: "disabled\n", stderr: "" },
+      { exitCode: 3, stdout: "inactive\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      // tick
+      { exitCode: 1, stdout: "disabled\n", stderr: "" },
+      { exitCode: 3, stdout: "inactive\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: "/usr/local/bin/phantombot",
+      ...paths(),
+      systemctl: sys,
+    });
+    expect(r.rewrote.sort()).toEqual(
+      [
+        "phantombot-heartbeat.service",
+        "phantombot-heartbeat.timer",
+        "phantombot-nightly.service",
+        "phantombot-nightly.timer",
+        "phantombot-tick.service",
+        "phantombot-tick.timer",
+        "phantombot.service",
+      ].sort(),
+    );
+    expect(r.backups).toEqual([]); // nothing pre-existing to back up
+    expect(r.repairedTimers).toEqual([
+      "phantombot-heartbeat.timer",
+      "phantombot-nightly.timer",
+      "phantombot-tick.timer",
+    ]);
+    // Verify each canonical body landed on disk.
+    expect(await readFile(unitPath, "utf8")).toContain(
+      "ExecStart=/usr/local/bin/phantombot run",
+    );
+    expect(await readFile(hbTimerPath, "utf8")).toContain(
+      "Phantombot heartbeat timer",
+    );
+    // daemon-reload runs exactly once (not 7 times) when content changed.
+    const reloadCount = sys.calls.filter(
+      (c) => c[0] === "--user" && c[1] === "daemon-reload",
+    ).length;
+    expect(reloadCount).toBe(1);
+  });
+
+  test("backs up a hand-edited unit file before overwriting", async () => {
+    const sys = new FakeSystemctl();
+    await writeFile(unitPath, "HAND_EDITED_CONTENT_DO_NOT_LOSE", "utf8");
+    sys.responses = [
+      { exitCode: 0, stdout: "", stderr: "" }, // daemon-reload
+      isEnabledActive(),
+      isActiveActive(),
+      isEnabledActive(),
+      isActiveActive(),
+      isEnabledActive(),
+      isActiveActive(),
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: "/usr/local/bin/phantombot",
+      ...paths(),
+      systemctl: sys,
+    });
+    // phantombot.service was rewritten; others (missing) also rewritten;
+    // but only the existing-and-different one produces a backup.
+    expect(r.rewrote).toContain("phantombot.service");
+    expect(r.backups).toEqual([`${unitPath}.bak`]);
+    expect(await readFile(`${unitPath}.bak`, "utf8")).toBe(
+      "HAND_EDITED_CONTENT_DO_NOT_LOSE",
+    );
+  });
+
+  test("re-arms a timer whose is-active reports inactive", async () => {
+    // All unit files in place and current, but the heartbeat timer
+    // claims active=no — simulates a rotted timers.target.wants/ symlink.
+    const bin = "/usr/local/bin/phantombot";
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      // heartbeat: enabled but inactive → enable --now
+      isEnabledActive(),
+      { exitCode: 3, stdout: "inactive\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      // nightly OK
+      isEnabledActive(),
+      isActiveActive(),
+      // tick OK
+      isEnabledActive(),
+      isActiveActive(),
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+    });
+    expect(r.rewrote).toEqual([]);
+    expect(r.repairedTimers).toEqual(["phantombot-heartbeat.timer"]);
+    // Verify the repair call was enable --now (not just start), which
+    // both arms the symlink and starts the timer in one shot.
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "enable",
+      "--now",
+      "phantombot-heartbeat.timer",
+    ]);
   });
 });
 

--- a/tests/lib-timerHealth.test.ts
+++ b/tests/lib-timerHealth.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  HEARTBEAT_STALE_MINUTES,
+  TICK_STALE_MINUTES,
+  heartbeatMarkerPath,
+  loadHeartbeatLastFired,
+  loadTickLastFired,
+  recordHeartbeatFired,
+  recordTickFired,
+  tickMarkerPath,
+} from "../src/lib/timerHealth.ts";
+
+let workdir: string;
+let prevState: string | undefined;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-timerhealth-"));
+  prevState = process.env.XDG_STATE_HOME;
+  process.env.XDG_STATE_HOME = workdir;
+});
+
+afterEach(async () => {
+  if (prevState === undefined) {
+    delete process.env.XDG_STATE_HOME;
+  } else {
+    process.env.XDG_STATE_HOME = prevState;
+  }
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("timerHealth", () => {
+  test("recordHeartbeatFired writes a marker with ISO + runs counter", async () => {
+    await recordHeartbeatFired();
+    const path = heartbeatMarkerPath();
+    expect(existsSync(path)).toBe(true);
+    const text = readFileSync(path, "utf8");
+    expect(text).toMatch(/^ISO=\S+ runs=1\n$/);
+  });
+
+  test("repeat fires bump the runs counter", async () => {
+    await recordHeartbeatFired();
+    await recordHeartbeatFired();
+    await recordHeartbeatFired();
+    const text = readFileSync(heartbeatMarkerPath(), "utf8");
+    expect(text).toMatch(/runs=3/);
+  });
+
+  test("loadHeartbeatLastFired returns {} when no marker exists", () => {
+    const r = loadHeartbeatLastFired();
+    expect(r).toEqual({});
+  });
+
+  test("loadHeartbeatLastFired returns iso + ageMinutes after a fire", async () => {
+    await recordHeartbeatFired();
+    const now = new Date(Date.now() + 5 * 60_000); // simulate 5m later
+    const r = loadHeartbeatLastFired(now);
+    expect(r.iso).toBeDefined();
+    expect(r.ageMinutes).toBe(5);
+    expect(r.runs).toBe(1);
+  });
+
+  test("recordTickFired and loadTickLastFired share the tick marker", async () => {
+    await recordTickFired();
+    expect(existsSync(tickMarkerPath())).toBe(true);
+    const r = loadTickLastFired();
+    expect(r.iso).toBeDefined();
+    expect(r.ageMinutes).toBeLessThanOrEqual(1);
+  });
+
+  test("heartbeat and tick markers are separate files", async () => {
+    await recordHeartbeatFired();
+    await recordTickFired();
+    expect(heartbeatMarkerPath()).not.toBe(tickMarkerPath());
+    expect(existsSync(heartbeatMarkerPath())).toBe(true);
+    expect(existsSync(tickMarkerPath())).toBe(true);
+  });
+
+  test("corrupt marker falls back to mtime, doesn't throw", async () => {
+    const p = heartbeatMarkerPath();
+    // Pre-create XDG state dir by firing once, then overwrite with garbage.
+    await recordHeartbeatFired();
+    await writeFile(p, "garbage with no ISO\n", "utf8");
+    const r = loadHeartbeatLastFired();
+    // Falls back to mtime-derived iso, age should be small.
+    expect(r.iso).toBeDefined();
+    expect(r.ageMinutes).toBeLessThanOrEqual(1);
+  });
+
+  test("default thresholds are sane (heartbeat > tick)", () => {
+    expect(HEARTBEAT_STALE_MINUTES).toBeGreaterThan(TICK_STALE_MINUTES);
+    expect(HEARTBEAT_STALE_MINUTES).toBeGreaterThanOrEqual(60);
+    expect(TICK_STALE_MINUTES).toBeLessThanOrEqual(15);
+  });
+});


### PR DESCRIPTION
## Summary

After a successful `phantombot update`, on-disk systemd unit files used to be left exactly as the previous version installed them. If a release renamed or moved a unit, OR a host's `~/.config/systemd/user/timers.target.wants/` symlinks had rotted from a previous bad update, the timers reported as enabled but never fired — silently stranding every scheduled task.

## The bug in production

On hz-phantombot in May 2026, `phantombot task list` showed two tasks with `runs=0` and next-run timestamps two days in the past. `systemctl --user list-timers phantombot-*` returned the units but with no `NEXT` line. The `timers.target.wants/` directory had symlinks pointing at unit files that no longer existed on disk. Re-running `phantombot install` fixed it in one shot — which means the same step belongs in `update`.

## What this PR does

**Three small changes, none destructive:**

1. **New `ensureSystemdUnitsCurrent` helper in `src/lib/systemd.ts`**
   - Compares every expected unit file against the canonical template
   - Rewrites any that are missing or differ (with `.bak` of the original)
   - Runs `daemon-reload` exactly once (only if something changed)
   - Re-enables any timer that is not currently active via `enable --now`
   - Idempotent: a healthy box gets zero writes and zero state changes, just six is-enabled/is-active probes

2. **`runUpdate` calls it after the atomic binary swap**
   - Runs between the swap and the restart step
   - Failure is non-fatal: binary swap is the critical op, and `phantombot install` remains a manual fallback. Matches the existing `restart failed → warn, exit 0` contract.
   - Linux-only (launchd hosts skip)

3. **`runDoctor` gains a systemd-health section**
   - Lists missing unit files and inactive timers
   - Auto-repairs in default `--repair` mode by calling `ensureSystemdUnitsCurrent`
   - Reports outcome in both human summary and JSON envelope
   - Exits 1 when systemd is broken AND was not repaired (so cron callers can alert)

## Test seams

- `RunUpdateInput.healSystemdUnits?: false | fn` — existing tests opt out with `false`; new tests inject a fake to verify the wiring without touching real systemctl
- `RunDoctorInput.checkSystemd?: false | fn` — same pattern for the doctor side
- A new `defaultHealUnits` / `defaultCheckSystemd` wire up the production paths via `BunSystemctlRunner` + `ensureUserSystemdEnv`

## Test plan

- [x] `bun test` — 872 pass / 1 skip / 0 fail (was 815 before this PR)
- [x] `bun run typecheck` — clean
- [x] `bun run build` — compiles cleanly
- [x] New tests cover:
  - `ensureSystemdUnitsCurrent`: no-op when current, full rewrite when missing, backup of hand-edits, single daemon-reload, re-arm of an inactive timer
  - `runUpdate`: heal called with swapped binPath, output mentions rewrites + re-armed timers, heal failure is non-fatal, darwin skips heal
  - `runDoctor`: healthy section, broken-but-unrepaired (exit 1), broken-and-repaired (exit 0), `checkSystemd: false` omits section, JSON envelope includes the block
- [ ] On a real box: trigger update on a host with a broken `timers.target.wants/` symlink, observe heal log + `phantombot task list` showing future NEXT

## Why no `ExecStartPost=phantombot doctor` in the unit

Considered, rejected. `doctor --repair` calls into systemctl, which would interact with the service that just started — restart-loop risk for marginal benefit. The two healers we have (update-time and explicit doctor invocation) cover the realistic recovery paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)