### PR TITLE
fix(tick): quiet by default — never auto-post harness reply to Telegram

### DIFF
--- a/src/cli/task.ts
+++ b/src/cli/task.ts
@@ -52,7 +52,13 @@ export interface RunTaskAddInput {
   count?: number;
   /** --for 30d — recurring expiry (relative) */
   relFor?: string;
-  /** --silent — suppress user notification after fire */
+  /**
+   * @deprecated `--silent` is a no-op as of the quiet-by-default fix.
+   * Tick never auto-posts the harness reply to Telegram anymore; the
+   * agent decides whether to call `phantombot notify` from inside the
+   * prompt. Accepted for back-compat (with a stderr warning) until a
+   * follow-up PR drops the flag and the DB column.
+   */
   silent?: boolean;
   /** --force-long-running — allow recurring > 90d */
   forceLongRunning?: boolean;
@@ -69,6 +75,18 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
   const store = input.store ?? (await openTaskStore(config.memoryDbPath));
   try {
     const now = new Date();
+
+    // `--silent` is now a no-op (see RunTaskAddInput JSDoc). Warn loudly
+    // so the agent / caller stops scheduling around it before it goes
+    // away entirely.
+    if (input.silent) {
+      err.write(
+        "warning: --silent is deprecated and now a no-op. " +
+        "Scheduled task fires are silent by default; call " +
+        "`phantombot notify` from inside the task prompt if you " +
+        "want the user notified.\n",
+      );
+    }
 
     // Determine mode: one-off or recurring.
     const isRecurring = Boolean(input.every);
@@ -192,7 +210,6 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
       (t.oneOff
         ? `  type:        one-off\n`
         : `  schedule:    ${t.schedule}\n  expiry:      ${describeExpiry(t)}\n`) +
-      (t.silent ? `  silent:      yes\n` : "") +
       (!t.oneOff && !hasExpiry
         ? `  hygiene:     no expiry — every fire will ask if it's still needed.\n` +
           `               cancel with: phantombot task cancel ${t.id}\n`
@@ -404,7 +421,6 @@ function formatTaskFull(t: Task): string {
     `type:         ${t.oneOff ? "one-off" : "recurring"}\n` +
     `schedule:     ${t.schedule || "(none — one-off)"}\n` +
     `active:       ${t.active}\n` +
-    `silent:       ${t.silent}\n` +
     `created:      ${t.createdAt.toISOString()}\n` +
     `last run:     ${t.lastRunAt ? formatLocal(t.lastRunAt) : "(never)"}\n` +
     `next run:     ${formatLocal(t.nextRunAt)}\n` +
@@ -488,7 +504,8 @@ export default defineCommand({
         silent: {
           type: "boolean",
           required: false,
-          description: "Suppress user notification after tick fires this task.",
+          description:
+            "DEPRECATED — no-op. Scheduled task fires are silent by default; use `phantombot notify` inside the task prompt to surface anything to the user.",
           default: false,
         },
         "force-long-running": {

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -3,10 +3,19 @@
  *
  * Reads tasks where next_run_at <= now() AND active=1, runs each through
  * the harness chain, and either:
- *   - runs the task's normal prompt (yielding to the agent's notify rule
- *     embedded in that prompt), then advances next_run_at;
+ *   - runs the task's normal prompt (the agent owns whether to surface
+ *     anything to the user; tick itself is silent), then advances
+ *     next_run_at;
  *   - or, if next_review_at <= now(), runs the SELF-REVIEW prompt that
  *     asks the agent KEEP / STOP, and updates the task accordingly.
+ *
+ * Quiet-by-default contract: tick does NOT post the harness reply to
+ * Telegram. The harnessed agent is the sole arbiter of whether the
+ * user hears about a fire — if it wants to notify, it calls
+ * `phantombot notify` from inside the prompt. This matches the standing
+ * rule embedded in the persona builder ("Scheduled tasks run silently
+ * by default — no Telegram chatter on every fire") which the previous
+ * auto-delivery branch directly contradicted.
  *
  * Lockfile prevents overlapping ticks: if a previous tick is still
  * running (e.g. a slow Claude call), this minute's tick exits 0 and
@@ -23,10 +32,6 @@ import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
-import {
-  HttpTelegramTransport,
-  type TelegramTransport,
-} from "../channels/telegram.ts";
 import { type Config, loadConfig, personaDir, xdgStateHome } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import type { Harness } from "../harnesses/types.ts";
@@ -55,8 +60,6 @@ export interface RunTickInput {
   taskStore?: TaskStore;
   memory?: MemoryStore;
   harnesses?: Harness[];
-  /** Inject telegram transport for testing. */
-  transport?: TelegramTransport;
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -93,13 +96,6 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
     if (!input.memory) await memory.close();
     lock.release();
     return 1;
-  }
-
-  // Init telegram transport for notifications.
-  let transport: TelegramTransport | undefined;
-  const tg = config.channels.telegram;
-  if (tg && tg.allowedUserIds.length > 0) {
-    transport = input.transport ?? new HttpTelegramTransport(tg.token);
   }
 
   try {
@@ -170,38 +166,20 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
       const status = runError ? "error" : "ok";
       const exitCode = runError ? 1 : 0;
 
-      // For non-silent, non-review tasks: notify the user via Telegram.
-      let delivered = false;
-      if (!isReview && !task.silent && !runError && finalText.trim().length > 0 && transport) {
-        try {
-          const notifyMsg = formatTaskNotify(task, finalText);
-          for (const chatId of tg!.allowedUserIds) {
-            try {
-              await transport.sendMessage(chatId, notifyMsg);
-              delivered = true;
-            } catch (e) {
-              log.warn("tick: notify send failed", {
-                taskId: task.id,
-                chatId,
-                error: (e as Error).message,
-              });
-            }
-          }
-        } catch (e) {
-          log.warn("tick: notify failed", {
-            taskId: task.id,
-            error: (e as Error).message,
-          });
-        }
-      }
-
+      // Quiet-by-default: tick never auto-posts the harness reply to
+      // Telegram. The agent calls `phantombot notify` from inside the
+      // prompt if it wants the user to see something. `delivered` is
+      // recorded false here for back-compat with the task_runs schema;
+      // it no longer corresponds to a tick-side delivery decision. If
+      // we ever wire up post-hoc "did notify fire during this run"
+      // tracking, this is the field to revive.
       taskStore.logRun({
         taskId: task.id,
         firedAt: now,
         status: status as "ok" | "error",
         exitCode,
         outputExcerpt,
-        delivered,
+        delivered: false,
       });
 
       if (isReview) {
@@ -216,7 +194,7 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
         taskStore.recordRun(task.id, now);
       }
       out.write(
-        `tick: task ${task.id} done (${finalText.length} chars, ${status}, notified=${delivered})\n`,
+        `tick: task ${task.id} done (${finalText.length} chars, ${status})\n`,
       );
     }
     return 0;
@@ -256,16 +234,6 @@ export function appendHygieneFooter(task: Task): string {
     `If not, run \`phantombot task cancel ${task.id}\` to retire it. ` +
     `If yes, ignore this footer and continue.`
   );
-}
-
-/**
- * Format a task's output as a Telegram notification message.
- * Truncates to avoid hitting Telegram's 4096 char limit.
- */
-function formatTaskNotify(task: Task, output: string): string {
-  const header = `📋 *${task.description}*`;
-  const body = output.trim().slice(0, 3500); // leave room for Markdown
-  return `${header}\n\n${body}`;
 }
 
 /**

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -44,7 +44,13 @@ export interface Task {
   expiresAt?: Date;
   /** Max number of runs for this recurring task. Null = no limit. */
   maxRuns?: number;
-  /** If true, tick will NOT notify the user after firing. */
+  /**
+   * @deprecated No-op as of the quiet-by-default fix. Tick never
+   * auto-posts harness output to Telegram anymore — the agent is the
+   * sole arbiter via `phantombot notify`. Kept on the type and column
+   * for back-compat with existing DB rows; will be dropped in a
+   * follow-up migration.
+   */
   silent: boolean;
   /** Conversation/channel that created this task (for daily-file audit). */
   createdBy: string;
@@ -57,7 +63,15 @@ export interface TaskRunRow {
   status: "ok" | "error";
   exitCode: number;
   outputExcerpt: string; // first 500 chars
-  delivered: boolean; // whether notify was sent to user
+  /**
+   * Historical: in pre-quiet-by-default builds this was true when tick
+   * auto-posted the harness reply to Telegram. Tick no longer does
+   * auto-delivery, so this is always false on rows written by current
+   * code. Old rows retain their original value; the column stays for
+   * back-compat and as a slot if we ever wire up post-hoc "did the
+   * agent call notify during this run" tracking.
+   */
+  delivered: boolean;
 }
 
 export interface TaskAddInput {
@@ -78,7 +92,11 @@ export interface TaskAddInput {
   expiresAt?: Date;
   /** Max runs for recurring tasks. */
   maxRuns?: number;
-  /** Suppress user notification after tick fire. */
+  /**
+   * @deprecated No-op as of the quiet-by-default fix. Accepted for
+   * back-compat with the CLI's deprecated `--silent` flag. See the
+   * Task interface for the field-level note.
+   */
   silent?: boolean;
   /** Channel/conversation that created this task. */
   createdBy?: string;

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -12,6 +12,32 @@ import type {
 import { openTaskStore, type TaskStore } from "../src/lib/tasks.ts";
 import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
 
+// Test seam: capture any HTTP egress so a quiet-by-default regression
+// (tick trying to POST to the Telegram API on every fire) fails loud
+// instead of silently working in the test environment.
+type FetchCall = { url: string; init?: RequestInit };
+function installFetchTrap(): { calls: FetchCall[]; restore: () => void } {
+  const calls: FetchCall[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: RequestInit,
+  ) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    return new Response(JSON.stringify({ ok: true, result: {} }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { calls, restore: () => { globalThis.fetch = original; } };
+}
+
 class ScriptedHarness implements Harness {
   invocations = 0;
   lastUserMessage?: string;
@@ -314,6 +340,101 @@ describe("runTick — lockfile", () => {
     });
     expect(code).toBe(0);
     expect(harness.invocations).toBe(0);
+  });
+});
+
+describe("runTick — quiet-by-default (no auto-Telegram delivery)", () => {
+  // The system prompt promises tick fires are silent unless the agent
+  // explicitly calls `phantombot notify`. These tests pin that contract
+  // so the regression that produced PR #117 can't sneak back in.
+
+  test("a fired task with Telegram fully configured does NOT post to the Telegram API", async () => {
+    const created = store.add({
+      persona: "phantom",
+      description: "should be silent",
+      schedule: "0 * * * *",
+      prompt: "x",
+      now: new Date("2026-05-02T09:30:00Z"),
+    });
+    if (!created.ok) throw new Error("setup");
+
+    const configWithTelegram: Config = {
+      ...config,
+      channels: {
+        telegram: {
+          token: "fake-token",
+          pollTimeoutS: 30,
+          allowedUserIds: [12345],
+        },
+      },
+    };
+
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "this is the agent's reply — nothing material" },
+    ]);
+    const trap = installFetchTrap();
+    try {
+      await runTick({
+        config: configWithTelegram,
+        taskStore: store,
+        memory,
+        harnesses: [harness],
+        lockPath,
+        now: new Date("2026-05-02T10:00:00Z"),
+      });
+    } finally {
+      trap.restore();
+    }
+    // No Telegram API call at all — tick is the wrong place for it.
+    const telegramCalls = trap.calls.filter((c) =>
+      c.url.includes("api.telegram.org"),
+    );
+    expect(telegramCalls).toEqual([]);
+    // Run row records the fire but `delivered` is false (we never auto-deliver).
+    const runs = store.taskRuns(created.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.delivered).toBe(false);
+  });
+
+  test("legacy `silent: true` tasks also fire silently — the field is a no-op", async () => {
+    const created = store.add({
+      persona: "phantom",
+      description: "legacy quiet flag",
+      schedule: "0 * * * *",
+      prompt: "x",
+      silent: true,
+      now: new Date("2026-05-02T09:30:00Z"),
+    });
+    if (!created.ok) throw new Error("setup");
+    const configWithTelegram: Config = {
+      ...config,
+      channels: {
+        telegram: {
+          token: "fake-token",
+          pollTimeoutS: 30,
+          allowedUserIds: [12345],
+        },
+      },
+    };
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "still silent" },
+    ]);
+    const trap = installFetchTrap();
+    try {
+      await runTick({
+        config: configWithTelegram,
+        taskStore: store,
+        memory,
+        harnesses: [harness],
+        lockPath,
+        now: new Date("2026-05-02T10:00:00Z"),
+      });
+    } finally {
+      trap.restore();
+    }
+    expect(
+      trap.calls.filter((c) => c.url.includes("api.telegram.org")),
+    ).toEqual([]);
   });
 });
 

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -16,6 +16,18 @@ import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
 // (tick trying to POST to the Telegram API on every fire) fails loud
 // instead of silently working in the test environment.
 type FetchCall = { url: string; init?: RequestInit };
+
+// Hostname-precise match — substring matching against arbitrary URLs is
+// what CodeQL's "Incomplete URL substring sanitization" rule flags, even
+// in test code. Use the parsed hostname so we never accept e.g.
+// `https://evil.com/api.telegram.org/x`.
+function isTelegramApiUrl(u: string): boolean {
+  try {
+    return new URL(u).hostname === "api.telegram.org";
+  } catch {
+    return false;
+  }
+}
 function installFetchTrap(): { calls: FetchCall[]; restore: () => void } {
   const calls: FetchCall[] = [];
   const original = globalThis.fetch;
@@ -386,9 +398,7 @@ describe("runTick — quiet-by-default (no auto-Telegram delivery)", () => {
       trap.restore();
     }
     // No Telegram API call at all — tick is the wrong place for it.
-    const telegramCalls = trap.calls.filter((c) =>
-      c.url.includes("api.telegram.org"),
-    );
+    const telegramCalls = trap.calls.filter((c) => isTelegramApiUrl(c.url));
     expect(telegramCalls).toEqual([]);
     // Run row records the fire but `delivered` is false (we never auto-deliver).
     const runs = store.taskRuns(created.id);
@@ -432,9 +442,7 @@ describe("runTick — quiet-by-default (no auto-Telegram delivery)", () => {
     } finally {
       trap.restore();
     }
-    expect(
-      trap.calls.filter((c) => c.url.includes("api.telegram.org")),
-    ).toEqual([]);
+    expect(trap.calls.filter((c) => isTelegramApiUrl(c.url))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## The bug

The persona builder promises a clear contract:

> Scheduled tasks (`phantombot tick`) run silently by default — no Telegram chatter on every fire. When something material happens, surface it explicitly with `phantombot notify`.

Tick was doing the exact opposite. Any non-review, non-`silent`, non-error task with non-empty output had its full harness reply formatted as `📋 *<description>*\n\n<text>` and sent to every `allowed_user_ids` chat in Telegram. `silent` defaulted to `false` in the store, so **every task ever scheduled** has been getting its complete LLM transcript blasted to the user — including replies the agent itself wrote believing it had stayed quiet ("Andrew not notified — nothing material" followed by the entire payload arriving on his phone anyway).

Reproduced by Andrew on task #29 today (image attached on Telegram).

## The fix — option A

This is the **remove auto-delivery entirely** option from the two we discussed:

- **A. Remove auto-delivery.** Tick is silent. The harnessed agent is the sole arbiter of notifications, via `phantombot notify` from inside the prompt — same mechanism it already uses for ad-hoc alerts. Cleanest, matches the prompt verbatim. ← THIS PR
- B. Flip default + keep `--silent`/`--notify-output` opt-in. Rejected: two mechanisms with overlapping semantics, easy to drift from intent at scheduling-time vs fire-time.

The "friendly escape hatch" of B is illusory — for a "scheduled message" task you just put the message in the prompt and tell it to call notify. Same tokens, no flag, no surprises.

## What changed

**`src/cli/tick.ts`**
- Drops the `HttpTelegramTransport` import, the transport init block, the `transport?` test seam, and the entire auto-notify branch.
- `formatTaskNotify` removed (no callers).
- `delivered` on the task_runs row is always `false` now. The field is kept on the schema for back-compat with historical rows and as a slot if we ever wire up post-hoc "did the agent call notify during this run" tracking.
- Header comment + JSDoc updated to spell out the quiet-by-default contract so the next reader can't miss it.

**`src/cli/task.ts`**
- `--silent` is a no-op now. Accepted for back-compat with a loud stderr deprecation warning so callers stop scheduling around it.
- Removed from `task add` output and from `task show` (`formatTaskFull`). Help text marks it DEPRECATED.

**`src/lib/tasks.ts`**
- `Task.silent`, `TaskAddInput.silent`, and `TaskRunRow.delivered` gained @deprecated / historical JSDoc explaining the field is preserved for migration safety, not for current behaviour.
- DB column stays. Migration to drop it lands in a follow-up PR.

**`tests/cli-tick.test.ts`**
- New `runTick — quiet-by-default` describe block installs a global fetch trap, configures a Telegram channel that *would* have triggered the old auto-delivery, fires a task, and asserts:
  - zero calls to `api.telegram.org`
  - `delivered = false` on the run row
- A second test confirms legacy `silent: true` rows are equally silent — the field has no effect either way.

## Verification

- `bun test` → **891 pass / 0 fail / 1 skip** (was 889; +2 quiet-by-default tests)
- `bun run typecheck` — clean
- `bun run build` — clean
- No remaining references to `formatTaskNotify` or the auto-delivery pattern in `src/`.

## Follow-up (separate PR, not blocking)

Drop `--silent` from the CLI surface, drop the `silent` column from `tasks`, and drop the `delivered` column from `task_runs` once enough time has passed that no on-disk DBs in the wild still reference them.

## What I deliberately did NOT do

- **Did not** keep `--silent` as a functional opt-in. The premise of the bug is that two mechanisms (auto-send + manual notify) is one too many; preserving one as opt-out reintroduces the same drift surface.
- **Did not** drop the DB columns. Existing DBs on Andrew's boxes have rows with `silent` and `delivered` set; ripping the columns would require a migration that's risky for zero behavioural payoff right now.