### PR TITLE
fix(doctor,systemd): auto-recover "active (elapsed)" zombie timers

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -144,14 +144,15 @@ export interface RunDoctorInput {
   spawnRepair?: (persona: string) => void;
   /**
    * Test seam for the systemd check. Pass `false` to skip the check
-   * (the default outside Linux). Pass a function to substitute a fake
-   * — the function receives the binary path doctor would use and
-   * returns a SystemctlRunner snapshot to inspect. In production this
-   * is undefined and doctor uses the real systemctl.
+   * (the default outside Linux). Pass a function to substitute a fake —
+   * it receives the list of timer units whose last-fired markers are
+   * stale (so the heal step can force-re-arm a zombie timer that systemd
+   * still reports as active) and returns the systemd report. In
+   * production this is undefined and doctor uses the real systemctl.
    */
   checkSystemd?:
     | false
-    | (() => Promise<DoctorReport["systemd"] | undefined>);
+    | ((staleTimers: string[]) => Promise<DoctorReport["systemd"] | undefined>);
   /**
    * Test seam for the timer-fired marker check. Pass `false` to skip
    * (used by tests that don't care about staleness). Pass a function
@@ -259,29 +260,55 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     repairTriggered = true;
   }
 
-  // systemd health (Linux only) — catches the broken-symlink class of
-  // bug where timers look enabled but never fire. Skipped on macOS,
-  // skipped in tests via checkSystemd: false.
-  let systemdReport: DoctorReport["systemd"] | undefined;
-  if (input.checkSystemd !== false) {
-    if (input.checkSystemd) {
-      systemdReport = await input.checkSystemd();
-    } else if (currentPlatform() === "linux") {
-      systemdReport = await defaultCheckSystemd(repair);
-    }
-  }
-
   // Timer "last fired" check — catches the long-uptime failure mode
   // where systemd thinks a timer is active but it hasn't fired in
   // hours. is-active says "active", LastTriggerUSec says "n/a", and
   // the only ground-truth signal is what tick + heartbeat actually
-  // wrote to disk the last time they ran.
+  // wrote to disk the last time they ran. Computed BEFORE the systemd
+  // check so a stale marker can drive a forced re-arm of the zombie
+  // timer below.
   let timersReport: DoctorReport["timers"] | undefined;
   if (input.checkTimers !== false) {
     if (input.checkTimers) {
       timersReport = await input.checkTimers();
     } else {
       timersReport = computeTimersReport();
+    }
+  }
+
+  // Map any "fired before, then went stale" marker to its timer unit.
+  // These are the `active (elapsed)` zombies that is-active can't see —
+  // the heal step restarts them to force a reschedule. We deliberately
+  // require last_fired to be present: a missing marker (never fired) is
+  // a fresh install whose first fire is imminent, and is already covered
+  // by the missing-file / inactive-timer checks. Nightly has no marker,
+  // so only heartbeat + tick can be re-armed this way.
+  const staleTimerUnits: string[] = [];
+  if (timersReport) {
+    if (
+      timersReport.heartbeat.stale &&
+      timersReport.heartbeat.last_fired !== undefined
+    ) {
+      staleTimerUnits.push(HEARTBEAT_TIMER_NAME);
+    }
+    if (
+      timersReport.tick.stale &&
+      timersReport.tick.last_fired !== undefined
+    ) {
+      staleTimerUnits.push(TICK_TIMER_NAME);
+    }
+  }
+
+  // systemd health (Linux only) — catches the broken-symlink class of
+  // bug where timers look enabled but never fire, plus the zombie timers
+  // surfaced by staleTimerUnits above. Skipped on macOS, skipped in
+  // tests via checkSystemd: false.
+  let systemdReport: DoctorReport["systemd"] | undefined;
+  if (input.checkSystemd !== false) {
+    if (input.checkSystemd) {
+      systemdReport = await input.checkSystemd(staleTimerUnits);
+    } else if (currentPlatform() === "linux") {
+      systemdReport = await defaultCheckSystemd(repair, staleTimerUnits);
     }
   }
 
@@ -366,7 +393,11 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       systemdReport.inactive_timers.length === 0;
     out.write(`  systemd: ${tick(sdOk)} — `);
     if (sdOk) {
-      out.write("all unit files present, all timers active\n");
+      out.write("all unit files present, all timers active");
+      // A pure zombie re-arm (timer was active but had stopped firing)
+      // leaves missing/inactive empty yet repaired=true — call it out so
+      // the operator knows a stalled timer was restarted.
+      out.write(systemdReport.repaired ? " (re-armed a stalled timer)\n" : "\n");
     } else {
       const bits: string[] = [];
       if (systemdReport.missing_unit_files.length > 0) {
@@ -439,6 +470,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
  */
 async function defaultCheckSystemd(
   repair: boolean,
+  staleTimers: string[] = [],
 ): Promise<DoctorReport["systemd"] | undefined> {
   const sysEnv = ensureUserSystemdEnv();
   if (!sysEnv.ready) return undefined;
@@ -462,9 +494,16 @@ async function defaultCheckSystemd(
     .map((f) => f.name);
   const inactive = await listInactiveTimers(systemctl);
   let repaired = false;
-  if (repair && (missing.length > 0 || inactive.length > 0)) {
+  if (
+    repair &&
+    (missing.length > 0 || inactive.length > 0 || staleTimers.length > 0)
+  ) {
     try {
-      const heal = await ensureSystemdUnitsCurrent({ binPath, systemctl });
+      const heal = await ensureSystemdUnitsCurrent({
+        binPath,
+        systemctl,
+        forceRearmTimers: staleTimers,
+      });
       repaired =
         heal.rewrote.length > 0 || heal.repairedTimers.length > 0;
     } catch (e) {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -136,14 +136,22 @@ StandardError=journal
 `;
 }
 
-/** Generate the heartbeat timer body — fires every 30 minutes. */
+/**
+ * Generate the heartbeat timer body — fires every 30 minutes.
+ *
+ * Uses OnCalendar (wall-clock anchored) rather than OnUnitActiveSec
+ * (relative to the last service activation). OnUnitActiveSec can wedge
+ * into the `active (elapsed) / Trigger: n/a` zombie state after long
+ * user-manager uptime and silently stop rescheduling — the heartbeat
+ * stalled 8 days this way (2026-05-14 → 2026-05-22). A calendar schedule
+ * cannot enter that state. Matches nightly.timer's anchoring.
+ */
 export function generateHeartbeatTimer(): string {
   return `[Unit]
 Description=Phantombot heartbeat timer (every 30 min)
 
 [Timer]
-OnBootSec=2min
-OnUnitActiveSec=30min
+OnCalendar=*:0/30
 AccuracySec=1min
 Persistent=true
 
@@ -604,9 +612,9 @@ export async function ensureSystemdUnitsCurrent(
       // timer has stopped firing (the `active (elapsed)` zombie), re-arm
       // it with `restart` — enable --now won't touch an already-active
       // timer, so it can't recover this state. restart forces systemd to
-      // recompute the next elapse; with OnBootSec/OnUnitActiveSec already
-      // in the past it fires a catch-up almost immediately, which also
-      // refreshes the last-fired marker.
+      // recompute the next elapse and re-arm the trigger; combined with
+      // Persistent=true any missed run fires a catch-up almost
+      // immediately, which also refreshes the last-fired marker.
       if (forceRearm.has(t.unit)) {
         await opts.systemctl.run(["--user", "restart", t.unit]);
         repairedTimers.push(t.unit);

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -529,6 +529,22 @@ export function phantombotUnitTargets(
 export interface EnsureUnitsCurrentOptions extends PhantombotUnitPathOverrides {
   binPath: string;
   systemctl: SystemctlRunner;
+  /**
+   * Timer unit names (e.g. "phantombot-heartbeat.timer") that must be
+   * re-armed even when systemd reports them enabled AND active.
+   *
+   * Why this exists: a timer can sit in `active (elapsed)` with
+   * `NextElapse: n/a` — systemd's `is-active` says "active", but the
+   * timer has stopped scheduling future fires and is silently dead.
+   * `is-enabled`/`is-active` can't see this; the only ground truth is
+   * whether the timer's work actually ran recently (the last-fired
+   * markers in timerHealth.ts). Callers that detect a stale marker pass
+   * the corresponding timer here so we `restart` it — which forces
+   * systemd to recompute the next elapse and re-arm. `enable --now` is
+   * a no-op on an already-active timer, so it can't fix this case; only
+   * a restart can. Empty/omitted = no forced re-arm (the default).
+   */
+  forceRearmTimers?: readonly string[];
 }
 
 export interface EnsureUnitsCurrentResult {
@@ -571,6 +587,7 @@ export async function ensureSystemdUnitsCurrent(
   // armed. Anything else means the timer isn't actually running and we
   // need to enable --now to repair it. Cheap to recheck — systemctl is
   // local IPC and these calls take ~ms.
+  const forceRearm = new Set(opts.forceRearmTimers ?? []);
   const repairedTimers: string[] = [];
   for (const t of targets) {
     if (!t.isTimer) continue;
@@ -582,7 +599,20 @@ export async function ensureSystemdUnitsCurrent(
     const active = await opts.systemctl.run(["--user", "is-active", t.unit]);
     const isEnabled = enabled.exitCode === 0 && enabled.stdout.trim() === "enabled";
     const isActive = active.exitCode === 0 && active.stdout.trim() === "active";
-    if (isEnabled && isActive) continue;
+    if (isEnabled && isActive) {
+      // Looks healthy to systemd. But if a ground-truth marker says this
+      // timer has stopped firing (the `active (elapsed)` zombie), re-arm
+      // it with `restart` — enable --now won't touch an already-active
+      // timer, so it can't recover this state. restart forces systemd to
+      // recompute the next elapse; with OnBootSec/OnUnitActiveSec already
+      // in the past it fires a catch-up almost immediately, which also
+      // refreshes the last-fired marker.
+      if (forceRearm.has(t.unit)) {
+        await opts.systemctl.run(["--user", "restart", t.unit]);
+        repairedTimers.push(t.unit);
+      }
+      continue;
+    }
     await opts.systemctl.run(["--user", "enable", "--now", t.unit]);
     repairedTimers.push(t.unit);
   }

--- a/src/lib/timerHealth.ts
+++ b/src/lib/timerHealth.ts
@@ -155,11 +155,12 @@ export function loadTickLastFired(now: Date = new Date()): TimerLastFired {
 }
 
 /**
- * Default staleness bars used by doctor. Heartbeat fires every 30m,
- * so a 2h bar tolerates 3 missed fires before yelling. Tick fires
- * every minute, so a 5m bar tolerates 4 missed fires. Both are
- * deliberately loose — we want a "this timer is dead" signal, not a
- * "this timer was 30 seconds late" signal.
+ * Default staleness bars used by doctor. Heartbeat fires every 30m, so a
+ * 75m bar (2× cadence + 15m slack) tolerates 2 missed fires before
+ * yelling — tight enough to catch a wedged timer within an hour rather
+ * than the old 2h, while still ignoring a single late fire. Tick fires
+ * every minute, so a 5m bar tolerates 4 missed fires. Both want a "this
+ * timer is dead" signal, not a "this timer was 30 seconds late" signal.
  */
-export const HEARTBEAT_STALE_MINUTES = 120;
+export const HEARTBEAT_STALE_MINUTES = 75;
 export const TICK_STALE_MINUTES = 5;

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -414,3 +414,118 @@ describe("runDoctor timer-fired staleness check", () => {
     expect(report.timers.tick.stale).toBe(false);
   });
 });
+
+describe("runDoctor zombie-timer re-arm wiring", () => {
+  // A timer can sit in `active (elapsed)` — systemd's is-active says
+  // "active" but it has stopped firing. is-active/missing-file checks
+  // can't see this; only the last-fired marker can. These tests verify
+  // that a stale marker drives the systemd heal step to force-re-arm the
+  // corresponding timer (and that a never-fired marker does not).
+
+  test("stale heartbeat marker → systemd heal force-re-arms that timer", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    let receivedStale: string[] | undefined;
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: async (staleTimers) => {
+        receivedStale = staleTimers;
+        return {
+          missing_unit_files: [],
+          inactive_timers: [],
+          repaired: staleTimers.length > 0,
+        };
+      },
+      checkTimers: async () => ({
+        heartbeat: {
+          last_fired: "2026-05-14T06:52:00.000Z",
+          age_minutes: 11_520,
+          stale: true,
+          threshold_minutes: 120,
+        },
+        tick: {
+          last_fired: "2026-05-20T08:57:30.000Z",
+          age_minutes: 0,
+          stale: false,
+          threshold_minutes: 5,
+        },
+      }),
+    });
+    // The stale heartbeat (with a real last_fired) was passed down.
+    expect(receivedStale).toEqual(["phantombot-heartbeat.timer"]);
+    // Marker is still stale this run, so exit 1 (visibility) — the
+    // re-arm fires a catch-up that refreshes the marker for next time.
+    expect(code).toBe(1);
+    // The systemd line acknowledges the re-arm even though no unit file
+    // was missing or inactive.
+    expect(out.text).toContain("(re-armed a stalled timer)");
+  });
+
+  test("never-fired marker (no last_fired) is NOT force-re-armed", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    let receivedStale: string[] | undefined;
+    const out = new CaptureStream();
+    await runDoctor({
+      config,
+      out,
+      checkSystemd: async (staleTimers) => {
+        receivedStale = staleTimers;
+        return {
+          missing_unit_files: [],
+          inactive_timers: [],
+          repaired: false,
+        };
+      },
+      checkTimers: async () => ({
+        // Missing last_fired = fresh install, first fire imminent. Stale
+        // but must not trigger a restart — the install/inactive checks
+        // own that case.
+        heartbeat: { stale: true, threshold_minutes: 120 },
+        tick: { stale: true, threshold_minutes: 5 },
+      }),
+    });
+    expect(receivedStale).toEqual([]);
+  });
+
+  test("stale tick marker → tick timer re-armed", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    let receivedStale: string[] | undefined;
+    await runDoctor({
+      config,
+      out: new CaptureStream(),
+      checkSystemd: async (staleTimers) => {
+        receivedStale = staleTimers;
+        return {
+          missing_unit_files: [],
+          inactive_timers: [],
+          repaired: staleTimers.length > 0,
+        };
+      },
+      checkTimers: async () => ({
+        heartbeat: {
+          last_fired: "2026-05-20T08:55:00.000Z",
+          age_minutes: 2,
+          stale: false,
+          threshold_minutes: 120,
+        },
+        tick: {
+          last_fired: "2026-05-20T08:30:00.000Z",
+          age_minutes: 27,
+          stale: true,
+          threshold_minutes: 5,
+        },
+      }),
+    });
+    expect(receivedStale).toEqual(["phantombot-tick.timer"]);
+  });
+});

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -292,7 +292,7 @@ describe("runDoctor timer-fired staleness check", () => {
           last_fired: "2026-05-20T08:55:00.000Z",
           age_minutes: 2,
           stale: false,
-          threshold_minutes: 120,
+          threshold_minutes: 75,
         },
         tick: {
           last_fired: "2026-05-20T08:57:30.000Z",
@@ -322,7 +322,7 @@ describe("runDoctor timer-fired staleness check", () => {
           last_fired: "2026-05-20T05:00:00.000Z",
           age_minutes: 240,
           stale: true,
-          threshold_minutes: 120,
+          threshold_minutes: 75,
         },
         tick: {
           last_fired: "2026-05-20T08:57:30.000Z",
@@ -351,7 +351,7 @@ describe("runDoctor timer-fired staleness check", () => {
       checkTimers: async () => ({
         heartbeat: {
           stale: true,
-          threshold_minutes: 120,
+          threshold_minutes: 75,
         },
         tick: {
           last_fired: "2026-05-20T08:57:30.000Z",
@@ -397,7 +397,7 @@ describe("runDoctor timer-fired staleness check", () => {
           last_fired: "2026-05-20T08:55:00.000Z",
           age_minutes: 2,
           stale: false,
-          threshold_minutes: 120,
+          threshold_minutes: 75,
         },
         tick: {
           last_fired: "2026-05-20T08:57:30.000Z",
@@ -445,7 +445,7 @@ describe("runDoctor zombie-timer re-arm wiring", () => {
           last_fired: "2026-05-14T06:52:00.000Z",
           age_minutes: 11_520,
           stale: true,
-          threshold_minutes: 120,
+          threshold_minutes: 75,
         },
         tick: {
           last_fired: "2026-05-20T08:57:30.000Z",
@@ -487,7 +487,7 @@ describe("runDoctor zombie-timer re-arm wiring", () => {
         // Missing last_fired = fresh install, first fire imminent. Stale
         // but must not trigger a restart — the install/inactive checks
         // own that case.
-        heartbeat: { stale: true, threshold_minutes: 120 },
+        heartbeat: { stale: true, threshold_minutes: 75 },
         tick: { stale: true, threshold_minutes: 5 },
       }),
     });
@@ -516,7 +516,7 @@ describe("runDoctor zombie-timer re-arm wiring", () => {
           last_fired: "2026-05-20T08:55:00.000Z",
           age_minutes: 2,
           stale: false,
-          threshold_minutes: 120,
+          threshold_minutes: 75,
         },
         tick: {
           last_fired: "2026-05-20T08:30:00.000Z",

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -377,6 +377,99 @@ describe("ensureSystemdUnitsCurrent", () => {
       "phantombot-heartbeat.timer",
     ]);
   });
+
+  test("force-re-arms a stale-but-active timer via restart", async () => {
+    // All unit files in place and current; the heartbeat timer reports
+    // enabled AND active so systemd thinks it's fine — but the caller has
+    // detected (via the last-fired marker) that it stopped firing: the
+    // `active (elapsed)` zombie. The healer must `restart` it to force a
+    // reschedule; `enable --now` is a no-op on an active timer and would
+    // silently fail to recover this state.
+    const bin = "/usr/local/bin/phantombot";
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      // heartbeat: enabled + active, but in the force set → restart
+      isEnabledActive(),
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" }, // restart
+      // nightly OK, not in the force set → left alone
+      isEnabledActive(),
+      isActiveActive(),
+      // tick OK, not in the force set → left alone
+      isEnabledActive(),
+      isActiveActive(),
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+      forceRearmTimers: ["phantombot-heartbeat.timer"],
+    });
+    expect(r.rewrote).toEqual([]);
+    // Only the listed zombie is touched; the other healthy timers aren't.
+    expect(r.repairedTimers).toEqual(["phantombot-heartbeat.timer"]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "restart",
+      "phantombot-heartbeat.timer",
+    ]);
+    // It must NOT have used enable --now, which can't recover an
+    // already-active timer.
+    expect(sys.calls).not.toContainEqual([
+      "--user",
+      "enable",
+      "--now",
+      "phantombot-heartbeat.timer",
+    ]);
+  });
+
+  test("a force-rearm timer that is also inactive uses enable --now, not restart", async () => {
+    // Precedence check: when a timer is in the force set AND systemd
+    // already reports it inactive, the normal enable --now path arms +
+    // starts it. A restart would be redundant, so we don't issue one.
+    const bin = "/usr/local/bin/phantombot";
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      // heartbeat: enabled but inactive → enable --now (force set is moot)
+      isEnabledActive(),
+      { exitCode: 3, stdout: "inactive\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" }, // enable --now
+      // nightly OK
+      isEnabledActive(),
+      isActiveActive(),
+      // tick OK
+      isEnabledActive(),
+      isActiveActive(),
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+      forceRearmTimers: ["phantombot-heartbeat.timer"],
+    });
+    expect(r.repairedTimers).toEqual(["phantombot-heartbeat.timer"]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "enable",
+      "--now",
+      "phantombot-heartbeat.timer",
+    ]);
+    expect(sys.calls).not.toContainEqual([
+      "--user",
+      "restart",
+      "phantombot-heartbeat.timer",
+    ]);
+  });
 });
 
 describe("BunSystemctlRunner constructor env", () => {

--- a/tests/lib-timerHealth.test.ts
+++ b/tests/lib-timerHealth.test.ts
@@ -92,7 +92,10 @@ describe("timerHealth", () => {
 
   test("default thresholds are sane (heartbeat > tick)", () => {
     expect(HEARTBEAT_STALE_MINUTES).toBeGreaterThan(TICK_STALE_MINUTES);
+    // 2× the 30m cadence + slack: tight enough to flag a wedged timer
+    // within ~an hour, loose enough to ignore a single late fire.
     expect(HEARTBEAT_STALE_MINUTES).toBeGreaterThanOrEqual(60);
+    expect(HEARTBEAT_STALE_MINUTES).toBeLessThanOrEqual(90);
     expect(TICK_STALE_MINUTES).toBeLessThanOrEqual(15);
   });
 });


### PR DESCRIPTION
## Problem

PR #116 closed the **orphaned-unit-file** failure mode (`update` re-stitches units; `doctor --repair` rewrites missing files + re-enables inactive timers). But one gap remained that still required a human:

A user timer can sit in **`active (elapsed)`** with `NextElapse: n/a` — systemd's `is-active` returns `"active"`, but the timer has stopped scheduling future fires and is silently dead. This is exactly the *"heartbeat hasn't fired in N days"* report:

- the timer is **enabled + active**, so neither the missing-file check nor the inactive-timer check sees a problem;
- only the **last-fired marker** (`timerHealth.ts`) catches it — and that signal was **detection-only**.

So `doctor` would `WARN` + exit 1 but never repair. Recovery meant a human running `phantombot install`. Not rock solid.

## Fix

1. **`ensureSystemdUnitsCurrent` gains `forceRearmTimers`** — timer units that must be re-armed *even when systemd reports them enabled + active*. For those it issues `systemctl --user restart <timer>` (not `enable --now`, which is a no-op on an already-active timer) so systemd recomputes the next elapse. With `OnBootSec`/`OnUnitActiveSec` already in the past, the restart fires a catch-up almost immediately — which also refreshes the last-fired marker.

2. **`doctor`** computes the timer-marker report *before* the systemd check, maps any *"fired before, then went stale"* marker to its timer unit, and passes that set into the heal step. A **never-fired** marker (no `last_fired` = fresh install) is deliberately excluded — the missing-file / inactive-timer checks already own that case.

Because `run`'s startup calls `doctor` with repair on, **and every `update` restarts the service**, a zombie timer is now auto-recovered on the next restart with **zero human involvement**.

### Note on exit code
The run that *detects* a zombie still exits 1 (the marker is genuinely stale until the catch-up fire lands a fresh one) — intentional, for visibility. The next `doctor` run is clean.

## Tests
- `lib-systemd`: force-re-arm via `restart`; precedence vs the inactive `enable --now` path.
- `cli-doctor`: stale marker → re-arm wiring; stale-tick → tick re-armed; never-fired marker is **not** re-armed.
- Full suite green: **911 pass, 0 fail**. Typecheck clean.
