### PR TITLE
feat(telegram): pace progress and split reply bubbles

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,30 @@ systemctl --user restart phantombot
 
 ---
 
+## Telegram reply pacing
+
+Telegram replies are paced for phone-sized chats:
+
+- progress narration is coalesced on a timer instead of posted once per tool call
+- final text is split into smaller bubbles at sentence/character boundaries
+- markdown blocks such as tables and code fences are kept intact where possible
+- voice replies are split into short voice notes
+
+Defaults are conservative, but you can tune them:
+
+```toml
+[channels.telegram.streaming]
+narration_flush_ms = 4500
+bubble_max_sentences = 4
+bubble_max_chars = 700
+bubble_delay_ms = 800
+voice_max_sentences = 3
+```
+
+Environment overrides use the same names in screaming snake case, for example `PHANTOMBOT_TELEGRAM_BUBBLE_MAX_CHARS=900`.
+
+---
+
 ## Voice replies in Telegram
 
 When a Telegram voice message comes in (and the configured provider can do TTS), phantombot transcribes via STT, runs the harness, and synthesizes the reply as a voice note. **For these voice-in/voice-out turns only**, phantombot appends a one-paragraph brevity directive to the system prompt — telling the model to keep the reply to 1-3 sentences (~30 seconds of speech, ≈100 tokens), drop work narration ("Let me check…"), and skip markdown the TTS would read awkwardly.

--- a/src/channels/streamSegmenter.ts
+++ b/src/channels/streamSegmenter.ts
@@ -1,0 +1,250 @@
+export interface StreamSegmenterOptions {
+  maxSentences: number;
+  maxChars: number;
+  hardMaxChars?: number;
+}
+
+export interface SegmentResult {
+  segments: string[];
+}
+
+const DEFAULT_HARD_MAX_CHARS = 3500;
+
+interface BlockState {
+  inFence: boolean;
+  fenceMarker: "```" | "~~~" | undefined;
+  inTable: boolean;
+  inList: boolean;
+}
+
+const sentenceSegmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "sentence" })
+    : undefined;
+
+/**
+ * Markdown-aware streaming splitter for chat-sized bubbles.
+ *
+ * It accepts arbitrary text chunks, buffers incomplete lines so markdown
+ * block markers are seen whole, and only cuts at safe boundaries. Code fences
+ * are held together unless they exceed Telegram's practical source cap; in
+ * that forced case the fence is closed and reopened across bubbles.
+ */
+export class StreamSegmenter {
+  private readonly maxSentences: number;
+  private readonly maxChars: number;
+  private readonly hardMaxChars: number;
+  private readonly state: BlockState = {
+    inFence: false,
+    fenceMarker: undefined,
+    inTable: false,
+    inList: false,
+  };
+  private current = "";
+  private lineBuffer = "";
+  private sentenceCount = 0;
+  private forceReopenFence: "```" | "~~~" | undefined;
+
+  constructor(options: StreamSegmenterOptions) {
+    this.maxSentences = Math.max(1, options.maxSentences);
+    this.maxChars = Math.max(1, options.maxChars);
+    this.hardMaxChars = options.hardMaxChars ?? DEFAULT_HARD_MAX_CHARS;
+  }
+
+  push(text: string): SegmentResult {
+    if (text.length === 0) return { segments: [] };
+    const segments: string[] = [];
+    this.lineBuffer += text;
+
+    while (true) {
+      const nl = this.lineBuffer.indexOf("\n");
+      if (nl < 0) break;
+      const line = this.lineBuffer.slice(0, nl + 1);
+      this.lineBuffer = this.lineBuffer.slice(nl + 1);
+      this.consumeLine(line, segments);
+    }
+
+    this.flushProseFromLineBuffer(segments);
+    return { segments };
+  }
+
+  finish(): SegmentResult {
+    const segments: string[] = [];
+    if (this.lineBuffer.length > 0) {
+      const line = this.lineBuffer;
+      this.lineBuffer = "";
+      this.consumeLine(line, segments);
+    }
+    this.flushCurrent(segments, { force: true });
+    return { segments };
+  }
+
+  private consumeLine(line: string, segments: string[]): void {
+    const fence = fenceMarker(line);
+    if (fence) {
+      this.append(line);
+      if (this.state.inFence && this.state.fenceMarker === fence) {
+        this.state.inFence = false;
+        this.state.fenceMarker = undefined;
+        this.flushCurrent(segments);
+      } else if (!this.state.inFence) {
+        this.state.inFence = true;
+        this.state.fenceMarker = fence;
+      }
+      this.enforceHardCap(segments);
+      return;
+    }
+
+    if (this.state.inFence) {
+      this.append(line);
+      this.enforceHardCap(segments);
+      return;
+    }
+
+    const table = isTableLine(line);
+    const list = isListLine(line);
+    const heading = isHeadingLine(line);
+
+    if (this.state.inTable && !table) {
+      this.state.inTable = false;
+      this.flushCurrent(segments);
+    }
+    if (this.state.inList && !list) {
+      this.state.inList = false;
+      this.flushCurrent(segments);
+    }
+
+    this.state.inTable = table;
+    this.state.inList = list;
+
+    if (table || list || heading) {
+      this.append(line);
+      this.flushCurrent(segments);
+      return;
+    }
+
+    this.consumeProse(line, segments);
+  }
+
+  private flushProseFromLineBuffer(segments: string[]): void {
+    if (
+      this.lineBuffer.length === 0 ||
+      this.state.inFence ||
+      this.state.inTable ||
+      this.state.inList
+    ) {
+      return;
+    }
+    const text = this.lineBuffer;
+    if (!sentenceLooksComplete(text) && this.current.length + text.length < this.maxChars) {
+      return;
+    }
+    this.lineBuffer = "";
+    this.consumeProse(text, segments);
+  }
+
+  private append(text: string): void {
+    if (this.forceReopenFence) {
+      this.current += `${this.forceReopenFence}\n`;
+      this.forceReopenFence = undefined;
+    }
+    this.current += text;
+  }
+
+  private consumeProse(text: string, segments: string[]): void {
+    for (const sentence of splitSentences(text)) {
+      this.append(sentence);
+      if (sentenceLooksComplete(sentence)) this.sentenceCount++;
+      this.flushCurrent(segments);
+    }
+  }
+
+  private flushCurrent(
+    segments: string[],
+    opts: { force?: boolean } = {},
+  ): void {
+    if (this.current.trim().length === 0) {
+      if (opts.force) this.current = "";
+      return;
+    }
+    const safeBoundary =
+      !this.state.inFence && !this.state.inTable && !this.state.inList;
+    const shouldFlush =
+      opts.force ||
+      (safeBoundary &&
+        (this.sentenceCount >= this.maxSentences ||
+          this.current.length >= this.maxChars));
+    if (!shouldFlush) return;
+    segments.push(this.current);
+    this.current = "";
+    this.sentenceCount = 0;
+  }
+
+  private enforceHardCap(segments: string[]): void {
+    if (this.current.length < this.hardMaxChars) return;
+    if (this.state.inFence && this.state.fenceMarker) {
+      const marker = this.state.fenceMarker;
+      segments.push(`${this.current}\n${marker}\n`);
+      this.current = "";
+      this.forceReopenFence = marker;
+      this.sentenceCount = 0;
+      return;
+    }
+    this.flushCurrent(segments, { force: true });
+  }
+}
+
+export function splitIntoSegments(
+  text: string,
+  options: StreamSegmenterOptions,
+): string[] {
+  const s = new StreamSegmenter(options);
+  const out = s.push(text).segments;
+  out.push(...s.finish().segments);
+  return out;
+}
+
+function fenceMarker(line: string): "```" | "~~~" | undefined {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("```")) return "```";
+  if (trimmed.startsWith("~~~")) return "~~~";
+  return undefined;
+}
+
+function isTableLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith("|") && trimmed.endsWith("|") && trimmed.includes("|");
+}
+
+function isListLine(line: string): boolean {
+  return /^\s*(?:[-*+]\s+|\d+\.\s+)/.test(line);
+}
+
+function isHeadingLine(line: string): boolean {
+  return /^\s{0,3}#{1,6}\s+/.test(line);
+}
+
+function splitSentences(text: string): string[] {
+  if (!sentenceSegmenter) return fallbackSplitSentences(text);
+  const out: string[] = [];
+  for (const part of sentenceSegmenter.segment(text)) {
+    if (part.segment.length > 0) out.push(part.segment);
+  }
+  return out;
+}
+
+function fallbackSplitSentences(text: string): string[] {
+  const out: string[] = [];
+  let start = 0;
+  const re = /[.!?…]["')\]]?\s+/g;
+  while (re.exec(text)) {
+    out.push(text.slice(start, re.lastIndex));
+    start = re.lastIndex;
+  }
+  if (start < text.length) out.push(text.slice(start));
+  return out;
+}
+
+function sentenceLooksComplete(text: string): boolean {
+  return /[.!?…]["')\]]?\s*$/.test(text.trimEnd());
+}

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -6,21 +6,15 @@
  * memory uses conversation key `telegram:<chatId>` so DMs and groups are
  * isolated from the CLI's `cli:default` history.
  *
- * Streaming: we send `sendChatAction(typing)` at the start of each turn,
- * refresh it on every harness chunk, and — for text-out turns — flush
- * any buffered prose as a separate Telegram message right before each
- * tool call (signalled by a `progress` chunk). That makes one-line
- * narrations like "Checking your inboxes…" land *before* the silent
- * tool-run window instead of arriving stapled to the back of the final
- * answer. Voice-out skips chunked flushing — voice is one synthesized
- * clip at the end, mid-turn flushes would just bloat the audio.
+ * Streaming: we send `sendChatAction(typing)` at the start of each turn
+ * and refresh it on every harness chunk. Text before a tool call is
+ * classified as progress narration, but it is posted only on a timer so
+ * many tool calls coalesce into one bubble. Final answers stream through
+ * a markdown-aware segmenter that cuts into smaller Telegram bubbles at
+ * sentence/char boundaries without splitting code fences or tables.
  *
- * Gemini-cli models often go straight to tool calls without narration.
- * For that case: we run a background typing-indicator refresh timer
- * during tool execution (the status bar keeps showing "typing…" or
- * "recording voice…" — no canned chat messages), and flush accumulated
- * text on post-tool heartbeat events so replies stream progressively
- * instead of arriving as one blob at turn-end.
+ * Voice-out skips text streaming; after the full reply is known, it is
+ * split into short voice clips.
  *
  * Token-by-token live edits would be nicer still but Telegram
  * rate-limits edits at ~1/sec — not worth the complexity.
@@ -32,7 +26,11 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 
-import { type Config, xdgDataHome } from "../config.ts";
+import {
+  DEFAULT_TELEGRAM_STREAMING,
+  type Config,
+  xdgDataHome,
+} from "../config.ts";
 import type { Harness } from "../harnesses/types.ts";
 import {
   type AudioSupport,
@@ -54,6 +52,10 @@ import {
   handleSlashCommand,
 } from "./commands.ts";
 import { markdownToTelegramHtml } from "./telegramFormat.ts";
+import {
+  splitIntoSegments,
+  StreamSegmenter,
+} from "./streamSegmenter.ts";
 
 /**
  * Telegram bot-API hard cap on file downloads. `getFile` rejects requests
@@ -418,6 +420,10 @@ function abortReasonString(reason: unknown): string {
   if (typeof reason === "string") return reason;
   if (reason instanceof Error) return reason.message;
   return "aborted";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 interface TelegramRawFile {
@@ -1129,6 +1135,11 @@ async function processChatMessage(
     willReplyWithVoice
       ? input.transport.sendRecording(msg.chatId)
       : input.transport.sendTyping(msg.chatId);
+  const streaming = input.config.telegramStreaming ?? DEFAULT_TELEGRAM_STREAMING;
+  const segmenterOptions = {
+    maxSentences: streaming.bubbleMaxSentences,
+    maxChars: streaming.bubbleMaxChars,
+  };
 
   // Indicator policy: refresh on EVERY harness chunk (text, heartbeat,
   // progress). When chunks stop, the indicator naturally expires after
@@ -1158,8 +1169,9 @@ async function processChatMessage(
   const startToolRefresh = () => {
     if (toolRefreshTimer) return; // already running
     toolRefreshTimer = setInterval(() => {
-      void sendStatus();
-    }, 4000);
+      refreshIndicator();
+      void flushNarration();
+    }, Math.min(1000, streaming.narrationFlushMs));
   };
   const stopToolRefresh = () => {
     if (toolRefreshTimer) {
@@ -1180,57 +1192,82 @@ async function processChatMessage(
   };
   activeTurns.set(msg.chatId, turnHandle);
 
-  // Streaming-narration accumulators. The text-out path flushes
-  // buffered prose as a separate Telegram message right before each
-  // tool call (signalled by a `progress` chunk), so the user sees
-  // "Checking your inboxes…" land *before* the silent tool-run window.
-  // Without this, the entire turn batches into one bubble at the end
-  // and narration is invisible.
+  // Streaming accumulators.
   //
-  //   streamedReply  — running sum of `text` chunks seen so far
-  //   flushedReply   — what's already been sent as narration bubbles;
-  //                    a prefix of streamedReply (and, in the happy
-  //                    path, of the final reply too)
-  //   finalReply     — set on the `done` chunk; authoritative full
-  //                    text the harness wants delivered
+  //   streamedReply       — running sum of `text` chunks seen so far
+  //   consumedReplyChars  — prefix length already delivered as final text OR
+  //                         classified as narration and intentionally removed
+  //                         from the final answer
+  //   narrationBuffer     — classified progress text waiting for the timed
+  //                         progress flush, coalesced across tool calls
+  //   finalSegmenter      — markdown-aware live splitter for candidate final
+  //                         answer text
+  //   finalReply          — set on the `done` chunk; authoritative full text
   //
-  // Voice-out skips flushing entirely — voice is one synthesized clip
-  // at the end, so mid-turn flushes would just bloat the audio.
+  // Voice-out skips text streaming entirely; it is split into short voice
+  // clips after the full reply is known.
   let streamedReply = "";
-  let flushedReply = "";
+  let consumedReplyChars = 0;
+  let narrationBuffer = "";
+  let narrationBubblesSent = 0;
+  let finalSegmenter = new StreamSegmenter(segmenterOptions);
+  let finalCandidateText = "";
+  let finalCandidateSentChars = 0;
+  let finalBubblesSent = 0;
   let finalReply: string | undefined;
   let errored: string | undefined;
   let progressCount = 0;
   let chosenHarness: string | undefined;
-  // Gemini-cli streaming UX: track whether we're past the first tool
-  // call (so we know when heartbeat events signal post-tool reply
-  // streaming), and throttle heartbeat-triggered text flushes so
-  // replies stream progressively instead of arriving as one blob.
-  let pastFirstTool = false;
-  let lastHeartbeatFlushAt = 0;
+  let lastNarrationFlushAt = Date.now();
 
-  // Flush whatever's buffered since the last flush as a narration
-  // bubble. No-ops in voice-out (we synthesize once at the end) and
-  // when there's nothing meaningful to send (whitespace-only). Logs
-  // and swallows send failures rather than aborting the turn — a
-  // dropped narration bubble is a cosmetic loss, not a correctness
-  // one.
-  const flushNarration = async () => {
-    if (willReplyWithVoice) return;
-    const pending = streamedReply.slice(flushedReply.length);
-    if (pending.trim().length === 0) return;
-    flushedReply = streamedReply;
+  const sendTextSegment = async (
+    text: string,
+    kind: "narration" | "final" | "error",
+  ) => {
+    if (text.trim().length === 0) return;
     try {
-      await input.transport.sendMessage(msg.chatId, pending);
+      await input.transport.sendMessage(msg.chatId, text);
+      if (kind === "narration") narrationBubblesSent++;
+      if (kind === "final") finalBubblesSent++;
     } catch (e) {
-      log.warn("telegram: narration flush failed", {
+      log.warn(`telegram: ${kind} send failed`, {
         error: (e as Error).message,
         chatId: msg.chatId,
       });
     }
-    // Sending a real message replaces the typing indicator — re-arm
-    // it so the user sees we're still working on the next step.
     refreshIndicator();
+  };
+
+  const sendFinalSegments = async (text: string) => {
+    const segments = splitIntoSegments(text, segmenterOptions);
+    for (let i = 0; i < segments.length; i++) {
+      await sendTextSegment(segments[i]!, "final");
+      if (i < segments.length - 1 && streaming.bubbleDelayMs > 0) {
+        await sleep(streaming.bubbleDelayMs);
+      }
+    }
+  };
+
+  const resetFinalCandidate = () => {
+    finalSegmenter = new StreamSegmenter(segmenterOptions);
+    finalCandidateText = "";
+    finalCandidateSentChars = 0;
+  };
+
+  // Flush coalesced progress narration on a clock, not on every tool
+  // boundary. Tool boundaries classify preceding text as narration; this
+  // timer decides when, if ever, that narration becomes a progress bubble.
+  const flushNarration = async (force = false) => {
+    if (willReplyWithVoice) return;
+    if (narrationBuffer.trim().length === 0) return;
+    const now = Date.now();
+    if (!force && now - lastNarrationFlushAt < streaming.narrationFlushMs) {
+      return;
+    }
+    const pending = narrationBuffer;
+    narrationBuffer = "";
+    lastNarrationFlushAt = now;
+    await sendTextSegment(pending, "narration");
   };
 
   // Mechanical capture nudge: every CAPTURE_NUDGE_INTERVAL user turns
@@ -1298,9 +1335,9 @@ async function processChatMessage(
       // Pre-tool narration: ON for text-out (the user sees streamed
       // text as it lands, so a "checking your calendar..." sentence
       // before a tool call usefully fills the silence). OFF for
-      // voice-out: the reply is synthesized as one clip at the end,
-      // so narration would just lengthen the spoken output without
-      // helping with perceived latency. VOICE_REPLY_INSTRUCTION
+      // voice-out: the reply is synthesized after the full response is
+      // known, so narration would just lengthen the spoken output
+      // without helping with perceived latency. VOICE_REPLY_INSTRUCTION
       // already forbids work narration too, so off is consistent.
       toolNarration: !willReplyWithVoice,
     })) {
@@ -1308,40 +1345,28 @@ async function processChatMessage(
         streamedReply += chunk.text;
         stopToolRefresh();
         refreshIndicator();
+        if (!willReplyWithVoice) {
+          finalCandidateText += chunk.text;
+          const { segments } = finalSegmenter.push(chunk.text);
+          for (const segment of segments) {
+            await sendTextSegment(segment, "final");
+            consumedReplyChars += segment.length;
+            finalCandidateSentChars += segment.length;
+            if (streaming.bubbleDelayMs > 0) {
+              await sleep(streaming.bubbleDelayMs);
+            }
+          }
+        }
       }
       if (chunk.type === "heartbeat") {
         // Tool completed (or model is thinking) — stop the background
         // tool-refresh timer and show the indicator naturally.
         stopToolRefresh();
         refreshIndicator();
-        // After the first tool call, heartbeat events signal the model
-        // has started streaming its post-tool reply. Flush accumulated
-        // text so gemini-cli users see replies progressively instead of
-        // waiting for the entire turn to finish. Throttled to avoid
-        // sending a new message on every heartbeat/token pair.
-        if (pastFirstTool) {
-          const now = Date.now();
-          if (now - lastHeartbeatFlushAt >= 1500) {
-            const pending = streamedReply.slice(flushedReply.length);
-            if (pending.trim().length > 0) {
-              flushedReply = streamedReply;
-              try {
-                await input.transport.sendMessage(msg.chatId, pending);
-                lastHeartbeatFlushAt = now;
-              } catch (e) {
-                log.warn("telegram: heartbeat flush failed", {
-                  error: (e as Error).message,
-                  chatId: msg.chatId,
-                });
-              }
-              refreshIndicator();
-            }
-          }
-        }
+        await flushNarration();
       }
       if (chunk.type === "progress") {
         progressCount++;
-        pastFirstTool = true;
         // Stash the latest progress note on the active-turn handle so
         // /status can show "currently: <tool>" in real time.
         turnHandle.lastProgressNote = chunk.note.slice(0, 500);
@@ -1349,16 +1374,20 @@ async function processChatMessage(
           chatId: msg.chatId,
           note: chunk.note.slice(0, 200),
         });
-        // A tool is about to run — flush whatever narration the model
-        // emitted before this point so the user sees it during the
-        // silence. (Inside the loop so multi-tool turns get one
-        // bubble per tool, not one wall at the end.)
-        // flushNarration() re-arms the typing indicator after sending,
-        // so we don't need to call refreshIndicator() again here.
-        const pendingBeforeTool = streamedReply.slice(flushedReply.length);
-        if (pendingBeforeTool.trim().length > 0) {
-          await flushNarration();
+        // A tool is about to run. The text emitted since the previous
+        // boundary was progress narration unless it already crossed the
+        // markdown-aware final-answer splitter and got sent as a readable
+        // final bubble. Buffer the unsent remainder for the timed progress
+        // flush, then consume it so it is not duplicated in finalText.
+        const unsentCandidate = finalCandidateText.slice(
+          finalCandidateSentChars,
+        );
+        if (unsentCandidate.trim().length > 0) {
+          narrationBuffer += unsentCandidate;
         }
+        consumedReplyChars = streamedReply.length;
+        resetFinalCandidate();
+        await flushNarration();
         // Start a background timer to keep the typing/recording
         // indicator visible during tool execution. Without this,
         // gemini-cli's multi-minute tool runs cause Telegram's
@@ -1438,26 +1467,25 @@ async function processChatMessage(
   // (which may have been reformatted), fall back to whatever streamed.
   const fullReply = finalReply ?? streamedReply;
 
-  // Compute what to send in the FINAL bubble (post-tool answer):
+  // Compute what still needs to be sent after live streaming:
   //   - error: surface the diagnostic
-  //   - flushed prefix matches: send only the suffix (the part of the
-  //     answer the user hasn't seen yet)
-  //   - flushed prefix doesn't match (harness reformatted): send the
-  //     full reply. We accept some duplication of the narration text
-  //     over silently truncating the answer.
-  //   - nothing came back AND nothing was flushed: "(no reply)"
-  //   - nothing came back BUT we flushed: stay silent (the narration
-  //     bubbles are the user-visible reply)
+  //   - consumed prefix matches: send only the suffix (the part the user
+  //     hasn't seen yet, after live final bubbles and classified narration)
+  //   - consumed prefix doesn't match (harness reformatted): send the
+  //     full reply. We accept some duplication over silently truncating.
+  //   - nothing came back AND nothing visible was sent: "(no reply)"
+  //   - nothing came back BUT progress/final bubbles landed: stay silent
   let outText: string;
   if (errored) {
     outText = `(error: ${errored})`;
   } else if (fullReply.length === 0) {
-    outText = flushedReply.length > 0 ? "" : "(no reply)";
+    outText =
+      narrationBubblesSent > 0 || finalBubblesSent > 0 ? "" : "(no reply)";
   } else if (
-    flushedReply.length > 0 &&
-    fullReply.startsWith(flushedReply)
+    consumedReplyChars > 0 &&
+    fullReply.startsWith(streamedReply.slice(0, consumedReplyChars))
   ) {
-    outText = fullReply.slice(flushedReply.length);
+    outText = fullReply.slice(consumedReplyChars);
   } else {
     outText = fullReply;
   }
@@ -1467,36 +1495,42 @@ async function processChatMessage(
   // so Telegram pushes a notification — important when the user kicked
   // off a long job and walked away from the chat.
   //
-  // Voice-out always synthesizes the *full* reply (ignoring the chunked
-  // outText), since flushNarration is a no-op for voice and the user
-  // expects one coherent audio clip.
+  // Voice-out synthesizes the full reply, split into short clips. Text
+  // streaming is disabled for voice, so there is nothing to dedupe.
   let sentAsVoice = false;
   try {
     if (willReplyWithVoice && !errored && fullReply.length > 0) {
-      const r = await synthesize(input.config, fullReply);
-      if (r.ok) {
-        await input.transport.sendVoice(
-          msg.chatId,
-          r.audio.data,
-          r.audio.mime,
-        );
-        sentAsVoice = true;
-      } else {
-        log.warn("telegram: TTS failed; falling back to text", {
-          error: r.error,
-        });
-        // TTS failure fallback: send the full reply as text (not the
-        // prefix-trimmed outText) since we never flushed narration on
-        // the voice path — there's nothing to dedupe against.
-        await input.transport.sendMessage(msg.chatId, fullReply);
+      const voiceSegments = splitIntoSegments(fullReply, {
+        maxSentences: streaming.voiceMaxSentences,
+        maxChars: streaming.bubbleMaxChars,
+      });
+      for (const segment of voiceSegments) {
+        const r = await synthesize(input.config, segment);
+        if (r.ok) {
+          await input.transport.sendVoice(
+            msg.chatId,
+            r.audio.data,
+            r.audio.mime,
+          );
+          sentAsVoice = true;
+        } else {
+          log.warn("telegram: TTS failed; falling back to text", {
+            error: r.error,
+          });
+          await sendFinalSegments(fullReply);
+          sentAsVoice = false;
+          break;
+        }
       }
     } else if (outText.length > 0) {
-      // Empty outText is intentional silence: we already flushed the
-      // narration bubbles and the harness produced nothing further
-      // (and there's no error to surface). Skipping the send avoids
-      // a stray "(no reply)" tacked onto the end of a perfectly
-      // delivered turn.
-      await input.transport.sendMessage(msg.chatId, outText);
+      // Empty outText is intentional silence: streaming/progress bubbles
+      // already delivered all useful output. Otherwise, split the remaining
+      // final reply into markdown-safe Telegram bubbles.
+      if (errored) {
+        await sendTextSegment(outText, "error");
+      } else {
+        await sendFinalSegments(outText);
+      }
     }
   } catch (e) {
     log.error("telegram: send failed", {
@@ -1509,7 +1543,9 @@ async function processChatMessage(
     chatId: msg.chatId,
     durationMs: Date.now() - startedAt,
     replyChars: outText.length,
-    flushedChars: flushedReply.length,
+    consumedReplyChars,
+    narrationBubbles: narrationBubblesSent,
+    finalBubbles: finalBubblesSent,
     progressEvents: progressCount,
     harness: chosenHarness ?? (errored ? "(error)" : "(unknown)"),
     modality: sentAsVoice ? "voice" : "text",

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,27 @@ export const DEFAULT_RETRIEVAL: RetrievalSettings = {
   turnIndexing: DEFAULT_TURN_INDEXING,
 };
 
+export interface TelegramStreamingSettings {
+  /** Coalesce progress narration bubbles to at most this cadence. */
+  narrationFlushMs: number;
+  /** Cut final text bubbles after this many sentences when markdown-safe. */
+  bubbleMaxSentences: number;
+  /** Cut final text bubbles after roughly this many chars when markdown-safe. */
+  bubbleMaxChars: number;
+  /** Pause between final bubbles so Telegram renders them as readable bursts. */
+  bubbleDelayMs: number;
+  /** Split voice replies into short notes by sentence count. */
+  voiceMaxSentences: number;
+}
+
+export const DEFAULT_TELEGRAM_STREAMING: TelegramStreamingSettings = {
+  narrationFlushMs: 4500,
+  bubbleMaxSentences: 4,
+  bubbleMaxChars: 700,
+  bubbleDelayMs: 800,
+  voiceMaxSentences: 3,
+};
+
 export interface Config {
   /** Persona used by `ask`/`chat` when --persona is omitted. */
   defaultPersona: string;
@@ -160,6 +181,8 @@ export interface Config {
      */
     telegramPersonas?: Record<string, TelegramAccount>;
   };
+
+  telegramStreaming?: TelegramStreamingSettings;
 
   embeddings: {
     /** "gemini" | "none". "none" = FTS5-only search. */
@@ -332,11 +355,56 @@ export async function loadConfig(): Promise<Config> {
       telegramPersonas: buildTelegramPersonasConfig(tomlTelegram),
     },
 
+    telegramStreaming: buildTelegramStreamingConfig(tomlTelegram),
+
     embeddings: buildEmbeddingsConfig(tomlEmbeddings, tomlGemini),
 
     retrieval: buildRetrievalConfig(tomlRetrieval, tomlTurnIndexing),
 
     voice: buildVoiceConfig(tomlVoice),
+  };
+}
+
+function buildTelegramStreamingConfig(
+  tomlTelegram: Record<string, unknown>,
+): TelegramStreamingSettings {
+  const tomlStreaming = (tomlTelegram.streaming ?? {}) as Record<string, unknown>;
+  return {
+    narrationFlushMs: clampInt(
+      asInt(process.env.PHANTOMBOT_TELEGRAM_NARRATION_FLUSH_MS) ??
+        asInt(tomlStreaming.narration_flush_ms) ??
+        DEFAULT_TELEGRAM_STREAMING.narrationFlushMs,
+      500,
+      30_000,
+    ),
+    bubbleMaxSentences: clampInt(
+      asInt(process.env.PHANTOMBOT_TELEGRAM_BUBBLE_MAX_SENTENCES) ??
+        asInt(tomlStreaming.bubble_max_sentences) ??
+        DEFAULT_TELEGRAM_STREAMING.bubbleMaxSentences,
+      1,
+      20,
+    ),
+    bubbleMaxChars: clampInt(
+      asInt(process.env.PHANTOMBOT_TELEGRAM_BUBBLE_MAX_CHARS) ??
+        asInt(tomlStreaming.bubble_max_chars) ??
+        DEFAULT_TELEGRAM_STREAMING.bubbleMaxChars,
+      100,
+      3500,
+    ),
+    bubbleDelayMs: clampInt(
+      asInt(process.env.PHANTOMBOT_TELEGRAM_BUBBLE_DELAY_MS) ??
+        asInt(tomlStreaming.bubble_delay_ms) ??
+        DEFAULT_TELEGRAM_STREAMING.bubbleDelayMs,
+      0,
+      10_000,
+    ),
+    voiceMaxSentences: clampInt(
+      asInt(process.env.PHANTOMBOT_TELEGRAM_VOICE_MAX_SENTENCES) ??
+        asInt(tomlStreaming.voice_max_sentences) ??
+        DEFAULT_TELEGRAM_STREAMING.voiceMaxSentences,
+      1,
+      20,
+    ),
   };
 }
 
@@ -582,6 +650,11 @@ function buildTelegramPersonasConfig(
 function clampPollTimeout(s: number): number {
   if (!Number.isFinite(s)) return 30;
   return Math.max(1, Math.min(50, Math.floor(s)));
+}
+
+function clampInt(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) return min;
+  return Math.max(min, Math.min(max, Math.floor(n)));
 }
 
 function asIntArray(v: unknown): number[] | undefined {

--- a/tests/channels-streamSegmenter.test.ts
+++ b/tests/channels-streamSegmenter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { splitIntoSegments, StreamSegmenter } from "../src/channels/streamSegmenter.ts";
+
+describe("StreamSegmenter", () => {
+  test("cuts prose after the configured sentence count", () => {
+    expect(
+      splitIntoSegments("One. Two. Three.", {
+        maxSentences: 2,
+        maxChars: 100,
+      }),
+    ).toEqual(["One. Two. ", "Three."]);
+  });
+
+  test("cuts prose at the char ceiling only on a sentence boundary", () => {
+    expect(
+      splitIntoSegments("A long first sentence. Short second.", {
+        maxSentences: 10,
+        maxChars: 12,
+      }),
+    ).toEqual(["A long first sentence. ", "Short second."]);
+  });
+
+  test("does not split an ordinary code fence", () => {
+    const text = "Before.\n```ts\nconst x = 1;\n```\nAfter.";
+    expect(
+      splitIntoSegments(text, {
+        maxSentences: 1,
+        maxChars: 20,
+      }),
+    ).toEqual(["Before.\n", "```ts\nconst x = 1;\n```\n", "After."]);
+  });
+
+  test("keeps table rows together until the table ends", () => {
+    const text = "| A | B |\n| - | - |\n| 1 | 2 |\nDone.";
+    expect(
+      splitIntoSegments(text, {
+        maxSentences: 1,
+        maxChars: 10,
+      }),
+    ).toEqual(["| A | B |\n| - | - |\n| 1 | 2 |\n", "Done."]);
+  });
+
+  test("closes and reopens oversized fences at the hard cap", () => {
+    const s = new StreamSegmenter({
+      maxSentences: 10,
+      maxChars: 100,
+      hardMaxChars: 30,
+    });
+    const first = s.push("```txt\n012345678901234567890123456789\n").segments;
+    const rest = s.push("tail\n```\n").segments.concat(s.finish().segments);
+
+    expect(first).toEqual(["```txt\n012345678901234567890123456789\n\n```\n"]);
+    expect(rest.join("")).toContain("```");
+    expect(rest.join("")).toContain("tail");
+  });
+
+  test("buffers incomplete lines before classifying markdown", () => {
+    const s = new StreamSegmenter({ maxSentences: 1, maxChars: 10 });
+    expect(s.push("```").segments).toEqual([]);
+    expect(s.push("ts\nconst x = 1;\n```\n").segments).toEqual([
+      "```ts\nconst x = 1;\n```\n",
+    ]);
+  });
+});

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -615,6 +615,13 @@ const baseConfig = (
       ...overrides,
     },
   },
+  telegramStreaming: {
+    narrationFlushMs: 4500,
+    bubbleMaxSentences: 4,
+    bubbleMaxChars: 700,
+    bubbleDelayMs: 0,
+    voiceMaxSentences: 3,
+  },
   embeddings: { provider: "none" },
   voice: { provider: "none" },
 });
@@ -1532,14 +1539,13 @@ describe("runTelegramServer system-prompt suffixes", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Pre-tool narration: flush buffered prose as a separate Telegram message
-// before each tool call so the user sees "Checking your inboxes…" land
-// during the silent tool-run window instead of stapled to the back of the
-// final answer. Voice-out skips chunked flushing.
+// Progress/final streaming: pre-tool narration is classified at tool
+// boundaries but only sent on a timer, while final answers are split into
+// markdown-safe bubbles.
 // ---------------------------------------------------------------------------
 
 describe("runTelegramServer narration flush (text-out)", () => {
-  test("text → progress → text → done sends two messages: narration first, answer second", async () => {
+  test("short text → progress → text → done drops unsent narration and sends answer", async () => {
     class NarrationHarness implements Harness {
       readonly id = "narration";
       async available(): Promise<boolean> {
@@ -1575,14 +1581,12 @@ describe("runTelegramServer narration flush (text-out)", () => {
     });
 
     expect(transport.sent.map((s) => s.text)).toEqual([
-      "Checking your inboxes…",
       "Found 3 threads from Turtle Crossing.",
     ]);
-    // Both bubbles land in the right chat.
     expect(transport.sent.every((s) => s.chatId === 1001)).toBe(true);
   });
 
-  test("multi-tool turn: one narration bubble per tool, then the final answer", async () => {
+  test("multi-tool turn: narration coalesces instead of sending one bubble per tool", async () => {
     class MultiToolHarness implements Harness {
       readonly id = "multitool";
       async available(): Promise<boolean> {
@@ -1623,9 +1627,85 @@ describe("runTelegramServer narration flush (text-out)", () => {
     });
 
     expect(transport.sent.map((s) => s.text)).toEqual([
-      "Checking your calendar…",
-      "Now scanning your inboxes…",
       "Calendar is clear; you have 2 unread emails.",
+    ]);
+  });
+
+  test("long tool gap flushes coalesced narration on the timer", async () => {
+    class SlowToolHarness implements Harness {
+      readonly id = "slow-tool";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        yield { type: "text", text: "Checking your calendar…" };
+        yield { type: "progress", note: "tool: gog calendar-list" };
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        yield { type: "done", finalText: "Checking your calendar…" };
+      }
+    }
+
+    const cfg = baseConfig();
+    cfg.telegramStreaming!.narrationFlushMs = 5;
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "check calendar",
+    });
+    await runTelegramServer({
+      config: cfg,
+      memory,
+      harnesses: [new SlowToolHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+      typingThrottleMs: 0,
+    });
+
+    expect(transport.sent.map((s) => s.text)).toEqual([
+      "Checking your calendar…",
+    ]);
+  });
+
+  test("final answer splits progressively into smaller sentence bubbles", async () => {
+    class LongAnswerHarness implements Harness {
+      readonly id = "long-answer";
+      async available(): Promise<boolean> {
+        return true;
+      }
+      async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+        const reply = "One. Two. Three. Four. Five.";
+        yield { type: "text", text: reply };
+        yield { type: "done", finalText: reply };
+      }
+    }
+
+    const cfg = baseConfig();
+    cfg.telegramStreaming!.bubbleMaxSentences = 2;
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "explain",
+    });
+    await runTelegramServer({
+      config: cfg,
+      memory,
+      harnesses: [new LongAnswerHarness()],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.sent.map((s) => s.text)).toEqual([
+      "One. Two. ",
+      "Three. Four. ",
+      "Five.",
     ]);
   });
 
@@ -1702,11 +1782,10 @@ describe("runTelegramServer narration flush (text-out)", () => {
       oneShot: true,
     });
 
-    // No empty/whitespace narration bubble; the full reply lands as
-    // one message. The leading whitespace was never flushed, so the
-    // prefix-match path doesn't trigger and we send `fullReply` whole.
+    // No empty/whitespace narration bubble. The whitespace before the
+    // tool is classified as progress text and removed from the final.
     expect(transport.sent).toHaveLength(1);
-    expect(transport.sent[0]!.text).toBe("  \n real answer");
+    expect(transport.sent[0]!.text).toBe("real answer");
   });
 
   test("flushed prefix matches finalText: post-tool message is the suffix only (no duplication)", async () => {
@@ -1744,10 +1823,7 @@ describe("runTelegramServer narration flush (text-out)", () => {
       oneShot: true,
     });
 
-    expect(transport.sent.map((s) => s.text)).toEqual([
-      "Looking that up…\n",
-      "It's 42.",
-    ]);
+    expect(transport.sent.map((s) => s.text)).toEqual(["It's 42."]);
   });
 
   test("harness reformats final reply: send full final, accept duplication over truncation", async () => {
@@ -1786,13 +1862,9 @@ describe("runTelegramServer narration flush (text-out)", () => {
       oneShot: true,
     });
 
-    // First bubble: the narration we flushed before the tool fired.
-    // Second bubble: the full reformatted final, NOT a sliced suffix
-    // (because the prefix didn't match). User sees a duplicated word
-    // — acceptable. Truncating would be worse.
-    expect(transport.sent).toHaveLength(2);
-    expect(transport.sent[0]!.text).toBe("Checking…");
-    expect(transport.sent[1]!.text).toBe("Result: X (after a check).");
+    // The narration was not on screen yet, so only the reformatted final lands.
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]!.text).toBe("Result: X (after a check).");
   });
 
   test("narration flushed but model emits nothing further: no '(no reply)' tacked on", async () => {
@@ -1828,14 +1900,13 @@ describe("runTelegramServer narration flush (text-out)", () => {
       oneShot: true,
     });
 
-    // Just the narration bubble. No "(no reply)" follow-up.
-    expect(transport.sent.map((s) => s.text)).toEqual(["Checking…"]);
+    // The progress text never reached the timer, and no "(no reply)" follows.
+    expect(transport.sent.map((s) => s.text)).toEqual([]);
   });
 
-  test("error after a flushed narration bubble: error message follows the narration", async () => {
-    // Narration landed, then the tool blew up. The error diagnostic
-    // still has to surface — we suppress "(no reply)" specifically,
-    // not real errors.
+  test("error after short narration: error message still surfaces", async () => {
+    // Narration may or may not have reached the timer before the tool
+    // blows up. The error diagnostic still has to surface.
     class ErrorAfterToolHarness implements Harness {
       readonly id = "error-after-tool";
       async available(): Promise<boolean> {
@@ -1865,10 +1936,7 @@ describe("runTelegramServer narration flush (text-out)", () => {
       oneShot: true,
     });
 
-    expect(transport.sent.map((s) => s.text)).toEqual([
-      "Checking…",
-      "(error: boom)",
-    ]);
+    expect(transport.sent.map((s) => s.text)).toEqual(["(error: boom)"]);
   });
 });
 
@@ -1893,10 +1961,9 @@ describe("runTelegramServer narration flush (voice-out)", () => {
     };
   }
 
-  test("voice-in/voice-out: progress chunks do NOT flush text bubbles; full reply synthesized at end", async () => {
-    // Voice replies are one synthesized clip — chunked text flushes
-    // would just bloat the audio AND leak text into a voice-only
-    // conversation. The flush function is gated off for voice.
+  test("voice-in/voice-out: progress chunks do NOT flush text bubbles; reply is synthesized", async () => {
+    // Voice replies synthesize after the full reply is known; progress
+    // text bubbles would leak text into a voice-only conversation.
     const originalFetch = globalThis.fetch;
     let ttsBodyText: string | undefined;
     (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (
@@ -1958,8 +2025,7 @@ describe("runTelegramServer narration flush (voice-out)", () => {
 
       // No text bubbles emitted — voice-out path stays silent on text.
       expect(transport.sent).toEqual([]);
-      // One voice clip went out with the FULL reply (not just the
-      // suffix), since the voice path ignores `flushedReply`.
+      // One voice clip went out with the FULL reply (not just the suffix).
       expect(transport.voiceSent).toHaveLength(1);
       expect(ttsBodyText).toBe("Checking…Done.");
     } finally {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   DEFAULT_RETRIEVAL,
+  DEFAULT_TELEGRAM_STREAMING,
   DEFAULT_TURN_INDEXING,
   loadConfig,
   memoryIndexPath,
@@ -54,6 +55,11 @@ const ENV_KEYS = [
   "PHANTOMBOT_TELEGRAM_ALLOWED_USERS_MILES",
   "PHANTOMBOT_TELEGRAM_POLL_S",
   "PHANTOMBOT_TELEGRAM_POLL_S_MILES",
+  "PHANTOMBOT_TELEGRAM_NARRATION_FLUSH_MS",
+  "PHANTOMBOT_TELEGRAM_BUBBLE_MAX_SENTENCES",
+  "PHANTOMBOT_TELEGRAM_BUBBLE_MAX_CHARS",
+  "PHANTOMBOT_TELEGRAM_BUBBLE_DELAY_MS",
+  "PHANTOMBOT_TELEGRAM_VOICE_MAX_SENTENCES",
 ];
 
 let workdir: string;
@@ -98,6 +104,7 @@ describe("loadConfig — defaults (no file)", () => {
       bin: "codex",
       model: "",
     });
+    expect(c.telegramStreaming).toEqual(DEFAULT_TELEGRAM_STREAMING);
   });
 
   test("XDG paths resolve to ~/.config and ~/.local/share by default", async () => {
@@ -151,6 +158,56 @@ model = "gpt-5.3-codex"
     expect(c.harnesses.codex!.bin).toBe("/opt/codex/codex");
     expect(c.harnesses.codex!.model).toBe("gpt-5.3-codex");
   });
+
+  test("reads Telegram streaming knobs from [channels.telegram.streaming]", async () => {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(
+      join(cfgDir, "config.toml"),
+      `[channels.telegram.streaming]
+narration_flush_ms = 3000
+bubble_max_sentences = 3
+bubble_max_chars = 500
+bubble_delay_ms = 250
+voice_max_sentences = 2
+`,
+      "utf8",
+    );
+
+    const c = await loadConfig();
+    expect(c.telegramStreaming).toEqual({
+      narrationFlushMs: 3000,
+      bubbleMaxSentences: 3,
+      bubbleMaxChars: 500,
+      bubbleDelayMs: 250,
+      voiceMaxSentences: 2,
+    });
+  });
+
+  test("clamps Telegram streaming knobs to sane bounds", async () => {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(
+      join(cfgDir, "config.toml"),
+      `[channels.telegram.streaming]
+narration_flush_ms = 1
+bubble_max_sentences = 0
+bubble_max_chars = 50
+bubble_delay_ms = 99999
+voice_max_sentences = 99
+`,
+      "utf8",
+    );
+
+    const c = await loadConfig();
+    expect(c.telegramStreaming).toEqual({
+      narrationFlushMs: 500,
+      bubbleMaxSentences: 1,
+      bubbleMaxChars: 100,
+      bubbleDelayMs: 10_000,
+      voiceMaxSentences: 20,
+    });
+  });
 });
 
 describe("loadConfig — env overrides", () => {
@@ -176,6 +233,37 @@ model = "from-toml"
     process.env.PHANTOMBOT_HARNESS_CHAIN = "claude, pi";
     const c = await loadConfig();
     expect(c.harnesses.chain).toEqual(["claude", "pi"]);
+  });
+
+  test("Telegram streaming env vars override TOML", async () => {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(
+      join(cfgDir, "config.toml"),
+      `[channels.telegram.streaming]
+narration_flush_ms = 3000
+bubble_max_sentences = 3
+bubble_max_chars = 500
+bubble_delay_ms = 250
+voice_max_sentences = 2
+`,
+      "utf8",
+    );
+
+    process.env.PHANTOMBOT_TELEGRAM_NARRATION_FLUSH_MS = "6000";
+    process.env.PHANTOMBOT_TELEGRAM_BUBBLE_MAX_SENTENCES = "5";
+    process.env.PHANTOMBOT_TELEGRAM_BUBBLE_MAX_CHARS = "900";
+    process.env.PHANTOMBOT_TELEGRAM_BUBBLE_DELAY_MS = "100";
+    process.env.PHANTOMBOT_TELEGRAM_VOICE_MAX_SENTENCES = "4";
+
+    const c = await loadConfig();
+    expect(c.telegramStreaming).toEqual({
+      narrationFlushMs: 6000,
+      bubbleMaxSentences: 5,
+      bubbleMaxChars: 900,
+      bubbleDelayMs: 100,
+      voiceMaxSentences: 4,
+    });
   });
 
   test("PHANTOMBOT_CONFIG overrides the config file path", async () => {


### PR DESCRIPTION
## Summary
- coalesce progress narration on a timer instead of flushing once per tool call
- stream final Telegram text through a markdown-aware segmenter that splits smaller bubbles by sentence/char boundaries
- split voice replies into shorter clips and expose tuning knobs under [channels.telegram.streaming]
- document Telegram reply pacing in README

## Defaults
- narration_flush_ms = 4500
- bubble_max_sentences = 4
- bubble_max_chars = 700
- voice_max_sentences = 3

## Tests
- PATH=/home/robbie/.bun/bin:$PATH bun run typecheck
- PATH=/home/robbie/.bun/bin:$PATH bun test tests/config.test.ts tests/channels-streamSegmenter.test.ts tests/channels-telegram.test.ts
- PATH=/home/robbie/.bun/bin:$PATH bun test
- PATH=/home/robbie/.bun/bin:$PATH bun run build