### PR TITLE
fix(doctor,systemd): detect + heal systemd unit content drift on existing boxes

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -20,7 +20,7 @@
 
 import { spawn } from "node:child_process";
 import { defineCommand } from "citty";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { basename } from "node:path";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
@@ -38,6 +38,7 @@ import {
   BunSystemctlRunner,
   buildSystemctlEnv,
   defaultUnitPath,
+  driftedUnitNames,
   ensureSystemdUnitsCurrent,
   ensureUserSystemdEnv,
   HEARTBEAT_TIMER_NAME,
@@ -46,6 +47,7 @@ import {
   NIGHTLY_TIMER_NAME,
   nightlyServicePath,
   nightlyTimerPath,
+  phantombotUnitTargets,
   type SystemctlRunner,
   TICK_TIMER_NAME,
   tickServicePath,
@@ -93,12 +95,21 @@ export interface DoctorReport {
   };
   /**
    * Linux-only — undefined on macOS and dev hosts without a user-systemd
-   * bus. When present, lists which unit files are missing from disk and
-   * which timers are not active right now. A healthy box reports empty
-   * arrays for both.
+   * bus. When present, lists which unit files are missing from disk, which
+   * present-but-stale unit files have drifted from the running binary's
+   * templates, and which timers are not active right now. A healthy box
+   * reports empty arrays for all three.
    */
   systemd?: {
     missing_unit_files: string[];
+    /**
+     * Unit files present on disk but whose content no longer matches the
+     * running binary's templates — e.g. a pre-`OnCalendar` heartbeat timer
+     * that an in-place `update` left behind because the post-swap heal
+     * couldn't reach the systemd bus. Healed by the same re-render path as
+     * missing files (and, for timers, restarted so the new schedule arms).
+     */
+    drifted_unit_files: string[];
     inactive_timers: string[];
     /** True when we re-rendered or re-armed at least one thing. */
     repaired: boolean;
@@ -390,18 +401,22 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   if (systemdReport) {
     const sdOk =
       systemdReport.missing_unit_files.length === 0 &&
+      systemdReport.drifted_unit_files.length === 0 &&
       systemdReport.inactive_timers.length === 0;
     out.write(`  systemd: ${tick(sdOk)} — `);
     if (sdOk) {
-      out.write("all unit files present, all timers active");
+      out.write("all unit files present and current, all timers active");
       // A pure zombie re-arm (timer was active but had stopped firing)
-      // leaves missing/inactive empty yet repaired=true — call it out so
-      // the operator knows a stalled timer was restarted.
+      // leaves missing/drifted/inactive empty yet repaired=true — call it
+      // out so the operator knows a stalled timer was restarted.
       out.write(systemdReport.repaired ? " (re-armed a stalled timer)\n" : "\n");
     } else {
       const bits: string[] = [];
       if (systemdReport.missing_unit_files.length > 0) {
         bits.push(`missing: ${systemdReport.missing_unit_files.join(", ")}`);
+      }
+      if (systemdReport.drifted_unit_files.length > 0) {
+        bits.push(`drifted: ${systemdReport.drifted_unit_files.join(", ")}`);
       }
       if (systemdReport.inactive_timers.length > 0) {
         bits.push(`inactive: ${systemdReport.inactive_timers.join(", ")}`);
@@ -442,6 +457,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     !!systemdReport &&
     !systemdReport.repaired &&
     (systemdReport.missing_unit_files.length > 0 ||
+      systemdReport.drifted_unit_files.length > 0 ||
       systemdReport.inactive_timers.length > 0);
   const timersBroken =
     !!timersReport &&
@@ -492,11 +508,23 @@ async function defaultCheckSystemd(
   const missing = expectedFiles
     .filter((f) => !existsSync(f.path))
     .map((f) => f.name);
+  // Detect content drift: a unit file that exists but no longer matches the
+  // running binary's template. This is the gap that let the wedge-prone
+  // pre-OnCalendar heartbeat timer hide in plain sight — it was present and
+  // "active", so missing/inactive both stayed empty and doctor reported
+  // "ok". Comparing on-disk bytes against `phantombotUnitTargets` is the
+  // only way to see it.
+  const drifted = driftedUnitNames(phantombotUnitTargets(binPath), (p) =>
+    existsSync(p) ? readFileSync(p, "utf8") : undefined,
+  );
   const inactive = await listInactiveTimers(systemctl);
   let repaired = false;
   if (
     repair &&
-    (missing.length > 0 || inactive.length > 0 || staleTimers.length > 0)
+    (missing.length > 0 ||
+      drifted.length > 0 ||
+      inactive.length > 0 ||
+      staleTimers.length > 0)
   ) {
     try {
       const heal = await ensureSystemdUnitsCurrent({
@@ -514,6 +542,7 @@ async function defaultCheckSystemd(
   }
   return {
     missing_unit_files: missing,
+    drifted_unit_files: drifted,
     inactive_timers: inactive,
     repaired,
   };

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -515,6 +515,35 @@ export function phantombotUnitTargets(
 }
 
 /**
+ * Names of phantombot unit files that exist on disk but whose content no
+ * longer matches the running binary's templates. This is the *detection*
+ * half of the reconcile loop — `ensureSystemdUnitsCurrent` does the
+ * rewriting; this just names what would be rewritten, so `doctor` can SEE
+ * and report drift instead of cheerfully printing "systemd: ok" while a
+ * stale unit (e.g. a pre-`OnCalendar` heartbeat timer that an in-place
+ * `update` swapped the binary but never rewrote) sits latent on disk.
+ *
+ * Only existing files count: a missing file isn't "drift" (you can't drift
+ * from a file that isn't there) and is reported separately as
+ * `missing_unit_files`. Pure on its inputs — the caller supplies the
+ * targets (from `phantombotUnitTargets`) and a reader that returns the
+ * on-disk content or `undefined` when the file is absent — so it unit-tests
+ * without touching the filesystem.
+ */
+export function driftedUnitNames(
+  targets: PhantombotUnitTarget[],
+  readUnit: (path: string) => string | undefined,
+): string[] {
+  const drifted: string[] = [];
+  for (const t of targets) {
+    const current = readUnit(t.path);
+    if (current === undefined) continue; // missing, not drift
+    if (current !== t.content) drifted.push(basename(t.path));
+  }
+  return drifted;
+}
+
+/**
  * Surgical re-render of all six phantombot systemd unit files, plus a
  * re-enable / re-start of any timer that isn't currently active.
  *
@@ -571,6 +600,12 @@ export async function ensureSystemdUnitsCurrent(
 
   const rewrote: string[] = [];
   const backups: string[] = [];
+  // Timer units whose *content* we just rewrote. A daemon-reload alone is
+  // not enough to recover a timer whose definition changed while it sat in
+  // the `active (elapsed)` zombie state (the pre-OnCalendar bug): the unit
+  // stays wedged until restarted. We restart these below so the new
+  // schedule actually arms.
+  const rewroteTimerUnits = new Set<string>();
   for (const t of targets) {
     let current: string | undefined;
     if (existsSync(t.path)) {
@@ -585,6 +620,7 @@ export async function ensureSystemdUnitsCurrent(
     }
     await writeFile(t.path, t.content, "utf8");
     rewrote.push(basename(t.path));
+    if (t.isTimer) rewroteTimerUnits.add(t.unit);
   }
   if (rewrote.length > 0) {
     await opts.systemctl.run(["--user", "daemon-reload"]);
@@ -608,14 +644,19 @@ export async function ensureSystemdUnitsCurrent(
     const isEnabled = enabled.exitCode === 0 && enabled.stdout.trim() === "enabled";
     const isActive = active.exitCode === 0 && active.stdout.trim() === "active";
     if (isEnabled && isActive) {
-      // Looks healthy to systemd. But if a ground-truth marker says this
-      // timer has stopped firing (the `active (elapsed)` zombie), re-arm
-      // it with `restart` — enable --now won't touch an already-active
-      // timer, so it can't recover this state. restart forces systemd to
-      // recompute the next elapse and re-arm the trigger; combined with
-      // Persistent=true any missed run fires a catch-up almost
-      // immediately, which also refreshes the last-fired marker.
-      if (forceRearm.has(t.unit)) {
+      // Looks healthy to systemd. But re-arm with `restart` if either:
+      //   (a) a ground-truth marker says this timer has stopped firing (the
+      //       `active (elapsed)` zombie), or
+      //   (b) we just rewrote this timer's content (its schedule changed,
+      //       e.g. OnUnitActiveSec → OnCalendar) — a daemon-reload doesn't
+      //       un-wedge an elapsed timer, only a restart re-evaluates and
+      //       arms the new definition.
+      // `enable --now` won't touch an already-active timer, so it can't
+      // recover either case. restart forces systemd to recompute the next
+      // elapse and re-arm the trigger; combined with Persistent=true any
+      // missed run fires a catch-up almost immediately, which also
+      // refreshes the last-fired marker.
+      if (forceRearm.has(t.unit) || rewroteTimerUnits.has(t.unit)) {
         await opts.systemctl.run(["--user", "restart", t.unit]);
         repairedTimers.push(t.unit);
       }

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -179,13 +179,14 @@ describe("runDoctor systemd health check", () => {
       out,
       checkSystemd: async () => ({
         missing_unit_files: [],
+        drifted_unit_files: [],
         inactive_timers: [],
         repaired: false,
       }),
     });
     expect(code).toBe(0);
     expect(out.text).toContain(
-      "systemd: ok — all unit files present, all timers active",
+      "systemd: ok — all unit files present and current, all timers active",
     );
   });
 
@@ -200,6 +201,7 @@ describe("runDoctor systemd health check", () => {
       out,
       checkSystemd: async () => ({
         missing_unit_files: ["phantombot-tick.timer"],
+        drifted_unit_files: [],
         inactive_timers: ["phantombot-tick.timer"],
         repaired: false,
       }),
@@ -223,6 +225,7 @@ describe("runDoctor systemd health check", () => {
       out,
       checkSystemd: async () => ({
         missing_unit_files: ["phantombot-tick.timer"],
+        drifted_unit_files: [],
         inactive_timers: [],
         repaired: true,
       }),
@@ -258,6 +261,7 @@ describe("runDoctor systemd health check", () => {
       out,
       checkSystemd: async () => ({
         missing_unit_files: [],
+        drifted_unit_files: [],
         inactive_timers: ["phantombot-tick.timer"],
         repaired: false,
       }),
@@ -265,9 +269,57 @@ describe("runDoctor systemd health check", () => {
     const report = JSON.parse(out.text);
     expect(report.systemd).toEqual({
       missing_unit_files: [],
+      drifted_unit_files: [],
       inactive_timers: ["phantombot-tick.timer"],
       repaired: false,
     });
+  });
+
+  test("reports drifted unit files and exits 1 when unrepaired", async () => {
+    // A unit file that exists and is "active" but whose content no longer
+    // matches the binary's template (the pre-OnCalendar heartbeat timer that
+    // an in-place update left behind). missing/inactive stay empty, so only
+    // the drift signal catches it — the gap that made doctor say "ok" while
+    // a wedge-prone timer sat on disk.
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: async () => ({
+        missing_unit_files: [],
+        drifted_unit_files: ["phantombot-heartbeat.timer"],
+        inactive_timers: [],
+        repaired: false,
+      }),
+    });
+    expect(code).toBe(1);
+    expect(out.text).toContain("systemd: WARN");
+    expect(out.text).toContain("drifted: phantombot-heartbeat.timer");
+    expect(out.text).toContain("run `phantombot install` to repair");
+  });
+
+  test("drift healed in place → exit 0 and no manual action needed", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: async () => ({
+        missing_unit_files: [],
+        drifted_unit_files: ["phantombot-heartbeat.timer"],
+        inactive_timers: [],
+        repaired: true,
+      }),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("re-rendered units and re-armed timers");
   });
 });
 
@@ -436,6 +488,7 @@ describe("runDoctor zombie-timer re-arm wiring", () => {
         receivedStale = staleTimers;
         return {
           missing_unit_files: [],
+          drifted_unit_files: [],
           inactive_timers: [],
           repaired: staleTimers.length > 0,
         };
@@ -479,6 +532,7 @@ describe("runDoctor zombie-timer re-arm wiring", () => {
         receivedStale = staleTimers;
         return {
           missing_unit_files: [],
+          drifted_unit_files: [],
           inactive_timers: [],
           repaired: false,
         };
@@ -507,6 +561,7 @@ describe("runDoctor zombie-timer re-arm wiring", () => {
         receivedStale = staleTimers;
         return {
           missing_unit_files: [],
+          drifted_unit_files: [],
           inactive_timers: [],
           repaired: staleTimers.length > 0,
         };

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -11,11 +11,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildSystemctlEnv,
+  driftedUnitNames,
   ensureSystemdUnitsCurrent,
   ensureUnitCurrent,
   ensureUserSystemdEnv,
   generateSystemdUnit,
   installPhantombotUnit,
+  phantombotUnitTargets,
   SELF_RESTART_ARGS,
   uninstallPhantombotUnit,
   type SystemctlResult,
@@ -428,6 +430,62 @@ describe("ensureSystemdUnitsCurrent", () => {
     ]);
   });
 
+  test("rewriting a timer's content also restarts it to arm the new schedule", async () => {
+    // The drifted-timer cure: a timer file whose body changed (e.g.
+    // OnUnitActiveSec → OnCalendar) needs more than a daemon-reload — an
+    // `active (elapsed)` timer stays wedged until restarted. So when we
+    // rewrite a timer's content, we restart it even though systemd still
+    // reports it enabled + active. Without this, doctor would rewrite the
+    // unit but the box would stay on the dead schedule until a manual kick.
+    const bin = "/usr/local/bin/phantombot";
+    // Populate every unit with canonical content first.
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    // Now corrupt only the heartbeat *timer* so its content drifts.
+    await writeFile(hbTimerPath, "OnUnitActiveSec=30min\n", "utf8");
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      { exitCode: 0, stdout: "", stderr: "" }, // daemon-reload (content changed)
+      // heartbeat: enabled + active, but its content was just rewritten → restart
+      isEnabledActive(),
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" }, // restart
+      // nightly: unchanged, enabled + active → left alone
+      isEnabledActive(),
+      isActiveActive(),
+      // tick: unchanged, enabled + active → left alone
+      isEnabledActive(),
+      isActiveActive(),
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+    });
+    expect(r.rewrote).toEqual(["phantombot-heartbeat.timer"]);
+    expect(r.backups).toEqual([`${hbTimerPath}.bak`]);
+    // The rewritten timer was restarted; the untouched ones were not.
+    expect(r.repairedTimers).toEqual(["phantombot-heartbeat.timer"]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "restart",
+      "phantombot-heartbeat.timer",
+    ]);
+    expect(sys.calls).not.toContainEqual([
+      "--user",
+      "restart",
+      "phantombot-nightly.timer",
+    ]);
+    expect(sys.calls).not.toContainEqual([
+      "--user",
+      "restart",
+      "phantombot-tick.timer",
+    ]);
+  });
+
   test("a force-rearm timer that is also inactive uses enable --now, not restart", async () => {
     // Precedence check: when a timer is in the force set AND systemd
     // already reports it inactive, the normal enable --now path arms +
@@ -469,6 +527,41 @@ describe("ensureSystemdUnitsCurrent", () => {
       "restart",
       "phantombot-heartbeat.timer",
     ]);
+  });
+});
+
+describe("driftedUnitNames", () => {
+  const bin = "/usr/local/bin/phantombot";
+
+  test("returns [] when every on-disk unit matches its template", () => {
+    const targets = phantombotUnitTargets(bin);
+    const byPath = new Map(targets.map((t) => [t.path, t.content]));
+    const drifted = driftedUnitNames(targets, (p) => byPath.get(p));
+    expect(drifted).toEqual([]);
+  });
+
+  test("flags only the unit whose on-disk content differs", () => {
+    const targets = phantombotUnitTargets(bin);
+    const byPath = new Map(targets.map((t) => [t.path, t.content]));
+    const heartbeat = targets.find(
+      (t) => t.unit === "phantombot-heartbeat.timer",
+    );
+    if (!heartbeat) throw new Error("heartbeat timer target missing");
+    // Simulate the pre-OnCalendar body left behind by an in-place update.
+    byPath.set(heartbeat.path, "OnUnitActiveSec=30min\n");
+    const drifted = driftedUnitNames(targets, (p) => byPath.get(p));
+    expect(drifted).toEqual(["phantombot-heartbeat.timer"]);
+  });
+
+  test("a missing file (reader returns undefined) is not counted as drift", () => {
+    const targets = phantombotUnitTargets(bin);
+    const byPath = new Map(targets.map((t) => [t.path, t.content]));
+    const tick = targets.find((t) => t.unit === "phantombot-tick.timer");
+    if (!tick) throw new Error("tick timer target missing");
+    byPath.delete(tick.path); // absent on disk
+    const drifted = driftedUnitNames(targets, (p) => byPath.get(p));
+    // Missing ≠ drift — doctor reports absent files via missing_unit_files.
+    expect(drifted).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Why

PR #121 made the **heartbeat timer** ship as `OnCalendar=*:0/30` — but that only fixes *new installs*. Existing boxes keep the old, wedge-prone `OnUnitActiveSec=30min` timer through any number of `phantombot update`s. This is the "fix broken phantoms across the fleet" follow-up.

### Corrected root cause (my earlier diagnosis was wrong)

I previously said "`update` only backfills *missing* unit files." That's **not true** — `phantombot update` already calls `ensureSystemdUnitsCurrent`, which compares on-disk unit *content* against the new binary's templates and rewrites drift. So does the heartbeat (every 30 min) and doctor's repair path.

The real residual gaps:

1. **The update-time heal silently no-ops** when the user-systemd bus isn't reachable — `defaultHealUnits` returns `null`. That's exactly the **self-update / deferred-restart** context this box uses, so v1.1.74 swapped the binary but never rewrote the timer.
2. **`doctor` was blind to content drift.** `defaultCheckSystemd` only checked `missing_unit_files` + `inactive_timers`. A unit that *exists* and is *"active"* but whose content is the old template was invisible — doctor cheerfully reported `systemd: ok` while the stale, wedge-prone timer sat right there.

### Why fixing #2 cures both

`doctor` runs at **every service startup** (`run.ts`) and **every heartbeat** — both contexts where the systemd bus *is* live. Once doctor detects content drift → triggers the (already-existing) heal → every existing broken phantom self-heals on its next restart or heartbeat, regardless of how it got updated.

## What

- **`systemd.ts`** — new pure detector `driftedUnitNames(targets, reader)`: names existing unit files whose on-disk content no longer matches the binary's templates. Missing files are *not* drift (reported separately). Pure → unit-tests without touching the fs.
- **`systemd.ts`** — `ensureSystemdUnitsCurrent` now **restarts any timer whose content it just rewrote**. A `daemon-reload` alone can't un-wedge an `active (elapsed)` timer whose schedule changed (`OnUnitActiveSec → OnCalendar`); only a restart re-evaluates and arms the new definition. Without this, doctor would rewrite the file but the box would stay on the dead schedule until a manual kick.
- **`doctor.ts`** — `defaultCheckSystemd` computes `drifted_unit_files`, adds drift to the heal trigger, and reports it. Drift is now a `WARN` + non-zero exit in read-only mode, and a "re-rendered units" success once healed.

## Tests

- `driftedUnitNames`: matches → `[]`; one drifted unit flagged; missing file ≠ drift.
- `ensureSystemdUnitsCurrent`: rewriting a timer's content also restarts it (and leaves untouched timers alone).
- `doctor`: drift reported + exit 1 unrepaired; drift healed → exit 0 / "re-rendered units"; JSON includes `drifted_unit_files`; existing fixtures updated.

Full suite: **917 pass / 1 skip / 0 fail**. Typecheck clean.

## Notes for review

- Left as separate scope (Miles's ask #3): scheduling `doctor` itself + notify-on-non-ok with dedup. Happy to add as a further PR.
- Open question worth a look: should we *also* make the update-time heal louder when the bus is unreachable (`defaultHealUnits` returns null today), or is "doctor self-heals on next startup/heartbeat" enough? I think the latter makes it rock-solid, but flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
