### PR TITLE
Add codex to harness selection TUI

### DIFF
--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -17,11 +17,12 @@ import {
   type ServiceControl,
 } from "../lib/platform.ts";
 
-export type HarnessId = "claude" | "pi" | "gemini";
+export type HarnessId = "claude" | "pi" | "gemini" | "codex";
 export const SUPPORTED_HARNESSES: ReadonlyArray<HarnessId> = [
   "claude",
   "pi",
   "gemini",
+  "codex",
 ];
 
 export async function whichBinary(bin: string): Promise<string | undefined> {
@@ -47,6 +48,11 @@ export async function whichBinary(bin: string): Promise<string | undefined> {
   return undefined;
 }
 
+function harnessBin(config: Config, id: HarnessId): string {
+  if (id === "codex") return config.harnesses.codex?.bin ?? "codex";
+  return config.harnesses[id].bin;
+}
+
 export async function detectAvailability(
   config: Config,
 ): Promise<Record<HarnessId, string | undefined>> {
@@ -54,6 +60,7 @@ export async function detectAvailability(
     claude: await whichBinary(config.harnesses.claude.bin),
     pi: await whichBinary(config.harnesses.pi.bin),
     gemini: await whichBinary(config.harnesses.gemini.bin),
+    codex: await whichBinary(config.harnesses.codex?.bin ?? "codex"),
   };
 }
 
@@ -86,7 +93,7 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
 
   p.note(
     SUPPORTED_HARNESSES.map(
-      (id) => `  ${availability[id] ? "[ok]  " : "[NOT FOUND]"} ${id}: ${availability[id] ?? config.harnesses[id].bin}`,
+      (id) => `  ${availability[id] ? "[ok]  " : "[NOT FOUND]"} ${id}: ${availability[id] ?? harnessBin(config, id)}`,
     ).join("\n"),
     "Detected harnesses",
   );
@@ -94,7 +101,7 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
   const hasAnyHarness = Object.values(availability).some((path) => path !== undefined);
   if (!hasAnyHarness) {
     p.note(
-      "No supported harness (claude, pi, gemini) was found on your PATH.\n" +
+      "No supported harness (claude, pi, gemini, codex) was found on your PATH.\n" +
       "You will need to install at least one of them before the agent can think.\n" +
       "We will continue the setup anyway so your configuration is ready.",
       "Warning: No Harness Found",

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -85,7 +85,7 @@ export default defineCommand({
 
     p.note(
       "This wizard will guide you through 4 quick steps to get your agent running:\n" +
-      "  1. Pick your AI harness (claude, pi, or gemini)\n" +
+      "  1. Pick your AI harness (claude, pi, gemini, or codex)\n" +
       "  2. Create a persona (identity & memory)\n" +
       "  3. Connect to Telegram\n" +
       "  4. Install as a background service",
@@ -132,7 +132,7 @@ export default defineCommand({
     } else {
       p.note(
         "No AI harness responded to '--version'.\n" +
-        "You might need to install one (claude, pi, or gemini) first, " +
+        "You might need to install one (claude, pi, gemini, or codex) first, " +
         "but we can still set up the configuration now.",
         "Probe result"
       );

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -27,6 +27,8 @@ import { join } from "node:path";
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { ClaudeHarness } from "../harnesses/claude.ts";
 import { PiHarness } from "../harnesses/pi.ts";
+import { GeminiHarness } from "../harnesses/gemini.ts";
+import { CodexHarness } from "../harnesses/codex.ts";
 import type { Harness } from "../harnesses/types.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
@@ -261,6 +263,8 @@ function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
   for (const id of config.harnesses.chain) {
     if (id === "claude") out.push(new ClaudeHarness(config.harnesses.claude));
     else if (id === "pi") out.push(new PiHarness(config.harnesses.pi));
+    else if (id === "gemini") out.push(new GeminiHarness(config.harnesses.gemini));
+    else if (id === "codex") out.push(new CodexHarness(config.harnesses.codex ?? { bin: "codex", model: "" }));
     else err.write(`warning: unknown harness '${id}', skipping\n`);
   }
   return out;

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,11 +78,12 @@ export interface Config {
   configPath: string;
 
   harnesses: {
-    /** Order = primary → fallback. Recognized ids: "claude", "pi", "gemini". */
+    /** Order = primary → fallback. Recognized ids: "claude", "pi", "gemini", "codex". */
     chain: string[];
     claude: { bin: string; model: string; fallbackModel: string };
     pi: { bin: string; maxPayloadBytes: number };
     gemini: { bin: string; model: string };
+    codex?: { bin: string; model: string };
   };
 
   channels: {
@@ -134,6 +135,7 @@ export async function loadConfig(): Promise<Config> {
   const tomlClaude = (tomlHarnesses.claude ?? {}) as Record<string, unknown>;
   const tomlPi = (tomlHarnesses.pi ?? {}) as Record<string, unknown>;
   const tomlGeminiHarness = (tomlHarnesses.gemini ?? {}) as Record<string, unknown>;
+  const tomlCodex = (tomlHarnesses.codex ?? {}) as Record<string, unknown>;
   const tomlChannels = (toml.channels ?? {}) as Record<string, unknown>;
   const tomlTelegram = (tomlChannels.telegram ?? {}) as Record<string, unknown>;
   const tomlEmbeddings = (toml.embeddings ?? {}) as Record<string, unknown>;
@@ -228,6 +230,18 @@ export async function loadConfig(): Promise<Config> {
         model:
           process.env.PHANTOMBOT_GEMINI_MODEL ??
           asString(tomlGeminiHarness.model) ??
+          "",
+      },
+
+      codex: {
+        bin:
+          process.env.PHANTOMBOT_CODEX_BIN ??
+          asString(tomlCodex.bin) ??
+          "codex",
+        // Empty string = "let codex pick its own default".
+        model:
+          process.env.PHANTOMBOT_CODEX_MODEL ??
+          asString(tomlCodex.model) ??
           "",
       },
     },

--- a/src/harnesses/buildChain.ts
+++ b/src/harnesses/buildChain.ts
@@ -14,6 +14,7 @@ import type { WriteSink } from "../lib/io.ts";
 import { ClaudeHarness } from "./claude.ts";
 import { GeminiHarness } from "./gemini.ts";
 import { PiHarness } from "./pi.ts";
+import { CodexHarness } from "./codex.ts";
 import type { Harness } from "./types.ts";
 
 export function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
@@ -25,6 +26,8 @@ export function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
       out.push(new PiHarness(config.harnesses.pi));
     } else if (id === "gemini") {
       out.push(new GeminiHarness(config.harnesses.gemini));
+    } else if (id === "codex") {
+      out.push(new CodexHarness(config.harnesses.codex ?? { bin: "codex", model: "" }));
     } else {
       err.write(`warning: unknown harness '${id}', skipping\n`);
     }

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -1,0 +1,229 @@
+/**
+ * Codex harness.
+ *
+ * Uses `codex exec --json` for non-interactive JSONL streaming. We run with
+ * `--ephemeral --ignore-user-config --ignore-rules` so phantombot-managed
+ * persona/memory stays authoritative and Codex local memory/rules do not leak
+ * into agent behavior.
+ */
+
+import { access, constants } from "node:fs/promises";
+import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { reloadEnvFiles } from "../lib/envBootstrap.ts";
+import {
+  createKillCoordinator,
+  killCauseToErrorChunk,
+} from "../lib/harnessRunner.ts";
+import { log } from "../lib/logger.ts";
+import { spawnInNewSession } from "../lib/processGroup.ts";
+
+export interface CodexHarnessConfig {
+  bin: string;
+  model: string;
+}
+
+export class CodexHarness implements Harness {
+  readonly id = "codex";
+
+  constructor(private readonly config: CodexHarnessConfig) {}
+
+  async available(): Promise<boolean> {
+    try {
+      if (this.config.bin.startsWith("/")) {
+        await access(this.config.bin, constants.X_OK);
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    const args = this.buildArgs();
+    log.debug("codex.invoke spawning", {
+      bin: this.config.bin,
+      argCount: args.length,
+    });
+
+    await reloadEnvFiles();
+
+    const proc = spawnInNewSession([this.config.bin, ...args], {
+      cwd: req.workingDir,
+      env: process.env,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    try {
+      proc.stdin.write(renderStdinPayload(req));
+      await proc.stdin.end();
+    } catch (e) {
+      log.warn("codex.invoke stdin write failed", {
+        error: (e as Error).message,
+      });
+    }
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: req.idleTimeoutMs,
+      hardTimeoutMs: req.hardTimeoutMs,
+      signal: req.signal,
+      harnessId: this.id,
+    });
+
+    void consumeStderr(proc.stderr);
+
+    let buffer = "";
+    let finalText = "";
+    let usageMeta: Record<string, unknown> | undefined;
+    const decoder = new TextDecoder();
+
+    try {
+      for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+        killer.touch();
+        buffer += decoder.decode(chunk, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(trimmed);
+          } catch {
+            yield { type: "progress", note: trimmed.slice(0, 200) };
+            continue;
+          }
+          const c = parseCodexEvent(parsed);
+          if (!c) continue;
+          if (c.type === "text") finalText += c.text;
+          if (c.type === "done") {
+            usageMeta = c.meta;
+            continue;
+          }
+          yield c;
+        }
+      }
+    } finally {
+      await killer.dispose();
+    }
+
+    const errChunk = killCauseToErrorChunk(
+      killer.killCause(),
+      this.id,
+      req.hardTimeoutMs,
+      req.idleTimeoutMs,
+    );
+    if (errChunk) {
+      yield errChunk;
+      return;
+    }
+
+    const code = await proc.exited;
+    if (code !== 0) {
+      yield {
+        type: "error",
+        error: `codex exited with code ${code}`,
+        recoverable: code !== 127,
+      };
+      return;
+    }
+
+    yield {
+      type: "done",
+      finalText,
+      meta: {
+        harnessId: this.id,
+        model: this.config.model || "(default)",
+        ...(usageMeta ?? {}),
+      },
+    };
+  }
+
+  private buildArgs(): string[] {
+    const args = [
+      "-a", "never",
+      "exec",
+      "--json",
+      "--skip-git-repo-check",
+      "--sandbox", "workspace-write",
+      ...PHANTOMBOT_INJECTED_CODEX_FLAGS,
+    ];
+    if (this.config.model) {
+      args.push("-m", this.config.model);
+    }
+    args.push("-");
+    return args;
+  }
+}
+
+export function renderStdinPayload(req: HarnessRequest): string {
+  const parts: string[] = [];
+  if (req.systemPrompt && req.systemPrompt.trim().length > 0) {
+    parts.push(req.systemPrompt.trim());
+  }
+  for (const turn of req.history) {
+    if (turn.role === "user") {
+      parts.push(turn.text);
+    } else {
+      parts.push(`<previous_response>\n${turn.text}\n</previous_response>`);
+    }
+  }
+  parts.push(req.userMessage);
+  return parts.join("\n\n");
+}
+
+export const PHANTOMBOT_INJECTED_CODEX_FLAGS = [
+  "--ephemeral",
+  "--ignore-user-config",
+  "--ignore-rules",
+] as const;
+
+export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const obj = parsed as Record<string, unknown>;
+  const type = obj.type;
+  if (type === "item.completed") {
+    const item = obj.item;
+    if (typeof item !== "object" || item === null) return undefined;
+    const it = item as Record<string, unknown>;
+    if (it.type === "agent_message" && typeof it.text === "string") {
+      return { type: "text", text: it.text };
+    }
+    if (typeof it.type === "string" && it.type.includes("tool")) {
+      return { type: "progress", note: "tool" };
+    }
+    return { type: "heartbeat" };
+  }
+  if (type === "turn.started") return { type: "heartbeat" };
+  if (type === "turn.completed") {
+    const usage = obj.usage;
+    if (typeof usage === "object" && usage !== null) {
+      return { type: "done", finalText: "", meta: { usage } };
+    }
+    return { type: "done", finalText: "", meta: undefined };
+  }
+  return undefined;
+}
+
+async function consumeStderr(
+  stream: ReadableStream<Uint8Array>,
+): Promise<void> {
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for await (const chunk of stream) {
+      buf += decoder.decode(chunk, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.trim()) {
+          log.info("codex stderr", { text: line.slice(0, 500) });
+        }
+      }
+    }
+  } catch {
+    /* swallow */
+  }
+}

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -28,6 +28,7 @@ function fakeInput(): InitFlowInput {
       claude: undefined,
       pi: undefined,
       gemini: undefined,
+      codex: undefined,
     } as Record<HarnessId, string | undefined>,
   };
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -24,6 +24,8 @@ const ENV_KEYS = [
   "PHANTOMBOT_CLAUDE_FALLBACK_MODEL",
   "PHANTOMBOT_PI_BIN",
   "PHANTOMBOT_PI_MAX_PAYLOAD",
+  "PHANTOMBOT_CODEX_BIN",
+  "PHANTOMBOT_CODEX_MODEL",
   "XDG_CONFIG_HOME",
   "XDG_DATA_HOME",
 ];
@@ -66,6 +68,10 @@ describe("loadConfig — defaults (no file)", () => {
       bin: "pi",
       maxPayloadBytes: 1_500_000,
     });
+    expect(c.harnesses.codex).toEqual({
+      bin: "codex",
+      model: "",
+    });
   });
 
   test("XDG paths resolve to ~/.config and ~/.local/share by default", async () => {
@@ -95,6 +101,10 @@ fallback_model = ""
 [harnesses.pi]
 bin = "/opt/pi/pi"
 max_payload_bytes = 500000
+
+[harnesses.codex]
+bin = "/opt/codex/codex"
+model = "gpt-5.3-codex"
 `,
       "utf8",
     );
@@ -111,6 +121,9 @@ max_payload_bytes = 500000
     expect(c.harnesses.claude.fallbackModel).toBe("");
     expect(c.harnesses.pi.bin).toBe("/opt/pi/pi");
     expect(c.harnesses.pi.maxPayloadBytes).toBe(500_000);
+    expect(c.harnesses.codex).toBeDefined();
+    expect(c.harnesses.codex!.bin).toBe("/opt/codex/codex");
+    expect(c.harnesses.codex!.model).toBe("gpt-5.3-codex");
   });
 });
 

--- a/tests/fixtures/fake-codex.sh
+++ b/tests/fixtures/fake-codex.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Fake codex CLI used by tests/harnesses-codex.test.ts.
+# Modes via FAKE_CODEX_MODE:
+#   normal   -> one agent message + turn.completed, exit 0
+#   error    -> stderr + exit 1
+#   notfound -> exit 127
+#   hang     -> sleep forever
+#   argv     -> echo argv in an agent message
+
+mode="${FAKE_CODEX_MODE:-normal}"
+
+# Drain stdin so harness stdin.end() resolves.
+stdin_payload="$(cat)"
+
+case "$mode" in
+  normal)
+    printf '%s\n' '{"type":"thread.started","thread_id":"t1"}'
+    printf '%s\n' '{"type":"turn.started"}'
+    printf '%s\n' '{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"hello codex"}}'
+    printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":2}}'
+    exit 0
+    ;;
+  error)
+    echo "simulated codex error" >&2
+    exit 1
+    ;;
+  notfound)
+    exit 127
+    ;;
+  hang)
+    exec sleep 3600
+    ;;
+  argv)
+    payload="$*"
+    payload="${payload//\\/\\\\}"
+    payload="${payload//\"/\\\"}"
+    printf '%s\n' "{\"type\":\"item.completed\",\"item\":{\"id\":\"i1\",\"type\":\"agent_message\",\"text\":\"argv:${payload}\"}}"
+    printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+    exit 0
+    ;;
+  *)
+    echo "fake-codex.sh: unknown FAKE_CODEX_MODE=$mode" >&2
+    exit 2
+    ;;
+esac

--- a/tests/harnesses-codex.test.ts
+++ b/tests/harnesses-codex.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmod } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  CodexHarness,
+  parseCodexEvent,
+  PHANTOMBOT_INJECTED_CODEX_FLAGS,
+  renderStdinPayload,
+} from "../src/harnesses/codex.ts";
+import type { HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
+
+const FAKE_CODEX = resolve(__dirname, "fixtures/fake-codex.sh");
+
+function newRequest(overrides: Partial<HarnessRequest> = {}): HarnessRequest {
+  return {
+    systemPrompt: "you are codex",
+    userMessage: "hi",
+    history: [],
+    workingDir: process.cwd(),
+    idleTimeoutMs: 5_000, hardTimeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+async function collect(
+  iter: AsyncIterable<HarnessChunk>,
+): Promise<HarnessChunk[]> {
+  const chunks: HarnessChunk[] = [];
+  for await (const c of iter) chunks.push(c);
+  return chunks;
+}
+
+beforeEach(async () => {
+  await chmod(FAKE_CODEX, 0o755);
+});
+
+afterEach(() => {
+  delete process.env.FAKE_CODEX_MODE;
+});
+
+describe("renderStdinPayload (Codex)", () => {
+  test("includes system prompt and wraps assistant history", () => {
+    const out = renderStdinPayload(newRequest({
+      history: [
+        { role: "user", text: "q1" },
+        { role: "assistant", text: "a1" },
+      ],
+      userMessage: "q2",
+    }));
+    expect(out).toContain("you are codex");
+    expect(out).toContain("q1");
+    expect(out).toContain("<previous_response>\na1\n</previous_response>");
+    expect(out).toContain("q2");
+  });
+});
+
+describe("parseCodexEvent", () => {
+  test("agent_message -> text", () => {
+    expect(parseCodexEvent({
+      type: "item.completed",
+      item: { type: "agent_message", text: "hello" },
+    })).toEqual({ type: "text", text: "hello" });
+  });
+
+  test("turn.started -> heartbeat", () => {
+    expect(parseCodexEvent({ type: "turn.started" })).toEqual({ type: "heartbeat" });
+  });
+
+  test("turn.completed -> done-shaped stats carrier", () => {
+    const c = parseCodexEvent({ type: "turn.completed", usage: { output_tokens: 2 } });
+    expect(c?.type).toBe("done");
+  });
+});
+
+describe("CodexHarness.invoke", () => {
+  const mkHarness = (model = "") => new CodexHarness({ bin: FAKE_CODEX, model });
+
+  test("normal: emits text then done", async () => {
+    process.env.FAKE_CODEX_MODE = "normal";
+    const chunks = await collect(mkHarness("gpt-5.3-codex").invoke(newRequest()));
+    const done = chunks.find((c) => c.type === "done");
+    expect(chunks.some((c) => c.type === "text")).toBe(true);
+    expect(done).toBeDefined();
+    if (done?.type !== "done") return;
+    expect(done.finalText).toContain("hello codex");
+    expect(done.meta?.harnessId).toBe("codex");
+  });
+
+  test("non-zero exit -> recoverable error", async () => {
+    process.env.FAKE_CODEX_MODE = "error";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const err = chunks.find((c) => c.type === "error");
+    expect(err).toBeDefined();
+    if (err?.type !== "error") return;
+    expect(err.recoverable).toBe(true);
+  });
+
+  test("exit 127 -> terminal error", async () => {
+    process.env.FAKE_CODEX_MODE = "notfound";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const err = chunks.find((c) => c.type === "error");
+    if (err?.type !== "error") throw new Error("expected error chunk");
+    expect(err.recoverable).toBe(false);
+  });
+
+  test("timeout path emits error and no done", async () => {
+    process.env.FAKE_CODEX_MODE = "hang";
+    const chunks = await collect(
+      mkHarness().invoke(newRequest({ idleTimeoutMs: 100, hardTimeoutMs: 100 })),
+    );
+    expect(chunks.find((c) => c.type === "done")).toBeUndefined();
+    const err = chunks.find((c) => c.type === "error");
+    if (err?.type !== "error") throw new Error("expected error chunk");
+    expect(err.error).toContain("timed out");
+  });
+
+  test("argv includes injected memory override flags", async () => {
+    process.env.FAKE_CODEX_MODE = "argv";
+    const chunks = await collect(mkHarness("gpt-5.3-codex").invoke(newRequest()));
+    const text = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join(" ");
+    for (const flag of PHANTOMBOT_INJECTED_CODEX_FLAGS) {
+      expect(text).toContain(flag);
+    }
+    expect(text).toContain("-m gpt-5.3-codex");
+  });
+});


### PR DESCRIPTION
## Summary
- add `codex` to supported harness IDs in `phantombot harness`
- detect Codex availability on PATH and include it in primary/fallback selection
- extend config parsing/defaults with `[harnesses.codex]` and env overrides
- update init wizard copy/probe messaging to include Codex
- update harness/init/config tests

## Notes
- Scope is harness selection/config UX only.
- Existing test fixtures remain compatible (`harnesses.codex` is optional in typing).

## Validation
- `~/.bun/bin/bun test tests/cli-harness.test.ts tests/cli-init.test.ts tests/config.test.ts`
- `~/.bun/bin/bun tsc --noEmit`