### PR TITLE
Fix persona-aware update restart notifications

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -169,12 +169,14 @@ async function handleUpdate(
   }
   log.info("commands: /update invoked", {
     chatId: ctx.chatId,
+    persona: ctx.persona,
     currentVersion: VERSION,
   });
   const r = await runUpdateFlow({
     config: ctx.config,
     currentVersion: VERSION,
     chatId: ctx.chatId,
+    persona: ctx.persona,
   });
   return { reply: r.reply, afterSend: r.restart };
 }
@@ -368,4 +370,3 @@ export function nominalContextWindow(harnessId: string): number {
       return 128_000;
   }
 }
-

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -195,17 +195,13 @@ export async function runRun(input: RunInput = {}): Promise<number> {
 
   const memory = await openMemoryStore(config.memoryDbPath);
 
-  // The post-restart-notify + startup-doctor hooks operate against the
-  // DEFAULT persona's bot. That's intentional — they're administrative
-  // signals to the operator, and the operator is the same human across
-  // all personas, so picking one channel keeps them from getting four
-  // copies of the same notification. Falls back to the first listener
-  // when no default account is configured.
+  // The post-restart-notify hook uses the persona stored in a pending
+  // `/update` marker when present, and falls back to this admin listener
+  // for legacy markers. Prefer the default listener for that fallback;
+  // use the first listener when no default account is configured.
   // Non-null: we returned above if plan.listeners.length === 0.
   const adminListener: ListenerSpec =
     plan.listeners.find((l) => l.source === "default") ?? plan.listeners[0]!;
-  const adminTransport = new HttpTelegramTransport(adminListener.account.token);
-
   // Post-restart check: if `/update` wrote a pending-update marker before
   // we got SIGTERMed, surface the result to the chat that triggered it.
   // Runs once at startup; if no marker exists this is a quick no-op stat.
@@ -215,7 +211,6 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     const r = await notifyPostRestartIfPending({
       config,
       currentVersion: VERSION,
-      transport: adminTransport,
       adminAccount: adminListener.account,
     });
     if (r.status === "success_notified" || r.status === "failure_notified") {
@@ -278,13 +273,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         agentDir: l.agentDir,
         persona: l.persona,
         account: l.account,
-        transport:
-          // Reuse the admin transport for the admin listener — the
-          // post-restart notify already opened it. Other listeners
-          // get their own.
-          l === adminListener
-            ? adminTransport
-            : new HttpTelegramTransport(l.account.token),
+        transport: new HttpTelegramTransport(l.account.token),
         signal: ac.signal,
         out,
         err,

--- a/src/lib/updateNotify.ts
+++ b/src/lib/updateNotify.ts
@@ -78,6 +78,12 @@ export interface PendingUpdate {
    */
   chatId?: number;
   /**
+   * Persona whose Telegram bot handled `/update`. Used after restart to
+   * send the confirmation through the same bot in hybrid default+persona
+   * configs. Optional so markers written by older versions still work.
+   */
+  persona?: string;
+  /**
    * Version we were on before the update. Stored so we can render
    * "v1.0.42 → v1.0.99" on success and distinguish a real upgrade from
    * a "we were already current" no-op.
@@ -119,7 +125,8 @@ export async function readPendingUpdate(
       typeof parsed?.targetVersion !== "string" ||
       typeof parsed?.targetTag !== "string" ||
       typeof parsed?.previousVersion !== "string" ||
-      typeof parsed?.writtenAt !== "string"
+      typeof parsed?.writtenAt !== "string" ||
+      (parsed.persona !== undefined && typeof parsed.persona !== "string")
     ) {
       log.warn("updateNotify: pending-update marker missing required fields", {
         path,
@@ -193,6 +200,8 @@ export interface RunUpdateFlowInput {
    * post-restart notify lands in the same DM the request came from.
    */
   chatId: number;
+  /** Persona whose Telegram listener handled `/update`. */
+  persona?: string;
   fetchImpl?: typeof fetch;
   serviceControl?: ServiceControl;
   /** Test seam — defaults to the real `runUpdate` CLI handler. */
@@ -275,6 +284,7 @@ export async function runUpdateFlow(
       targetVersion: release.version,
       targetTag: release.tag,
       chatId: input.chatId,
+      persona: input.persona,
       previousVersion: input.currentVersion,
       writtenAt: new Date().toISOString(),
     },
@@ -460,6 +470,7 @@ export interface NotifyPostRestartInput {
   config: Config;
   currentVersion: string;
   transport?: TelegramTransport;
+  createTransport?: (account: TelegramAccount) => TelegramTransport;
   pendingPath?: string;
   /**
    * Account to use for the post-restart notify when there's no default
@@ -500,10 +511,16 @@ export async function notifyPostRestartIfPending(
   const marker = await readPendingUpdate(input.pendingPath);
   if (!marker) return { status: "no_marker" };
 
-  // Pick the account that drives this notify. Explicit adminAccount wins
-  // (personas-only setups have no default block); fall back to the
-  // default so the legacy single-bot path keeps working.
-  const adminAccount = input.adminAccount ?? input.config.channels.telegram;
+  // Pick the account that drives this notify. New markers include the
+  // persona that handled `/update`, so hybrid default+persona configs can
+  // reply through that same bot. Older markers have no persona and fall
+  // back to the admin/default behavior.
+  const adminAccount =
+    (marker.persona
+      ? input.config.channels.telegramPersonas?.[marker.persona]
+      : undefined) ??
+    input.adminAccount ??
+    input.config.channels.telegram;
   if (!adminAccount) {
     // Marker exists but Telegram isn't configured — just clear it. No
     // way to notify; the user will see the version change on their next
@@ -517,7 +534,9 @@ export async function notifyPostRestartIfPending(
   }
 
   const transport =
-    input.transport ?? new HttpTelegramTransport(adminAccount.token);
+    input.transport ??
+    input.createTransport?.(adminAccount) ??
+    new HttpTelegramTransport(adminAccount.token);
 
   const success = marker.targetVersion === input.currentVersion;
   const message = success

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -183,6 +183,7 @@ describe("pending-update marker", () => {
       targetVersion: "1.0.99",
       targetTag: "v1.0.99",
       chatId: 42,
+      persona: "miles",
       previousVersion: "1.0.42",
       writtenAt: "2026-05-11T09:00:00.000Z",
     };
@@ -318,6 +319,7 @@ describe("runUpdateFlow", () => {
     expect(marker?.targetVersion).toBe("1.0.99");
     expect(marker?.targetTag).toBe("v1.0.99");
     expect(marker?.chatId).toBe(42);
+    expect(marker?.persona).toBeUndefined();
     expect(marker?.previousVersion).toBe("1.0.42");
     // runUpdate was invoked with force:true, restart:false (we control
     // the restart ourselves so it can fire AFTER the reply lands).
@@ -330,6 +332,25 @@ describe("runUpdateFlow", () => {
     // Invoke it and verify it routes to the injected ServiceControl.
     await r.restart!();
     expect(calls).toContain("restart");
+  });
+
+  test("update available from persona listener → stores persona in marker", async () => {
+    const r = await runUpdateFlow({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      chatId: 42,
+      persona: "miles",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: fakeSvc().svc,
+      runUpdateImpl: fakeRunUpdate(0),
+      pendingPath,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.reply).toContain("installed v1.0.99");
+    const marker = await readPendingUpdate(pendingPath);
+    expect(marker?.persona).toBe("miles");
   });
 
   test("update available but runUpdate exits non-zero → marker cleared, error reply", async () => {
@@ -730,6 +751,51 @@ describe("notifyPostRestartIfPending", () => {
     expect(r.status).toBe("success_notified");
     // Broadcast to adminAccount.allowedUserIds, NOT no-op.
     expect(transport.sent.map((s) => s.chatId).sort()).toEqual([42, 99]);
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+  });
+
+  test("hybrid marker with persona → notify uses persona account, not default account", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram = {
+      token: "default-tok",
+      pollTimeoutS: 30,
+      allowedUserIds: [1, 2],
+    };
+    cfg.channels.telegramPersonas = {
+      miles: {
+        token: "miles-tok",
+        pollTimeoutS: 30,
+        allowedUserIds: [42, 99],
+      },
+    };
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        chatId: 4242,
+        persona: "miles",
+        previousVersion: "1.0.42",
+        writtenAt: "2026-05-11T00:00:00Z",
+      },
+      pendingPath,
+    );
+
+    const createdForTokens: string[] = [];
+    const transport = new FakeTransport();
+    const r = await notifyPostRestartIfPending({
+      config: cfg,
+      currentVersion: "1.0.99",
+      pendingPath,
+      adminAccount: cfg.channels.telegram,
+      createTransport: (account) => {
+        createdForTokens.push(account.token);
+        return transport;
+      },
+    });
+
+    expect(r.status).toBe("success_notified");
+    expect(createdForTokens).toEqual(["miles-tok"]);
+    expect(transport.sent.map((s) => s.chatId)).toEqual([4242]);
     expect(await readPendingUpdate(pendingPath)).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- store the Telegram listener persona in pending `/update` markers
- resolve post-restart notifications through that persona account before falling back to the legacy admin/default account
- add regression coverage for hybrid default + persona Telegram configs

Closes #129

## Tests
- `~/.bun/bin/bun tsc --noEmit`
- `~/.bun/bin/bun test tests/lib-updateNotify.test.ts`
- `~/.bun/bin/bun test tests/channels-commands.test.ts tests/cli-run.test.ts`
- `~/.bun/bin/bun test`