### PR TITLE
feat(task): add command-backed scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ mkdir -p ~/.local/bin && cp dist/phantombot ~/.local/bin/
 | `phantombot env get / list / unset` | Read / list-names-only / remove |
 | `phantombot notify --message "…"` | Telegram text to all allowed users |
 | `phantombot notify --voice "…"` | Synthesize via configured TTS, send as voice note |
-| `phantombot task add --schedule "<cron>" --prompt "…" --description "…"` | Schedule a recurring agent task |
+| `phantombot task add "<prompt>" "<description>" --every 1h` | Schedule a recurring agent task |
+| `phantombot task add "<prompt>" "<description>" --every 1h --command "/path/to/script"` | Schedule a cheap local command without waking an LLM |
 | `phantombot task list / show <id> / cancel <id>` | Manage tasks |
 | `phantombot tick` | Fire any due tasks (called every minute by `phantombot-tick.timer`) |
 | `phantombot memory today / search / get / list / index` | Read/write the persona's memory + KB |
@@ -274,16 +275,16 @@ The agent can schedule recurring work for itself. You ask Phantom on Telegram: *
 
 ```bash
 phantombot task add \
-  --schedule "0 * * * *" \
-  --description "hourly email check" \
-  --prompt "Check my Gmail since the last run. If anything is important, call \`phantombot notify --message \"…\"\`. Reply NONE otherwise."
+  "Check my Gmail since the last run. If anything is important, call \`phantombot notify --message \"...\"\`. Reply NONE otherwise." \
+  "hourly email check" \
+  --every 1h
 ```
 
 `phantombot-tick.timer` fires every minute and calls `phantombot tick`, which:
 
 1. Reads tasks from `memory.sqlite` where `next_run_at <= now() AND active=1`.
-2. Spawns the harness with the stored prompt as the user message.
-3. The agent does its thing — including calling `phantombot notify` if the user should hear about it.
+2. Spawns the harness with the stored prompt as the user message, or runs the stored command directly for command-backed tasks.
+3. The agent or command does its thing — including calling `phantombot notify` if the user should hear about it.
 4. Records the run, recomputes `next_run_at` from the cron expression.
 
 **Notification is opt-in.** Tasks run silently by default. The agent only calls `phantombot notify` when something genuinely needs surfacing. *"Nothing important happened"* is a successful run.
@@ -291,6 +292,18 @@ phantombot task add \
 **Missed runs are skipped.** Box off for 5 hours, hourly task missed 5 fires? The next tick after boot runs it once, not five times. No avalanche.
 
 **Self-review prevents task accretion.** Every task has a `next_review_at` scaled to its cadence (hourly→14d, daily→30d, weekly→90d). When the date arrives, the next tick runs a review prompt — agent decides KEEP / STOP / MODIFY based on recent context. KEEP doubles the review interval. STOP deactivates and notifies you why.
+
+**Command-backed tasks are for cheap integrations.** If a task can be answered by a deterministic local script, add `--command` and keep the LLM asleep:
+
+```bash
+phantombot task add \
+  "Poll Jira, Linear, email, or monitoring. Notify only for new actionable items." \
+  "hourly external notification poll" \
+  --every 1h \
+  --command "/usr/local/bin/check-agent-notifications"
+```
+
+The command runs with the same environment as Phantombot, from the persona directory, under the existing tick lock. `stdout`, `stderr`, exit status, and the next run are recorded in `task_runs`; command output is not sent to Telegram automatically. Use `phantombot notify` inside the script when there is genuinely something to surface.
 
 Manage from anywhere: ask Phantom on Telegram *"list my scheduled tasks"* / *"cancel the email check"* — the agent runs `phantombot task list` / `phantombot task cancel <id>`. Or use the same CLI commands directly.
 

--- a/README.md
+++ b/README.md
@@ -297,13 +297,19 @@ phantombot task add \
 
 ```bash
 phantombot task add \
-  "Poll Jira, Linear, email, or monitoring. Notify only for new actionable items." \
+  "Poll Jira, Linear, email, or monitoring. If there is new work for the agent, call phantombot ask. Notify the user only if explicitly requested." \
   "hourly external notification poll" \
   --every 1h \
-  --command "/usr/local/bin/check-agent-notifications"
+  --command "/usr/local/bin/check-agent-notifications" \
+  --secret JIRA_API_KEY \
+  --secret LINEAR_API_KEY
 ```
 
-The command runs with the same environment as Phantombot, from the persona directory, under the existing tick lock. `stdout`, `stderr`, exit status, and the next run are recorded in `task_runs`; command output is not sent to Telegram automatically. Use `phantombot notify` inside the script when there is genuinely something to surface.
+The command runs from the persona directory, under the existing tick lock, with a minimal environment (`PATH`, `HOME`, temp/XDG basics) plus only the env vars named by repeated `--secret NAME` flags. It does **not** inherit the full Phantombot env. `stdout`, `stderr`, exit status, and the next run are recorded in `task_runs`; command output is not sent to Telegram automatically.
+
+Use `phantombot ask` inside the script when the poller finds work that needs an agent/LLM turn. Use `phantombot notify` only when the user explicitly asked to be interrupted or the event genuinely needs direct surfacing.
+
+Recurring command tasks do not get the agent self-review prompt, because they do not wake an agent on quiet runs. Add `--until`, `--count`, or `--for` when the poller has a natural end; otherwise cancel it manually when it is no longer useful.
 
 Manage from anywhere: ask Phantom on Telegram *"list my scheduled tasks"* / *"cancel the email check"* — the agent runs `phantombot task list` / `phantombot task cancel <id>`. Or use the same CLI commands directly.
 

--- a/src/cli/task.ts
+++ b/src/cli/task.ts
@@ -24,9 +24,12 @@
  *     script directly instead of waking an LLM harness.
  *   - The positional prompt is still required and kept as audit context,
  *     but tick executes the command and logs stdout/stderr/exit status.
+ *   - Commands receive a minimal environment by default. Use
+ *     --secret NAME to expose specific env vars to the command.
  *   - This is for cheap pollers and integrations (Jira, Linear, mail,
- *     monitoring, local scripts) that only call `phantombot notify` when
- *     there is genuinely something to surface.
+ *     monitoring, local scripts) that wake the agent or call
+ *     `phantombot notify` only when there is genuinely something to
+ *     surface.
  */
 
 import { defineCommand } from "citty";
@@ -73,6 +76,8 @@ export interface RunTaskAddInput {
   forceLongRunning?: boolean;
   /** --command — run a shell command directly instead of waking a harness. */
   command?: string;
+  /** --secret NAME — env var names to expose to a command task. */
+  commandSecrets?: string[];
   config?: Config;
   store?: TaskStore;
   out?: WriteSink;
@@ -102,6 +107,17 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
     if (input.command !== undefined && input.command.trim() === "") {
       err.write("--command cannot be empty.\n");
       return 2;
+    }
+    const commandSecrets = normalizeSecrets(input.commandSecrets ?? []);
+    if (commandSecrets.length > 0 && input.command === undefined) {
+      err.write("--secret requires --command.\n");
+      return 2;
+    }
+    for (const name of commandSecrets) {
+      if (!isEnvName(name)) {
+        err.write(`invalid --secret name: ${name}\n`);
+        return 2;
+      }
     }
 
     // Determine mode: one-off or recurring.
@@ -197,6 +213,7 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
       maxRuns,
       silent: input.silent ?? false,
       command: input.command?.trim(),
+      commandSecrets,
       createdBy: "cli", // agent should set explicitly; fallback for humans
     });
 
@@ -227,7 +244,7 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
       `  fires at:    ${formatLocal(t.nextRunAt)} (${t.nextRunAt.toISOString()})\n` +
       (t.oneOff
         ? `  type:        one-off\n`
-        : `  schedule:    ${t.schedule}\n  expiry:      ${describeExpiry(t)}\n`) +
+        : `  schedule:    ${t.schedule}\n  expiry:      ${describeExpiry(t, isCommandTask)}\n`) +
       (!t.oneOff && !hasExpiry && !isCommandTask
         ? `  hygiene:     no expiry — every fire will ask if it's still needed.\n` +
           `               cancel with: phantombot task cancel ${t.id}\n`
@@ -239,11 +256,22 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
   }
 }
 
-function describeExpiry(t: Task): string {
+function normalizeSecrets(values: string[]): string[] {
+  return [...new Set(values.map((v) => v.trim()).filter(Boolean))];
+}
+
+function isEnvName(name: string): boolean {
+  return /^[A-Z_][A-Z0-9_]*$/i.test(name);
+}
+
+function describeExpiry(t: Task, isCommandTask = false): string {
   const parts: string[] = [];
   if (t.expiresAt) parts.push(`until ${formatLocal(t.expiresAt)}`);
   if (t.maxRuns !== undefined) parts.push(`${t.maxRuns} runs`);
-  return parts.join(" or ") || "none (runs forever — agent self-polices)";
+  if (parts.length > 0) return parts.join(" or ");
+  return isCommandTask
+    ? "none (runs forever — command tasks do not self-review)"
+    : "none (runs forever — agent self-polices)";
 }
 
 /**
@@ -449,6 +477,9 @@ function formatTaskFull(t: Task): string {
     (t.expiresAt ? `expires:      ${formatLocal(t.expiresAt)}\n` : "") +
     `reviews:      ${t.reviewCount}\n` +
     (t.command ? `--- command ---\n${t.command}\n` : "") +
+    (t.command && t.commandSecrets.length > 0
+      ? `secrets:      ${t.commandSecrets.join(", ")}\n`
+      : "") +
     `--- prompt ---\n${t.prompt}\n`
   );
 }
@@ -473,7 +504,7 @@ export default defineCommand({
       meta: {
         name: "add",
         description:
-          "Add a task. One-off by default (--in 10m or --at <time>). Recurring with --every (e.g. --every 1h) runs forever unless you add --until, --count, or --for. Add --command to run a local checker directly instead of waking the harness.",
+          "Add a task. One-off by default (--in 10m or --at <time>). Recurring with --every (e.g. --every 1h) runs forever unless you add --until, --count, or --for. Add --command to run a local checker directly instead of waking the harness. Examples: phantombot task add \"Check mail\" \"mail check\" --every 1h; phantombot task add \"Poll Jira\" \"jira poll\" --every 1h --command /usr/local/bin/jira-poll --secret JIRA_API_KEY.",
       },
       args: {
         prompt: {
@@ -532,7 +563,13 @@ export default defineCommand({
           type: "string",
           required: false,
           description:
-            "Run this shell command directly at fire time instead of invoking the harness. Use for cheap pollers/integrations; call `phantombot notify` from the command only when something is new.",
+            "Run this shell command directly at fire time instead of invoking the harness. Use for cheap pollers/integrations; call `phantombot ask` to wake the agent or `phantombot notify` only when something is new.",
+        },
+        secret: {
+          type: "string",
+          required: false,
+          description:
+            "Expose this env var to the command. Repeat for each secret; command tasks do not inherit the full Phantombot env.",
         },
         "force-long-running": {
           type: "boolean",
@@ -554,6 +591,7 @@ export default defineCommand({
           relFor: args.for as string | undefined,
           silent: args.silent as boolean,
           command: args.command as string | undefined,
+          commandSecrets: normalizeCliSecretArg(args.secret),
           forceLongRunning: args["force-long-running"] as boolean,
         });
       },
@@ -612,3 +650,9 @@ export default defineCommand({
     }),
   },
 });
+
+function normalizeCliSecretArg(value: unknown): string[] {
+  if (value === undefined || value === null || value === false) return [];
+  if (Array.isArray(value)) return value.map(String);
+  return [String(value)];
+}

--- a/src/cli/task.ts
+++ b/src/cli/task.ts
@@ -18,6 +18,15 @@
  *     (`phantombot task cancel <id>`) when not — see the hygiene footer in
  *     src/cli/tick.ts. Expiries remain available for tasks with a known
  *     end (e.g. "ping me every hour for the next 8 hours").
+ *
+ * Command-backed tasks:
+ *   - Add --command "<shell command>" when the fire should run a local
+ *     script directly instead of waking an LLM harness.
+ *   - The positional prompt is still required and kept as audit context,
+ *     but tick executes the command and logs stdout/stderr/exit status.
+ *   - This is for cheap pollers and integrations (Jira, Linear, mail,
+ *     monitoring, local scripts) that only call `phantombot notify` when
+ *     there is genuinely something to surface.
  */
 
 import { defineCommand } from "citty";
@@ -62,6 +71,8 @@ export interface RunTaskAddInput {
   silent?: boolean;
   /** --force-long-running — allow recurring > 90d */
   forceLongRunning?: boolean;
+  /** --command — run a shell command directly instead of waking a harness. */
+  command?: string;
   config?: Config;
   store?: TaskStore;
   out?: WriteSink;
@@ -86,6 +97,11 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
         "`phantombot notify` from inside the task prompt if you " +
         "want the user notified.\n",
       );
+    }
+
+    if (input.command !== undefined && input.command.trim() === "") {
+      err.write("--command cannot be empty.\n");
+      return 2;
     }
 
     // Determine mode: one-off or recurring.
@@ -180,6 +196,7 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
       expiresAt,
       maxRuns,
       silent: input.silent ?? false,
+      command: input.command?.trim(),
       createdBy: "cli", // agent should set explicitly; fallback for humans
     });
 
@@ -203,6 +220,7 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
     // Mandatory echo — agent contract requires repeating this to user.
     const hasExpiry =
       t.expiresAt !== undefined || t.maxRuns !== undefined;
+    const isCommandTask = Boolean(t.command);
     out.write(
       `task ${t.id} scheduled\n` +
       `  description: ${t.description}\n` +
@@ -210,7 +228,7 @@ export async function runTaskAdd(input: RunTaskAddInput): Promise<number> {
       (t.oneOff
         ? `  type:        one-off\n`
         : `  schedule:    ${t.schedule}\n  expiry:      ${describeExpiry(t)}\n`) +
-      (!t.oneOff && !hasExpiry
+      (!t.oneOff && !hasExpiry && !isCommandTask
         ? `  hygiene:     no expiry — every fire will ask if it's still needed.\n` +
           `               cancel with: phantombot task cancel ${t.id}\n`
         : ""),
@@ -406,9 +424,10 @@ export async function runTaskSelftest(
 function formatTaskOneLine(t: Task): string {
   const flag = t.active ? "" : " [inactive]";
   const type = t.oneOff ? "once" : "recur";
+  const mode = t.command ? " command" : "";
   return (
     `[${t.id}] ${t.description}${flag}` +
-    `  type=${type}  next=${formatLocal(t.nextRunAt)}  runs=${t.runCount}` +
+    `  type=${type}${mode}  next=${formatLocal(t.nextRunAt)}  runs=${t.runCount}` +
     (t.schedule ? `  schedule=${t.schedule}` : "")
   );
 }
@@ -429,6 +448,7 @@ function formatTaskFull(t: Task): string {
     `next review:  ${formatLocal(t.nextReviewAt)}\n` +
     (t.expiresAt ? `expires:      ${formatLocal(t.expiresAt)}\n` : "") +
     `reviews:      ${t.reviewCount}\n` +
+    (t.command ? `--- command ---\n${t.command}\n` : "") +
     `--- prompt ---\n${t.prompt}\n`
   );
 }
@@ -453,7 +473,7 @@ export default defineCommand({
       meta: {
         name: "add",
         description:
-          "Add a task. One-off by default (--in 10m or --at <time>). Recurring with --every (e.g. --every 1h) runs forever unless you add --until, --count, or --for. The agent is asked at every fire whether the task is still needed.",
+          "Add a task. One-off by default (--in 10m or --at <time>). Recurring with --every (e.g. --every 1h) runs forever unless you add --until, --count, or --for. Add --command to run a local checker directly instead of waking the harness.",
       },
       args: {
         prompt: {
@@ -508,6 +528,12 @@ export default defineCommand({
             "DEPRECATED — no-op. Scheduled task fires are silent by default; use `phantombot notify` inside the task prompt to surface anything to the user.",
           default: false,
         },
+        command: {
+          type: "string",
+          required: false,
+          description:
+            "Run this shell command directly at fire time instead of invoking the harness. Use for cheap pollers/integrations; call `phantombot notify` from the command only when something is new.",
+        },
         "force-long-running": {
           type: "boolean",
           required: false,
@@ -527,6 +553,7 @@ export default defineCommand({
           count: args.count ? Number(args.count) : undefined,
           relFor: args.for as string | undefined,
           silent: args.silent as boolean,
+          command: args.command as string | undefined,
           forceLongRunning: args["force-long-running"] as boolean,
         });
       },

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -1,11 +1,12 @@
 /**
  * `phantombot tick` — fired every minute by phantombot-tick.timer.
  *
- * Reads tasks where next_run_at <= now() AND active=1, runs each through
- * the harness chain, and either:
+ * Reads tasks where next_run_at <= now() AND active=1, and either:
  *   - runs the task's normal prompt (the agent owns whether to surface
  *     anything to the user; tick itself is silent), then advances
  *     next_run_at;
+ *   - runs a command-backed task directly, logging stdout/stderr and exit
+ *     status without constructing a harness;
  *   - or, if next_review_at <= now(), runs the SELF-REVIEW prompt that
  *     asks the agent KEEP / STOP, and updates the task accordingly.
  *
@@ -31,6 +32,7 @@
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { spawn } from "node:child_process";
 
 import { type Config, loadConfig, personaDir, xdgStateHome } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
@@ -89,14 +91,7 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
   const taskStore =
     input.taskStore ?? (await openTaskStore(config.memoryDbPath));
   const memory = input.memory ?? (await openMemoryStore(config.memoryDbPath));
-  const harnesses = input.harnesses ?? buildHarnessChain(config, err);
-  if (harnesses.length === 0) {
-    err.write("tick: no harnesses configured; skipping\n");
-    if (!input.taskStore) taskStore.close();
-    if (!input.memory) await memory.close();
-    lock.release();
-    return 1;
-  }
+  let harnesses = input.harnesses;
 
   try {
     // Expire any tasks past their expires_at before processing due.
@@ -110,7 +105,8 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
     log.info("tick: running due tasks", { count: due.length });
 
     for (const task of due) {
-      const isReview = task.nextReviewAt.getTime() <= now.getTime();
+      const isCommandTask = task.command !== undefined && task.command.trim() !== "";
+      const isReview = !isCommandTask && task.nextReviewAt.getTime() <= now.getTime();
       const promptText = isReview
         ? buildReviewPrompt(task)
         : appendHygieneFooter(task);
@@ -137,22 +133,40 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
 
       let finalText = "";
       let runError: string | undefined;
+      let exitCode = 0;
       try {
-        for await (const chunk of runTurn({
-          persona: task.persona,
-          conversation,
-          userMessage: promptText,
-          agentDir,
-          harnesses,
-          memory,
-          idleTimeoutMs: config.harnessIdleTimeoutMs,
-          hardTimeoutMs: config.harnessHardTimeoutMs,
-        })) {
-          if (chunk.type === "text") finalText += chunk.text;
-          if (chunk.type === "done") finalText = chunk.finalText;
+        if (isCommandTask) {
+          const result = await runCommandTask(task.command!, {
+            timeoutMs: config.harnessHardTimeoutMs,
+            cwd: agentDir,
+          });
+          finalText = result.output;
+          exitCode = result.exitCode;
+          if (result.exitCode !== 0) {
+            runError = `command exited ${result.exitCode}`;
+          }
+        } else {
+          harnesses ??= buildHarnessChain(config, err);
+          if (harnesses.length === 0) {
+            throw new Error("no harnesses configured");
+          }
+          for await (const chunk of runTurn({
+            persona: task.persona,
+            conversation,
+            userMessage: promptText,
+            agentDir,
+            harnesses,
+            memory,
+            idleTimeoutMs: config.harnessIdleTimeoutMs,
+            hardTimeoutMs: config.harnessHardTimeoutMs,
+          })) {
+            if (chunk.type === "text") finalText += chunk.text;
+            if (chunk.type === "done") finalText = chunk.finalText;
+          }
         }
       } catch (e) {
         runError = (e as Error).message;
+        exitCode = 1;
         log.error("tick: task threw", {
           id: task.id,
           error: runError,
@@ -161,10 +175,9 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
 
       // Log the fire to task_runs for auditability.
       const outputExcerpt = runError
-        ? `ERROR: ${runError}`.slice(0, 500)
+        ? `ERROR: ${runError}${finalText ? `\n${finalText}` : ""}`.slice(0, 500)
         : finalText.slice(0, 500);
       const status = runError ? "error" : "ok";
-      const exitCode = runError ? 1 : 0;
 
       // Quiet-by-default: tick never auto-posts the harness reply to
       // Telegram. The agent calls `phantombot notify` from inside the
@@ -203,6 +216,52 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
     if (!input.memory) await memory.close();
     lock.release();
   }
+}
+
+async function runCommandTask(
+  command: string,
+  opts: { timeoutMs: number; cwd: string },
+): Promise<{ exitCode: number; output: string }> {
+  return await new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const finish = (result: { exitCode: number; output: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const child = spawn(command, {
+      shell: true,
+      cwd: opts.cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    const append = (chunk: Buffer) => {
+      output = (output + chunk.toString()).slice(-4000);
+    };
+    child.stdout.on("data", append);
+    child.stderr.on("data", append);
+    timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      output = (output + "\nERROR: command timed out").slice(-4000);
+      finish({ exitCode: 124, output });
+    }, opts.timeoutMs);
+    child.on("close", (code, signal) => {
+      if (signal) {
+        finish({
+          exitCode: 128,
+          output: (output + `\nterminated by ${signal}`).slice(-4000),
+        });
+      } else {
+        finish({ exitCode: code ?? 0, output });
+      }
+    });
+    child.on("error", (e) => {
+      finish({ exitCode: 1, output: e.message });
+    });
+  });
 }
 
 /**

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -26,7 +26,9 @@
  * The tick runs as the OS user that owns the systemd timer
  * (typically the same user as `phantombot run`), so it inherits both
  * EnvironmentFile=-%h/.config/phantombot/.env and EnvironmentFile=-%h/.env
- * from the unit. Spawned harnesses see the merged environment.
+ * from the unit. Spawned harnesses see the merged environment; command
+ * tasks do not. They get a minimal env plus explicitly allowlisted
+ * `--secret NAME` values.
  */
 
 import { defineCommand } from "citty";
@@ -139,6 +141,7 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
           const result = await runCommandTask(task.command!, {
             timeoutMs: config.harnessHardTimeoutMs,
             cwd: agentDir,
+            env: buildCommandEnv(task.commandSecrets),
           });
           finalText = result.output;
           exitCode = result.exitCode;
@@ -220,7 +223,7 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
 
 async function runCommandTask(
   command: string,
-  opts: { timeoutMs: number; cwd: string },
+  opts: { timeoutMs: number; cwd: string; env: NodeJS.ProcessEnv },
 ): Promise<{ exitCode: number; output: string }> {
   return await new Promise((resolve) => {
     let settled = false;
@@ -234,25 +237,25 @@ async function runCommandTask(
     const child = spawn(command, {
       shell: true,
       cwd: opts.cwd,
-      env: process.env,
+      env: opts.env,
       stdio: ["ignore", "pipe", "pipe"],
     });
     let output = "";
     const append = (chunk: Buffer) => {
-      output = (output + chunk.toString()).slice(-4000);
+      output = appendCommandOutput(output, chunk.toString());
     };
     child.stdout.on("data", append);
     child.stderr.on("data", append);
     timer = setTimeout(() => {
       child.kill("SIGTERM");
-      output = (output + "\nERROR: command timed out").slice(-4000);
+      output = appendCommandOutput(output, "\nERROR: command timed out");
       finish({ exitCode: 124, output });
     }, opts.timeoutMs);
     child.on("close", (code, signal) => {
       if (signal) {
         finish({
           exitCode: 128,
-          output: (output + `\nterminated by ${signal}`).slice(-4000),
+          output: appendCommandOutput(output, `\nterminated by ${signal}`),
         });
       } else {
         finish({ exitCode: code ?? 0, output });
@@ -262,6 +265,41 @@ async function runCommandTask(
       finish({ exitCode: 1, output: e.message });
     });
   });
+}
+
+function buildCommandEnv(secretNames: string[]): NodeJS.ProcessEnv {
+  const allowlist = [
+    "HOME",
+    "PATH",
+    "SHELL",
+    "USER",
+    "LOGNAME",
+    "LANG",
+    "LC_ALL",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_STATE_HOME",
+  ];
+  const env: NodeJS.ProcessEnv = {};
+  for (const name of allowlist) {
+    if (process.env[name] !== undefined) env[name] = process.env[name];
+  }
+  if (env.PATH === undefined) {
+    env.PATH = "/usr/local/bin:/usr/bin:/bin";
+  }
+  for (const name of secretNames) {
+    if (process.env[name] !== undefined) env[name] = process.env[name];
+  }
+  return env;
+}
+
+function appendCommandOutput(current: string, next: string): string {
+  const combined = current + next;
+  if (combined.length <= 4000) return combined;
+  return `${combined.slice(0, 1900)}\n... output truncated ...\n${combined.slice(-1900)}`;
 }
 
 /**

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -54,6 +54,8 @@ export interface Task {
   silent: boolean;
   /** Conversation/channel that created this task (for daily-file audit). */
   createdBy: string;
+  /** Direct shell command task. Empty/null means normal harness prompt. */
+  command?: string;
 }
 
 export interface TaskRunRow {
@@ -100,6 +102,8 @@ export interface TaskAddInput {
   silent?: boolean;
   /** Channel/conversation that created this task. */
   createdBy?: string;
+  /** Direct shell command to run instead of waking the harness. */
+  command?: string;
 }
 
 export type TaskAddResult =
@@ -124,7 +128,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   expires_at      TEXT,
   max_runs        INTEGER,
   silent          INTEGER NOT NULL DEFAULT 0,
-  created_by      TEXT NOT NULL DEFAULT ''
+  created_by      TEXT NOT NULL DEFAULT '',
+  command         TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_runs (
@@ -153,6 +158,8 @@ const MIGRATIONS: string[] = [
   `ALTER TABLE tasks ADD COLUMN max_runs INTEGER`,
   `ALTER TABLE tasks ADD COLUMN silent INTEGER NOT NULL DEFAULT 0`,
   `ALTER TABLE tasks ADD COLUMN created_by TEXT NOT NULL DEFAULT ''`,
+  // v2 -> v3: command-backed tasks that do not wake an LLM harness
+  `ALTER TABLE tasks ADD COLUMN command TEXT`,
 ];
 
 interface RawTaskRow {
@@ -173,6 +180,7 @@ interface RawTaskRow {
   max_runs: number | null;
   silent: number;
   created_by: string;
+  command?: string | null;
 }
 
 function rowToTask(r: RawTaskRow): Task {
@@ -194,6 +202,7 @@ function rowToTask(r: RawTaskRow): Task {
     maxRuns: r.max_runs ?? undefined,
     silent: r.silent === 1,
     createdBy: r.created_by,
+    command: r.command ?? undefined,
   };
 }
 
@@ -210,7 +219,7 @@ export class TaskStore {
     // Check which columns exist by querying a limited row.
     try {
       const row = this.db
-        .prepare("SELECT one_off, expires_at, max_runs, silent, created_by FROM tasks LIMIT 1")
+        .prepare("SELECT one_off, expires_at, max_runs, silent, created_by, command FROM tasks LIMIT 1")
         .get() as Record<string, unknown> | null;
       // If we got here without error, columns exist.
       void row;
@@ -264,8 +273,8 @@ export class TaskStore {
       `INSERT INTO tasks (
          persona, description, schedule, prompt,
          created_at, next_run_at, next_review_at, active,
-         one_off, expires_at, max_runs, silent, created_by
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?)`,
+         one_off, expires_at, max_runs, silent, created_by, command
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`,
     );
     const result = stmt.run(
       input.persona,
@@ -280,6 +289,7 @@ export class TaskStore {
       input.maxRuns ?? null,
       silent ? 1 : 0,
       createdBy,
+      input.command ?? null,
     );
     const id = Number(result.lastInsertRowid);
     const task = this.get(id);
@@ -500,11 +510,11 @@ export class TaskStore {
       `INSERT INTO tasks (
          persona, description, schedule, prompt,
          created_at, next_run_at, next_review_at, active,
-         one_off, expires_at, max_runs, silent, created_by
+         one_off, expires_at, max_runs, silent, created_by, command
        ) VALUES (
          $persona, $description, $schedule, $prompt,
          $createdAt, $nextRunAt, $nextReviewAt, $active,
-         $oneOff, $expiresAt, $maxRuns, $silent, $createdBy
+         $oneOff, $expiresAt, $maxRuns, $silent, $createdBy, $command
        )`,
     );
     const result = stmt.run({
@@ -524,6 +534,7 @@ export class TaskStore {
       $maxRuns: null,
       $silent: 0,
       $createdBy: "selftest",
+      $command: null,
     });
     return { id: Number(result.lastInsertRowid), firesAt };
   }

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -56,6 +56,8 @@ export interface Task {
   createdBy: string;
   /** Direct shell command task. Empty/null means normal harness prompt. */
   command?: string;
+  /** Env var names to expose to a command-backed task. */
+  commandSecrets: string[];
 }
 
 export interface TaskRunRow {
@@ -104,6 +106,8 @@ export interface TaskAddInput {
   createdBy?: string;
   /** Direct shell command to run instead of waking the harness. */
   command?: string;
+  /** Env var names to expose to a command-backed task. */
+  commandSecrets?: string[];
 }
 
 export type TaskAddResult =
@@ -129,7 +133,8 @@ CREATE TABLE IF NOT EXISTS tasks (
   max_runs        INTEGER,
   silent          INTEGER NOT NULL DEFAULT 0,
   created_by      TEXT NOT NULL DEFAULT '',
-  command         TEXT
+  command         TEXT,
+  command_secrets TEXT NOT NULL DEFAULT '[]'
 );
 
 CREATE TABLE IF NOT EXISTS task_runs (
@@ -160,6 +165,8 @@ const MIGRATIONS: string[] = [
   `ALTER TABLE tasks ADD COLUMN created_by TEXT NOT NULL DEFAULT ''`,
   // v2 -> v3: command-backed tasks that do not wake an LLM harness
   `ALTER TABLE tasks ADD COLUMN command TEXT`,
+  // v3 -> v4: least-privilege env for command-backed tasks
+  `ALTER TABLE tasks ADD COLUMN command_secrets TEXT NOT NULL DEFAULT '[]'`,
 ];
 
 interface RawTaskRow {
@@ -181,6 +188,18 @@ interface RawTaskRow {
   silent: number;
   created_by: string;
   command?: string | null;
+  command_secrets?: string | null;
+}
+
+function parseCommandSecrets(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
 }
 
 function rowToTask(r: RawTaskRow): Task {
@@ -203,6 +222,7 @@ function rowToTask(r: RawTaskRow): Task {
     silent: r.silent === 1,
     createdBy: r.created_by,
     command: r.command ?? undefined,
+    commandSecrets: parseCommandSecrets(r.command_secrets),
   };
 }
 
@@ -216,21 +236,13 @@ export class TaskStore {
   }
 
   private applyMigrations(): void {
-    // Check which columns exist by querying a limited row.
-    try {
-      const row = this.db
-        .prepare("SELECT one_off, expires_at, max_runs, silent, created_by, command FROM tasks LIMIT 1")
-        .get() as Record<string, unknown> | null;
-      // If we got here without error, columns exist.
-      void row;
-    } catch {
-      // Columns missing — run migrations.
-      for (const sql of MIGRATIONS) {
-        try {
-          this.db.exec(sql);
-        } catch {
-          // Column already exists (idempotent).
-        }
+    // Run all migrations idempotently. SQLite reports duplicate columns
+    // when a database is already current; that is the desired no-op path.
+    for (const sql of MIGRATIONS) {
+      try {
+        this.db.exec(sql);
+      } catch {
+        // Column already exists (idempotent).
       }
     }
   }
@@ -273,8 +285,8 @@ export class TaskStore {
       `INSERT INTO tasks (
          persona, description, schedule, prompt,
          created_at, next_run_at, next_review_at, active,
-         one_off, expires_at, max_runs, silent, created_by, command
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`,
+         one_off, expires_at, max_runs, silent, created_by, command, command_secrets
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)`,
     );
     const result = stmt.run(
       input.persona,
@@ -290,6 +302,7 @@ export class TaskStore {
       silent ? 1 : 0,
       createdBy,
       input.command ?? null,
+      JSON.stringify(input.commandSecrets ?? []),
     );
     const id = Number(result.lastInsertRowid);
     const task = this.get(id);
@@ -510,11 +523,11 @@ export class TaskStore {
       `INSERT INTO tasks (
          persona, description, schedule, prompt,
          created_at, next_run_at, next_review_at, active,
-         one_off, expires_at, max_runs, silent, created_by, command
+         one_off, expires_at, max_runs, silent, created_by, command, command_secrets
        ) VALUES (
          $persona, $description, $schedule, $prompt,
          $createdAt, $nextRunAt, $nextReviewAt, $active,
-         $oneOff, $expiresAt, $maxRuns, $silent, $createdBy, $command
+         $oneOff, $expiresAt, $maxRuns, $silent, $createdBy, $command, $commandSecrets
        )`,
     );
     const result = stmt.run({
@@ -535,6 +548,7 @@ export class TaskStore {
       $silent: 0,
       $createdBy: "selftest",
       $command: null,
+      $commandSecrets: "[]",
     });
     return { id: Number(result.lastInsertRowid), firesAt };
   }

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -183,7 +183,7 @@ scheduling flag:
   phantombot task add "<prompt>" "<description>" --every 5m  --for 2h
 
   # Command-backed recurring task (runs a local script directly; no LLM)
-  phantombot task add "<audit prompt>" "<description>" --every 1h --command "/path/to/checker"
+  phantombot task add "<audit prompt>" "<description>" --every 1h --command "/path/to/checker" --secret API_TOKEN
 
   # Inspect / cancel
   phantombot task list                                 # active tasks
@@ -210,9 +210,15 @@ Command-backed tasks — use \`--command\` for cheap deterministic
 pollers and integrations, such as Jira, Linear, email, monitoring, or
 any local checker script. The command runs directly under
 \`phantombot tick\`, records stdout/stderr/exit status in
-\`task_runs\`, and does not wake an LLM. The positional prompt remains
-as audit context. The command should call \`phantombot notify\` itself
-only when it detects something new and actionable.
+\`task_runs\`, and does not wake an LLM. It receives a minimal
+environment by default; repeat \`--secret NAME\` to expose only the
+specific env vars it needs. The positional prompt remains as audit
+context. The command should call \`phantombot ask\` when it detects work
+that needs an agent turn. It should call \`phantombot notify\` only when
+the user explicitly asked to be interrupted or something genuinely needs
+direct surfacing. Recurring command tasks do not get the agent
+self-review prompt on quiet runs, so add \`--until\`, \`--count\`, or
+\`--for\` when the poller has a natural end.
 
 When you call \`task add\`, the CLI echoes:
 

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -182,6 +182,9 @@ scheduling flag:
   phantombot task add "<prompt>" "<description>" --every 1h --count 24
   phantombot task add "<prompt>" "<description>" --every 5m  --for 2h
 
+  # Command-backed recurring task (runs a local script directly; no LLM)
+  phantombot task add "<audit prompt>" "<description>" --every 1h --command "/path/to/checker"
+
   # Inspect / cancel
   phantombot task list                                 # active tasks
   phantombot task log <id>                             # fire history for one task
@@ -202,6 +205,14 @@ many times it has fired, and the exact \`phantombot task cancel <id>\`
 command. After completing the actual work, take a beat: is this
 task still useful? If not, cancel it. If yes, ignore the footer
 and continue. This is how the system stays clean.
+
+Command-backed tasks — use \`--command\` for cheap deterministic
+pollers and integrations, such as Jira, Linear, email, monitoring, or
+any local checker script. The command runs directly under
+\`phantombot tick\`, records stdout/stderr/exit status in
+\`task_runs\`, and does not wake an LLM. The positional prompt remains
+as audit context. The command should call \`phantombot notify\` itself
+only when it detects something new and actionable.
 
 When you call \`task add\`, the CLI echoes:
 
@@ -410,4 +421,3 @@ only places they live.
 If after checking starter spots and following your nose the
 credential genuinely isn't anywhere, then ask the user. Asking
 first — without scanning — is the lazy path; don't take it.`;
-

--- a/tests/cli-task.test.ts
+++ b/tests/cli-task.test.ts
@@ -152,6 +152,44 @@ describe("runTaskAdd", () => {
     const t = store.get(1)!;
     expect(t.expiresAt?.toISOString()).toBe("2026-06-01T00:00:00.000Z");
   });
+
+  test("--command stores a direct command task", async () => {
+    const out = new CaptureStream();
+    const code = await runTaskAdd({
+      config,
+      store,
+      every: "1h",
+      prompt: "poll external systems",
+      description: "command poll",
+      command: "/usr/local/bin/check-notifications",
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(out.text).not.toContain("hygiene:");
+    const t = store.get(1)!;
+    expect(t.command).toBe("/usr/local/bin/check-notifications");
+    const showOut = new CaptureStream();
+    await runTaskShow({ config, store, id: 1, out: showOut });
+    expect(showOut.text).toContain("--- command ---");
+    expect(showOut.text).toContain("/usr/local/bin/check-notifications");
+  });
+
+  test("--command rejects empty commands", async () => {
+    const err = new CaptureStream();
+    const code = await runTaskAdd({
+      config,
+      store,
+      every: "1h",
+      prompt: "poll external systems",
+      description: "command poll",
+      command: "   ",
+      out: new CaptureStream(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("--command cannot be empty");
+  });
 });
 
 describe("runTaskList", () => {

--- a/tests/cli-task.test.ts
+++ b/tests/cli-task.test.ts
@@ -169,10 +169,63 @@ describe("runTaskAdd", () => {
     expect(out.text).not.toContain("hygiene:");
     const t = store.get(1)!;
     expect(t.command).toBe("/usr/local/bin/check-notifications");
+    expect(t.commandSecrets).toEqual([]);
     const showOut = new CaptureStream();
     await runTaskShow({ config, store, id: 1, out: showOut });
     expect(showOut.text).toContain("--- command ---");
     expect(showOut.text).toContain("/usr/local/bin/check-notifications");
+  });
+
+  test("--secret stores command env allowlist", async () => {
+    const out = new CaptureStream();
+    const code = await runTaskAdd({
+      config,
+      store,
+      every: "1h",
+      prompt: "poll external systems",
+      description: "command poll",
+      command: "/usr/local/bin/check-notifications",
+      commandSecrets: ["JIRA_API_KEY", " JIRA_API_KEY ", "LINEAR_API_KEY"],
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    const t = store.get(1)!;
+    expect(t.commandSecrets).toEqual(["JIRA_API_KEY", "LINEAR_API_KEY"]);
+    const showOut = new CaptureStream();
+    await runTaskShow({ config, store, id: 1, out: showOut });
+    expect(showOut.text).toContain("secrets:      JIRA_API_KEY, LINEAR_API_KEY");
+  });
+
+  test("--secret requires --command and valid env names", async () => {
+    const errNoCommand = new CaptureStream();
+    const codeNoCommand = await runTaskAdd({
+      config,
+      store,
+      every: "1h",
+      prompt: "poll external systems",
+      description: "bad poll",
+      commandSecrets: ["JIRA_API_KEY"],
+      out: new CaptureStream(),
+      err: errNoCommand,
+    });
+    expect(codeNoCommand).toBe(2);
+    expect(errNoCommand.text).toContain("--secret requires --command");
+
+    const errBadName = new CaptureStream();
+    const codeBadName = await runTaskAdd({
+      config,
+      store,
+      every: "1h",
+      prompt: "poll external systems",
+      description: "bad poll",
+      command: "/usr/local/bin/check-notifications",
+      commandSecrets: ["not-a-var"],
+      out: new CaptureStream(),
+      err: errBadName,
+    });
+    expect(codeBadName).toBe(2);
+    expect(errBadName.text).toContain("invalid --secret name");
   });
 
   test("--command rejects empty commands", async () => {

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runTick } from "../src/cli/tick.ts";
@@ -148,6 +148,75 @@ describe("runTick — no-op cases", () => {
 });
 
 describe("runTick — normal task fire", () => {
+  test("command-backed due task runs without invoking any harness", async () => {
+    const markerPath = join(workdir, "command-ran.txt");
+    const created = store.add({
+      persona: "phantom",
+      description: "command poll",
+      schedule: "0 * * * *",
+      prompt: "audit context only",
+      command: `printf ok > ${markerPath}`,
+      reviewIntervalMs: 1,
+      now: new Date("2026-05-02T09:30:00Z"),
+    });
+    if (!created.ok) throw new Error("setup");
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const code = await runTick({
+      config,
+      taskStore: store,
+      memory,
+      harnesses: [harness],
+      lockPath,
+      now: new Date("2026-05-02T10:00:00Z"),
+    });
+    expect(code).toBe(0);
+    expect(harness.invocations).toBe(0);
+    expect(await readFile(markerPath, "utf8")).toBe("ok");
+    const t = store.get(created.id)!;
+    expect(t.runCount).toBe(1);
+    expect(t.active).toBe(true);
+    const runs = store.taskRuns(created.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.status).toBe("ok");
+  });
+
+  test("command-backed task failure is logged and still advances", async () => {
+    const created = store.add({
+      persona: "phantom",
+      description: "failing command poll",
+      schedule: "0 * * * *",
+      prompt: "audit context only",
+      command: "printf failed >&2; exit 7",
+      reviewIntervalMs: 1,
+      now: new Date("2026-05-02T09:30:00Z"),
+    });
+    if (!created.ok) throw new Error("setup");
+    const harness = new ScriptedHarness("h", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const code = await runTick({
+      config,
+      taskStore: store,
+      memory,
+      harnesses: [harness],
+      lockPath,
+      now: new Date("2026-05-02T10:00:00Z"),
+    });
+    expect(code).toBe(0);
+    expect(harness.invocations).toBe(0);
+    const t = store.get(created.id)!;
+    expect(t.runCount).toBe(1);
+    expect(t.nextRunAt.toISOString()).toBe("2026-05-02T11:00:00.000Z");
+    const runs = store.taskRuns(created.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.status).toBe("error");
+    expect(runs[0]!.exitCode).toBe(7);
+    expect(runs[0]!.outputExcerpt).toContain("command exited 7");
+    expect(runs[0]!.outputExcerpt).toContain("failed");
+  });
+
   test("due task runs with its prompt; recordRun advances next_run_at", async () => {
     const created = store.add({
       persona: "phantom",

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -148,6 +148,45 @@ describe("runTick — no-op cases", () => {
 });
 
 describe("runTick — normal task fire", () => {
+  test("command-backed due task gets only explicitly requested secrets", async () => {
+    const oldSecret = process.env.PHANTOMBOT_TEST_SECRET;
+    const oldOther = process.env.PHANTOMBOT_TEST_OTHER_SECRET;
+    process.env.PHANTOMBOT_TEST_SECRET = "visible";
+    process.env.PHANTOMBOT_TEST_OTHER_SECRET = "hidden";
+    try {
+      const markerPath = join(workdir, "command-env.txt");
+      const created = store.add({
+        persona: "phantom",
+        description: "command poll",
+        schedule: "0 * * * *",
+        prompt: "audit context only",
+        command:
+          `printf "%s/%s" "$PHANTOMBOT_TEST_SECRET" "$PHANTOMBOT_TEST_OTHER_SECRET" > ${markerPath}`,
+        commandSecrets: ["PHANTOMBOT_TEST_SECRET"],
+        reviewIntervalMs: 1,
+        now: new Date("2026-05-02T09:30:00Z"),
+      });
+      if (!created.ok) throw new Error("setup");
+      const code = await runTick({
+        config,
+        taskStore: store,
+        memory,
+        harnesses: [
+          new ScriptedHarness("h", [{ type: "done", finalText: "should not run" }]),
+        ],
+        lockPath,
+        now: new Date("2026-05-02T10:00:00Z"),
+      });
+      expect(code).toBe(0);
+      expect(await readFile(markerPath, "utf8")).toBe("visible/");
+    } finally {
+      if (oldSecret === undefined) delete process.env.PHANTOMBOT_TEST_SECRET;
+      else process.env.PHANTOMBOT_TEST_SECRET = oldSecret;
+      if (oldOther === undefined) delete process.env.PHANTOMBOT_TEST_OTHER_SECRET;
+      else process.env.PHANTOMBOT_TEST_OTHER_SECRET = oldOther;
+    }
+  });
+
   test("command-backed due task runs without invoking any harness", async () => {
     const markerPath = join(workdir, "command-ran.txt");
     const created = store.add({

--- a/tests/lib-tasks.test.ts
+++ b/tests/lib-tasks.test.ts
@@ -68,6 +68,36 @@ describe("TaskStore.add", () => {
     if (!r.ok) return;
     expect(r.task.nextReviewAt.toISOString()).toBe("2026-05-02T09:31:00.000Z");
   });
+
+  test("commandSecrets default empty and persist when provided", () => {
+    const noSecrets = store.add({
+      persona: "phantom",
+      description: "plain command",
+      schedule: "0 * * * *",
+      prompt: "x",
+      command: "/usr/local/bin/poll",
+      now: NOW,
+    });
+    expect(noSecrets.ok).toBe(true);
+    if (!noSecrets.ok) return;
+    expect(noSecrets.task.commandSecrets).toEqual([]);
+
+    const withSecrets = store.add({
+      persona: "phantom",
+      description: "secret command",
+      schedule: "0 * * * *",
+      prompt: "x",
+      command: "/usr/local/bin/poll",
+      commandSecrets: ["JIRA_API_KEY", "LINEAR_API_KEY"],
+      now: NOW,
+    });
+    expect(withSecrets.ok).toBe(true);
+    if (!withSecrets.ok) return;
+    expect(store.get(withSecrets.id)!.commandSecrets).toEqual([
+      "JIRA_API_KEY",
+      "LINEAR_API_KEY",
+    ]);
+  });
 });
 
 describe("TaskStore.list / get", () => {

--- a/tests/persona-builder-scheduling.test.ts
+++ b/tests/persona-builder-scheduling.test.ts
@@ -65,6 +65,14 @@ describe("buildSystemPrompt — scheduling tools section", () => {
     expect(SCHEDULING_TOOLS_SECTION).toContain('"<prompt>" "<description>"');
   });
 
+  test("documents command-backed tasks as no-LLM generic pollers", () => {
+    expect(SCHEDULING_TOOLS_SECTION).toContain("--command");
+    expect(SCHEDULING_TOOLS_SECTION).toContain("does not wake an LLM");
+    expect(SCHEDULING_TOOLS_SECTION).toContain("Jira");
+    expect(SCHEDULING_TOOLS_SECTION).toContain("Linear");
+    expect(SCHEDULING_TOOLS_SECTION).toContain("phantombot notify");
+  });
+
   test("documents the proof-of-creation echo contract", () => {
     // The CLI echoes "task <id> scheduled" — the persona must repeat
     // that verbatim. This is the audit trail that defeats hallucinated


### PR DESCRIPTION
## Summary
- add command-backed scheduled tasks via `phantombot task add ... --command`
- run command tasks directly from `phantombot tick` without constructing a harness
- document generic usage for cheap Jira/Linear/mail/monitoring pollers and expose it in CLI help/persona instructions

## Verification
- `bun test tests/cli-task.test.ts tests/cli-tick.test.ts tests/persona-builder-scheduling.test.ts`
- `bun run typecheck`
- `bun test`
- `bun run build`