### PR TITLE
fix(persona): heal invalid default persona dirs

### DIFF
--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -27,7 +27,6 @@
  */
 
 import { defineCommand } from "citty";
-import { existsSync } from "node:fs";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
@@ -35,6 +34,7 @@ import type { Harness } from "../harnesses/types.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { openMemoryStore, type MemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
+import { hasPersonaIdentity } from "../persona/loader.ts";
 import { makeRetriever } from "../orchestrator/retrieval.ts";
 import { makeTurnIndexer } from "../orchestrator/turnIndexer.ts";
 
@@ -80,7 +80,7 @@ export async function runAsk(input: RunAskInput): Promise<number> {
   const config = input.config ?? (await loadConfig());
   const persona = input.persona ?? config.defaultPersona;
   const agentDir = personaDir(config, persona);
-  if (!existsSync(agentDir)) {
+  if (!hasPersonaIdentity(agentDir)) {
     err.write(
       `phantombot ask: persona '${persona}' not found at ${agentDir}\n`,
     );

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -33,6 +33,7 @@ import {
   type NightlyProgress,
   type NightlyState,
 } from "../lib/nightly.ts";
+import { healDefaultPersonaIfBroken } from "../lib/personaDefault.ts";
 import { currentPlatform } from "../lib/platform.ts";
 import {
   BunSystemctlRunner,
@@ -61,6 +62,7 @@ import {
   type TimerLastFired,
 } from "../lib/timerHealth.ts";
 import { openMemoryStore } from "../memory/store.ts";
+import { hasPersonaIdentity } from "../persona/loader.ts";
 
 /** Window for the capture-health check: a "dry day" is judged over 24h. */
 const CAPTURE_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -244,9 +246,17 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   const repair = input.repair ?? true;
 
   const config = input.config ?? (await loadConfig());
-  const persona = input.persona ?? config.defaultPersona;
-  const dir = personaDir(config, persona);
-  if (!existsSync(dir)) {
+  let persona = input.persona ?? config.defaultPersona;
+  let dir = personaDir(config, persona);
+  if (!hasPersonaIdentity(dir) && !input.persona) {
+    const healed = await healDefaultPersonaIfBroken(config, err);
+    if (healed) {
+      persona = healed;
+      config.defaultPersona = healed;
+      dir = personaDir(config, persona);
+    }
+  }
+  if (!hasPersonaIdentity(dir)) {
     err.write(`persona '${persona}' not found at ${dir}\n`);
     return 2;
   }

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -6,14 +6,15 @@
  */
 
 import { defineCommand } from "citty";
-import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { runHeartbeat } from "../lib/heartbeat.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
+import { healDefaultPersonaIfBroken } from "../lib/personaDefault.ts";
 import { currentPlatform } from "../lib/platform.ts";
+import { hasPersonaIdentity } from "../persona/loader.ts";
 import {
   BunSystemctlRunner,
   buildSystemctlEnv,
@@ -54,10 +55,21 @@ export async function runHeartbeatCli(
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
   const config = input.config ?? (await loadConfig());
-  const persona = input.persona ?? config.defaultPersona;
-  const dir = personaDir(config, persona);
+  let persona = input.persona ?? config.defaultPersona;
+  let dir = personaDir(config, persona);
 
-  if (!existsSync(dir)) {
+  if (!hasPersonaIdentity(dir)) {
+    if (!input.persona) {
+      const healed = await healDefaultPersonaIfBroken(config, err);
+      if (healed) {
+        persona = healed;
+        config.defaultPersona = healed;
+        dir = personaDir(config, persona);
+      }
+    }
+  }
+
+  if (!hasPersonaIdentity(dir)) {
     err.write(`persona '${persona}' not found at ${dir}\n`);
     return 2;
   }

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -32,6 +32,8 @@ import { CodexHarness } from "../harnesses/codex.ts";
 import type { Harness } from "../harnesses/types.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
+import { healDefaultPersonaIfBroken } from "../lib/personaDefault.ts";
+import { hasPersonaIdentity } from "../persona/loader.ts";
 import {
   buildNightlyPromptForPersona,
   buildNightlyStagePrompt,
@@ -112,9 +114,17 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
   const err = input.err ?? process.stderr;
 
   const config = input.config ?? (await loadConfig());
-  const persona = input.persona ?? config.defaultPersona;
-  const dir = personaDir(config, persona);
-  if (!existsSync(dir)) {
+  let persona = input.persona ?? config.defaultPersona;
+  let dir = personaDir(config, persona);
+  if (!hasPersonaIdentity(dir) && !input.persona) {
+    const healed = await healDefaultPersonaIfBroken(config, err);
+    if (healed) {
+      persona = healed;
+      config.defaultPersona = healed;
+      dir = personaDir(config, persona);
+    }
+  }
+  if (!hasPersonaIdentity(dir)) {
     err.write(`persona '${persona}' not found at ${dir}\n`);
     return 2;
   }

--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -35,6 +35,7 @@ import { log } from "../lib/logger.ts";
 import { listArchives } from "../lib/personaArchive.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
 import { loadState, saveState } from "../state.ts";
+import { hasPersonaIdentity } from "../persona/loader.ts";
 import { runCreatePersona } from "./create-persona.ts";
 import { runImportPersona } from "./import-persona.ts";
 import { maybePromptRestart } from "./harness.ts";
@@ -117,7 +118,7 @@ export async function runSwitchPersona(
   const config = input.config ?? (await loadConfig());
 
   const targetDir = personaDir(config, input.name);
-  if (!existsSync(targetDir)) {
+  if (!hasPersonaIdentity(targetDir)) {
     const available = listExistingPersonas(config);
     err.write(
       `persona '${input.name}' not found at ${targetDir}\n` +
@@ -259,7 +260,7 @@ async function runPersonaMenu(input: RunPersonaMenuInput): Promise<number> {
 
 /**
  * Read the personas directory and return the names of subdirectories
- * (each subdir = one persona). Returns [] if the personas dir doesn't
+ * that contain an identity file. Returns [] if the personas dir doesn't
  * exist yet — fresh installs have no personas.
  *
  * Non-ENOENT read failures (EACCES, EIO, etc.) still return [] so the
@@ -272,6 +273,7 @@ export function listExistingPersonas(config: Config): string[] {
     return readdirSync(config.personasDir, { withFileTypes: true })
       .filter((e) => e.isDirectory())
       .map((e) => e.name)
+      .filter((name) => hasPersonaIdentity(personaDir(config, name)))
       .sort();
   } catch (e) {
     log.warn("persona: failed to read personas dir", {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -7,7 +7,6 @@
  */
 
 import { defineCommand } from "citty";
-import { existsSync } from "node:fs";
 
 import {
   HttpTelegramTransport,
@@ -23,6 +22,7 @@ import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import { healDefaultPersonaIfBroken } from "../lib/personaDefault.ts";
+import { hasPersonaIdentity } from "../persona/loader.ts";
 import { logsCommand, statusCommand } from "../lib/platform.ts";
 import {
   acquireRunLock,
@@ -72,7 +72,7 @@ export function planListeners(
 
   if (config.channels.telegram) {
     const agentDir = personaDir(config, defaultPersona);
-    if (existsSync(agentDir)) {
+    if (hasPersonaIdentity(agentDir)) {
       listeners.push({
         persona: defaultPersona,
         agentDir,
@@ -90,9 +90,9 @@ export function planListeners(
     config.channels.telegramPersonas ?? {},
   )) {
     const agentDir = personaDir(config, persona);
-    if (!existsSync(agentDir)) {
+    if (!hasPersonaIdentity(agentDir)) {
       err.write(
-        `warning: channels.telegram.personas.${persona} references persona '${persona}' but no agent dir at ${agentDir} — skipping\n`,
+        `warning: channels.telegram.personas.${persona} references persona '${persona}' but no valid persona identity at ${agentDir} — skipping\n`,
       );
       continue;
     }
@@ -146,7 +146,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   let defaultPersona = config.defaultPersona;
   if (hasDefault) {
     const agentDir = personaDir(config, defaultPersona);
-    if (!existsSync(agentDir)) {
+    if (!hasPersonaIdentity(agentDir)) {
       const healed = await healDefaultPersonaIfBroken(config, err);
       if (healed) {
         defaultPersona = healed;

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -29,7 +29,6 @@
  */
 
 import { defineCommand } from "citty";
-import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import { type Config, loadConfig, personaDir, xdgStateHome } from "../config.ts";
@@ -45,6 +44,7 @@ import { openTaskStore, type Task, type TaskStore } from "../lib/tasks.ts";
 import { recordTickFired } from "../lib/timerHealth.ts";
 import { openMemoryStore, type MemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
+import { hasPersonaIdentity } from "../persona/loader.ts";
 
 export function defaultTickLockPath(): string {
   return join(xdgStateHome(), "phantombot", "tick.lock");
@@ -126,7 +126,7 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
       });
 
       const agentDir = personaDir(config, task.persona);
-      if (!existsSync(agentDir)) {
+      if (!hasPersonaIdentity(agentDir)) {
         log.error("tick: persona dir missing — skipping task", {
           id: task.id,
           persona: task.persona,

--- a/src/lib/personaDefault.ts
+++ b/src/lib/personaDefault.ts
@@ -13,6 +13,7 @@
 import { existsSync, readdirSync } from "node:fs";
 
 import { type Config, personaDir } from "../config.ts";
+import { hasPersonaIdentity } from "../persona/loader.ts";
 import { loadState, saveState } from "../state.ts";
 import type { WriteSink } from "./io.ts";
 import { log } from "./logger.ts";
@@ -30,7 +31,7 @@ export async function adoptAsDefaultIfMissing(
   out?: WriteSink,
 ): Promise<boolean> {
   const currentDefaultDir = personaDir(config, config.defaultPersona);
-  if (existsSync(currentDefaultDir)) return false;
+  if (hasPersonaIdentity(currentDefaultDir)) return false;
   const state = await loadState();
   state.default_persona = name;
   await saveState(state);
@@ -42,8 +43,8 @@ export async function adoptAsDefaultIfMissing(
 
 /**
  * Startup safety net: if the resolved `defaultPersona` doesn't exist on
- * disk, scan the personas directory for a valid replacement, write it to
- * state.json, and return the healed name.
+ * disk or has no identity file, scan the personas directory for a valid
+ * replacement, write it to state.json, and return the healed name.
  *
  * Without this, a corrupted `state.json` (e.g. pointing at a persona
  * that was never created on this host, or one that was deleted) causes
@@ -51,7 +52,7 @@ export async function adoptAsDefaultIfMissing(
  * `phantombot persona` to switch back.
  *
  * Strategy:
- *   1. If the resolved default exists on disk → return it (no-op).
+ *   1. If the resolved default is a valid persona → return it (no-op).
  *   2. Scan the personas dir. If empty → return null (caller bails).
  *   3. If exactly one persona exists → adopt it.
  *   4. If multiple exist → try the one with the same name as the broken
@@ -65,7 +66,7 @@ export async function healDefaultPersonaIfBroken(
   out?: WriteSink,
 ): Promise<string | null> {
   const currentDefaultDir = personaDir(config, config.defaultPersona);
-  if (existsSync(currentDefaultDir)) return config.defaultPersona;
+  if (hasPersonaIdentity(currentDefaultDir)) return config.defaultPersona;
 
   const existing = listPersonaDirs(config);
   if (existing.length === 0) return null;
@@ -97,6 +98,7 @@ export function listPersonaDirs(config: Config): string[] {
     return readdirSync(config.personasDir, { withFileTypes: true })
       .filter((e) => e.isDirectory())
       .map((e) => e.name)
+      .filter((name) => hasPersonaIdentity(personaDir(config, name)))
       .sort();
   } catch (e) {
     log.warn("personaDefault: failed to read personas dir", {

--- a/src/persona/loader.ts
+++ b/src/persona/loader.ts
@@ -21,6 +21,7 @@
  * agentDir, so e.g. claude can `Read` arbitrary files there.
  */
 
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -51,6 +52,10 @@ export class PersonaNotFoundError extends Error {
     );
     this.name = "PersonaNotFoundError";
   }
+}
+
+export function hasPersonaIdentity(agentDir: string): boolean {
+  return IDENTITY_FILES.some((name) => existsSync(join(agentDir, name)));
 }
 
 export async function loadPersona(agentDir: string): Promise<PersonaFiles> {

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -24,6 +24,7 @@ beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-doctor-"));
   personaMemoryDir = join(workdir, "personas", "phantom", "memory");
   await mkdir(personaMemoryDir, { recursive: true });
+  await writeFile(join(workdir, "personas", "phantom", "BOOT.md"), "# Phantom");
   config = {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 600_000,

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -29,6 +29,7 @@ beforeEach(async () => {
   await mkdir(join(workdir, "personas", "phantom", "kb"), {
     recursive: true,
   });
+  await writeFile(join(workdir, "personas", "phantom", "BOOT.md"), "# Phantom");
   process.env.XDG_DATA_HOME = workdir;
   // Redirect the timer-fired marker path so heartbeat writes into the
   // test workdir, not the developer's real ~/.local/state/.

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runNightly } from "../src/cli/nightly.ts";
@@ -22,6 +22,7 @@ let config: Config;
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-ngcli-"));
   await mkdir(join(workdir, "personas", "phantom"), { recursive: true });
+  await writeFile(join(workdir, "personas", "phantom", "BOOT.md"), "# Phantom");
   config = {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,

--- a/tests/cli-persona.test.ts
+++ b/tests/cli-persona.test.ts
@@ -100,7 +100,9 @@ describe("runPersona arg validation", () => {
 describe("runSwitchPersona", () => {
   test("missing persona dir → exit 1 with available list", async () => {
     await mkdir(join(personasDir, "phantom"), { recursive: true });
+    await writeFile(join(personasDir, "phantom", "BOOT.md"), "# Phantom");
     await mkdir(join(personasDir, "robbie"), { recursive: true });
+    await writeFile(join(personasDir, "robbie", "BOOT.md"), "# Robbie");
     const err = new CaptureStream();
     const code = await runSwitchPersona({
       name: "missing",
@@ -130,6 +132,7 @@ describe("runSwitchPersona", () => {
 
   test("happy path: writes default_persona to state.json", async () => {
     await mkdir(join(personasDir, "robbie"), { recursive: true });
+    await writeFile(join(personasDir, "robbie", "BOOT.md"), "# Robbie");
     const out = new CaptureStream();
     const code = await runSwitchPersona({
       name: "robbie",
@@ -148,6 +151,7 @@ describe("runSwitchPersona", () => {
 
   test("already-current → no-op exit 0, no state write", async () => {
     await mkdir(join(personasDir, "phantom"), { recursive: true });
+    await writeFile(join(personasDir, "phantom", "BOOT.md"), "# Phantom");
     // Pre-write state with phantom as default.
     await writeFile(
       process.env.PHANTOMBOT_STATE!,
@@ -170,6 +174,7 @@ describe("runSwitchPersona", () => {
 describe("runPersona dispatch", () => {
   test("positional <name> routes to runSwitchPersona", async () => {
     await mkdir(join(personasDir, "robbie"), { recursive: true });
+    await writeFile(join(personasDir, "robbie", "BOOT.md"), "# Robbie");
     const out = new CaptureStream();
     const code = await runPersona({
       name: "robbie",

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -124,6 +124,37 @@ describe("runRun — early exits", () => {
     expect(err.text).toContain("phantombot harness");
   });
 
+  test("heals when default dir exists but has no identity file", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    await mkdir(join(workdir, "personas", "robbie"), { recursive: true });
+    await mkdir(join(workdir, "personas", "kai"), { recursive: true });
+    await writeFile(join(workdir, "personas", "kai", "BOOT.md"), "# Kai");
+
+    const code = await runRun({
+      config: {
+        ...config,
+        defaultPersona: "robbie",
+        harnesses: { ...config.harnesses, chain: [] },
+        channels: {
+          telegram: {
+            token: "abc",
+            pollTimeoutS: 30,
+            allowedUserIds: [],
+          },
+        },
+      },
+      lockPath: join(workdir, "run.lock"),
+      out,
+      err,
+    });
+
+    expect(code).toBe(2);
+    expect(err.text).toContain("robbie' → 'kai'");
+    expect(err.text).toContain("phantombot harness");
+    expect(err.text).not.toContain("No identity file");
+  });
+
   test("returns 2 when harness chain is empty", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
@@ -278,7 +309,7 @@ describe("runRun — multi-persona telegram", () => {
     expect(code).toBe(2); // empty harness chain (planner did NOT fatal)
     expect(err.text).toContain("phantombot harness");
     expect(err.text).toContain("personas.miles");
-    expect(err.text).toContain("no agent dir");
+    expect(err.text).toContain("no valid persona identity");
   });
 
   test("fatal when default + persona share the same token", async () => {

--- a/tests/lib-personaDefault.test.ts
+++ b/tests/lib-personaDefault.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -63,8 +63,9 @@ afterEach(async () => {
 });
 
 describe("healDefaultPersonaIfBroken", () => {
-  test("returns the current default when it exists on disk", async () => {
+  test("returns the current default when it has an identity file", async () => {
     await mkdir(join(personasDir, "phantom"), { recursive: true });
+    await writeFile(join(personasDir, "phantom", "BOOT.md"), "# Phantom");
     const config = makeConfig(personasDir, "phantom");
     const healed = await healDefaultPersonaIfBroken(config);
     expect(healed).toBe("phantom");
@@ -78,6 +79,7 @@ describe("healDefaultPersonaIfBroken", () => {
 
   test("heals to the only persona on disk", async () => {
     await mkdir(join(personasDir, "kai"), { recursive: true });
+    await writeFile(join(personasDir, "kai", "BOOT.md"), "# Kai");
     const config = makeConfig(personasDir, "ghostfixture");
     const out = new CaptureStream();
     const healed = await healDefaultPersonaIfBroken(config, out);
@@ -91,7 +93,9 @@ describe("healDefaultPersonaIfBroken", () => {
 
   test("picks first alphabetically when no name match exists", async () => {
     await mkdir(join(personasDir, "lena"), { recursive: true });
+    await writeFile(join(personasDir, "lena", "BOOT.md"), "# Lena");
     await mkdir(join(personasDir, "kai"), { recursive: true });
+    await writeFile(join(personasDir, "kai", "BOOT.md"), "# Kai");
     const config = makeConfig(personasDir, "ghostfixture");
     const healed = await healDefaultPersonaIfBroken(config);
     // Sorted: "kai", "lena" → picks "kai"
@@ -100,7 +104,9 @@ describe("healDefaultPersonaIfBroken", () => {
 
   test("prefers case-insensitive name match over first alphabetical", async () => {
     await mkdir(join(personasDir, "Ghostfixture"), { recursive: true });
+    await writeFile(join(personasDir, "Ghostfixture", "BOOT.md"), "# Ghost");
     await mkdir(join(personasDir, "kai"), { recursive: true });
+    await writeFile(join(personasDir, "kai", "BOOT.md"), "# Kai");
     const config = makeConfig(personasDir, "ghostfixture");
     const healed = await healDefaultPersonaIfBroken(config);
     expect(healed).toBe("Ghostfixture");
@@ -112,11 +118,26 @@ describe("healDefaultPersonaIfBroken", () => {
     const healed = await healDefaultPersonaIfBroken(config);
     expect(healed).toBeNull();
   });
+
+  test("heals away from an empty default directory to a valid persona", async () => {
+    await mkdir(join(personasDir, "robbie"), { recursive: true });
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    await writeFile(join(personasDir, "kai", "BOOT.md"), "# Kai");
+    const config = makeConfig(personasDir, "robbie");
+    const out = new CaptureStream();
+
+    const healed = await healDefaultPersonaIfBroken(config, out);
+
+    expect(healed).toBe("kai");
+    expect(out.text).toContain("robbie' → 'kai'");
+    expect((await loadState()).default_persona).toBe("kai");
+  });
 });
 
 describe("adoptAsDefaultIfMissing", () => {
   test("no-ops when default already exists on disk", async () => {
     await mkdir(join(personasDir, "phantom"), { recursive: true });
+    await writeFile(join(personasDir, "phantom", "BOOT.md"), "# Phantom");
     const config = makeConfig(personasDir, "phantom");
     const changed = await adoptAsDefaultIfMissing(config, "kai");
     expect(changed).toBe(false);
@@ -124,6 +145,7 @@ describe("adoptAsDefaultIfMissing", () => {
 
   test("adopts the given name when default is missing", async () => {
     await mkdir(join(personasDir, "kai"), { recursive: true });
+    await writeFile(join(personasDir, "kai", "BOOT.md"), "# Kai");
     const config = makeConfig(personasDir, "ghostfixture");
     const out = new CaptureStream();
     const changed = await adoptAsDefaultIfMissing(config, "kai", out);
@@ -132,5 +154,17 @@ describe("adoptAsDefaultIfMissing", () => {
 
     const state = await loadState();
     expect(state.default_persona).toBe("kai");
+  });
+
+  test("adopts the given name when default dir exists but has no identity", async () => {
+    await mkdir(join(personasDir, "robbie"), { recursive: true });
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    await writeFile(join(personasDir, "kai", "BOOT.md"), "# Kai");
+    const config = makeConfig(personasDir, "robbie");
+
+    const changed = await adoptAsDefaultIfMissing(config, "kai");
+
+    expect(changed).toBe(true);
+    expect((await loadState()).default_persona).toBe("kai");
   });
 });


### PR DESCRIPTION
## Summary
- Treat a persona directory as valid only when it contains BOOT.md, SOUL.md, or IDENTITY.md.
- Heal default persona drift away from empty/stub dirs during run, heartbeat, nightly, and doctor.
- Make persona list/switch plus ask/tick use the same validation.

## Diagnosis
Kai's logs show the bad default had already drifted to robbie before the v1.1.84 update: heartbeat at 08:30 failed with persona robbie not found, while the long-running listener still served kai from memory. Later a transient memory/nightly path created an empty personas/robbie directory. Existing startup healing only checked whether the directory existed, so once that empty dir existed, run treated robbie as valid and crashed later with No identity file found instead of healing back to kai.

The update did not write state.json; it restarted the process and exposed the stale default. This PR closes the source bug that let an empty default-persona dir block recovery.

## Tests
- PATH="/home/robbie/.bun/bin:$PATH" bun run typecheck
- PATH="/home/robbie/.bun/bin:$PATH" bun test (1020 pass, 1 skip)
