### PR TITLE
fix(harnesses): only reset idle timer on productive output (#123)

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -143,7 +143,10 @@ export class ClaudeHarness implements Harness {
 
     try {
       for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
-        killer.touch();
+        // NB: do NOT touch() here. The idle timer must measure time since
+        // last *productive* output, not since last raw chunk — otherwise
+        // synthetic heartbeats (streamed thinking blocks etc.) keep
+        // postponing the idle kill on a wedged turn. See issue #123.
         buffer += decoder.decode(chunk, { stream: true });
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
@@ -155,11 +158,15 @@ export class ClaudeHarness implements Harness {
             parsed = JSON.parse(trimmed);
           } catch {
             // Not stream-json — surface as out-of-band progress note.
+            killer.touch(); // non-JSON line is real output
             yield { type: "progress", note: trimmed };
             continue;
           }
           const c = parseStreamJson(parsed);
           if (c) {
+            // Only reset the idle window on productive chunks; heartbeats
+            // keep the UI typing indicator alive but must not extend idle.
+            if (c.type !== "heartbeat") killer.touch();
             if (c.type === "text") finalText += c.text;
             yield c;
           }

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -82,7 +82,10 @@ export class CodexHarness implements Harness {
 
     try {
       for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
-        killer.touch();
+        // NB: do NOT touch() here. The idle timer must measure time since
+        // last *productive* output, not since last raw chunk — otherwise
+        // synthetic heartbeats keep postponing the idle kill on a wedged
+        // turn. See issue #123.
         buffer += decoder.decode(chunk, { stream: true });
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
@@ -93,11 +96,15 @@ export class CodexHarness implements Harness {
           try {
             parsed = JSON.parse(trimmed);
           } catch {
+            killer.touch(); // non-JSON line is real output
             yield { type: "progress", note: trimmed.slice(0, 200) };
             continue;
           }
           const c = parseCodexEvent(parsed);
           if (!c) continue;
+          // Only reset the idle window on productive chunks; heartbeats
+          // keep the UI typing indicator alive but must not extend idle.
+          if (c.type !== "heartbeat") killer.touch();
           if (c.type === "text") finalText += c.text;
           if (c.type === "done") {
             usageMeta = c.meta;

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -186,7 +186,10 @@ export class GeminiHarness implements Harness {
 
     try {
       for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
-        killer.touch();
+        // NB: do NOT touch() here. The idle timer must measure time since
+        // last *productive* output, not since last raw chunk — otherwise
+        // synthetic heartbeats keep postponing the idle kill on a wedged
+        // turn. See issue #123.
         buffer += decoder.decode(chunk, { stream: true });
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
@@ -207,11 +210,15 @@ export class GeminiHarness implements Harness {
             log.debug("gemini: non-JSON stdout line", {
               line: trimmed.slice(0, 200),
             });
+            killer.touch(); // non-JSON line is real output
             yield { type: "progress", note: trimmed.slice(0, 200) };
             continue;
           }
           const c = parseGeminiEvent(parsed);
           if (!c) continue;
+          // Only reset the idle window on productive chunks; heartbeats
+          // keep the UI typing indicator alive but must not extend idle.
+          if (c.type !== "heartbeat") killer.touch();
           if (c.type === "text") finalText += c.text;
           if (c.type === "done") {
             // gemini's `result` event carries the authoritative stats.

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -116,7 +116,10 @@ export class PiHarness implements Harness {
 
     try {
       for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
-        killer.touch();
+        // NB: do NOT touch() here. The idle timer must measure time since
+        // last *productive* output, not since last raw chunk — otherwise
+        // synthetic heartbeats (thinking_delta etc.) keep postponing the
+        // idle kill on a wedged turn. See issue #123.
         buffer += decoder.decode(chunk, { stream: true });
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
@@ -127,11 +130,15 @@ export class PiHarness implements Harness {
           try {
             parsed = JSON.parse(trimmed);
           } catch {
+            killer.touch(); // non-JSON line is real output
             yield { type: "progress", note: trimmed };
             continue;
           }
           const c = parsePiEvent(parsed);
           if (c) {
+            // Only reset the idle window on productive chunks; heartbeats
+            // keep the UI typing indicator alive but must not extend idle.
+            if (c.type !== "heartbeat") killer.touch();
             if (c.type === "text") finalText += c.text;
             yield c;
           }

--- a/tests/fixtures/fake-codex.sh
+++ b/tests/fixtures/fake-codex.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # Fake codex CLI used by tests/harnesses-codex.test.ts.
 # Modes via FAKE_CODEX_MODE:
-#   normal   -> one agent message + turn.completed, exit 0
-#   error    -> stderr + exit 1
-#   notfound -> exit 127
-#   hang     -> sleep forever
-#   argv     -> echo argv in an agent message
+#   normal     -> one agent message + turn.completed, exit 0
+#   error      -> stderr + exit 1
+#   notfound   -> exit 127
+#   hang       -> sleep forever
+#   argv       -> echo argv in an agent message
+#   heartbeats -> stream turn.started heartbeats spaced under the idle
+#                 window for ~3s, then a late agent_message + turn.completed.
+#                 Used to prove heartbeats do NOT reset the idle timer: the
+#                 harness must idle-kill long before the late finish lands.
+#   productive -> stream agent_message text spaced under the idle window,
+#                 then turn.completed. Used to prove productive output DOES
+#                 keep resetting the idle timer, so the turn finishes cleanly.
 
 mode="${FAKE_CODEX_MODE:-normal}"
 
@@ -29,6 +36,24 @@ case "$mode" in
     ;;
   hang)
     exec sleep 3600
+    ;;
+  heartbeats)
+    printf '%s\n' '{"type":"turn.started"}'
+    for i in $(seq 1 15); do
+      printf '%s\n' '{"type":"item.completed","item":{"id":"hb'"$i"'","type":"reasoning","text":"thinking"}}'
+      sleep 0.2
+    done
+    printf '%s\n' '{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"late finish"}}'
+    printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+    exit 0
+    ;;
+  productive)
+    for i in $(seq 1 6); do
+      printf '%s\n' "{\"type\":\"item.completed\",\"item\":{\"id\":\"i$i\",\"type\":\"agent_message\",\"text\":\"chunk$i \"}}"
+      sleep 0.2
+    done
+    printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":6}}'
+    exit 0
     ;;
   argv)
     payload="$*"

--- a/tests/harnesses-codex.test.ts
+++ b/tests/harnesses-codex.test.ts
@@ -114,6 +114,49 @@ describe("CodexHarness.invoke", () => {
     expect(err.error).toContain("timed out");
   });
 
+  // Regression for #123: heartbeats (streamed reasoning) must NOT reset the
+  // idle timer. The fixture emits heartbeats spaced under the idle window for
+  // ~3s before a late agent_message. With the pre-fix touch()-on-every-chunk
+  // behaviour those heartbeats kept postponing the idle kill, so the wedged
+  // turn ran to completion. With the fix the idle timer fires regardless of
+  // heartbeats, so we get an idle error and never reach the late finish.
+  test("repeated heartbeats do not reset idle -> idle-killed before finish", async () => {
+    process.env.FAKE_CODEX_MODE = "heartbeats";
+    const chunks = await collect(
+      mkHarness().invoke(
+        newRequest({ idleTimeoutMs: 800, hardTimeoutMs: 10_000 }),
+      ),
+    );
+    // Heartbeats really did stream through (otherwise the test is vacuous)...
+    expect(chunks.some((c) => c.type === "heartbeat")).toBe(true);
+    // ...yet the turn was idle-killed before the late agent_message landed.
+    expect(chunks.some((c) => c.type === "done")).toBe(false);
+    expect(
+      chunks.some((c) => c.type === "text" && c.text.includes("late finish")),
+    ).toBe(false);
+    const err = chunks.find((c) => c.type === "error");
+    if (err?.type !== "error") throw new Error("expected idle error chunk");
+    expect(err.error).toContain("no output");
+    expect(err.recoverable).toBe(true);
+  });
+
+  // Counterpart to the heartbeat test: productive text spaced under the idle
+  // window must keep resetting the timer, so a turn that streams steadily for
+  // longer than idleTimeoutMs still completes cleanly rather than idle-dying.
+  test("steady productive output keeps resetting idle -> completes", async () => {
+    process.env.FAKE_CODEX_MODE = "productive";
+    const chunks = await collect(
+      mkHarness().invoke(
+        newRequest({ idleTimeoutMs: 800, hardTimeoutMs: 10_000 }),
+      ),
+    );
+    expect(chunks.some((c) => c.type === "error")).toBe(false);
+    const done = chunks.find((c) => c.type === "done");
+    if (done?.type !== "done") throw new Error("expected done chunk");
+    expect(done.finalText).toContain("chunk1");
+    expect(done.finalText).toContain("chunk6");
+  });
+
   test("argv includes injected memory override flags", async () => {
     process.env.FAKE_CODEX_MODE = "argv";
     const chunks = await collect(mkHarness("gpt-5.3-codex").invoke(newRequest()));


### PR DESCRIPTION
## Summary

The idle killer was `touch()`'d on every raw stdout chunk in all four
harnesses, so synthetic heartbeats (e.g. streamed thinking deltas) kept
postponing the idle kill on a wedged turn. The idle timer should measure
time since last *productive* output, not since last raw chunk.

## What

- Drop the unconditional `killer.touch()` at the top of the stdout loop in
  `pi`, `claude`, `codex` and `gemini`.
- Touch only on genuinely productive output: non-JSON progress lines and
  non-heartbeat parsed events.

`pi` and `claude` are the real exposure — both stream reasoning/thinking
that maps to `heartbeat`, so a runaway loop kept the killer alive. `codex`
and `gemini` only emit discrete completion events as heartbeats, so the
change is defensive there, but the invariant is now consistent across all
harnesses.

## Test plan

- `bun run typecheck` — clean
- `bun test claude codex gemini pi` — 90 pass, 0 fail (includes the
  idle-kill behaviour tests)
- The 14 unrelated failures elsewhere in the suite are pre-existing
  (systemd/`runUpdate` tests that fail on macOS) and not touched here.

Fixes #123