### PR TITLE
feat(state): audit-log every default_persona change

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -9,7 +9,7 @@
  * Resolution priority for any value that lives in both: env > state > toml > default.
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile, appendFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { xdgDataHome } from "./config.ts";
 
@@ -35,8 +35,52 @@ export async function loadState(): Promise<State> {
   }
 }
 
+export function auditPath(): string {
+  return (
+    process.env.PHANTOMBOT_STATE_AUDIT ??
+    join(xdgDataHome(), "phantombot", "state-audit.log")
+  );
+}
+
+/**
+ * Append-only forensic log of every default_persona change. Best-effort:
+ * an audit failure must never block the actual state write. Records the
+ * timestamp, PID, parent PID, old→new value, and a trimmed stack trace so
+ * the *writer* of a bad persona is identifiable after the fact.
+ */
+async function auditPersonaChange(prev: State, next: State): Promise<void> {
+  try {
+    const before = prev.default_persona ?? null;
+    const after = next.default_persona ?? null;
+    if (before === after) return;
+    const stack = (new Error().stack ?? "")
+      .split("\n")
+      .slice(2)
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith("at "))
+      .slice(0, 6)
+      .join(" <- ");
+    const entry = {
+      ts: new Date().toISOString(),
+      pid: process.pid,
+      ppid: process.ppid,
+      argv: process.argv.slice(1).join(" "),
+      from: before,
+      to: after,
+      stack,
+    };
+    const path = auditPath();
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, JSON.stringify(entry) + "\n", "utf8");
+  } catch {
+    // never let auditing break a real state write
+  }
+}
+
 export async function saveState(state: State): Promise<string> {
   const path = statePath();
+  const prev = await loadState();
+  await auditPersonaChange(prev, state);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf8");
   return path;

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,11 +35,29 @@ export async function loadState(): Promise<State> {
   }
 }
 
+/**
+ * Best-effort read of the current state, used only to compute the old→new
+ * delta for the audit log. A corrupt/unreadable state.json must NOT block a
+ * repair write (persona/config commands exist precisely to overwrite a bad
+ * file), so any failure here resolves to an empty state.
+ */
+async function loadStateForAudit(): Promise<State> {
+  try {
+    return await loadState();
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Audit log lives next to the state file it tracks, so pointing
+ * PHANTOMBOT_STATE at a tmp path (as the test suite does) also redirects the
+ * audit log there instead of polluting the live data dir. An explicit
+ * PHANTOMBOT_STATE_AUDIT still wins if set.
+ */
 export function auditPath(): string {
-  return (
-    process.env.PHANTOMBOT_STATE_AUDIT ??
-    join(xdgDataHome(), "phantombot", "state-audit.log")
-  );
+  if (process.env.PHANTOMBOT_STATE_AUDIT) return process.env.PHANTOMBOT_STATE_AUDIT;
+  return join(dirname(statePath()), "state-audit.log");
 }
 
 /**
@@ -79,7 +97,7 @@ async function auditPersonaChange(prev: State, next: State): Promise<void> {
 
 export async function saveState(state: State): Promise<string> {
   const path = statePath();
-  const prev = await loadState();
+  const prev = await loadStateForAudit();
   await auditPersonaChange(prev, state);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf8");

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -40,9 +40,16 @@ class CaptureStream {
 let workdir: string;
 let source: string;
 let config: Config;
+// Suite-wide state isolation. runImportPersona → adoptAsDefaultIfMissing →
+// saveState() writes the live state.json unless PHANTOMBOT_STATE is redirected.
+// This is the exact leak that poisoned Kai's persona (→ "robbie") whenever the
+// suite was run on his box. Isolate EVERY test, not just the auto-adopt block.
+let savedStateEnv: string | undefined;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-imp-"));
+  savedStateEnv = process.env.PHANTOMBOT_STATE;
+  process.env.PHANTOMBOT_STATE = join(workdir, "state.json");
   source = join(workdir, "openclaw-agent");
   await mkdir(source, { recursive: true });
   await writeFile(join(source, "BOOT.md"), "# id");
@@ -66,6 +73,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  if (savedStateEnv === undefined) delete process.env.PHANTOMBOT_STATE;
+  else process.env.PHANTOMBOT_STATE = savedStateEnv;
   await rm(workdir, { recursive: true, force: true });
 });
 
@@ -232,19 +241,9 @@ describe("runImportPersona — telegram sniff", () => {
 });
 
 describe("runImportPersona — auto-adopt as default", () => {
-  let savedStateEnv: string | undefined;
-  let stateFile: string;
-
-  beforeEach(async () => {
-    savedStateEnv = process.env.PHANTOMBOT_STATE;
-    stateFile = join(workdir, "state.json");
-    process.env.PHANTOMBOT_STATE = stateFile;
-  });
-
-  afterEach(() => {
-    if (savedStateEnv === undefined) delete process.env.PHANTOMBOT_STATE;
-    else process.env.PHANTOMBOT_STATE = savedStateEnv;
-  });
+  // State isolation is now suite-wide (see top-level beforeEach/afterEach):
+  // PHANTOMBOT_STATE → workdir/state.json for every test.
+  const stateFile = () => join(workdir, "state.json");
 
   test("first import on fresh box: adopts imported name as default_persona", async () => {
     // Fresh state — no personas/phantom/ exists. The configured default
@@ -262,7 +261,7 @@ describe("runImportPersona — auto-adopt as default", () => {
     });
     expect(code).toBe(0);
     expect(out.text).toContain("adopted 'robbie' as default_persona");
-    const state = JSON.parse(await readFile(stateFile, "utf8"));
+    const state = JSON.parse(await readFile(stateFile(), "utf8"));
     expect(state.default_persona).toBe("robbie");
   });
 
@@ -288,6 +287,6 @@ describe("runImportPersona — auto-adopt as default", () => {
     expect(code).toBe(0);
     expect(out.text).not.toContain("adopted");
     // No state file written.
-    await expect(readFile(stateFile, "utf8")).rejects.toThrow();
+    await expect(readFile(stateFile(), "utf8")).rejects.toThrow();
   });
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for phantombot-managed runtime state (state.json) and its
+ * forensic audit log.
+ *
+ * Covers: load/save round-trip, the default_persona audit log, and two
+ * regressions caught in review of the audit hook —
+ *   1. a corrupt state.json must NOT block a repair write (saveState);
+ *   2. the audit log must follow PHANTOMBOT_STATE into a tmp dir instead
+ *      of leaking into the live data dir during tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { auditPath, loadState, saveState } from "../src/state.ts";
+
+const ENV_KEYS = [
+  "PHANTOMBOT_STATE",
+  "PHANTOMBOT_STATE_AUDIT",
+  "XDG_DATA_HOME",
+];
+const SAVED_ENV: Record<string, string | undefined> = {};
+
+let workdir: string;
+let stateFile: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-state-"));
+  for (const k of ENV_KEYS) {
+    SAVED_ENV[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.XDG_DATA_HOME = join(workdir, "data");
+  stateFile = join(workdir, "state.json");
+  process.env.PHANTOMBOT_STATE = stateFile;
+});
+
+afterEach(async () => {
+  for (const k of ENV_KEYS) {
+    if (SAVED_ENV[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED_ENV[k];
+  }
+  await rm(workdir, { recursive: true, force: true });
+});
+
+async function readAudit(): Promise<Array<Record<string, unknown>>> {
+  const raw = await readFile(auditPath(), "utf8");
+  return raw
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+describe("saveState — round-trip", () => {
+  test("writes and reads back default_persona", async () => {
+    await saveState({ default_persona: "kai" });
+    expect(await loadState()).toEqual({ default_persona: "kai" });
+  });
+});
+
+describe("audit log — default_persona changes", () => {
+  test("logs a from→to entry when the persona changes", async () => {
+    await saveState({ default_persona: "kai" });
+    await saveState({ default_persona: "robbie" });
+    const entries = await readAudit();
+    expect(entries.length).toBeGreaterThan(0);
+    const last = entries[entries.length - 1]!;
+    expect(last.from).toBe("kai");
+    expect(last.to).toBe("robbie");
+    expect(typeof last.pid).toBe("number");
+    expect(typeof last.ppid).toBe("number");
+    expect(typeof last.ts).toBe("string");
+  });
+
+  test("does NOT log a no-op write (unchanged persona)", async () => {
+    await saveState({ default_persona: "kai" });
+    await saveState({ default_persona: "kai" });
+    const entries = await readAudit();
+    // Only the first (undefined→kai) change is recorded.
+    expect(entries.length).toBe(1);
+    expect(entries[0]!.from).toBe(null);
+    expect(entries[0]!.to).toBe("kai");
+  });
+});
+
+describe("regression: corrupt state.json must not block a repair write", () => {
+  test("saveState overwrites a malformed state.json instead of throwing", async () => {
+    await writeFile(stateFile, "{ this is not valid json", "utf8");
+    // This is the repair path: persona/config commands must be able to
+    // overwrite a poisoned state.json. The pre-write audit read must be
+    // best-effort and never propagate the parse error.
+    await saveState({ default_persona: "kai" });
+    expect(await loadState()).toEqual({ default_persona: "kai" });
+    // The audit entry records the unreadable prior state as a null `from`.
+    const entries = await readAudit();
+    expect(entries.length).toBeGreaterThan(0);
+    expect(entries[entries.length - 1]!.to).toBe("kai");
+    expect(entries[entries.length - 1]!.from).toBe(null);
+  });
+});
+
+describe("regression: audit log follows PHANTOMBOT_STATE", () => {
+  test("audit log lands next to the state file, not in the live data dir", () => {
+    expect(auditPath()).toBe(join(dirname(stateFile), "state-audit.log"));
+  });
+
+  test("writing state does not create state-audit.log in XDG_DATA_HOME", async () => {
+    await saveState({ default_persona: "kai" });
+    const leaked = join(
+      process.env.XDG_DATA_HOME!,
+      "phantombot",
+      "state-audit.log",
+    );
+    await expect(access(leaked)).rejects.toThrow();
+    // But it DOES exist next to the tmp state file.
+    await expect(access(auditPath())).resolves.toBeNil();
+  });
+
+  test("explicit PHANTOMBOT_STATE_AUDIT still wins", () => {
+    const custom = join(workdir, "custom-audit.log");
+    process.env.PHANTOMBOT_STATE_AUDIT = custom;
+    expect(auditPath()).toBe(custom);
+  });
+});


### PR DESCRIPTION
## What

Adds a best-effort forensic audit log of every `default_persona` change in `saveState`. Each change appends one JSON line to `state-audit.log` (override via `PHANTOMBOT_STATE_AUDIT`) recording: `ts`, `pid`, `ppid`, `argv`, `from`, `to`, and a trimmed stack trace identifying the calling code path.

## Why

Recurring incident: a host's `state.json` silently flips `default_persona` to a persona it does not own (e.g. Kai → `robbie`), which then crashes every transient process with `No identity file found`. We have repeatedly mopped it up without ever proving **which process wrote the bad value** — state writes were never recorded. This hook makes the writer identifiable the next time it happens, instead of guessing after the fact.

## Behaviour

- Only logs when `default_persona` actually changes (no-op writes are ignored).
- Audit failures are swallowed — they must never block the real state write.
- Append-only; no rotation (entries are tiny and rare).

## Verification

- `bun run typecheck` ✅
- `bun test` ✅ 1017 pass, 1 skip, 0 fail
- Smoke test: confirmed change is logged with from→to/pid/argv/stack; unchanged-persona write produces no entry.

## Note

This is the diagnostic prerequisite, not a band-aid. Per Andrew's direction we are **not** auto-healing or suppressing the crash (that would hide the fault across the fleet). PR #138 (silent self-heal) is being closed in favour of this.
