### PR TITLE
fix(telegram): forward reply_to_message into turn context

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -121,6 +121,28 @@ export interface TelegramAttachment {
     | "sticker";
 }
 
+/**
+ * Quoted-message metadata when the user taps "Reply" on a previous
+ * Telegram message and sends a new one. Carried alongside the new
+ * message so the agent can disambiguate which earlier message the
+ * user is actually replying to — without this, a "merge" / "yes"
+ * lands with no referent and the agent assumes it's a response to
+ * the most recent assistant turn (which is wrong if the user
+ * deliberately scrolled up to reply to something older).
+ */
+export interface TelegramReplyTo {
+  /** Telegram's `message_id` of the quoted message. */
+  messageId: number;
+  /** Text snippet of the quoted message, truncated for prompt sanity.
+   *  Empty when the quoted message had no text (e.g. media without
+   *  caption). */
+  text: string;
+  /** True when the quoted message was sent by the bot (i.e. the
+   *  assistant itself). Lets the agent distinguish "user replied to
+   *  my earlier turn" vs "user quoted their own earlier message". */
+  fromBot: boolean;
+}
+
 export interface TelegramMessage {
   updateId: number;
   chatId: number;
@@ -144,6 +166,11 @@ export interface TelegramMessage {
    *  Downloaded to the per-chat inbox and surfaced to the harness as
    *  an absolute path the agent can `read`. */
   attachment?: TelegramAttachment;
+  /** Populated when this message was sent as a Telegram reply (the
+   *  user tapped "Reply" on an earlier message). Forwarded into the
+   *  agent's user-message envelope so it can disambiguate which past
+   *  turn the new text is actually about. */
+  replyTo?: TelegramReplyTo;
 }
 
 export interface TelegramTransport {
@@ -405,6 +432,13 @@ interface TelegramRawPhotoSize {
   height?: number;
 }
 
+interface TelegramRawReplyToMessage {
+  message_id?: number;
+  text?: string;
+  caption?: string;
+  from?: { id?: number; is_bot?: boolean; username?: string };
+}
+
 interface TelegramRawUpdate {
   update_id?: number;
   message?: {
@@ -425,6 +459,10 @@ interface TelegramRawUpdate {
     animation?: TelegramRawFile;
     sticker?: TelegramRawFile;
     photo?: TelegramRawPhotoSize[];
+    /** Populated by Telegram when the sender used the "Reply" UI on a
+     *  prior message. Only a small subset of fields is actually relayed
+     *  through to the agent — see {@link extractReplyTo}. */
+    reply_to_message?: TelegramRawReplyToMessage;
   };
 }
 
@@ -503,6 +541,63 @@ function synthesizeFileName(
   mimeType: string | undefined,
 ): string {
   return `${msgId}-${kind}${extensionFromMime(mimeType)}`;
+}
+
+/** Max chars of quoted text we forward into the agent prompt. Long
+ *  enough to disambiguate, short enough not to bloat the context when a
+ *  user replies to a wall of earlier text. */
+export const REPLY_TO_SNIPPET_MAX = 280;
+
+/**
+ * Pull the subset of `reply_to_message` we want to forward into the
+ * agent's user-message envelope. Returns `undefined` when the raw field
+ * is missing or the quoted message has no `message_id` we can latch
+ * onto. We prefer `text`; if absent (media reply), fall back to
+ * `caption`; if still absent, the snippet is the empty string and only
+ * the message id + bot flag are forwarded — still enough for the agent
+ * to tell "user replied to message N from me" from "user replied to a
+ * media message they sent earlier".
+ *
+ * Exported for testing.
+ */
+export function extractReplyTo(
+  raw: TelegramRawReplyToMessage | undefined,
+): TelegramReplyTo | undefined {
+  if (!raw || typeof raw.message_id !== "number") return undefined;
+  const source =
+    (typeof raw.text === "string" && raw.text.length > 0
+      ? raw.text
+      : typeof raw.caption === "string"
+        ? raw.caption
+        : "") ?? "";
+  const truncated =
+    source.length > REPLY_TO_SNIPPET_MAX
+      ? `${source.slice(0, REPLY_TO_SNIPPET_MAX)}…`
+      : source;
+  return {
+    messageId: raw.message_id,
+    text: truncated,
+    fromBot: Boolean(raw.from?.is_bot),
+  };
+}
+
+/**
+ * Render a single bracketed line describing the message the user
+ * tapped "Reply" on. Mirrors the `[attached: <path>]` convention so the
+ * agent reads it as a structured envelope marker, not as free-form
+ * prose from the user. Exported for testing.
+ */
+export function formatReplyToContext(replyTo: TelegramReplyTo): string {
+  const who = replyTo.fromBot
+    ? "your earlier message"
+    : "user's earlier message";
+  if (replyTo.text.length === 0) {
+    return `[in reply to ${who} (no text content)]`;
+  }
+  // Collapse whitespace so a multi-line quoted message doesn't break
+  // the single-line envelope marker shape.
+  const snippet = replyTo.text.replace(/\s+/g, " ").trim();
+  return `[in reply to ${who}: "${snippet}"]`;
 }
 
 /**
@@ -586,6 +681,11 @@ export function parseGetUpdatesResult(
       continue;
     }
 
+    // `reply_to_message` is parsed once and attached to whichever
+    // envelope we end up pushing — it's orthogonal to text vs voice vs
+    // attachment, but all three paths benefit from carrying it through.
+    const replyTo = extractReplyTo(msg.reply_to_message);
+
     // Attachments take priority over plain text, but if BOTH text and an
     // attachment are present (rare; Telegram normally uses `caption` not
     // `text` for media), use text as the caption.
@@ -605,6 +705,7 @@ export function parseGetUpdatesResult(
         text: "", // filled by processChatMessage after download
         caption: captionFromMedia ?? captionFromText,
         attachment,
+        ...(replyTo ? { replyTo } : {}),
       });
       continue;
     }
@@ -615,6 +716,7 @@ export function parseGetUpdatesResult(
         fromUserId: msg.from.id,
         fromUsername: msg.from.username,
         text: msg.text,
+        ...(replyTo ? { replyTo } : {}),
       });
       continue;
     }
@@ -630,6 +732,7 @@ export function parseGetUpdatesResult(
           mimeType: msg.voice.mime_type ?? "audio/ogg",
           durationS: msg.voice.duration ?? 0,
         },
+        ...(replyTo ? { replyTo } : {}),
       });
     }
   }
@@ -1001,6 +1104,15 @@ async function processChatMessage(
         ? false
         : isVoice;
   const willReplyWithVoice = wantsVoiceReply && ttsSupported(input.config);
+
+  // Forward `reply_to_message` context AFTER modality detection so a
+  // quoted "send a voice note" can't flip routing for a fresh "merge"
+  // reply. We mutate `msg.text` so both the harness call and the
+  // interrupted-pair persistence (further down) see the same envelope.
+  if (msg.replyTo) {
+    const prefix = formatReplyToContext(msg.replyTo);
+    msg.text = msg.text.length > 0 ? `${prefix}\n\n${msg.text}` : prefix;
+  }
   const sendStatus = () =>
     willReplyWithVoice
       ? input.transport.sendRecording(msg.chatId)

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -565,11 +565,11 @@ export function extractReplyTo(
 ): TelegramReplyTo | undefined {
   if (!raw || typeof raw.message_id !== "number") return undefined;
   const source =
-    (typeof raw.text === "string" && raw.text.length > 0
+    typeof raw.text === "string" && raw.text.length > 0
       ? raw.text
       : typeof raw.caption === "string"
         ? raw.caption
-        : "") ?? "";
+        : "";
   const truncated =
     source.length > REPLY_TO_SNIPPET_MAX
       ? `${source.slice(0, REPLY_TO_SNIPPET_MAX)}…`
@@ -589,8 +589,8 @@ export function extractReplyTo(
  */
 export function formatReplyToContext(replyTo: TelegramReplyTo): string {
   const who = replyTo.fromBot
-    ? "your earlier message"
-    : "user's earlier message";
+    ? `your earlier message #${replyTo.messageId}`
+    : `user's earlier message #${replyTo.messageId}`;
   if (replyTo.text.length === 0) {
     return `[in reply to ${who} (no text content)]`;
   }

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -24,6 +24,9 @@ import {
   type TelegramMessage,
   type TelegramTransport,
   runTelegramServer,
+  extractReplyTo,
+  formatReplyToContext,
+  REPLY_TO_SNIPPET_MAX,
 } from "../src/channels/telegram.ts";
 import type { Config } from "../src/config.ts";
 import type {
@@ -269,6 +272,189 @@ describe("parseGetUpdatesResult", () => {
     );
     expect(r.updates[0]?.voice?.fileId).toBe("voice-1");
     expect(r.updates[0]?.attachment).toBeUndefined();
+  });
+
+  test("forwards reply_to_message on plain-text replies", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 400,
+          message: {
+            message_id: 12,
+            chat: { id: 1 },
+            from: { id: 42 },
+            text: "merge",
+            reply_to_message: {
+              message_id: 7,
+              text: "Should I merge the PR?",
+              from: { id: 99, is_bot: true, username: "phantom_bot" },
+            },
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates[0]?.replyTo).toEqual({
+      messageId: 7,
+      text: "Should I merge the PR?",
+      fromBot: true,
+    });
+  });
+
+  test("forwards reply_to_message on attachment replies", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 401,
+          message: {
+            message_id: 13,
+            chat: { id: 1 },
+            from: { id: 42 },
+            caption: "see this",
+            document: { file_id: "doc-1", file_name: "x.pdf" },
+            reply_to_message: {
+              message_id: 8,
+              text: "the report",
+              from: { id: 42, is_bot: false },
+            },
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates[0]?.replyTo).toMatchObject({
+      messageId: 8,
+      fromBot: false,
+    });
+    expect(r.updates[0]?.attachment?.fileId).toBe("doc-1");
+  });
+
+  test("forwards reply_to_message on voice replies", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 402,
+          message: {
+            chat: { id: 1 },
+            from: { id: 42 },
+            voice: { file_id: "voice-2", duration: 2, mime_type: "audio/ogg" },
+            reply_to_message: {
+              message_id: 9,
+              text: "earlier turn",
+              from: { id: 99, is_bot: true },
+            },
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates[0]?.replyTo?.messageId).toBe(9);
+    expect(r.updates[0]?.voice?.fileId).toBe("voice-2");
+  });
+
+  test("omits replyTo when reply_to_message is absent", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 403,
+          message: {
+            chat: { id: 1 },
+            from: { id: 42 },
+            text: "hi",
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates[0]?.replyTo).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractReplyTo / formatReplyToContext
+// ---------------------------------------------------------------------------
+
+describe("extractReplyTo", () => {
+  test("returns undefined when input is missing", () => {
+    expect(extractReplyTo(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined when message_id is missing", () => {
+    expect(extractReplyTo({ text: "no id" })).toBeUndefined();
+  });
+
+  test("prefers text over caption", () => {
+    const r = extractReplyTo({
+      message_id: 1,
+      text: "the text",
+      caption: "the caption",
+      from: { id: 99, is_bot: true },
+    });
+    expect(r?.text).toBe("the text");
+    expect(r?.fromBot).toBe(true);
+  });
+
+  test("falls back to caption when text is missing", () => {
+    const r = extractReplyTo({
+      message_id: 2,
+      caption: "the caption",
+      from: { id: 42, is_bot: false },
+    });
+    expect(r?.text).toBe("the caption");
+    expect(r?.fromBot).toBe(false);
+  });
+
+  test("emits empty text snippet when quoted message had no text/caption", () => {
+    const r = extractReplyTo({
+      message_id: 3,
+      from: { id: 42, is_bot: false },
+    });
+    expect(r).toEqual({ messageId: 3, text: "", fromBot: false });
+  });
+
+  test("truncates snippets longer than REPLY_TO_SNIPPET_MAX", () => {
+    const long = "x".repeat(REPLY_TO_SNIPPET_MAX + 50);
+    const r = extractReplyTo({ message_id: 4, text: long });
+    expect(r?.text.length).toBe(REPLY_TO_SNIPPET_MAX + 1); // ellipsis
+    expect(r?.text.endsWith("…")).toBe(true);
+  });
+});
+
+describe("formatReplyToContext", () => {
+  test("renders bot-quoted with the bot wording", () => {
+    expect(
+      formatReplyToContext({
+        messageId: 1,
+        text: "Should I merge?",
+        fromBot: true,
+      }),
+    ).toBe('[in reply to your earlier message: "Should I merge?"]');
+  });
+
+  test("renders user-quoted with the user wording", () => {
+    expect(
+      formatReplyToContext({
+        messageId: 2,
+        text: "I said this earlier",
+        fromBot: false,
+      }),
+    ).toBe('[in reply to user\'s earlier message: "I said this earlier"]');
+  });
+
+  test("collapses whitespace so multi-line quotes stay single-line", () => {
+    expect(
+      formatReplyToContext({
+        messageId: 3,
+        text: "line one\n\nline two",
+        fromBot: true,
+      }),
+    ).toBe('[in reply to your earlier message: "line one line two"]');
+  });
+
+  test("uses the no-content variant when snippet is empty", () => {
+    expect(
+      formatReplyToContext({ messageId: 4, text: "", fromBot: false }),
+    ).toBe("[in reply to user's earlier message (no text content)]");
   });
 });
 
@@ -716,6 +902,45 @@ describe("runTelegramServer dispatch", () => {
     const b = await memory.recentTurns("phantom", "telegram:200", 10);
     expect(a.map((t) => t.text)).toEqual(["from A", "ok"]);
     expect(b.map((t) => t.text)).toEqual(["from B", "ok"]);
+  });
+
+  test("forwards reply_to_message context into the harness user message", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 7,
+      chatId: 1001,
+      fromUserId: 42,
+      fromUsername: "alice",
+      text: "merge",
+      replyTo: {
+        messageId: 5,
+        text: "Should I merge the PR?",
+        fromBot: true,
+      },
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "merging" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(harness.lastRequest?.userMessage).toBe(
+      '[in reply to your earlier message: "Should I merge the PR?"]\n\nmerge',
+    );
+    // Persisted user turn carries the same envelope so future turns
+    // retain the disambiguation, not just the bare "merge".
+    const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
+    expect(stored[0]).toEqual({
+      role: "user",
+      text: '[in reply to your earlier message: "Should I merge the PR?"]\n\nmerge',
+    });
   });
 
   test("on harness error sends an error message and does not persist", async () => {

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -428,7 +428,7 @@ describe("formatReplyToContext", () => {
         text: "Should I merge?",
         fromBot: true,
       }),
-    ).toBe('[in reply to your earlier message: "Should I merge?"]');
+    ).toBe('[in reply to your earlier message #1: "Should I merge?"]');
   });
 
   test("renders user-quoted with the user wording", () => {
@@ -438,7 +438,7 @@ describe("formatReplyToContext", () => {
         text: "I said this earlier",
         fromBot: false,
       }),
-    ).toBe('[in reply to user\'s earlier message: "I said this earlier"]');
+    ).toBe('[in reply to user\'s earlier message #2: "I said this earlier"]');
   });
 
   test("collapses whitespace so multi-line quotes stay single-line", () => {
@@ -448,13 +448,32 @@ describe("formatReplyToContext", () => {
         text: "line one\n\nline two",
         fromBot: true,
       }),
-    ).toBe('[in reply to your earlier message: "line one line two"]');
+    ).toBe('[in reply to your earlier message #3: "line one line two"]');
   });
 
   test("uses the no-content variant when snippet is empty", () => {
     expect(
       formatReplyToContext({ messageId: 4, text: "", fromBot: false }),
-    ).toBe("[in reply to user's earlier message (no text content)]");
+    ).toBe("[in reply to user's earlier message #4 (no text content)]");
+  });
+
+  test("disambiguates two no-text replies by messageId", () => {
+    // Regression: before #N interpolation, media/sticker/voice replies all
+    // rendered as identical "[in reply to ... (no text content)]" envelopes,
+    // so the agent couldn't tell two such replies apart.
+    const a = formatReplyToContext({
+      messageId: 11,
+      text: "",
+      fromBot: true,
+    });
+    const b = formatReplyToContext({
+      messageId: 22,
+      text: "",
+      fromBot: true,
+    });
+    expect(a).toBe("[in reply to your earlier message #11 (no text content)]");
+    expect(b).toBe("[in reply to your earlier message #22 (no text content)]");
+    expect(a).not.toBe(b);
   });
 });
 
@@ -932,14 +951,54 @@ describe("runTelegramServer dispatch", () => {
     });
 
     expect(harness.lastRequest?.userMessage).toBe(
-      '[in reply to your earlier message: "Should I merge the PR?"]\n\nmerge',
+      '[in reply to your earlier message #5: "Should I merge the PR?"]\n\nmerge',
     );
     // Persisted user turn carries the same envelope so future turns
     // retain the disambiguation, not just the bare "merge".
     const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
     expect(stored[0]).toEqual({
       role: "user",
-      text: '[in reply to your earlier message: "Should I merge the PR?"]\n\nmerge',
+      text: '[in reply to your earlier message #5: "Should I merge the PR?"]\n\nmerge',
+    });
+  });
+
+  test("forwards reply_to_message envelope for no-text/media replies", async () => {
+    const transport = new FakeTransport();
+    // User replied to a sticker/voice/photo the bot sent earlier — the
+    // quoted message has no text and no caption, so only the messageId
+    // distinguishes it from any other no-text reply.
+    transport.pendingUpdates.push({
+      updateId: 8,
+      chatId: 1001,
+      fromUserId: 42,
+      fromUsername: "alice",
+      text: "got it",
+      replyTo: {
+        messageId: 9,
+        text: "",
+        fromBot: true,
+      },
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(harness.lastRequest?.userMessage).toBe(
+      "[in reply to your earlier message #9 (no text content)]\n\ngot it",
+    );
+    const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
+    expect(stored[0]).toEqual({
+      role: "user",
+      text: "[in reply to your earlier message #9 (no text content)]\n\ngot it",
     });
   });
 


### PR DESCRIPTION
## Summary
- Telegram bridge now forwards `reply_to_message` metadata (message id, text snippet, bot/user flag) into the agent's turn context.
- New `extractReplyTo()` + `formatReplyToContext()` helpers; parsed in all three update paths (text / voice / attachment).
- `processChatMessage` prepends `[in reply to your earlier message: "..."]` / `[in reply to user's earlier message: "..."]` to `msg.text` **after** `replyModalityOverride` so quoted text can't flip voice/text routing.

Fixes #124.

## Test plan
- [x] `bun test tests/channels-telegram.test.ts` — 80 pass, 0 fail (15 new tests)
- [x] `bun tsc --noEmit` — clean
- [ ] Manual: reply to an older message in Telegram, confirm agent sees the prefix in `userMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)