### PR TITLE
feat(embeddings): make semantic search a clearly-optional, discoverable choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,37 @@ The nightly runs as **five idempotent stages** — `essence` → `promote` → `
 
 `phantombot doctor` reads `.nightly-state.json`, `.nightly-progress.json` and `capture_log`, and reports — then auto-repairs — memory-subsystem problems: a nightly that never ran, errored, or is >24h stale; a partial checkpoint left behind; or a "dry day" (≥20 real user turns with zero captures). When repair is warranted it spawns a detached `phantombot nightly --resume`. The `run` startup catch-up routes through the same logic, so a box powered off overnight self-heals on next boot.
 
+### Semantic search (optional)
+
+Memory search has two modes. **Keyword search (FTS5/BM25)** is always on, needs no setup, and matches on the actual words in a note. **Semantic (vector) search** is an *optional* enhancement: it embeds your text into vectors so search can match on **meaning**, not just exact words — e.g. asking "how do I pay tax" can surface a note titled "VAT filing steps" even though they share no keywords.
+
+**Why it's nice.** Phantombot retrieves relevant memories automatically on every turn (the auto-retrieval "instinct" layer) and indexes past conversation turns so older context can resurface. With embeddings on, that retrieval runs as **hybrid** (keyword + semantic) and finds conceptually-related memories the keyword half would miss. It's what makes recall feel like instinct rather than grep.
+
+**Why it's optional.** Everything works without it. With no embedding key configured, the provider resolves to `none`, search degrades cleanly to keyword-only, and **nothing errors** — auto-retrieval still runs, just on FTS. Most users never need to touch this. It is an enhancement, not a requirement.
+
+**How to tell which mode you're in.** `phantombot doctor` prints an informational `embeddings:` line (semantic ON, or off with keyword search active), and `phantombot run` prints a one-line heads-up at startup when semantic search is off. Neither is a warning — off is a valid, fully-working state.
+
+**How to enable it.** Easiest is the interactive TUI, which validates your key before saving:
+
+```bash
+phantombot embedding          # pick Gemini, paste an API key (or pick "none")
+phantombot memory index --rebuild   # backfill embeddings for existing notes
+```
+
+The `phantombot init` setup wizard also offers this as an optional step. You can equally set it by hand — either `PHANTOMBOT_GEMINI_API_KEY` in the environment, or an `[embeddings]` block in `config.toml`:
+
+```toml
+[embeddings]
+provider = "gemini"
+
+[embeddings.gemini]
+api_key = "AIza…"            # https://aistudio.google.com/app/apikey
+model   = "gemini-embedding-001"
+dims    = 1536
+```
+
+Get a key at <https://aistudio.google.com/app/apikey>. The default model is free up to ~1500 requests/day on Gemini's free tier, and the nightly cycle only re-embeds changed notes, so steady-state usage is tiny. To turn it back off, run `phantombot embedding` and pick **none** (your key is preserved in `config.toml` so re-enabling doesn't require re-validating).
+
 ---
 
 ## OpenClaw persona import

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -94,6 +94,19 @@ export interface DoctorReport {
     dry_day: boolean;
   };
   /**
+   * Embeddings / semantic-search status. Purely INFORMATIONAL — this never
+   * feeds `repair_needed` or the exit code. Embeddings are optional: with no
+   * provider, memory search still works on keyword (FTS5/BM25) matching. We
+   * surface the easy-to-miss "running keyword-only" state so an operator can
+   * SEE that vector search is off (and how to turn it on) without it ever
+   * looking like a fault.
+   */
+  embeddings: {
+    provider: "gemini" | "none";
+    /** gemini provider AND a key present = vector/semantic search is live. */
+    semantic_search: boolean;
+  };
+  /**
    * Linux-only — undefined on macOS and dev hosts without a user-systemd
    * bus. When present, lists which unit files are missing from disk, which
    * present-but-stale unit files have drifted from the running binary's
@@ -263,6 +276,13 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   }
   const dryDay = userTurns >= DRY_DAY_TURN_THRESHOLD && captures === 0;
 
+  // Embeddings status — informational only. Vector search is live only when
+  // the provider is gemini AND a key is actually present; everything else
+  // (provider "none", or "gemini" with an empty key) means keyword-only.
+  const embProvider = config.embeddings.provider;
+  const semanticSearch =
+    embProvider === "gemini" && !!config.embeddings.gemini?.apiKey;
+
   const { needed, reason } = decideRepair(state, progress, ageHours);
 
   let repairTriggered = false;
@@ -349,6 +369,10 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       captures,
       dry_day: dryDay,
     },
+    embeddings: {
+      provider: embProvider,
+      semantic_search: semanticSearch,
+    },
     ...(systemdReport ? { systemd: systemdReport } : {}),
     ...(timersReport ? { timers: timersReport } : {}),
     repair_needed: needed,
@@ -386,6 +410,15 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       `user turn(s) in the last ${report.capture.window_hours}h` +
       (dryDay ? " — DRY DAY: turns but no captures" : "") +
       "\n",
+  );
+  // Embeddings line is deliberately neutral — no ok/WARN marker, never an
+  // exit-code input. Vector search is an optional enhancement, not a
+  // requirement; absence is a valid, fully-working configuration.
+  out.write(
+    semanticSearch
+      ? `  embeddings: semantic (vector) search ON — provider '${embProvider}'\n`
+      : "  embeddings: semantic (vector) search off — keyword (BM25) search " +
+        "active. Optional: enable with `phantombot embedding`\n",
   );
   if (needed) {
     out.write(`  repair: ${reason}\n`);

--- a/src/cli/embedding.ts
+++ b/src/cli/embedding.ts
@@ -59,11 +59,22 @@ interface RunInput {
   config?: Config;
   validate?: (key: string) => Promise<EmbedResult>;
   serviceControl?: ServiceControl;
+  /**
+   * When true, this runs as a sub-step of another wizard (e.g.
+   * `phantombot init`) rather than standalone. Two effects:
+   *   - suppresses the standalone intro/outro and the "Existing config"
+   *     note (the parent owns the framing; a nested clack intro renders a
+   *     stray bracket), and
+   *   - skips the post-save restart prompt (the parent installs/starts the
+   *     service afterwards, so there is nothing running to restart yet).
+   */
+  embedded?: boolean;
 }
 
 export async function runEmbedding(input: RunInput = {}): Promise<number> {
   const config = input.config ?? (await loadConfig());
   const svc = input.serviceControl ?? defaultServiceControl();
+  const embedded = input.embedded ?? false;
   const validate =
     input.validate ??
     ((key: string) =>
@@ -72,10 +83,10 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
         dims: DEFAULT_DIMS,
       }));
 
-  p.intro("Configure embeddings");
+  if (!embedded) p.intro("Configure embeddings");
 
   const existing = config.embeddings;
-  if (existing.provider === "gemini" && existing.gemini?.apiKey) {
+  if (!embedded && existing.provider === "gemini" && existing.gemini?.apiKey) {
     p.note(
       `provider:  gemini\n` +
         `model:     ${existing.gemini.model}\n` +
@@ -83,7 +94,7 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
         `api key:   ${maskKey(existing.gemini.apiKey)}`,
       "Existing config",
     );
-  } else if (existing.provider === "none") {
+  } else if (!embedded && existing.provider === "none") {
     p.note(`provider:  none (FTS5/BM25 search only)`, "Existing config");
   }
 
@@ -114,8 +125,10 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
       `provider set to "none"\nsearch will use FTS5/BM25 only`,
       "Saved",
     );
-    await maybePromptRestart(svc);
-    p.outro("done");
+    if (!embedded) {
+      await maybePromptRestart(svc);
+      p.outro("done");
+    }
     return 0;
   }
 
@@ -157,8 +170,10 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
     "Saved",
   );
 
-  await maybePromptRestart(svc);
-  p.outro("done");
+  if (!embedded) {
+    await maybePromptRestart(svc);
+    p.outro("done");
+  }
   return 0;
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -11,6 +11,7 @@ import {
   type HarnessId,
   runHarness,
 } from "./harness.ts";
+import { runEmbedding } from "./embedding.ts";
 import { runInstall } from "./install.ts";
 import { runPersona } from "./persona.ts";
 import { runTelegram } from "./telegram.ts";
@@ -84,11 +85,12 @@ export default defineCommand({
     p.intro("Welcome to Phantombot");
 
     p.note(
-      "This wizard will guide you through 4 quick steps to get your agent running:\n" +
+      "This wizard will guide you through a few quick steps to get your agent running:\n" +
       "  1. Pick your AI harness (claude, pi, gemini, or codex)\n" +
       "  2. Create a persona (identity & memory)\n" +
       "  3. Connect to Telegram\n" +
-      "  4. Install as a background service",
+      "  4. Enable semantic memory search (optional)\n" +
+      "  5. Install as a background service",
       "Setup Flow"
     );
 
@@ -153,7 +155,37 @@ export default defineCommand({
       return;
     }
 
-    // 4. Install
+    // 4. Optional: semantic memory search.
+    // Gated behind its own confirm (default OFF) so it never blocks a quick
+    // install — memory search works out of the box on keyword (FTS5/BM25)
+    // matching. This step exists purely to *expose* the option during setup;
+    // skipping it is a fully-supported, fully-working configuration.
+    // Like the install step below, it's a separate skippable confirmation
+    // rather than part of runInitFlow. We call runEmbedding in `embedded`
+    // mode so it doesn't render its own intro/outro (a nested clack intro
+    // prints a stray bracket) or prompt for a service restart (the service
+    // isn't installed until the next step). Its return is intentionally
+    // non-fatal: embeddings are optional, so a skip or a key-validation
+    // failure must never abort the wizard before install.
+    p.log.step("Semantic Memory Search (optional)");
+    p.note(
+      "Phantombot's memory search works out of the box using keyword matching.\n" +
+      "Adding an embeddings provider also enables SEMANTIC search — finding\n" +
+      "memories by meaning, not just exact words (e.g. \"how do I pay tax\"\n" +
+      "matches a note titled \"VAT filing steps\"). It's optional and free for\n" +
+      "typical use on Gemini's free tier. You can always enable it later with\n" +
+      "`phantombot embedding`.",
+      "What this improves"
+    );
+    const wantEmbeddings = await p.confirm({
+      message: "Set up semantic search now? (optional)",
+      initialValue: false,
+    });
+    if (!p.isCancel(wantEmbeddings) && wantEmbeddings) {
+      await runEmbedding({ embedded: true });
+    }
+
+    // 5. Install
     // Use a step marker, not a second p.intro — clack renders one
     // open / one close bracket per flow, and a second intro mid-flow
     // produces a stray opening bracket in the rendered TUI.

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -239,6 +239,18 @@ export async function runRun(input: RunInput = {}): Promise<number> {
       }\n`,
     );
   }
+  // Gentle, one-time heads-up that semantic search is off. Embeddings are
+  // optional — memory still works on keyword (BM25) search — so this is an
+  // informational line, not a warning, and never blocks startup.
+  const semanticSearch =
+    config.embeddings?.provider === "gemini" &&
+    !!config.embeddings?.gemini?.apiKey;
+  if (!semanticSearch) {
+    out.write(
+      "  memory: semantic (vector) search OFF — keyword search active. " +
+        "Optional: run `phantombot embedding` to enable.\n",
+    );
+  }
   out.write("Ctrl-C to stop.\n");
 
   // Startup catch-up: `doctor` checks for a stale, failed, or partially

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -584,3 +584,101 @@ describe("runDoctor zombie-timer re-arm wiring", () => {
     expect(receivedStale).toEqual(["phantombot-tick.timer"]);
   });
 });
+
+describe("runDoctor embeddings status line", () => {
+  // The embeddings line is purely informational: it tells the operator
+  // whether semantic (vector) search is live, but absence is a valid,
+  // fully-working config — so it must NEVER turn into a WARN or change
+  // the exit code. These tests pin both the wording and that invariant.
+
+  test("provider 'none' → neutral 'off' line, exit stays 0", async () => {
+    // config fixture defaults to embeddings.provider = "none".
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain(
+      "embeddings: semantic (vector) search off — keyword (BM25) search active",
+    );
+    expect(out.text).toContain("phantombot embedding");
+    // Crucially, NOT a WARN — the marker must never appear on this line.
+    expect(out.text).not.toContain("embeddings: WARN");
+  });
+
+  test("gemini provider with key → 'ON' line", async () => {
+    config.embeddings = {
+      provider: "gemini",
+      gemini: {
+        apiKey: "AIzaTEST123",
+        model: "gemini-embedding-001",
+        dims: 1536,
+      },
+    };
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain(
+      "embeddings: semantic (vector) search ON — provider 'gemini'",
+    );
+  });
+
+  test("gemini provider but EMPTY key → still reported off", async () => {
+    // Provider says gemini but no usable key = keyword-only in practice.
+    config.embeddings = {
+      provider: "gemini",
+      gemini: { apiKey: "", model: "gemini-embedding-001", dims: 1536 },
+    };
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({ config, out, checkSystemd: false, checkTimers: false });
+    expect(out.text).toContain("semantic (vector) search off");
+  });
+
+  test("json mode includes the embeddings block", async () => {
+    config.embeddings = {
+      provider: "gemini",
+      gemini: {
+        apiKey: "AIzaTEST123",
+        model: "gemini-embedding-001",
+        dims: 1536,
+      },
+    };
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({
+      config,
+      json: true,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+    });
+    const report = JSON.parse(out.text);
+    expect(report.embeddings).toEqual({
+      provider: "gemini",
+      semantic_search: true,
+    });
+  });
+});

--- a/tests/cli-embedding.test.ts
+++ b/tests/cli-embedding.test.ts
@@ -13,6 +13,11 @@ import { loadConfig } from "../src/config.ts";
 let workdir: string;
 let configPath: string;
 const SAVED_CONFIG = process.env.PHANTOMBOT_CONFIG;
+// Isolate from the ambient environment: loadConfig() prefers a real
+// PHANTOMBOT_GEMINI_API_KEY over the toml api_key, so a key present in the
+// shell (e.g. on a live phantombot box) would otherwise leak into these
+// config-roundtrip tests and fail them. Clear it per-test, restore after.
+let savedGeminiKey: string | undefined;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-emb-"));
@@ -20,11 +25,15 @@ beforeEach(async () => {
   process.env.PHANTOMBOT_CONFIG = configPath;
   process.env.XDG_CONFIG_HOME = join(workdir, "xdg-config");
   process.env.XDG_DATA_HOME = join(workdir, "xdg-data");
+  savedGeminiKey = process.env.PHANTOMBOT_GEMINI_API_KEY;
+  delete process.env.PHANTOMBOT_GEMINI_API_KEY;
 });
 
 afterEach(async () => {
   if (SAVED_CONFIG === undefined) delete process.env.PHANTOMBOT_CONFIG;
   else process.env.PHANTOMBOT_CONFIG = SAVED_CONFIG;
+  if (savedGeminiKey === undefined) delete process.env.PHANTOMBOT_GEMINI_API_KEY;
+  else process.env.PHANTOMBOT_GEMINI_API_KEY = savedGeminiKey;
   await rm(workdir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

Semantic (vector) search already degrades gracefully to keyword (FTS5/BM25) search when no embedding provider is configured — but that degraded state was **invisible**: no surfacing, no docs, no exposure during setup. An operator could run keyword-only indefinitely without realising vector search was never enabled (exactly what we just hit on the live box). This PR makes the optionality **explicit and discoverable** without ever turning absence into an error.

## Changes

- **doctor** — adds an *informational* `embeddings:` line (semantic ON / off with keyword search active). Deliberately neutral: **no ok/WARN marker, never feeds `repair_needed` or the exit code.** Absence is a valid, fully-working config, not a fault.
- **run** — a gentle one-line startup heads-up when semantic search is off.
- **init wizard** — a new **optional** step (default skip) that exposes semantic search during setup, with a short "what this improves" note. Reuses `runEmbedding`.
- **embedding** — adds an `embedded` mode so `runEmbedding` can run as a wizard sub-step without its own clack intro/outro (a nested intro renders a stray bracket) or a premature restart prompt (service isn't installed until the next step).
- **README** — a new "Semantic search (optional)" section: what it does, why it's nice, why it's optional, how to tell which mode you're in, how to enable.

## Also (flagged for the reviewer)

`cli-embedding.test.ts` had latent **env-isolation** bug: `loadConfig()` prefers a real `PHANTOMBOT_GEMINI_API_KEY` over the toml value, so the config-roundtrip tests false-failed on any box that has a key in the environment (e.g. this one). Fixed by clearing + restoring the var per test, matching the save/restore pattern the file already uses elsewhere. CI (clean env) was unaffected; this only bit local runs on the live box.

## Verification

- typecheck clean
- full suite **1006 pass / 1 skip / 0 fail** (4 new doctor tests pinning the wording + the never-WARN / never-exit-code invariant + the JSON block)
- production build bundles clean

## Test plan

- [ ] `phantombot doctor` shows the neutral `embeddings:` line in both states
- [ ] `phantombot run` prints the one-line heads-up only when semantic search is off
- [ ] `phantombot init` offers the optional step and skipping it completes setup cleanly
- [ ] enabling via the optional step writes `[embeddings]` and does not prompt for a restart mid-wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)