### PR TITLE
feat(telegram): name-based group routing + real command menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@ Phantombot's group routing is local and deterministic:
 - If a human message names another bot, this bot stays silent.
 - If a human follow-up names nobody, the last-addressed bot continues.
 - If a brand-new group thread names nobody, all bots stay silent.
-- A bot's own `@username` also counts as addressing that bot.
 
 Examples:
 
@@ -371,6 +370,25 @@ Examples:
 
 The bot strips its own `@username` before sending the message to the harness,
 so the assistant sees the user's actual request rather than addressing noise.
+
+#### Routing uses only shared signals — name your bots accordingly
+
+Routing is decided **purely from the persona-name list every bot shares**, never
+from a bot's own Telegram `@username` (which the other bots can't see). If one
+bot routed on a signal its peers couldn't observe, the bots' "last addressed"
+state would drift apart — the mentioned bot would switch while the others kept a
+previously-sticky bot answering, so two bots would reply and keep replying to
+every no-name follow-up.
+
+A native `@username` mention still routes correctly **when the persona name is
+embedded in the username** — `robbie` inside `@robbie_agh_bot` matches on letter
+boundaries, and because that match comes from the shared name list, every bot
+agrees on it. So give each bot a username that contains its persona name (the
+normal case). A bot whose username does *not* contain its persona name can only
+be addressed by name in the text, not by a bare `@username`.
+
+A bot that is *not* addressed stays completely silent — it produces no reply and
+no `(no reply)` placeholder bubble. Silence in a group is normal, not an error.
 
 ### Context Catch-Up
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ prepends those messages as context:
 Robbie, what do you think?
 ```
 
-The buffer is capped at 20 messages per group chat and is not persisted across
+The buffer is capped at 100 messages per group chat and is not persisted across
 process restarts.
 
 ### Bot-To-Bot Limitations

--- a/README.md
+++ b/README.md
@@ -1,30 +1,67 @@
 # Phantombot
 
-Giving the harness a Soul. The harness can do its own tools — let it. A personality-first chat agent for Telegram, built for minimalist, high-torque agency.
+Phantombot is a personality-first Telegram agent runner. It gives a terminal
+AI harness a durable identity, memory, Telegram presence, scheduled tasks,
+voice replies, and atomic self-updates.
 
-Phantombot extends **[Pi](https://pi.dev)** — the terminal-based coding agent from Earendil Works — onto Telegram, and uses **Claude Code**, **Google Gemini CLI**, or **OpenAI Codex CLI** as drop-in alternatives or fallbacks when Pi isn't the right fit. **Pi is the recommended primary; Claude, Gemini, and Codex are first-class but think of them as backup, not the default.** The harness runs its own tool loop; phantombot does identity, memory, channel, scheduling, and self-update.
+It does not implement a model abstraction or a tool-calling layer. The harness
+already knows how to use its own tools, so phantombot provides the surrounding
+agent runtime and lets the harness do the work.
 
-Grab Pi from <https://pi.dev> — `curl -fsSL https://pi.dev/install.sh | sh` — before configuring phantombot.
+Supported harnesses:
 
----
+- [Pi](https://pi.dev) - recommended primary harness.
+- Claude Code - first-class fallback or primary.
+- Google Gemini CLI - first-class fallback or primary.
+- OpenAI Codex CLI - first-class fallback or primary.
 
-## Why this exists
+## Contents
 
-Phantombot was built because the existing agent gateways became "enshitified." If you've used **OpenClaw**, you know the pain:
+- [Why Phantombot Exists](#why-phantombot-exists)
+- [Install](#install)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+- [Command Reference](#command-reference)
+- [Telegram](#telegram)
+- [Group Chats](#group-chats)
+- [Voice Replies](#voice-replies)
+- [Scheduled Tasks](#scheduled-tasks)
+- [Notifications](#notifications)
+- [Credentials](#credentials)
+- [Memory](#memory)
+- [Maintenance](#maintenance)
+- [Architecture](#architecture)
+- [Build From Source](#build-from-source)
+- [Project Layout](#project-layout)
+- [Design Principles](#design-principles)
+- [Contributing](#contributing)
 
-- Gateways that take forever to restart (if they restart at all).
-- Sluggish performance and fragile tool-call parsing.
-- Bloated abstractions that fight with the model's native abilities.
+## Why Phantombot Exists
 
-**Phantombot's answer:** a 98 MB single binary, atomic update in <2s, no tool-call layer at all. The harness already knows how to use Bash; phantombot doesn't second-guess it.
+The motivating rule is simple:
 
-**The motivating insight:** *the harness can do its own tools — let it.*
+> The harness can do its own tools. Let it.
 
-The author's daily-driver assistant ("Robbie") used to run on [OpenClaw](https://github.com/openclaw/openclaw). OpenClaw provides personality + channels + memory **and** its own model abstraction **and** its own tool layer. The model abstraction is fine. The tool layer fights with how Pi, Claude Code, and Gemini CLI already do tools — better than OpenClaw could. Phantombot keeps the personality + memory + Telegram channel and lets the harness be the brain *and* the hands.
+Traditional agent gateways often add a second tool layer in front of a coding
+agent that already has Bash, file access, SSH, browser tools, and its own
+permission model. That creates slow restarts, brittle tool-call translation,
+large config surfaces, and failure modes that the harness already solved.
 
-When Phantom is asked to *"SSH to the home lab and write a note to the Obsidian vault,"* the request goes to `pi --print --mode json` (or `claude --print` if Pi isn't the active harness) with Phantom's system prompt installed. The harness uses *its* Bash / Write / SSH tools to do the work and returns the final text. Phantombot relays it to Telegram. No tool-call translation layer, no permission gates, no `tools[]` array conversion. Phantombot just provides the *SOUL*, the memory, and the Telegram channel.
+Phantombot keeps the parts a personal assistant actually needs:
 
----
+- A persistent persona loaded from markdown.
+- Telegram text, group, attachment, and voice I/O.
+- Rolling conversation context.
+- Durable markdown memory and KB.
+- Scheduled tasks.
+- Safe credential discovery conventions.
+- Atomic binary self-update.
+- Systemd user-service installation.
+
+When a user asks, "SSH to the home lab and write a note to the Obsidian vault,"
+phantombot builds the persona prompt, loads relevant memory, sends the turn to
+the harness, and relays the final answer to Telegram. The harness performs the
+SSH, file edits, searches, and command execution through its native tool loop.
 
 ## Install
 
@@ -32,214 +69,225 @@ When Phantom is asked to *"SSH to the home lab and write a note to the Obsidian 
 curl -fsSL https://raw.githubusercontent.com/phantomyard/phantombot/main/install.sh | sh
 ```
 
-### Quick start
+The installer:
 
-After `install.sh` completes:
+- Detects host architecture (`x86_64` or `aarch64`).
+- Fetches the latest GitHub release.
+- Downloads the matching binary and `SHA256SUMS`.
+- Verifies the checksum before installing.
+- Installs to `~/.local/bin/phantombot` by default.
+- Warns if `~/.local/bin` is not on `PATH`.
+- Starts the persona setup TUI when stdin/stdout are interactive.
 
-**Getting a Telegram bot token:**
-
-1. Open Telegram and chat with [@BotFather](https://t.me/BotFather)
-2. Send `/newbot` and follow the prompts to name your bot
-3. Copy the token — it'll look like `1234567890:ABCdef...`
-
-**Getting your Telegram user ID:**
-
-1. Open Telegram and chat with [@userinfobot](https://t.me/userinfobot)
-2. Send any message (or `/start`)
-3. Copy the numeric ID it returns
-
-### Before you configure a harness
-
-Phantombot doesn't bundle an AI model — it delegates to one you already have installed. We call the AI tool a **harness**: phantombot passes your persona + conversation to it, the harness runs its own tools (Bash, file access, web search), and phantombot relays the result to Telegram.
-
-**You must install and authenticate at least one harness yourself before `phantombot harness` will work:**
-
-- **Pi** *(recommended primary)* — get it from [pi.dev](https://pi.dev) with `curl -fsSL https://pi.dev/install.sh | sh`, then run `pi` once to authenticate.
-- **Claude Code** — `npm install -g @anthropic-ai/claude-code`, then `claude /login` for OAuth.
-- **Gemini CLI** — install Google's Gemini CLI, then `gemini` and follow the `/auth` flow (or set `GEMINI_API_KEY` in `~/.env`).
-- **OpenAI Codex CLI** — install Codex, then authenticate with `codex login` (ChatGPT sign-in) or set `OPENAI_API_KEY` in `~/.env`. Phantombot drives it via `codex exec --json` in ephemeral mode, so your persona + memory stay authoritative.
-
-**Primary vs. fallback:** The primary handles every turn by default. If it fails (auth expiry, rate limit, transient error), phantombot automatically tries the fallback. Pi as primary + Claude as fallback is the recommended combo — you get Pi's speed and personality day-to-day, with Claude catching errors seamlessly.
-
-Then run:
-
-```bash
-phantombot persona   # TUI — create or import (OpenClaw works) your first persona
-phantombot harness   # TUI — picks up installed harnesses; choose primary + fallback
-phantombot telegram  # paste your @BotFather bot token + allowlisted user IDs
-phantombot voice     # (optional) pick TTS/STT provider for voice messages
-phantombot embedding # (recommended) turn on semantic memory — see callout below
-
-phantombot run       # foreground — Ctrl-C to stop.
-phantombot install   # install as a systemd --user service (survives logout)
-```
-
-> **💡 Recommended: turn on semantic memory.** Out of the box, memory search is **keyword-only** — it matches the literal words in a note. Add a free Gemini embeddings key and search also matches on *meaning*: asking *"how do I pay tax"* surfaces your *"VAT filing steps"* note even though they share no words. Phantombot retrieves relevant memories automatically on every turn, so this is what makes the agent's recall feel like instinct instead of grep. It's one command — `phantombot embedding` (paste a key from <https://aistudio.google.com/app/apikey>) — and **everything still works without it**, degrading cleanly to keyword search. Early installs predate this feature, so many setups never enabled it and are missing the upgrade. Full setup + the free-tier limits are in [Memory → Semantic search](#semantic-search-optional).
-
-The script:
-
-- Detects host arch (`x86_64` / `aarch64`).
-- Fetches the latest GitHub Release tag.
-- Downloads the matching binary + `SHA256SUMS`, **verifies the checksum**, refuses on mismatch.
-- Creates `~/.local/bin/` if needed and installs `phantombot` at mode 0755.
-- Warns if `~/.local/bin` isn't on your `PATH`.
-- Launches `phantombot persona` so you can set up your first persona — unless stdin/stdout aren't a TTY (e.g. running headless or piped from `curl … | sh` in a non-interactive context), in which case it prints a "run this next" hint and exits cleanly.
-
-Environment overrides:
+Installer environment overrides:
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `PHANTOMBOT_INSTALL_DIR` | `~/.local/bin` | Where to install the binary |
-| `PHANTOMBOT_SKIP_TUI` | unset | Set to skip the post-install persona TUI (useful in CI / unattended provisioning) |
-| `GITHUB_TOKEN` | unset | Sent as `Authorization: Bearer …` for the GitHub API call (lifts unauth rate limits). If the token is rejected (401) or rate-limited (403) — e.g. a GitHub App installation token scoped to a different org — `phantombot update` transparently retries once without the auth header before failing. |
+| `PHANTOMBOT_INSTALL_DIR` | `~/.local/bin` | Install destination |
+| `PHANTOMBOT_SKIP_TUI` | unset | Skip the post-install TUI |
+| `GITHUB_TOKEN` | unset | Optional token for GitHub API rate limits |
 
-After install, subsequent updates use:
+## Quick Start
 
-```bash
-phantombot update                       # interactive TUI
-phantombot update --check               # exit 2 if newer available, 0 if current
-phantombot update --force --restart     # cron-friendly: no prompts, restart after install
-```
+You need:
 
-Updates download to `${binPath}.update.tmp`, SHA256-verify, atomically rename over the live binary, and clean up after themselves — no `.bak` files left in your install dir.
+- A Telegram bot token from [@BotFather](https://t.me/BotFather).
+- Your numeric Telegram user ID from [@userinfobot](https://t.me/userinfobot).
+- At least one installed and authenticated harness.
 
-The heartbeat checks for new releases automatically, but waits 72 hours after a release before sending the Telegram `/update` heads-up. Manual `phantombot update` and `/update` are immediate.
-
----
-
-## Prerequisites
-
-- **At least one harness** installed and authenticated as the user that will run phantombot:
-  - **[Pi](https://pi.dev)** *(recommended primary)* — install via `curl -fsSL https://pi.dev/install.sh | sh`, then `pi` configured per its own setup
-  - **Claude Code** — `claude /login` (OAuth on host; phantombot filters `ANTHROPIC_API_KEY` so OAuth is the path)
-  - **Google Gemini CLI** — `gemini` then OAuth via the in-app `/auth`, OR set `GEMINI_API_KEY` in `~/.env`
-  - **OpenAI Codex CLI** — `codex login` (ChatGPT sign-in), OR set `OPENAI_API_KEY` in `~/.env`
-- A Telegram bot token from [@BotFather](https://t.me/BotFather)
-- Linux (`systemd --user` for the service install path; the binary itself is portable across Linux distros)
-
-If you'll run as a headless service account (no login session), enable linger so the unit survives logout:
+Install and authenticate a harness first:
 
 ```bash
-sudo loginctl enable-linger $USER
+# Pi, recommended
+curl -fsSL https://pi.dev/install.sh | sh
+pi
+
+# Claude Code
+npm install -g @anthropic-ai/claude-code
+claude /login
+
+# Gemini CLI
+gemini
+
+# Codex CLI
+codex login
 ```
 
-**Bun** is only needed if you're building from source — the released binary has no runtime dep.
-
-
----
-
-## Build from source (optional)
-
-> ⚠️ **The build target must remain `bun-linux-x64-baseline`.** If you "optimise" to plain `bun-linux-x64`, the binary will SIGILL on launch on any host without AVX2 (e.g. older silicon used by some self-hosters).
+Then configure phantombot:
 
 ```bash
-git clone https://github.com/phantomyard/phantombot.git
-cd phantombot
-bun install
-bun run build                # → ./dist/phantombot (~98 MB, linux-x64-baseline)
-# bun run build:arm64        # cross-compile arm64 from an x64 host
+phantombot persona     # create or import a persona
+phantombot harness     # choose primary and fallback harnesses
+phantombot telegram    # paste BotFather token and allowed user IDs
+phantombot voice       # optional TTS/STT setup
+phantombot embedding   # recommended semantic memory setup
 
-mkdir -p ~/.local/bin && cp dist/phantombot ~/.local/bin/
-# (or: scp dist/phantombot user@host:~/.local/bin/phantombot)
+phantombot run         # foreground listener
+phantombot install     # install systemd --user units
 ```
 
----
+For a headless Linux service account, enable linger so the user service keeps
+running after logout:
 
-## Commands
+```bash
+sudo loginctl enable-linger "$USER"
+```
 
-### First-time / config (interactive TUIs)
+## Configuration
 
-| Command | What it does |
+Phantombot resolves configuration in this order:
+
+1. `PHANTOMBOT_*` environment variables.
+2. TOML at `$XDG_CONFIG_HOME/phantombot/config.toml` or `PHANTOMBOT_CONFIG`.
+3. Built-in defaults.
+
+Common paths:
+
+| Path | Purpose |
 |---|---|
-| `phantombot persona` | Create / import / restore / switch the active persona |
-| `phantombot persona <name>` | Switch default persona to `<name>` |
-| `phantombot persona --import <dir> [--as <n>]` | Non-interactive import (OpenClaw or phantombot-shaped) |
-| `phantombot telegram` | Configure the Telegram channel (token + allowed users) |
-| `phantombot harness` | Pick primary + fallback harnesses (pi / claude / gemini / codex) |
-| `phantombot voice` | Pick TTS/STT provider (ElevenLabs / OpenAI / Azure Edge) |
-| `phantombot embedding` | (Optional) configure Gemini embeddings for memory search |
+| `~/.config/phantombot/config.toml` | Main config |
+| `~/.config/phantombot/.env` | Phantombot runtime secrets, such as voice provider keys |
+| `~/.env` | General credentials available to the harness |
+| `~/.local/share/phantombot/memory.sqlite` | Rolling turns, tasks, capture log |
+| `~/.local/share/phantombot/personas/<name>/` | Persona markdown memory and KB |
 
-### Day-to-day
+Minimal config example:
 
-| Command | What it does |
+```toml
+default_persona = "phantom"
+
+[harnesses]
+chain = ["pi", "claude", "gemini", "codex"]
+
+[channels.telegram]
+token = "123456:telegram-bot-token"
+allowed_user_ids = [123456789]
+```
+
+Harness notes:
+
+- Pi is the recommended primary harness.
+- Claude Code is normally authenticated with OAuth on the host.
+- Gemini can use CLI auth or `GEMINI_API_KEY`.
+- Codex can use `codex login` or `OPENAI_API_KEY`.
+- `chain` order is primary to fallback.
+
+## Command Reference
+
+Interactive setup:
+
+| Command | Purpose |
 |---|---|
-| `phantombot run` | Foreground long-running listener (Ctrl-C to stop) |
-| `phantombot ask "<prompt>"` | One-shot prompt through the persona + harness chain. Prints the assistant's reply to stdout and exits. Stateless by default — pass `--history --conversation <id>` to thread. Built for non-interactive callers (shell scripts, the Twilio voice-agent's `askRobbie` relay) that want the bot's brain without a Telegram conversation. |
-| `phantombot install` | Install systemd --user units (main + heartbeat + nightly + tick) |
-| `phantombot uninstall` | Remove the systemd units |
-| `phantombot update [--check] [--force] [--restart]` | Atomic, SHA256-verified self-update |
+| `phantombot persona` | Create, import, restore, or switch personas |
+| `phantombot harness` | Choose harness chain |
+| `phantombot telegram` | Configure Telegram token and allowlist |
+| `phantombot voice` | Configure TTS/STT providers |
+| `phantombot embedding` | Configure semantic memory |
 
-### Agent-facing tools (the harnessed agent calls these via Bash)
+Runtime:
 
-| Command | What it does |
+| Command | Purpose |
 |---|---|
-| `phantombot env set NAME "value"` | Atomic write to `~/.env` (mode 0o600) |
-| `phantombot env get / list / unset` | Read / list-names-only / remove |
-| `phantombot notify --message "…"` | Telegram text to all allowed users |
-| `phantombot notify --voice "…"` | Synthesize via configured TTS, send as voice note |
-| `phantombot task add "<prompt>" "<description>" --every 1h` | Schedule a recurring agent task |
-| `phantombot task add "<prompt>" "<description>" --every 1h --command "/path/to/script"` | Schedule a cheap local command without waking an LLM |
-| `phantombot task list / show <id> / cancel <id>` | Manage tasks |
-| `phantombot tick` | Fire any due tasks (called every minute by `phantombot-tick.timer`) |
-| `phantombot memory today / search / get / list / index` | Read/write the persona's memory + KB |
-| `phantombot memory capture "<text>" --tag <tag>` | Append a tagged line to today's daily file (`decision` / `lesson` / `person` / `commitment`; `--tag` repeatable) and record it in `capture_log` |
+| `phantombot run` | Foreground Telegram listener |
+| `phantombot install` | Install systemd user service and timers |
+| `phantombot uninstall` | Remove systemd user service and timers |
+| `phantombot ask "<prompt>"` | One-shot prompt through the persona and harness chain |
+| `phantombot update [--check] [--force] [--restart]` | Check, install, or restart after updates |
 
-### Periodic maintenance (called by systemd timers, occasionally by hand)
+Agent-facing tools:
 
-| Command | What it does |
+| Command | Purpose |
 |---|---|
-| `phantombot heartbeat` | Mechanical 30-min pass (no LLM) |
-| `phantombot nightly [--resume]` | Cognitive distillation pass (LLM), checkpointed in five stages; `--resume` continues from `.nightly-progress.json` |
-| `phantombot doctor [--no-repair]` | Memory-subsystem health check; auto-repairs a missed/failed/partial nightly by spawning `nightly --resume` |
+| `phantombot env set NAME "value"` | Save a credential atomically |
+| `phantombot notify --message "..."` | Send a Telegram text notification |
+| `phantombot notify --voice "..."` | Send a Telegram voice notification |
+| `phantombot task add "<prompt>" "<description>" --every 1h` | Schedule an LLM-backed task |
+| `phantombot task add "<prompt>" "<description>" --every 1h --command "/path/to/script"` | Schedule a command-backed task |
+| `phantombot task list / show / cancel` | Inspect and manage scheduled tasks |
+| `phantombot memory today / search / get / list / index` | Inspect memory and KB |
+| `phantombot memory capture "<text>" --tag decision` | Append a tagged memory capture |
 
----
+Maintenance:
 
-## Personas
+| Command | Purpose |
+|---|---|
+| `phantombot tick` | Fire due scheduled tasks |
+| `phantombot heartbeat` | Run mechanical maintenance |
+| `phantombot nightly [--resume]` | Run or resume memory distillation |
+| `phantombot doctor [--no-repair]` | Check memory health and optionally repair |
 
-> **Personas at runtime.** One process, one default persona, optionally several persona-bound Telegram bots fanned out from the same process.
+## Telegram
 
-A persona is a directory of markdown files (`BOOT.md`, `MEMORY.md`, `tools.md`, etc.). You can have **many** persona directories on disk — each `phantombot persona` (or `--import`) adds one. They all live under `~/.local/share/phantombot/personas/<name>/`.
+Phantombot runs one or more Telegram long-poll listeners. Each listener needs a
+unique BotFather token. Reusing one token across listeners is refused because
+Telegram allows only one active long-poll consumer per bot token.
 
-The default persona (read from `state.json` / `config.toml`) is the one bound to the single `[channels.telegram]` block — that's the bot used by `phantombot ask`, post-update notifies, and the heartbeat. If that's all you configure, you get the classic one-bot-one-persona setup.
-
-You can **additionally** bind extra personas to their own Telegram bots by adding `[channels.telegram.personas.<name>]` blocks:
+The default Telegram account is configured in `[channels.telegram]` and binds
+to `default_persona`:
 
 ```toml
 [channels.telegram]
-token = "111:default-bot"
-allowed_user_ids = [123]
-
-[channels.telegram.personas.miles]
-token = "222:miles-bot"
-allowed_user_ids = [123]
-
-[channels.telegram.personas.desiree]
-token = "333:desiree-bot"
-allowed_user_ids = [123]
+token = "111:default-bot-token"
+allowed_user_ids = [123456789]
+poll_timeout_s = 30
 ```
 
-`phantombot run` then spawns one long-poll listener per entry, all sharing one process, one memory store (persona-partitioned, as always), and one run-lock. Each persona needs its own bot from @BotFather — reusing a token across listeners is refused at startup because Telegram serializes long-poll on the bot.
+Additional persona-bound bots can run inside the same phantombot process:
 
-Switching the *default* persona is still one command — `phantombot persona <name>` — and only affects which persona answers the `[channels.telegram]` bot. The persona-bound entries don't move.
+```toml
+[channels.telegram]
+token = "111:default-bot-token"
+allowed_user_ids = [123456789]
 
-```bash
-phantombot persona --import ~/clawd/agents/robbie --as robbie
-phantombot persona robbie                    # makes 'robbie' the default
-systemctl --user restart phantombot
+[channels.telegram.personas.lena]
+token = "222:lena-bot-token"
+allowed_user_ids = [123456789]
+
+[channels.telegram.personas.kai]
+token = "333:kai-bot-token"
+allowed_user_ids = [123456789]
 ```
 
----
+Environment variable overrides:
 
-## Telegram reply pacing
+| Setting | Default bot | Persona bot example |
+|---|---|---|
+| Token | `TELEGRAM_BOT_TOKEN` | `TELEGRAM_BOT_TOKEN_LENA` |
+| Allowed users | `PHANTOMBOT_TELEGRAM_ALLOWED_USERS` | `PHANTOMBOT_TELEGRAM_ALLOWED_USERS_LENA` |
+| Poll timeout | `PHANTOMBOT_TELEGRAM_POLL_S` | `PHANTOMBOT_TELEGRAM_POLL_S_LENA` |
+| Group persona names | `PHANTOMBOT_TELEGRAM_GROUP_PERSONAS` | `PHANTOMBOT_TELEGRAM_GROUP_PERSONAS_LENA` |
 
-Telegram replies are paced for phone-sized chats:
+Persona env suffixes are uppercased and non-alphanumeric characters become
+underscores, so `my-bot.test` uses `TELEGRAM_BOT_TOKEN_MY_BOT_TEST`.
 
-- progress narration is coalesced on a timer instead of posted once per tool call
-- final text is split into smaller bubbles at sentence/character boundaries
-- markdown blocks such as tables and code fences are kept intact where possible
-- voice replies are split into short voice notes
+### Telegram Commands
 
-Defaults are conservative, but you can tune them:
+At startup, phantombot registers the real command menu with Telegram and
+overwrites stale BotFather commands. The supported commands are:
+
+| Command | Purpose |
+|---|---|
+| `/stop` | Abort the current turn |
+| `/reset` | Clear this chat's history |
+| `/status` | Show harness, uptime, and context usage |
+| `/harness` | List or switch the active harness |
+| `/update` | Install the latest phantombot release |
+| `/restart` | Restart the phantombot service |
+| `/help` | Show the command list |
+
+Unknown slash commands fall through to the harness so personas can define
+their own conventions.
+
+### Reply Pacing
+
+Telegram replies are shaped for phone chats:
+
+- Progress narration is coalesced instead of sent once per tool call.
+- Final replies are split into readable bubbles.
+- Markdown tables and code fences are kept intact where possible.
+- Voice replies are split into short voice notes.
+
+Tuning:
 
 ```toml
 [channels.telegram.streaming]
@@ -250,315 +298,500 @@ bubble_delay_ms = 800
 voice_max_sentences = 3
 ```
 
-Environment overrides use the same names in screaming snake case, for example `PHANTOMBOT_TELEGRAM_BUBBLE_MAX_CHARS=900`.
+## Group Chats
 
----
+Group chats require two separate pieces:
 
-## Voice replies in Telegram
+1. Telegram delivery must let each bot receive the human messages.
+2. Phantombot must decide which bot should answer.
 
-When a Telegram voice message comes in (and the configured provider can do TTS), phantombot transcribes via STT, runs the harness, and synthesizes the reply as a voice note. **For these voice-in/voice-out turns only**, phantombot appends a one-paragraph brevity directive to the system prompt — telling the model to keep the reply to 1-3 sentences (~30 seconds of speech, ≈100 tokens), drop work narration ("Let me check…"), and skip markdown the TTS would read awkwardly.
+### Telegram Privacy Mode
 
-The directive lives at the channel layer (`VOICE_REPLY_INSTRUCTION` in `src/channels/telegram.ts`), not in persona files — so text replies stay as detailed as the persona wants. If voice notes still feel too long after this, the next lever is the persona's tone in BOOT.md/SOUL.md, not a config knob.
+For natural group conversations, disable BotFather privacy mode for each bot in
+the group.
 
-### Per-message modality override
+With privacy mode ON, Telegram only delivers a small subset of group messages
+to a bot:
 
-The default is "mirror the input" (voice-in → voice-out, text-in → text-out). You can flip it per message with an explicit directive inside the message itself:
+- Slash commands.
+- Replies to that bot.
+- Some service messages.
 
-- *Voice-in, text-out:* send a voice note saying *"…and respond in text"* (or *"reply in text please"*, *"no voice"*, *"text reply only"*). The STT transcript is what gets inspected, so the directive lands.
-- *Text-in, voice-out:* send a text message saying *"…send me a voice note"* (or *"reply with voice"*, *"voice please"*, *"as a voice note"*). Synthesises the reply via the configured TTS provider.
+Plain `@username` mentions are not reliable as a delivery mechanism under
+privacy mode. If the bot never receives the update, phantombot cannot route it.
 
-The override is parsed by `replyModalityOverride()` in `src/lib/audio.ts` — deliberately conservative regexes anchored on reply-verbs ("reply/respond/answer with text") and unmistakable shorthand ("voice note", "no voice"). Bare nouns like *"compose a text message to John"* or *"the chapter is text-heavy"* do not trigger. If the user asks for voice but no TTS provider is configured, phantombot degrades to text gracefully (same fallback as a voice-in with a broken TTS provider).
+With privacy mode OFF, Telegram delivers human group messages to every bot in
+the group. Phantombot then applies local routing so only the addressed bot
+speaks.
 
----
+### Configure Shared Group Names
 
-## Scheduled tasks (`phantombot task` + `phantombot tick`)
+Every bot in the same group should know the same list of persona names:
 
-The agent can schedule recurring work for itself. You ask Phantom on Telegram: *"every hour, check my email and let me know if anything important comes in."* Phantom (via the harness's Bash tool) runs:
+```toml
+[channels.telegram]
+token = "111:robbie-bot-token"
+allowed_user_ids = [123456789]
+group_persona_names = ["robbie", "lena", "kai"]
+
+[channels.telegram.personas.lena]
+token = "222:lena-bot-token"
+allowed_user_ids = [123456789]
+group_persona_names = ["robbie", "lena", "kai"]
+
+[channels.telegram.personas.kai]
+token = "333:kai-bot-token"
+allowed_user_ids = [123456789]
+group_persona_names = ["robbie", "lena", "kai"]
+```
+
+If `group_persona_names` is omitted, a bot still recognizes its own persona
+name. That is enough for a single-bot group, but not enough for clean handoff
+between multiple bots.
+
+### Routing Rules
+
+Phantombot's group routing is local and deterministic:
+
+- If a human message names one persona, that persona answers.
+- If a human message names several personas, each named bot answers.
+- If a human message names another bot, this bot stays silent.
+- If a human follow-up names nobody, the last-addressed bot continues.
+- If a brand-new group thread names nobody, all bots stay silent.
+- A bot's own `@username` also counts as addressing that bot.
+
+Examples:
+
+| Human message | Result |
+|---|---|
+| `Robbie, check this PR` | Robbie answers |
+| `Lena and Kai, compare notes` | Lena and Kai both answer |
+| `What about the edge case?` after Robbie was addressed | Robbie answers |
+| `Anyone around?` in a new group | No bot answers |
+
+The bot strips its own `@username` before sending the message to the harness,
+so the assistant sees the user's actual request rather than addressing noise.
+
+### Context Catch-Up
+
+When privacy mode is OFF, a bot can observe messages it did not answer. Each
+bot keeps a small in-memory per-chat buffer of recent human messages it saw but
+did not deliver to its harness. When the bot is later addressed, phantombot
+prepends those messages as context:
+
+```text
+[Recent group messages you saw but didn't reply to, for context:
+@andrew: Lena, I think option B is cleaner
+@andrew: Kai, can you sanity-check the test path?
+]
+
+Robbie, what do you think?
+```
+
+The buffer is capped at 20 messages per group chat and is not persisted across
+process restarts.
+
+### Bot-To-Bot Limitations
+
+Telegram bots cannot see messages sent by other bots. This is a Telegram
+platform restriction, not a phantombot setting.
+
+Consequences:
+
+- Bots cannot coordinate by reading each other's Telegram replies.
+- A bot only routes from the human message stream it receives.
+- Shared `group_persona_names` is required because bots cannot infer the other
+  bot roster from bot messages.
+- If you need agents to coordinate internally, use an external shared system
+  such as Plane, GitHub, files, or a purpose-built handoff mechanism. Do not
+  rely on Telegram bot-to-bot conversation.
+
+### Group Setup Checklist
+
+1. Create one BotFather bot per persona.
+2. Disable privacy mode for each bot that should participate naturally.
+3. Add every bot to the Telegram group.
+4. Configure each persona bot with the same `group_persona_names` list.
+5. Keep `allowed_user_ids` restricted to trusted human users.
+6. Restart phantombot.
+7. Test with explicit names first, then no-name follow-ups.
+
+## Voice Replies
+
+When a Telegram voice message arrives, phantombot:
+
+1. Transcribes it with the configured STT provider.
+2. Runs the harness turn.
+3. Synthesizes the reply with the configured TTS provider.
+4. Sends the result as a Telegram voice note.
+
+For voice-in/voice-out turns only, phantombot adds a short brevity directive to
+the system prompt. Text replies are unaffected.
+
+Per-message modality overrides:
+
+- Voice in, text out: say "reply in text", "no voice", or "text reply only".
+- Text in, voice out: write "send me a voice note", "reply with voice", or
+  "voice please".
+
+If TTS is not configured, phantombot degrades to text.
+
+## Scheduled Tasks
+
+`phantombot task` lets the agent schedule durable work in SQLite. The systemd
+timer calls `phantombot tick` every minute.
+
+Examples:
 
 ```bash
 phantombot task add \
-  "Check my Gmail since the last run. If anything is important, call \`phantombot notify --message \"...\"\`. Reply NONE otherwise." \
-  "hourly email check" \
+  "Check mail. Notify only if something genuinely needs attention." \
+  "hourly mail check" \
   --every 1h
-```
 
-`phantombot-tick.timer` fires every minute and calls `phantombot tick`, which:
-
-1. Reads tasks from `memory.sqlite` where `next_run_at <= now() AND active=1`.
-2. Spawns the harness with the stored prompt as the user message, or runs the stored command directly for command-backed tasks.
-3. The agent or command does its thing — including calling `phantombot notify` if the user should hear about it.
-4. Records the run, recomputes `next_run_at` from the cron expression.
-
-**Notification is opt-in.** Tasks run silently by default. The agent only calls `phantombot notify` when something genuinely needs surfacing. *"Nothing important happened"* is a successful run.
-
-**Missed runs are skipped.** Box off for 5 hours, hourly task missed 5 fires? The next tick after boot runs it once, not five times. No avalanche.
-
-**Self-review prevents task accretion.** Every task has a `next_review_at` scaled to its cadence (hourly→14d, daily→30d, weekly→90d). When the date arrives, the next tick runs a review prompt — agent decides KEEP / STOP / MODIFY based on recent context. KEEP doubles the review interval. STOP deactivates and notifies you why.
-
-**Command-backed tasks are for cheap integrations.** If a task can be answered by a deterministic local script, add `--command` and keep the LLM asleep:
-
-```bash
 phantombot task add \
-  "Poll Jira, Linear, email, or monitoring. If there is new work for the agent, call phantombot ask. Notify the user only if explicitly requested." \
-  "hourly external notification poll" \
+  "Poll Jira. Call phantombot ask only when new work appears." \
+  "jira poll" \
   --every 1h \
-  --command "/usr/local/bin/check-agent-notifications" \
-  --secret JIRA_API_KEY \
-  --secret LINEAR_API_KEY
+  --command "/usr/local/bin/jira-poll" \
+  --secret JIRA_API_KEY
 ```
 
-The command runs from the persona directory, under the existing tick lock, with a minimal environment (`PATH`, `HOME`, temp/XDG basics) plus only the env vars named by repeated `--secret NAME` flags. It does **not** inherit the full Phantombot env. `stdout`, `stderr`, exit status, and the next run are recorded in `task_runs`; command output is not sent to Telegram automatically.
+Task behavior:
 
-Use `phantombot ask` inside the script when the poller finds work that needs an agent/LLM turn. Use `phantombot notify` only when the user explicitly asked to be interrupted or the event genuinely needs direct surfacing.
+- LLM-backed tasks spawn the configured harness.
+- Command-backed tasks run a local shell command directly.
+- Command tasks receive a minimal environment plus only named `--secret` vars.
+- Task stdout, stderr, exit status, and next run are recorded.
+- Tasks run silently by default.
+- Missed runs are skipped rather than replayed in a burst.
+- Recurring LLM tasks get periodic self-review prompts.
+- Recurring command tasks do not self-review, so add `--until`, `--count`, or
+  `--for` when the poller has a natural end.
 
-Recurring command tasks do not get the agent self-review prompt, because they do not wake an agent on quiet runs. Add `--until`, `--count`, or `--for` when the poller has a natural end; otherwise cancel it manually when it is no longer useful.
-
-Manage from anywhere: ask Phantom on Telegram *"list my scheduled tasks"* / *"cancel the email check"* — the agent runs `phantombot task list` / `phantombot task cancel <id>`. Or use the same CLI commands directly.
-
----
-
-## `phantombot notify` (agent's voice to you)
+Manage tasks:
 
 ```bash
-phantombot notify --message "Proxmox upgrade succeeded on all hosts."
-phantombot notify --voice   "Heads up — backup failed on pve-3."
-phantombot notify --message "Both" --voice "Both"   # text + voice
+phantombot task list
+phantombot task show <id>
+phantombot task cancel <id>
+phantombot tick
 ```
 
-Sends to every chat in `[channels.telegram].allowed_user_ids`. Refuses (exit 2) if the allowlist is empty — no accidental broadcasts. Voice synthesis uses your configured TTS provider (set via `phantombot voice`).
+## Notifications
 
----
-
-## Credentials (`phantombot env`)
-
-Two .env files, two roles:
-
-- **`~/.config/phantombot/.env`** — phantombot's own runtime secrets (TTS keys; written by `phantombot voice`). Don't hand-edit.
-- **`~/.env`** — your general-purpose credentials (`GITHUB_TOKEN`, ssh passphrases, anything the harnessed agent needs to call out to). The agent writes here via `phantombot env set`.
-
-Both are sourced into the running phantombot process via systemd `EnvironmentFile=`, so when the agent (Claude harness) is spawned, **all credentials are already in `process.env`** — no command-line value pasting, no fresh file reads, no leakage to bash history.
+`phantombot notify` is the agent-facing way to proactively contact the user
+from scheduled or background work:
 
 ```bash
-# Agent-facing CLI (sanctioned write path: atomic, 0o600, idempotent):
-phantombot env set GITHUB_TOKEN "ghp_..."        # acks "saved GITHUB_TOKEN" — never echoes value
-phantombot env get GITHUB_TOKEN                  # raw value (avoid in interactive — leaks to scrollback)
-phantombot env list                              # names only
+phantombot notify --message "Backup failed on pve-3."
+phantombot notify --voice "Backup failed on pve-3."
+phantombot notify --message "Text" --voice "Voice"
+```
+
+Notifications are sent to the Telegram allowlist. Phantombot refuses to notify
+if no allowed users are configured.
+
+Background work should stay quiet unless something material happened or the
+user explicitly asked to be interrupted.
+
+## Credentials
+
+Phantombot uses two environment files:
+
+| File | Purpose |
+|---|---|
+| `~/.config/phantombot/.env` | Phantombot runtime secrets, usually written by setup commands |
+| `~/.env` | General credentials for the harnessed agent |
+
+Systemd units load both files with optional `EnvironmentFile=` entries. The
+spawned harness inherits the merged environment, so agents can discover
+credentials through `process.env` without pasting secrets into commands.
+
+Agent-facing credential CLI:
+
+```bash
+phantombot env set GITHUB_TOKEN "ghp_..."
+phantombot env list
+phantombot env get GITHUB_TOKEN
 phantombot env unset GITHUB_TOKEN
 ```
 
-The persona system prompt includes a **credential discovery + hygiene** section the agent inherits automatically. It documents the discovery order (`process.env` → `~/.env` → `~/.ssh/` → memory) and forbids `echo … >> ~/.env` (loses atomicity, drops file mode), echoing values back ("acknowledge by name only"), and storing credentials in memory drawers / KB notes.
-
----
-
-## Architecture
-
-```
-phantombot run                    # the only long-running command
-       │
-       ▼
-┌─────────────────────────┐
-│  one-turn coordinator   │  src/orchestrator/turn.ts
-└──────────┬──────────────┘
-           │
-   ┌───────┼─────────────────┐
-   ▼       ▼                 ▼
-load     load history    run harness chain
-persona  (bun:sqlite)    (pi → claude → gemini → codex)
-                              │
-                              ▼
-                  spawn `pi --print --mode json …`
-                  stream stream-json from stdout
-                  yield text/heartbeat/progress/done chunks
-                              │
-                              ▼
-                  on recoverable error → next harness
-                              │
-                              ▼
-                  persist user + assistant turn (on success only)
-                              │
-                              ▼
-                  send reply via Telegram sendMessage / sendVoice
-```
-
-Tool execution happens entirely inside the harness — phantombot doesn't see it.
-
-Four systemd-user units run alongside `phantombot.service`:
-
-| Unit | Cadence | What it does |
-|---|---|---|
-| `phantombot.service` | always-on | The long-running Telegram listener |
-| `phantombot-tick.timer` | every 1 min | Fires due scheduled tasks |
-| `phantombot-heartbeat.timer` | every 30 min | Mechanical maintenance, no LLM |
-| `phantombot-nightly.timer` | daily 02:00 | Cognitive distillation pass, LLM |
-
-Every service has **two `EnvironmentFile=` lines** (`~/.config/phantombot/.env` and `~/.env`), both optional. The merged `process.env` is what spawned harnesses inherit, so the agent finds credentials without re-reading either file.
-
----
+Use `phantombot env set` instead of appending to `.env` by hand. It writes
+atomically, preserves file permissions, and avoids duplicate entries.
 
 ## Memory
 
-Phantombot's memory has **two layers** that do different jobs. The SQLite layer is short-term machine state; the markdown layer is the durable, human-readable knowledge the agent accumulates over time. Most "where did my memory go?" confusion comes from conflating the two — so they're documented separately below.
+Phantombot memory has two layers:
 
-### Layer 1 — SQLite (`memory.sqlite`)
+- SQLite for rolling machine state.
+- Markdown for durable human-readable memory and KB.
 
-Local SQLite at `~/.local/share/phantombot/memory.sqlite`. Three tables:
+### SQLite Layer
 
-```sql
-turns(id, persona, conversation, role, text, created_at)
-tasks(id, persona, description, schedule, prompt, created_at,
-      last_run_at, next_run_at, run_count,
-      next_review_at, review_count, active)
-capture_log(id, persona, conversation, tags, created_at)
+SQLite lives at `~/.local/share/phantombot/memory.sqlite`.
+
+Important tables:
+
+| Table | Purpose |
+|---|---|
+| `turns` | Rolling per-conversation context buffer |
+| `tasks` | Scheduled task store |
+| `task_runs` | Task execution history |
+| `capture_log` | Trace of explicit memory captures |
+
+`turns` is not a permanent transcript archive. It is a bounded context buffer
+used to keep recent conversations coherent.
+
+### Markdown Layer
+
+Markdown memory lives under each persona directory:
+
+```text
+~/.local/share/phantombot/personas/<name>/
+  MEMORY.md
+  memory/
+    YYYY-MM-DD.md
+    decisions.md
+    lessons.md
+    people.md
+    commitments.md
+  kb/
 ```
 
-- **`turns`** is a **rolling per-conversation context buffer, not an archive.** Each persona × conversation namespace (`telegram:<chatId>`, `tick:<task-id>`, `system:nightly:<date>`, …) keeps only its most recent turns so the harness has continuity when threading a reply. Older turns are pruned — on a live box the table holds ~100–150 rows even after thousands of turns. Don't treat it as a transcript log; yesterday's chat is already gone.
-- **`tasks`** backs `phantombot task` — the scheduled-task store.
-- **`capture_log`** records every `phantombot memory capture` invocation (one row, tags joined). It is *not* the memory itself — it's the **observability trail** that lets the 30-turn nudge and `phantombot doctor` answer "did capture actually fire today?".
+The flow:
 
-FTS5-based hybrid search via `phantombot memory search` (built into bun:sqlite); optional Gemini embeddings if `phantombot embedding` is configured.
+1. The agent captures important facts with `phantombot memory capture`.
+2. Heartbeat promotes tagged daily lines into structured drawers.
+3. Nightly distills drawers and `kb/inbox/` into durable KB notes.
+4. `MEMORY.md` stays lean and always-loaded.
 
-### Layer 2 — markdown (the persona working directory)
-
-The durable memory lives as plain markdown under `~/.local/share/phantombot/personas/<name>/`, and flows through a four-stage pipeline:
-
-```
-  capture             heartbeat (30 min)       nightly (02:00, LLM)
-  ───────             ──────────────────       ────────────────────
-  memory/             promote tagged lines     distill drawers → KB
-  <YYYY-MM-DD>.md ──▶  into the four drawers ──▶ atomic notes, sweep
-  (daily journal)     (mechanical, no LLM)     kb/inbox/, compress
-```
-
-1. **Daily journal** — `memory/<YYYY-MM-DD>.md`. The agent appends tagged lines as things happen via `phantombot memory capture "<text>" --tag <tag>`, which writes `- [tag] text · HH:MMZ` and creates the file on the day's first capture. Valid tags: `decision`, `lesson`, `person`, `commitment`.
-2. **Drawers** — `memory/{decisions,lessons,people,commitments}.md`. The **heartbeat** (mechanical, every 30 min, no LLM) promotes tagged daily-file lines into the matching structured drawer.
-3. **KB** — `kb/`, an Obsidian-shaped vault of atomic notes with frontmatter and `[[wikilinks]]`. The **nightly** (cognitive, LLM-driven) distills the drawers into KB notes and sweeps `kb/inbox/`.
-4. **Persistent memory** — `MEMORY.md`, the always-loaded summary the nightly keeps lean.
-
-`phantombot memory capture` exists so this protocol has the same shape as every other subsystem — a command, a log line, an exit code, a queryable trace — instead of being a prose-only instruction a harness might silently skip.
-
-### The nightly is checkpointed
-
-The nightly runs as **five idempotent stages** — `essence` → `promote` → `kb` → `compress` → `state` — each its own bounded harness turn. After every completed stage phantombot writes `.nightly-progress.json`. If a stage times out, or the box powers off mid-run, the next invocation (`phantombot nightly --resume`, the startup catch-up, or `phantombot doctor`) skips the finished stages and continues. A timeout therefore costs at most one stage, never the whole night. The final result is recorded in `.nightly-state.json` (`last_run`, `last_status`, item counts).
-
-### Health check
-
-`phantombot doctor` reads `.nightly-state.json`, `.nightly-progress.json` and `capture_log`, and reports — then auto-repairs — memory-subsystem problems: a nightly that never ran, errored, or is >24h stale; a partial checkpoint left behind; or a "dry day" (≥20 real user turns with zero captures). When repair is warranted it spawns a detached `phantombot nightly --resume`. The `run` startup catch-up routes through the same logic, so a box powered off overnight self-heals on next boot.
-
-### Semantic search (optional)
-
-Memory search has two modes. **Keyword search (FTS5/BM25)** is always on, needs no setup, and matches on the actual words in a note. **Semantic (vector) search** is an *optional* enhancement: it embeds your text into vectors so search can match on **meaning**, not just exact words — e.g. asking "how do I pay tax" can surface a note titled "VAT filing steps" even though they share no keywords.
-
-**Why it's nice.** Phantombot retrieves relevant memories automatically on every turn (the auto-retrieval "instinct" layer) and indexes past conversation turns so older context can resurface. With embeddings on, that retrieval runs as **hybrid** (keyword + semantic) and finds conceptually-related memories the keyword half would miss. It's what makes recall feel like instinct rather than grep.
-
-**Why it's optional.** Everything works without it. With no embedding key configured, the provider resolves to `none`, search degrades cleanly to keyword-only, and **nothing errors** — auto-retrieval still runs, just on FTS. Most users never need to touch this. It is an enhancement, not a requirement.
-
-**How to tell which mode you're in.** `phantombot doctor` prints an informational `embeddings:` line (semantic ON, or off with keyword search active), and `phantombot run` prints a one-line heads-up at startup when semantic search is off. Neither is a warning — off is a valid, fully-working state.
-
-**How to enable it.** Easiest is the interactive TUI, which validates your key before saving:
+Useful commands:
 
 ```bash
-phantombot embedding          # pick Gemini, paste an API key (or pick "none")
-phantombot memory index --rebuild   # backfill embeddings for existing notes
+phantombot memory today
+phantombot memory capture "Decision: use Pi as primary harness" --tag decision
+phantombot memory search "Pi primary harness"
+phantombot memory get memory/decisions.md
+phantombot memory list kb
+phantombot memory index --rebuild
 ```
 
-The `phantombot init` setup wizard also offers this as an optional step. You can equally set it by hand — either `PHANTOMBOT_GEMINI_API_KEY` in the environment, or an `[embeddings]` block in `config.toml`:
+### Semantic Search
+
+Keyword search works by default. Semantic search is optional and recommended.
+It uses Gemini embeddings so memory retrieval can match meaning, not just exact
+words.
+
+Enable it:
+
+```bash
+phantombot embedding
+phantombot memory index --rebuild
+```
+
+Equivalent TOML:
 
 ```toml
 [embeddings]
 provider = "gemini"
 
 [embeddings.gemini]
-api_key = "AIza…"            # https://aistudio.google.com/app/apikey
-model   = "gemini-embedding-001"
-dims    = 1536
+api_key = "AIza..."
+model = "gemini-embedding-001"
+dims = 1536
 ```
 
-Get a key at <https://aistudio.google.com/app/apikey>. The default model is free up to ~1500 requests/day on Gemini's free tier, and the nightly cycle only re-embeds changed notes, so steady-state usage is tiny. To turn it back off, run `phantombot embedding` and pick **none** (your key is preserved in `config.toml` so re-enabling doesn't require re-validating).
+Without embeddings, search degrades cleanly to FTS-only.
 
----
+### Nightly and Doctor
 
-## OpenClaw persona import
+The nightly distillation is checkpointed in five stages:
+
+```text
+essence -> promote -> kb -> compress -> state
+```
+
+If it times out or the machine restarts, `phantombot nightly --resume`
+continues from the checkpoint.
+
+`phantombot doctor` checks memory health and can auto-repair stale, failed, or
+partial nightly runs.
+
+## Maintenance
+
+Install service units:
 
 ```bash
-phantombot persona --import /path/to/openclaw-agent --as robbie [--no-telegram]
+phantombot install
 ```
 
-Recognized files (any layout works):
+Installed user units:
 
-| Slot | Filenames (first match wins) |
+| Unit | Cadence | Purpose |
+|---|---|---|
+| `phantombot.service` | Always on | Telegram listener |
+| `phantombot-tick.timer` | Every minute | Scheduled task runner |
+| `phantombot-heartbeat.timer` | Every 30 minutes | Mechanical maintenance |
+| `phantombot-nightly.timer` | Daily | LLM-backed memory distillation |
+
+Update commands:
+
+```bash
+phantombot update
+phantombot update --check
+phantombot update --force --restart
+```
+
+Updates download to a temporary file, verify SHA256, atomically rename over the
+live binary, and clean up after themselves.
+
+The heartbeat checks for new releases automatically, waits 72 hours after a
+release, then sends a Telegram `/update` heads-up. Manual update commands are
+immediate.
+
+## Architecture
+
+```text
+Telegram getUpdates
+        |
+        v
+Telegram adapter
+        |
+        |-- slash command handler
+        |-- group routing gate
+        |-- attachment / voice handling
+        |
+        v
+Turn coordinator
+        |
+        |-- load persona markdown
+        |-- load rolling conversation context
+        |-- retrieve memory / KB hits
+        |
+        v
+Harness chain: pi -> claude -> gemini -> codex
+        |
+        |-- native harness tool loop
+        |-- fallback on recoverable failure
+        |
+        v
+Persist turn and send Telegram reply
+```
+
+Tool execution happens inside the harness. Phantombot only coordinates the
+turn, memory, channel behavior, and runtime services.
+
+## Build From Source
+
+Bun is only required for source builds. Released binaries have no Bun runtime
+dependency.
+
+Important: the x64 build target must remain `bun-linux-x64-baseline`. Building
+plain `bun-linux-x64` can produce binaries that SIGILL on hosts without AVX2.
+
+```bash
+git clone https://github.com/phantomyard/phantombot.git
+cd phantombot
+bun install
+bun run build
+
+mkdir -p ~/.local/bin
+cp dist/phantombot ~/.local/bin/phantombot
+```
+
+Arm64 cross-build:
+
+```bash
+bun run build:arm64
+```
+
+## Project Layout
+
+```text
+phantombot/
+  README.md
+  AGENTS.md
+  install.sh
+  docs/
+    architecture.md
+    adding-a-harness.md
+  src/
+    index.ts
+    version.ts
+    config.ts
+    state.ts
+    persona/
+    memory/
+    importer/
+    orchestrator/
+    channels/
+    cli/
+    harnesses/
+    lib/
+  agents/phantom/
+  tests/
+  .github/workflows/release.yml
+  package.json
+  bunfig.toml
+  tsconfig.json
+```
+
+## OpenClaw Persona Import
+
+```bash
+phantombot persona --import /path/to/openclaw-agent --as robbie
+```
+
+Recognized files:
+
+| Slot | Filenames, first match wins |
 |---|---|
-| identity (required) | `BOOT.md` → `SOUL.md` → `IDENTITY.md` |
-| persistent memory | `MEMORY.md` |
-| tools / hints | `tools.md` → `AGENTS.md` |
+| Identity | `BOOT.md`, `SOUL.md`, `IDENTITY.md` |
+| Persistent memory | `MEMORY.md` |
+| Tools / hints | `tools.md`, `AGENTS.md` |
 
-Bonus `.md` files come along too. SQLite, JSONL, dotfiles, subdirs (other than `memory/` and `kb/`) are skipped with reasons in the summary. **Conversation history is not imported in v1.**
+Additional markdown files are copied. SQLite, JSONL, dotfiles, and unrelated
+subdirectories are skipped with reasons in the summary. Conversation history is
+not imported.
 
-By default the import also sniffs `~/.openclaw/openclaw.json` for a Telegram bot block; if found, it writes to `[channels.telegram]`. Pass `--no-telegram` to skip.
-
----
+By default, import also sniffs `~/.openclaw/openclaw.json` for a Telegram bot
+block. Pass `--no-telegram` to skip that.
 
 ## Versioning
 
-`major.minor.patch`, where **patch is the GitHub PR number**. Every merged PR auto-tags `v1.0.<PR_NUMBER>`, builds binaries, publishes a release. Intentionally not semver — `1.0.42` is "patch" of `1.0.41` only by coincidence (PRs aren't ordered by semantic impact). Don't bolt semver-aware logic onto `phantombot update`.
+Versions use `major.minor.patch`, where `patch` is the GitHub PR number.
+Merged PR #142 publishes `v1.0.142`.
 
----
+This is intentionally not semantic versioning. Do not add semver-aware update
+logic.
 
-## Layout
+## Design Principles
 
-```
-phantombot/
-├── README.md                      # this file
-├── AGENTS.md                      # contributor guide — read first if you're adding code
-├── install.sh                     # one-liner installer (curl … | sh)
-├── docs/
-│   ├── architecture.md
-│   └── adding-a-harness.md
-├── src/
-│   ├── index.ts                   # entry; runs the Citty dispatcher
-│   ├── version.ts                 # CI sed-replaces "0.1.0-dev" with "1.0.<PR_NUMBER>"
-│   ├── config.ts state.ts
-│   ├── persona/                   # loader + builder (system-prompt sections)
-│   ├── memory/                    # bun:sqlite store (turns + capture_log)
-│   ├── importer/                  # OpenClaw → phantombot persona import
-│   ├── orchestrator/              # turn coordinator + harness fallback chain
-│   ├── channels/telegram.ts       # Telegram adapter (HTTP + long-poll)
-│   ├── cli/                       # one file per Citty subcommand
-│   ├── harnesses/                 # pi + claude + gemini + codex wrappers
-│   └── lib/                       # logger, IO, configWriter, systemd, audio,
-│                                  # tasks, cronSchedule, binaryUpdate, githubReleases…
-├── agents/phantom/                # placeholder persona used by tests
-├── tests/                         # bun test
-├── .github/workflows/release.yml  # auto-release per merged PR
-└── package.json bunfig.toml tsconfig.json
-```
-
----
-
-## Design principles
-
-- **Small.** The CLI surface is deliberate. If you're tempted to build a model-provider abstraction, a tool-call translator, or a multi-tenant model, stop — you're rebuilding what we're explicitly *not* using.
-- **Harness-agnostic interface, harness-specific implementations.** Every harness wrapper translates the same `HarnessRequest` into its CLI's specific flags. No shared "model spec." See `src/harnesses/claude.ts` for the reference shape.
-- **Personality lives in markdown files, not config.** Persona changes are commits to `BOOT.md`, not config-knob flips. The TUI is bootstrap-only.
-- **Memory is local.** SQLite on disk. No cloud sync.
-- **OAuth on host. Phantombot holds no model API keys.** Pi / Claude / Gemini are pre-configured by you; phantombot just spawns them.
-- **Single-operator.** One person, one machine, one persona at a time.
-- **Updates are atomic.** `phantombot update` rename-swaps the binary on Linux (kernel keeps the running process backed by the original inode), SHA256-verifies before swap, and cleans up after itself — no `.bak` files left behind.
-
----
+- Keep the runtime small.
+- Let harnesses own tools and model behavior.
+- Store personality in markdown, not config knobs.
+- Keep memory local and inspectable.
+- Prefer host OAuth for model CLIs.
+- Make updates atomic.
+- Keep Telegram behavior predictable in both DMs and groups.
 
 ## Contributing
 
-Read [`AGENTS.md`](AGENTS.md) first. The contributing discipline: README and AGENTS must stay in sync with the code on every PR.
+Read [`AGENTS.md`](AGENTS.md) before changing code.
+
+README and AGENTS must stay in sync with behavior on every PR.
 
 ```bash
 bun install
-bun tsc --noEmit       # typecheck
-bun test               # full suite
-bun run build          # → dist/phantombot
+bun tsc --noEmit
+bun test
+bun run build
 ```
-
----
 
 ## Acknowledgements
 
-The motivating insight (*"the harness can do its own tools — let it"*) and the initial Claude harness implementation came from work on a Claude-Code proxy on the OpenClaw VPS. The five-patch reasoning at the top of `src/harnesses/claude.ts` (stdin prompt, `--system-prompt` separation, `bypassPermissions`, `--fallback-model`, no `--bare`) is the basis for the harness here.
+The initial Claude harness design came from work on a Claude Code proxy on the
+OpenClaw VPS. The same reasoning carries into phantombot: pass the persona as a
+real system prompt, send large prompts through stdin, use the harness's native
+permission and fallback mechanisms, and avoid reimplementing its tool layer.

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -95,15 +95,40 @@ export interface SlashCommandResult {
   afterSend?: () => Promise<void>;
 }
 
+/**
+ * The canonical list of slash commands phantombot actually implements.
+ *
+ * Single source of truth for two consumers:
+ *   1. {@link HELP} — the `/help` reply text (derived below).
+ *   2. The Telegram `setMyCommands` registration at channel startup,
+ *      which OVERWRITES whatever is in the bot's command menu — including
+ *      "ghost" commands a human added in BotFather (e.g. `/activation`)
+ *      that phantombot has no handler for. Without this, the `/` typeahead
+ *      in Telegram advertises commands that silently fall through to the
+ *      LLM, which is exactly the confusing behaviour we want to kill.
+ *
+ * `command` is the bare name (no leading slash) per the Bot API. Keep
+ * descriptions short — Telegram renders them inline in the menu and caps
+ * them at 256 chars.
+ */
+export const TELEGRAM_BOT_COMMANDS: Array<{
+  command: string;
+  description: string;
+}> = [
+  { command: "stop", description: "Abort the current turn" },
+  { command: "reset", description: "Clear this chat's history" },
+  { command: "status", description: "Show harness, uptime, context usage" },
+  { command: "harness", description: "List or switch the active harness" },
+  { command: "update", description: "Install the latest phantombot release" },
+  { command: "restart", description: "Restart the phantombot service" },
+  { command: "help", description: "Show this command list" },
+];
+
 const HELP =
   `available commands:\n` +
-  `/stop     — abort the current turn\n` +
-  `/reset    — clear this chat's history\n` +
-  `/status   — show harness, uptime, context usage\n` +
-  `/harness  — list or switch the active harness (e.g. /harness pi)\n` +
-  `/update   — install the latest phantombot release if newer than this build\n` +
-  `/restart  — restart the phantombot service\n` +
-  `/help     — this list`;
+  TELEGRAM_BOT_COMMANDS.map((c) => `/${c.command} — ${c.description}`).join(
+    "\n",
+  );
 
 /**
  * Parse + dispatch a slash command.

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -78,6 +78,13 @@ export interface SlashCommandContext {
    * runUpdateFlow.
    */
   serviceControl?: ServiceControl;
+  /**
+   * This bot's own @username (from startup getMe). Used to validate the
+   * `/cmd@BotName` suffix in groups: a command explicitly targeted at a
+   * different bot must NOT be handled here. Undefined if getMe failed or
+   * in contexts (DMs, tests) where targeting is irrelevant.
+   */
+  botUsername?: string;
 }
 
 export interface SlashCommandResult {
@@ -131,11 +138,37 @@ const HELP =
   );
 
 /**
+ * Extract the `@BotName` target from a slash command head, if present.
+ *
+ *   "/status@kai_agh_bot foo" → "kai_agh_bot"
+ *   "/status foo"             → undefined
+ *   "/status@"                → undefined (empty target)
+ *
+ * Telegram lets a user disambiguate which bot a command is for by
+ * appending `@<bot-username>`. Exported for the channel's group gate and
+ * for testing.
+ */
+export function slashCommandTarget(text: string): string | undefined {
+  const head = text.trim().split(/\s+/)[0] ?? "";
+  const at = head.indexOf("@");
+  if (at < 0) return undefined;
+  const target = head.slice(at + 1);
+  return target.length > 0 ? target : undefined;
+}
+
+/**
  * Parse + dispatch a slash command.
  *
  * Returns null if `text` is not a slash command we own — caller falls
  * through to the LLM for that message. Returns a SlashCommandResult when
  * the command is handled (recognized or refused).
+ *
+ * Group targeting: a `/cmd@BotName` whose `@BotName` names a *different*
+ * bot than this one returns null (we don't own it). Without this check a
+ * state-changing command like `/reset@otherbot` would be executed by
+ * every bot in the group, not just the addressed one. The check is only
+ * applied when `ctx.botUsername` is known; otherwise we keep the legacy
+ * behavior of stripping the suffix and handling the command.
  */
 export async function handleSlashCommand(
   text: string,
@@ -144,8 +177,19 @@ export async function handleSlashCommand(
   const trimmed = text.trim();
   if (!trimmed.startsWith("/")) return null;
 
-  // Telegram convention in groups: `/cmd@BotName arg1 arg2`. Strip the
-  // @suffix so the command matches whether the bot was @-mentioned or not.
+  // Telegram convention in groups: `/cmd@BotName arg1 arg2`. If the
+  // @suffix names a different bot, this command isn't ours — fall through.
+  const target = slashCommandTarget(trimmed);
+  if (
+    target &&
+    ctx.botUsername &&
+    target.toLowerCase() !== ctx.botUsername.toLowerCase()
+  ) {
+    return null;
+  }
+
+  // Strip the @suffix so the command matches whether the bot was
+  // @-mentioned or not.
   const parts = trimmed.split(/\s+/);
   const head = parts[0]!;
   const cmd = head.split("@")[0]!.toLowerCase();

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -50,6 +50,7 @@ import { makeTurnIndexer } from "../orchestrator/turnIndexer.ts";
 import {
   type ActiveTurnHandle,
   handleSlashCommand,
+  slashCommandTarget,
   TELEGRAM_BOT_COMMANDS,
 } from "./commands.ts";
 import { telegramGetMe } from "../lib/telegramApi.ts";
@@ -1150,11 +1151,53 @@ export async function runTelegramServer(
           captionLength: msg.caption?.length,
         });
 
+        const isGroupChat =
+          msg.chatType === "group" || msg.chatType === "supergroup";
+
         // Slash commands: handled INLINE so they bypass the per-chat queue
         // and any in-flight turn. Voice messages are never slash commands
         // (the body is empty until STT runs, by which point we've already
         // committed to the LLM path).
         if (!isVoice && msg.text.startsWith("/")) {
+          // Group addressing applies to slash commands too. With privacy
+          // mode off, EVERY bot in the group receives the command, so an
+          // ungated /reset, /stop, /restart would fan out and act on every
+          // bot at once. Decide eligibility the same way we gate normal
+          // messages, but using the slash-specific `@BotName` target:
+          //   - `/cmd@thisbot`   → only this bot acts.
+          //   - `/cmd@otherbot`  → another bot's command; stay silent.
+          //   - `/cmd` (no @)    → only the bot the thread is currently
+          //                        with acts (sticky). If nobody is sticky
+          //                        yet, stay silent — the user can target a
+          //                        bot explicitly with `/cmd@botname`.
+          // (DMs skip all of this; isGroupChat is false there.)
+          if (isGroupChat) {
+            const target = slashCommandTarget(msg.text);
+            if (target) {
+              if (
+                !botUsername ||
+                target.toLowerCase() !== botUsername.toLowerCase()
+              ) {
+                log.info("telegram: slash for another bot — ignoring", {
+                  chatId: msg.chatId,
+                  persona: input.persona,
+                  target,
+                });
+                continue;
+              }
+            } else {
+              const sticky = (
+                groupChats.get(msg.chatId)?.lastAddressed ?? []
+              ).some((n) => n.toLowerCase() === selfName.toLowerCase());
+              if (!sticky) {
+                log.info("telegram: untargeted group slash, not sticky — ignoring", {
+                  chatId: msg.chatId,
+                  persona: input.persona,
+                });
+                continue;
+              }
+            }
+          }
           const result = await handleSlashCommand(msg.text, {
             chatId: msg.chatId,
             persona: input.persona,
@@ -1165,6 +1208,7 @@ export async function runTelegramServer(
             activeTurn: activeTurns.get(msg.chatId),
             config: input.config,
             serviceControl: input.serviceControl,
+            botUsername,
           });
           if (result) {
             try {
@@ -1207,8 +1251,6 @@ export async function runTelegramServer(
         // with. Messages aimed at another bot are still buffered (for later
         // context) but produce no reply. DMs skip this entirely.
         let groupContext: string | undefined;
-        const isGroupChat =
-          msg.chatType === "group" || msg.chatType === "supergroup";
         if (isGroupChat) {
           const state = groupChats.get(msg.chatId) ?? {
             lastAddressed: [],

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -772,6 +772,98 @@ export function stripBotMention(
 }
 
 /**
+ * Find which of `names` are addressed in `text`. A name matches
+ * case-insensitively when bounded by non-letters, so "robbie" matches
+ * inside "@robbie_agh_bot", "Robbie," or "robbie!" but NOT "robbiee" or
+ * "scrobbie". Returns the matched names in the order they appear in
+ * `names` (deduped, original casing preserved). Exported for testing.
+ */
+export function matchPersonaNames(text: string, names: string[]): string[] {
+  if (text.length === 0 || names.length === 0) return [];
+  const out: string[] = [];
+  for (const name of names) {
+    if (name.length === 0 || out.some((n) => n.toLowerCase() === name.toLowerCase())) {
+      continue;
+    }
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Letter boundaries (not \b, which treats "_" as a word char and so
+    // would fail to match "robbie" inside "robbie_agh_bot").
+    const re = new RegExp(`(?<![a-z])${escaped}(?![a-z])`, "i");
+    if (re.test(text)) out.push(name);
+  }
+  return out;
+}
+
+/**
+ * Decide whether THIS bot (persona `self`) should reply to a group message,
+ * and what the chat's "last addressed" set becomes afterwards.
+ *
+ * Rules (all computed locally — Telegram never shows a bot another bot's
+ * messages, so this must work from the human message stream alone, which
+ * every bot in the group sees identically):
+ *   - One or more persona names are in the message → those bots are now
+ *     "addressed". I reply iff my own name is among them. Multiple names →
+ *     each named bot replies independently.
+ *   - No persona name at all → the message continues the current thread, so
+ *     only the bot(s) addressed last reply. I reply iff I'm in lastAddressed.
+ *   - No name AND nobody has ever been addressed (lastAddressed empty) →
+ *     silence, full stop.
+ *
+ * Exported for testing.
+ */
+export function decideGroupReply(input: {
+  self: string;
+  matched: string[];
+  lastAddressed: string[];
+}): { reply: boolean; nextLastAddressed: string[] } {
+  const eq = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+  if (input.matched.length > 0) {
+    return {
+      reply: input.matched.some((n) => eq(n, input.self)),
+      nextLastAddressed: input.matched,
+    };
+  }
+  return {
+    reply: input.lastAddressed.some((n) => eq(n, input.self)),
+    nextLastAddressed: input.lastAddressed,
+  };
+}
+
+/**
+ * Render the human messages a bot OBSERVED but didn't reply to (because they
+ * were aimed at another bot or were thread chatter) into a context preamble.
+ * Privacy-OFF means every bot sees every human message, so this is how a bot
+ * catches up on the conversation it stayed quiet through before it's finally
+ * addressed. Returns "" when there's nothing buffered. Exported for testing.
+ */
+export function formatGroupContext(
+  entries: { from: string; text: string }[],
+): string {
+  const lines = entries
+    .map((e) => `${e.from}: ${e.text}`.trim())
+    .filter((l) => l.length > 0);
+  if (lines.length === 0) return "";
+  return [
+    "[Recent group messages you saw but didn't reply to, for context:",
+    ...lines,
+    "]",
+  ].join("\n");
+}
+
+/** In-memory per-chat group routing state. Lives for the process lifetime;
+ *  intentionally not persisted (it's cheap to rebuild from the live stream
+ *  and bounded to GROUP_BUFFER_MAX entries per chat). */
+interface GroupChatState {
+  /** Persona names addressed by the most recent name-bearing message. */
+  lastAddressed: string[];
+  /** Rolling buffer of recent human messages for context catch-up. */
+  buffer: { from: string; text: string; delivered: boolean }[];
+}
+
+/** Cap on buffered human messages retained per group chat. */
+export const GROUP_BUFFER_MAX = 20;
+
+/**
  * Pure parser exposed for testing. Consumes Telegram getUpdates result
  * objects and returns the messages we care about — text or voice.
  */
@@ -950,6 +1042,26 @@ export async function runTelegramServer(
   // Set of every in-flight worker promise — drained at shutdown / oneShot.
   const inFlight = new Set<Promise<void>>();
 
+  // Per-chat group routing state (last-addressed bot + recent-message
+  // buffer). Only touched for group/supergroup chats; DMs never key in.
+  const groupChats = new Map<number, GroupChatState>();
+  // This bot's own addressing name in groups. The persona name is the
+  // canonical token (matches the configured group_persona_names list);
+  // if getMe succeeded we also accept the bare @username stem so a literal
+  // "@robbie_agh_bot" still counts as addressing even when the persona name
+  // differs from the bot username.
+  const selfName = input.persona;
+  const groupPersonaNames = (() => {
+    const configured = tg.groupPersonaNames ?? [];
+    // Always include our own persona name so a single-bot group works with
+    // zero config; dedup case-insensitively, preserve configured order.
+    const merged = [...configured];
+    if (!merged.some((n) => n.toLowerCase() === selfName.toLowerCase())) {
+      merged.push(selfName);
+    }
+    return merged;
+  })();
+
   if (allowedSet.size === 0) {
     log.warn(
       "telegram: no allowed_user_ids configured — anyone who DMs the bot is answered",
@@ -1087,6 +1199,96 @@ export async function runTelegramServer(
           // Unrecognized /command — fall through to the LLM.
         }
 
+        // Group reply gate. In a group/supergroup, privacy mode is OFF so
+        // we receive every human message — but we must only SPEAK when
+        // addressed (by name) or when we're the bot the thread is currently
+        // with. Messages aimed at another bot are still buffered (for later
+        // context) but produce no reply. DMs skip this entirely.
+        let groupContext: string | undefined;
+        const isGroupChat =
+          msg.chatType === "group" || msg.chatType === "supergroup";
+        if (isGroupChat) {
+          const state = groupChats.get(msg.chatId) ?? {
+            lastAddressed: [],
+            buffer: [],
+          };
+          const matchText = [msg.text, msg.caption]
+            .filter((s): s is string => Boolean(s && s.length > 0))
+            .join(" ");
+          const matched = matchPersonaNames(matchText, groupPersonaNames);
+          // Being @mentioned by our own bot username also counts as being
+          // addressed, even when the persona name isn't a substring of the
+          // username. Fold it into the matched set AS our persona name so
+          // the shared, name-based routing treats it uniformly (and other
+          // bots — which can't know our @username — still agree via the
+          // persona-name match they DO see).
+          const selfViaUsername = botUsername
+            ? matchPersonaNames(matchText, [botUsername]).length > 0
+            : false;
+          const effectiveMatched =
+            selfViaUsername &&
+            !matched.some((n) => n.toLowerCase() === selfName.toLowerCase())
+              ? [...matched, selfName]
+              : matched;
+          const decision = decideGroupReply({
+            self: selfName,
+            matched: effectiveMatched,
+            lastAddressed: state.lastAddressed,
+          });
+          state.lastAddressed = decision.nextLastAddressed;
+
+          // What to retain in the rolling buffer for context catch-up.
+          // Text messages keep their words; voice/attachments keep a label
+          // so the thread reads coherently even where we have no transcript.
+          const bufText =
+            msg.text.trim().length > 0
+              ? msg.text.trim()
+              : (msg.caption?.trim() ||
+                (msg.voice
+                  ? "[voice message]"
+                  : msg.attachment
+                    ? `[${msg.attachment.kind}]`
+                    : ""));
+          const fromLabel = msg.fromUsername
+            ? `@${msg.fromUsername}`
+            : String(msg.fromUserId);
+
+          if (!decision.reply) {
+            if (bufText.length > 0) {
+              state.buffer.push({
+                from: fromLabel,
+                text: bufText,
+                delivered: false,
+              });
+            }
+            while (state.buffer.length > GROUP_BUFFER_MAX) state.buffer.shift();
+            groupChats.set(msg.chatId, state);
+            log.info("telegram: group message not for this bot — staying quiet", {
+              chatId: msg.chatId,
+              persona: input.persona,
+              matched,
+              lastAddressed: state.lastAddressed,
+            });
+            continue;
+          }
+
+          // We're replying: hand the harness any messages we observed but
+          // never answered as a context preamble, then mark the buffer
+          // delivered and record this turn.
+          const undelivered = state.buffer.filter((e) => !e.delivered);
+          groupContext = formatGroupContext(undelivered) || undefined;
+          for (const e of state.buffer) e.delivered = true;
+          if (bufText.length > 0) {
+            state.buffer.push({
+              from: fromLabel,
+              text: bufText,
+              delivered: true,
+            });
+          }
+          while (state.buffer.length > GROUP_BUFFER_MAX) state.buffer.shift();
+          groupChats.set(msg.chatId, state);
+        }
+
         // Regular message. If a turn is already in flight for this
         // chat, abort it — the user typing again means "pay attention
         // to this instead." The aborted turn returns silently via the
@@ -1114,6 +1316,7 @@ export async function runTelegramServer(
             harnesses,
             activeTurns,
             botUsername,
+            groupContext,
           }),
         );
         // Detach completed entries so the maps don't leak.
@@ -1151,6 +1354,10 @@ async function processChatMessage(
      *  addressing mention from group messages. Undefined if getMe
      *  failed — stripping then no-ops. */
     botUsername?: string;
+    /** Recent group messages this bot observed but didn't answer,
+     *  pre-rendered as a context preamble. Prepended to the user text so
+     *  the harness has the thread it stayed quiet through. */
+    groupContext?: string;
   },
 ): Promise<void> {
   const { input, harnesses, activeTurns } = ctx;
@@ -1304,6 +1511,14 @@ async function processChatMessage(
   if (msg.replyTo) {
     const prefix = formatReplyToContext(msg.replyTo);
     msg.text = msg.text.length > 0 ? `${prefix}\n\n${msg.text}` : prefix;
+  }
+  // Group catch-up context goes at the very top, above any reply-quote, so
+  // the harness reads the room before the specific turn it's answering.
+  if (ctx.groupContext) {
+    msg.text =
+      msg.text.length > 0
+        ? `${ctx.groupContext}\n\n${msg.text}`
+        : ctx.groupContext;
   }
   const sendStatus = () =>
     willReplyWithVoice

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -861,7 +861,7 @@ interface GroupChatState {
 }
 
 /** Cap on buffered human messages retained per group chat. */
-export const GROUP_BUFFER_MAX = 20;
+export const GROUP_BUFFER_MAX = 100;
 
 /**
  * Pure parser exposed for testing. Consumes Telegram getUpdates result

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -50,7 +50,9 @@ import { makeTurnIndexer } from "../orchestrator/turnIndexer.ts";
 import {
   type ActiveTurnHandle,
   handleSlashCommand,
+  TELEGRAM_BOT_COMMANDS,
 } from "./commands.ts";
+import { telegramGetMe } from "../lib/telegramApi.ts";
 import { markdownToTelegramHtml } from "./telegramFormat.ts";
 import {
   splitIntoSegments,
@@ -152,6 +154,12 @@ export interface TelegramMessage {
   chatId: number;
   fromUserId: number;
   fromUsername?: string;
+  /** Telegram chat type: "private" for DMs, "group"/"supergroup" for
+   *  group chats, "channel" for channels. Drives group-only behaviour
+   *  like stripping the bot's @username mention from the text. Absent
+   *  when Telegram didn't include it (older/odd payloads) — callers treat
+   *  the absence as "not a group" (i.e. no mention stripping). */
+  chatType?: "private" | "group" | "supergroup" | "channel";
   /** For text messages — the text. For voice messages — empty string until
    *  STT runs. For attachment-only messages — empty until processChatMessage
    *  rewrites it to "<caption>\n\n[attached: <path>]". */
@@ -209,6 +217,22 @@ export interface TelegramTransport {
   sendRecording(chatId: number): Promise<void>;
   /** Download a file by Telegram file_id; returns audio bytes + content-type. */
   downloadFile(fileId: string): Promise<{ data: Buffer; mime: string }>;
+  /**
+   * Fetch the bot's own identity. Used once at startup to learn the
+   * bot's @username so group messages that mention it can have the
+   * mention stripped before dispatch. Optional so lightweight test
+   * transports don't have to implement it — callers guard with `?.`.
+   */
+  getMe?(): Promise<{ ok: true; username: string } | { ok: false }>;
+  /**
+   * Register the bot's slash-command menu with Telegram (the `/`
+   * typeahead). Called once at startup to OVERWRITE any commands a human
+   * set in BotFather — including ghost commands phantombot has no handler
+   * for. Optional for the same reason as getMe.
+   */
+  setMyCommands?(
+    commands: Array<{ command: string; description: string }>,
+  ): Promise<void>;
 }
 
 /**
@@ -401,6 +425,34 @@ export class HttpTelegramTransport implements TelegramTransport {
       file.headers.get("content-type") ?? guessMimeFromPath(metaBody.result.file_path);
     return { data, mime };
   }
+
+  async getMe(): Promise<{ ok: true; username: string } | { ok: false }> {
+    const r = await telegramGetMe(this.token);
+    return r.ok ? { ok: true, username: r.username } : { ok: false };
+  }
+
+  async setMyCommands(
+    commands: Array<{ command: string; description: string }>,
+  ): Promise<void> {
+    const url = `https://api.telegram.org/bot${this.token}/setMyCommands`;
+    // No `scope` → Telegram's default scope (BotCommandScopeDefault),
+    // which is the one BotFather's manual /setcommands writes to. Passing
+    // our full list here replaces whatever was there, so ghost commands
+    // vanish from the `/` menu in both DMs and groups.
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ commands }),
+    }).catch((e) => {
+      log.warn("telegram: setMyCommands fetch failed", {
+        error: (e as Error).message,
+      });
+      return undefined;
+    });
+    if (res && !res.ok) {
+      log.warn("telegram: setMyCommands non-OK", { status: res.status });
+    }
+  }
 }
 
 function guessMimeFromPath(path: string): string {
@@ -451,7 +503,7 @@ interface TelegramRawUpdate {
   update_id?: number;
   message?: {
     message_id?: number;
-    chat?: { id?: number };
+    chat?: { id?: number; type?: string };
     from?: { id?: number; username?: string };
     text?: string;
     caption?: string;
@@ -666,6 +718,60 @@ export function extensionFromMime(mime: string | undefined): string {
 }
 
 /**
+ * Narrow Telegram's free-string `chat.type` to the set we model. Unknown
+ * / missing values return undefined, which downstream code treats as
+ * "not a group" — the safe default (no mention stripping). Exported for
+ * testing.
+ */
+export function normalizeChatType(
+  raw: string | undefined,
+): TelegramMessage["chatType"] | undefined {
+  switch (raw) {
+    case "private":
+    case "group":
+    case "supergroup":
+    case "channel":
+      return raw;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Strip the bot's own `@username` mention from a group message so the
+ * harness sees the user's actual words, not the addressing noise. With
+ * Telegram privacy mode ON, the ONLY way a group message reaches the bot
+ * (short of a slash command or a reply) is by mentioning its @username —
+ * so the literal "@robbie_agh_bot " is present in essentially every group
+ * turn and would otherwise pollute the prompt.
+ *
+ * Removes every standalone, case-insensitive occurrence of `@username`
+ * (Telegram usernames are case-insensitive), then collapses the
+ * whitespace the removal leaves behind. A mention glued to other word
+ * characters (e.g. an email-like "x@usernamey") is NOT a Telegram mention
+ * and is left untouched via the word-boundary guards.
+ *
+ * No-ops when `username` is unknown (getMe failed at startup) or the text
+ * doesn't contain the mention. Exported for testing.
+ */
+export function stripBotMention(
+  text: string,
+  username: string | undefined,
+): string {
+  if (!username || text.length === 0) return text;
+  // Escape any regex-special chars in the username (usernames are
+  // [A-Za-z0-9_] so this is belt-and-braces) and match it only when
+  // preceded by start/whitespace and followed by end/whitespace/punct —
+  // i.e. a real standalone mention, not a substring of a larger token.
+  const escaped = username.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`(^|\\s)@${escaped}\\b`, "gi");
+  const stripped = text.replace(re, "$1");
+  // Collapse the doubled whitespace a mid-string removal can leave, and
+  // trim the edges. Keep internal single spaces/newlines otherwise intact.
+  return stripped.replace(/[ \t]{2,}/g, " ").trim();
+}
+
+/**
  * Pure parser exposed for testing. Consumes Telegram getUpdates result
  * objects and returns the messages we care about — text or voice.
  */
@@ -694,6 +800,10 @@ export function parseGetUpdatesResult(
     // attachment, but all three paths benefit from carrying it through.
     const replyTo = extractReplyTo(msg.reply_to_message);
 
+    // Chat type drives group-only behaviour (mention stripping). Parsed
+    // once and spread into whichever envelope we push, like replyTo.
+    const chatType = normalizeChatType(msg.chat?.type);
+
     // Attachments take priority over plain text, but if BOTH text and an
     // attachment are present (rare; Telegram normally uses `caption` not
     // `text` for media), use text as the caption.
@@ -714,6 +824,7 @@ export function parseGetUpdatesResult(
         caption: captionFromMedia ?? captionFromText,
         attachment,
         ...(replyTo ? { replyTo } : {}),
+        ...(chatType ? { chatType } : {}),
       });
       continue;
     }
@@ -725,6 +836,7 @@ export function parseGetUpdatesResult(
         fromUsername: msg.from.username,
         text: msg.text,
         ...(replyTo ? { replyTo } : {}),
+        ...(chatType ? { chatType } : {}),
       });
       continue;
     }
@@ -741,6 +853,7 @@ export function parseGetUpdatesResult(
           durationS: msg.voice.duration ?? 0,
         },
         ...(replyTo ? { replyTo } : {}),
+        ...(chatType ? { chatType } : {}),
       });
     }
   }
@@ -841,6 +954,42 @@ export async function runTelegramServer(
     log.warn(
       "telegram: no allowed_user_ids configured — anyone who DMs the bot is answered",
     );
+  }
+
+  // One-time startup handshake (best-effort, never blocks the loop):
+  //   1. getMe → learn our own @username so group messages that address
+  //      us by mention can have the "@bot" stripped before dispatch.
+  //   2. setMyCommands → register the real command menu, overwriting any
+  //      ghost commands a human left in BotFather (e.g. /activation).
+  // Both are wrapped so a transient Telegram hiccup at boot can't keep
+  // the listener out of its poll loop.
+  let botUsername: string | undefined;
+  try {
+    const me = await input.transport.getMe?.();
+    if (me?.ok) {
+      botUsername = me.username;
+      log.info("telegram: identified self", {
+        username: botUsername,
+        persona: input.persona,
+      });
+    }
+  } catch (e) {
+    log.warn("telegram: getMe failed at startup", {
+      error: (e as Error).message,
+    });
+  }
+  try {
+    if (input.transport.setMyCommands) {
+      await input.transport.setMyCommands(TELEGRAM_BOT_COMMANDS);
+      log.info("telegram: registered command menu", {
+        count: TELEGRAM_BOT_COMMANDS.length,
+        persona: input.persona,
+      });
+    }
+  } catch (e) {
+    log.warn("telegram: setMyCommands failed at startup", {
+      error: (e as Error).message,
+    });
   }
 
   let offset = 0;
@@ -964,6 +1113,7 @@ export async function runTelegramServer(
             input,
             harnesses,
             activeTurns,
+            botUsername,
           }),
         );
         // Detach completed entries so the maps don't leak.
@@ -997,11 +1147,35 @@ async function processChatMessage(
     input: RunTelegramServerInput;
     harnesses: Harness[];
     activeTurns: Map<number, ActiveTurnHandle>;
+    /** Our own @username (from startup getMe), used to strip the
+     *  addressing mention from group messages. Undefined if getMe
+     *  failed — stripping then no-ops. */
+    botUsername?: string;
   },
 ): Promise<void> {
   const { input, harnesses, activeTurns } = ctx;
   const startedAt = Date.now();
   const isVoice = Boolean(msg.voice);
+
+  // Group addressing: in a group/supergroup the only way a message
+  // reaches us under Telegram privacy mode is by mentioning our
+  // @username (or replying to us). Strip that mention so the harness
+  // sees the user's actual words — "@robbie_agh_bot deploy now" becomes
+  // "deploy now". Applied to both the text and any media caption, before
+  // STT/attachment handling rewrites msg.text. DMs are never touched
+  // (you don't @-address a bot in its own DM), and with privacy OFF the
+  // strip is still correct for the mentions that do carry it.
+  if (
+    (msg.chatType === "group" || msg.chatType === "supergroup") &&
+    ctx.botUsername
+  ) {
+    if (msg.text.length > 0) {
+      msg.text = stripBotMention(msg.text, ctx.botUsername);
+    }
+    if (msg.caption) {
+      msg.caption = stripBotMention(msg.caption, ctx.botUsername);
+    }
+  }
 
   // For voice messages: download → transcribe → use the transcript as
   // the user message before invoking the harness.

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1045,11 +1045,13 @@ export async function runTelegramServer(
   // Per-chat group routing state (last-addressed bot + recent-message
   // buffer). Only touched for group/supergroup chats; DMs never key in.
   const groupChats = new Map<number, GroupChatState>();
-  // This bot's own addressing name in groups. The persona name is the
-  // canonical token (matches the configured group_persona_names list);
-  // if getMe succeeded we also accept the bare @username stem so a literal
-  // "@robbie_agh_bot" still counts as addressing even when the persona name
-  // differs from the bot username.
+  // This bot's own addressing token in groups is its persona name, which
+  // must appear in the configured group_persona_names list (shared verbatim
+  // across every bot in the group). Native @mentions route through the same
+  // name matcher because a persona name embedded in the @username — "robbie"
+  // in "@robbie_agh_bot" — matches on letter boundaries. The getMe @username
+  // (botUsername, below) is used ONLY to strip the mention from dispatched
+  // text, never for routing, so all bots decide from the same shared signal.
   const selfName = input.persona;
   const groupPersonaNames = (() => {
     const configured = tg.groupPersonaNames ?? [];
@@ -1215,24 +1217,21 @@ export async function runTelegramServer(
           const matchText = [msg.text, msg.caption]
             .filter((s): s is string => Boolean(s && s.length > 0))
             .join(" ");
+          // Routing is driven ONLY by the shared, identically-configured
+          // persona-name list — never by this bot's own @username, which the
+          // other bots cannot see. Letting a self-only username match change
+          // the decision diverges state across bots: the addressed bot would
+          // flip its lastAddressed while everyone else kept theirs, so a
+          // previously-sticky bot keeps answering too and both answer every
+          // no-name follow-up. The name matcher already catches @mentions
+          // whose username embeds the persona name — "robbie" inside
+          // "@robbie_agh_bot" matches on letter boundaries — so usernames
+          // that follow that convention route correctly AND consistently for
+          // every bot. (See the groupPersonaNames docs in config.ts.)
           const matched = matchPersonaNames(matchText, groupPersonaNames);
-          // Being @mentioned by our own bot username also counts as being
-          // addressed, even when the persona name isn't a substring of the
-          // username. Fold it into the matched set AS our persona name so
-          // the shared, name-based routing treats it uniformly (and other
-          // bots — which can't know our @username — still agree via the
-          // persona-name match they DO see).
-          const selfViaUsername = botUsername
-            ? matchPersonaNames(matchText, [botUsername]).length > 0
-            : false;
-          const effectiveMatched =
-            selfViaUsername &&
-            !matched.some((n) => n.toLowerCase() === selfName.toLowerCase())
-              ? [...matched, selfName]
-              : matched;
           const decision = decideGroupReply({
             self: selfName,
-            matched: effectiveMatched,
+            matched,
             lastAddressed: state.lastAddressed,
           });
           state.lastAddressed = decision.nextLastAddressed;
@@ -1868,8 +1867,18 @@ async function processChatMessage(
   if (errored) {
     outText = `(error: ${errored})`;
   } else if (fullReply.length === 0) {
+    // Empty reply: in a DM the "(no reply)" placeholder is a useful signal
+    // that the turn produced nothing. In a GROUP it's pure noise — a bot
+    // legitimately stays silent for messages aimed at someone else (or when
+    // the persona simply chooses not to speak), and rendering "(no reply)"
+    // turns that silence into a visible bubble. Suppress it in groups, belt-
+    // and-braces with the routing gate that already skips most such turns.
+    const isGroupChat =
+      msg.chatType === "group" || msg.chatType === "supergroup";
     outText =
-      narrationBubblesSent > 0 || finalBubblesSent > 0 ? "" : "(no reply)";
+      narrationBubblesSent > 0 || finalBubblesSent > 0 || isGroupChat
+        ? ""
+        : "(no reply)";
   } else if (
     consumedReplyChars > 0 &&
     fullReply.startsWith(streamedReply.slice(0, consumedReplyChars))

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,20 @@ export interface TelegramAccount {
   pollTimeoutS: number;
   /** If non-empty, only these Telegram numeric user IDs can talk to the bot. */
   allowedUserIds: number[];
+  /**
+   * Persona names that act as addressing tokens in group chats — typically
+   * EVERY bot sharing a group (e.g. ["robbie", "lena", "kai"]). Used by the
+   * group reply gate: a bot replies when its OWN persona name appears, and a
+   * no-name message is routed to whichever bot was addressed last. Every bot
+   * needs the full list so it can tell "someone else was named" (go quiet)
+   * from "nobody was named" (the last-addressed bot continues). Empty =
+   * gate falls back to matching only this bot's own persona name, which still
+   * works in a single-bot group but can't track hand-offs between bots.
+   * Matched case-insensitively on letter boundaries (so "robbie" matches in
+   * "@robbie_agh_bot" and "Robbie," but not "robbiee"). Optional: omitted /
+   * undefined behaves the same as an empty list.
+   */
+  groupPersonaNames?: string[];
 }
 
 export interface TurnIndexingSettings {
@@ -574,7 +588,26 @@ function buildTelegramConfig(
   const allowedFromToml = asIntArray(tomlTelegram.allowed_user_ids);
   const allowedUserIds = allowedFromEnv ?? allowedFromToml ?? [];
 
-  return { token, pollTimeoutS, allowedUserIds };
+  const groupPersonaNames =
+    parseGroupPersonaNames(process.env.PHANTOMBOT_TELEGRAM_GROUP_PERSONAS) ??
+    asStringArray(tomlTelegram.group_persona_names) ??
+    [];
+
+  return { token, pollTimeoutS, allowedUserIds, groupPersonaNames };
+}
+
+/**
+ * Parse a comma-separated `PHANTOMBOT_TELEGRAM_GROUP_PERSONAS` env value into
+ * a trimmed, non-empty string list. Returns undefined when unset so callers
+ * can fall through to the TOML value.
+ */
+function parseGroupPersonaNames(raw: string | undefined): string[] | undefined {
+  if (raw === undefined) return undefined;
+  const names = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return names.length > 0 ? names : undefined;
 }
 
 /**
@@ -642,7 +675,18 @@ function buildTelegramPersonasConfig(
     );
     const allowedUserIds =
       allowedFromEnv ?? asIntArray(entry.allowed_user_ids) ?? [];
-    out[personaName] = { token, pollTimeoutS, allowedUserIds };
+    const groupPersonaNames =
+      parseGroupPersonaNames(
+        process.env[`PHANTOMBOT_TELEGRAM_GROUP_PERSONAS_${envSuffix}`],
+      ) ??
+      asStringArray(entry.group_persona_names) ??
+      [];
+    out[personaName] = {
+      token,
+      pollTimeoutS,
+      allowedUserIds,
+      groupPersonaNames,
+    };
   }
   return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   handleSlashCommand,
   nominalContextWindow,
+  slashCommandTarget,
   type ActiveTurnHandle,
   type SlashCommandContext,
 } from "../src/channels/commands.ts";
@@ -83,6 +84,54 @@ describe("handleSlashCommand recognition", () => {
   test("tolerates leading/trailing whitespace", async () => {
     const r = await handleSlashCommand("   /help   ", ctx());
     expect(r).not.toBeNull();
+  });
+
+  test("ignores /cmd@OtherBot — a command addressed to a different bot isn't ours", async () => {
+    // Without botUsername validation this would strip the suffix and run on
+    // every bot in a privacy-off group. With our own username known and the
+    // target naming someone else, we fall through (return null).
+    const r = await handleSlashCommand(
+      "/status@kai_agh_bot",
+      ctx({ botUsername: "robbie_agh_bot" }),
+    );
+    expect(r).toBeNull();
+  });
+
+  test("handles /cmd@thisbot when the suffix names us", async () => {
+    const r = await handleSlashCommand(
+      "/help@robbie_agh_bot",
+      ctx({ botUsername: "robbie_agh_bot" }),
+    );
+    expect(r).not.toBeNull();
+    expect(r!.reply).toContain("/stop");
+  });
+
+  test("@suffix matching is case-insensitive on the username", async () => {
+    const r = await handleSlashCommand(
+      "/help@Robbie_AGH_Bot",
+      ctx({ botUsername: "robbie_agh_bot" }),
+    );
+    expect(r).not.toBeNull();
+  });
+
+  test("without botUsername known, keeps legacy behavior (strips any @suffix)", async () => {
+    const r = await handleSlashCommand("/help@whoever", ctx());
+    expect(r).not.toBeNull();
+  });
+});
+
+describe("slashCommandTarget", () => {
+  test("extracts the @target from the command head", () => {
+    expect(slashCommandTarget("/status@kai_agh_bot foo")).toBe("kai_agh_bot");
+  });
+  test("returns undefined when there is no @suffix", () => {
+    expect(slashCommandTarget("/status foo")).toBeUndefined();
+  });
+  test("returns undefined for an empty target", () => {
+    expect(slashCommandTarget("/status@")).toBeUndefined();
+  });
+  test("only looks at the first token, not later args", () => {
+    expect(slashCommandTarget("/say hi@example.com")).toBeUndefined();
   });
 });
 

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -2698,6 +2698,96 @@ describe("runTelegramServer slash commands", () => {
     expect(transport.sent[0]!.text).toContain("/status");
   });
 
+  test("group: /cmd@otherbot is ignored — a state-changing command doesn't fan out to every bot", async () => {
+    // Privacy-off groups deliver every slash command to every bot. A
+    // /reset addressed to another bot must NOT clear this bot's history.
+    await memory.appendTurn({
+      persona: "nim",
+      conversation: "telegram:-1001",
+      role: "user",
+      text: "keep me",
+    });
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "tester",
+      chatType: "supergroup",
+      text: "/reset@pax_test_bot",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "x" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["nim", "pax"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "nim",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toEqual([]);
+    expect(
+      await memory.recentTurns("nim", "telegram:-1001", 10),
+    ).toEqual([{ role: "user", text: "keep me" }]);
+  });
+
+  test("group: untargeted /cmd with no sticky speaker is ignored", async () => {
+    // Bare /status in a group where nobody is sticky yet → stay silent so
+    // we don't get N identical /status replies. User can target /status@bot.
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "tester",
+      chatType: "supergroup",
+      text: "/status",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "x" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["nim", "pax"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "nim",
+      transport,
+      oneShot: true,
+    });
+    expect(transport.sent).toEqual([]);
+  });
+
+  test("group: /cmd@thisbot is handled by this bot", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "tester",
+      chatType: "supergroup",
+      text: "/status@nim_test_bot",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "x" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["nim", "pax"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "nim",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0); // /status is channel-handled
+    expect(transport.sent).toHaveLength(1);
+  });
+
   test("/reset clears prior history for this chat (and only this chat)", async () => {
     await memory.appendTurn({
       persona: "phantom",

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -29,6 +29,9 @@ import {
   REPLY_TO_SNIPPET_MAX,
   stripBotMention,
   normalizeChatType,
+  matchPersonaNames,
+  decideGroupReply,
+  formatGroupContext,
 } from "../src/channels/telegram.ts";
 import { TELEGRAM_BOT_COMMANDS } from "../src/channels/commands.ts";
 import type { Config } from "../src/config.ts";
@@ -1132,6 +1135,77 @@ describe("parseGetUpdatesResult chatType", () => {
   });
 });
 
+describe("matchPersonaNames", () => {
+  const names = ["robbie", "lena", "kai"];
+  test("matches a bare name case-insensitively", () => {
+    expect(matchPersonaNames("Lena, what do you think?", names)).toEqual([
+      "lena",
+    ]);
+  });
+  test("matches a name inside a bot @username (underscore boundary)", () => {
+    expect(matchPersonaNames("@robbie_agh_bot deploy", names)).toEqual([
+      "robbie",
+    ]);
+  });
+  test("returns every distinct name present, in list order", () => {
+    expect(matchPersonaNames("kai and robbie, jump in", names)).toEqual([
+      "robbie",
+      "kai",
+    ]);
+  });
+  test("does NOT match a name embedded in a longer word", () => {
+    expect(matchPersonaNames("the robbiee variant", names)).toEqual([]);
+    expect(matchPersonaNames("scrobbie", names)).toEqual([]);
+  });
+  test("empty text or empty list yields no matches", () => {
+    expect(matchPersonaNames("", names)).toEqual([]);
+    expect(matchPersonaNames("robbie", [])).toEqual([]);
+  });
+});
+
+describe("decideGroupReply", () => {
+  test("my name present → I reply, I become last-addressed", () => {
+    expect(
+      decideGroupReply({ self: "robbie", matched: ["robbie"], lastAddressed: [] }),
+    ).toEqual({ reply: true, nextLastAddressed: ["robbie"] });
+  });
+  test("another bot named → I stay quiet, they become last-addressed", () => {
+    expect(
+      decideGroupReply({ self: "robbie", matched: ["kai"], lastAddressed: ["robbie"] }),
+    ).toEqual({ reply: false, nextLastAddressed: ["kai"] });
+  });
+  test("no name + I was last addressed → I reply, set unchanged", () => {
+    expect(
+      decideGroupReply({ self: "robbie", matched: [], lastAddressed: ["robbie"] }),
+    ).toEqual({ reply: true, nextLastAddressed: ["robbie"] });
+  });
+  test("no name + someone else was last addressed → I stay quiet", () => {
+    expect(
+      decideGroupReply({ self: "robbie", matched: [], lastAddressed: ["kai"] }),
+    ).toEqual({ reply: false, nextLastAddressed: ["kai"] });
+  });
+  test("no name + brand-new chat (nobody addressed) → silence", () => {
+    expect(
+      decideGroupReply({ self: "robbie", matched: [], lastAddressed: [] }),
+    ).toEqual({ reply: false, nextLastAddressed: [] });
+  });
+});
+
+describe("formatGroupContext", () => {
+  test("renders buffered messages as a labelled preamble", () => {
+    const out = formatGroupContext([
+      { from: "@andrew", text: "topic A is tricky" },
+      { from: "@andrew", text: "what about edge cases" },
+    ]);
+    expect(out).toContain("@andrew: topic A is tricky");
+    expect(out).toContain("@andrew: what about edge cases");
+    expect(out.startsWith("[Recent group messages")).toBe(true);
+  });
+  test("empty buffer → empty string", () => {
+    expect(formatGroupContext([])).toBe("");
+  });
+});
+
 describe("runTelegramServer group addressing", () => {
   test("strips the bot @mention from a group message before dispatch", async () => {
     const transport = new FakeTransport();
@@ -1204,6 +1278,164 @@ describe("runTelegramServer group addressing", () => {
     const names = TELEGRAM_BOT_COMMANDS.map((c) => c.command);
     expect(names).toContain("status");
     expect(names).not.toContain("activation");
+  });
+
+  test("group: replies when addressed by name", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "andrew",
+      chatType: "supergroup",
+      text: "robbie, status?",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "all good" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "robbie",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(1);
+    expect(transport.sent.map((s) => s.text)).toContain("all good");
+  });
+
+  test("group: stays silent when another bot is named", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "andrew",
+      chatType: "supergroup",
+      text: "kai, status?",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "all good" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "robbie",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toEqual([]);
+  });
+
+  test("group: brand-new chat with no name → silence", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "andrew",
+      chatType: "supergroup",
+      text: "anyone around?",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "hi" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "robbie",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toEqual([]);
+  });
+
+  test("group: sticky thread — keeps replying to no-name follow-ups, and forwards observed context", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push(
+      {
+        updateId: 1,
+        chatId: -1001,
+        fromUserId: 42,
+        fromUsername: "andrew",
+        chatType: "supergroup",
+        text: "robbie, let's talk topic A",
+      },
+      {
+        updateId: 2,
+        chatId: -1001,
+        fromUserId: 42,
+        fromUsername: "andrew",
+        chatType: "supergroup",
+        text: "and what about the edge cases?",
+      },
+    );
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "robbie",
+      transport,
+      oneShot: true,
+    });
+    // Both messages answered: the named one and the no-name follow-up.
+    expect(harness.invocations).toBe(2);
+    // Last turn's user text is the follow-up (no stale context preamble,
+    // because the prior message was already delivered as its own turn).
+    expect(harness.lastRequest?.userMessage).toBe("and what about the edge cases?");
+  });
+
+  test("group: a bot catches up on context it observed but didn't answer", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push(
+      {
+        // Addressed to kai — robbie observes but stays silent.
+        updateId: 1,
+        chatId: -1001,
+        fromUserId: 42,
+        fromUsername: "andrew",
+        chatType: "supergroup",
+        text: "kai, my take on topic A is X",
+      },
+      {
+        // Now robbie is addressed — should receive the kai-directed line
+        // as context.
+        updateId: 2,
+        chatId: -1001,
+        fromUserId: 42,
+        fromUsername: "andrew",
+        chatType: "supergroup",
+        text: "robbie, what do you think of that?",
+      },
+    );
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "here's my view" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "robbie",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(1);
+    const sent = harness.lastRequest?.userMessage ?? "";
+    expect(sent).toContain("my take on topic A is X");
+    expect(sent).toContain("robbie, what do you think of that?");
   });
 });
 

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -1220,12 +1220,16 @@ describe("runTelegramServer group addressing", () => {
     const harness = new ScriptedHarness("fake", [
       { type: "done", finalText: "on it" },
     ]);
+    // Persona "nim" — its name is embedded in the @username "nim_test_bot",
+    // so the shared name matcher routes the @mention to this bot (the only
+    // routing path: a bot never decides from its own getMe username, which
+    // peers can't see). The mention is then stripped before dispatch.
     await runTelegramServer({
-      config: baseConfig(),
+      config: baseConfig({ groupPersonaNames: ["nim"] }),
       memory,
       harnesses: [harness],
       agentDir,
-      persona: "phantom",
+      persona: "nim",
       transport,
       oneShot: true,
     });
@@ -1436,6 +1440,72 @@ describe("runTelegramServer group addressing", () => {
     const sent = harness.lastRequest?.userMessage ?? "";
     expect(sent).toContain("my take on topic A is X");
     expect(sent).toContain("nim, what do you think of that?");
+  });
+
+  test("group: a self-only @username (persona name not embedded) does NOT route — no divergence", async () => {
+    // Regression for the sticky-routing bug: routing must come ONLY from the
+    // shared persona-name signal every bot sees, never from a bot's own getMe
+    // @username. Here persona "phantom" is NOT embedded in the bot's username
+    // "nim_test_bot", so an @username-only mention carries no name the matcher
+    // can see. With nobody ever addressed, the bot stays silent rather than
+    // folding its own username in (which would have made its lastAddressed
+    // diverge from its peers'). Address by name, or use a username that embeds
+    // the persona name, to route.
+    const transport = new FakeTransport();
+    transport.botUsername = "nim_test_bot";
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "tester",
+      chatType: "supergroup",
+      text: "@nim_test_bot are you there?",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not send" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["phantom", "pax", "vor"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toEqual([]);
+  });
+
+  test("group: empty reply renders no '(no reply)' bubble", async () => {
+    // Even when this bot IS addressed and runs a turn, an empty reply must
+    // not surface the "(no reply)" placeholder in a group — that silence is
+    // legitimate and a visible bubble is noise. (DMs keep the placeholder.)
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "tester",
+      chatType: "supergroup",
+      text: "nim, you there?",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig({ groupPersonaNames: ["nim", "pax", "vor"] }),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "nim",
+      transport,
+      oneShot: true,
+    });
+    // The bot was addressed, so it ran a turn…
+    expect(harness.invocations).toBe(1);
+    // …but the empty result produced no message at all.
+    expect(transport.sent).toEqual([]);
   });
 });
 

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -107,7 +107,7 @@ class FakeTransport implements TelegramTransport {
     return { data: this.fakeFileBytes, mime: "audio/ogg" };
   }
   /** Username returned by getMe — drives group @mention stripping. */
-  botUsername = "robbie_agh_bot";
+  botUsername = "nim_test_bot";
   /** Each setMyCommands call's payload, for assertions. */
   registeredCommands: Array<Array<{ command: string; description: string }>> =
     [];
@@ -1059,23 +1059,23 @@ describe("runTelegramServer dispatch", () => {
 
 describe("stripBotMention", () => {
   test("strips a leading @username mention", () => {
-    expect(stripBotMention("@robbie_agh_bot hello there", "robbie_agh_bot")).toBe(
+    expect(stripBotMention("@nim_test_bot hello there", "nim_test_bot")).toBe(
       "hello there",
     );
   });
 
   test("is case-insensitive on the username", () => {
-    expect(stripBotMention("@Robbie_AGH_Bot hi", "robbie_agh_bot")).toBe("hi");
+    expect(stripBotMention("@Nim_Test_Bot hi", "nim_test_bot")).toBe("hi");
   });
 
   test("strips a mid-string mention and collapses whitespace", () => {
     expect(
-      stripBotMention("hey @robbie_agh_bot deploy now", "robbie_agh_bot"),
+      stripBotMention("hey @nim_test_bot deploy now", "nim_test_bot"),
     ).toBe("hey deploy now");
   });
 
   test("leaves the text untouched when the mention is absent", () => {
-    expect(stripBotMention("just a normal message", "robbie_agh_bot")).toBe(
+    expect(stripBotMention("just a normal message", "nim_test_bot")).toBe(
       "just a normal message",
     );
   });
@@ -1083,13 +1083,13 @@ describe("stripBotMention", () => {
   test("does not strip a username that is a substring of a larger token", () => {
     // word-boundary guard: an email-like token is not a Telegram mention.
     expect(
-      stripBotMention("mail x@robbie_agh_bottle.com", "robbie_agh_bot"),
-    ).toBe("mail x@robbie_agh_bottle.com");
+      stripBotMention("mail x@nim_test_bottle.com", "nim_test_bot"),
+    ).toBe("mail x@nim_test_bottle.com");
   });
 
   test("no-ops when the username is unknown", () => {
-    expect(stripBotMention("@robbie_agh_bot hi", undefined)).toBe(
-      "@robbie_agh_bot hi",
+    expect(stripBotMention("@nim_test_bot hi", undefined)).toBe(
+      "@nim_test_bot hi",
     );
   });
 });
@@ -1117,7 +1117,7 @@ describe("parseGetUpdatesResult chatType", () => {
           message: {
             chat: { id: -100, type: "supergroup" },
             from: { id: 42 },
-            text: "@robbie_agh_bot hi",
+            text: "@nim_test_bot hi",
           },
         },
       ],
@@ -1136,57 +1136,57 @@ describe("parseGetUpdatesResult chatType", () => {
 });
 
 describe("matchPersonaNames", () => {
-  const names = ["robbie", "lena", "kai"];
+  const names = ["nim", "pax", "vor"];
   test("matches a bare name case-insensitively", () => {
-    expect(matchPersonaNames("Lena, what do you think?", names)).toEqual([
-      "lena",
+    expect(matchPersonaNames("Pax, what do you think?", names)).toEqual([
+      "pax",
     ]);
   });
   test("matches a name inside a bot @username (underscore boundary)", () => {
-    expect(matchPersonaNames("@robbie_agh_bot deploy", names)).toEqual([
-      "robbie",
+    expect(matchPersonaNames("@nim_test_bot deploy", names)).toEqual([
+      "nim",
     ]);
   });
   test("returns every distinct name present, in list order", () => {
-    expect(matchPersonaNames("kai and robbie, jump in", names)).toEqual([
-      "robbie",
-      "kai",
+    expect(matchPersonaNames("vor and nim, jump in", names)).toEqual([
+      "nim",
+      "vor",
     ]);
   });
   test("does NOT match a name embedded in a longer word", () => {
-    expect(matchPersonaNames("the robbiee variant", names)).toEqual([]);
-    expect(matchPersonaNames("scrobbie", names)).toEqual([]);
+    expect(matchPersonaNames("the nime variant", names)).toEqual([]);
+    expect(matchPersonaNames("scnim", names)).toEqual([]);
   });
   test("empty text or empty list yields no matches", () => {
     expect(matchPersonaNames("", names)).toEqual([]);
-    expect(matchPersonaNames("robbie", [])).toEqual([]);
+    expect(matchPersonaNames("nim", [])).toEqual([]);
   });
 });
 
 describe("decideGroupReply", () => {
   test("my name present → I reply, I become last-addressed", () => {
     expect(
-      decideGroupReply({ self: "robbie", matched: ["robbie"], lastAddressed: [] }),
-    ).toEqual({ reply: true, nextLastAddressed: ["robbie"] });
+      decideGroupReply({ self: "nim", matched: ["nim"], lastAddressed: [] }),
+    ).toEqual({ reply: true, nextLastAddressed: ["nim"] });
   });
   test("another bot named → I stay quiet, they become last-addressed", () => {
     expect(
-      decideGroupReply({ self: "robbie", matched: ["kai"], lastAddressed: ["robbie"] }),
-    ).toEqual({ reply: false, nextLastAddressed: ["kai"] });
+      decideGroupReply({ self: "nim", matched: ["vor"], lastAddressed: ["nim"] }),
+    ).toEqual({ reply: false, nextLastAddressed: ["vor"] });
   });
   test("no name + I was last addressed → I reply, set unchanged", () => {
     expect(
-      decideGroupReply({ self: "robbie", matched: [], lastAddressed: ["robbie"] }),
-    ).toEqual({ reply: true, nextLastAddressed: ["robbie"] });
+      decideGroupReply({ self: "nim", matched: [], lastAddressed: ["nim"] }),
+    ).toEqual({ reply: true, nextLastAddressed: ["nim"] });
   });
   test("no name + someone else was last addressed → I stay quiet", () => {
     expect(
-      decideGroupReply({ self: "robbie", matched: [], lastAddressed: ["kai"] }),
-    ).toEqual({ reply: false, nextLastAddressed: ["kai"] });
+      decideGroupReply({ self: "nim", matched: [], lastAddressed: ["vor"] }),
+    ).toEqual({ reply: false, nextLastAddressed: ["vor"] });
   });
   test("no name + brand-new chat (nobody addressed) → silence", () => {
     expect(
-      decideGroupReply({ self: "robbie", matched: [], lastAddressed: [] }),
+      decideGroupReply({ self: "nim", matched: [], lastAddressed: [] }),
     ).toEqual({ reply: false, nextLastAddressed: [] });
   });
 });
@@ -1194,11 +1194,11 @@ describe("decideGroupReply", () => {
 describe("formatGroupContext", () => {
   test("renders buffered messages as a labelled preamble", () => {
     const out = formatGroupContext([
-      { from: "@andrew", text: "topic A is tricky" },
-      { from: "@andrew", text: "what about edge cases" },
+      { from: "@tester", text: "topic A is tricky" },
+      { from: "@tester", text: "what about edge cases" },
     ]);
-    expect(out).toContain("@andrew: topic A is tricky");
-    expect(out).toContain("@andrew: what about edge cases");
+    expect(out).toContain("@tester: topic A is tricky");
+    expect(out).toContain("@tester: what about edge cases");
     expect(out.startsWith("[Recent group messages")).toBe(true);
   });
   test("empty buffer → empty string", () => {
@@ -1213,9 +1213,9 @@ describe("runTelegramServer group addressing", () => {
       updateId: 1,
       chatId: -1001,
       fromUserId: 42,
-      fromUsername: "andrew",
+      fromUsername: "tester",
       chatType: "supergroup",
-      text: "@robbie_agh_bot deploy the thing",
+      text: "@nim_test_bot deploy the thing",
     });
     const harness = new ScriptedHarness("fake", [
       { type: "done", finalText: "on it" },
@@ -1240,7 +1240,7 @@ describe("runTelegramServer group addressing", () => {
       chatId: 1001,
       fromUserId: 42,
       chatType: "private",
-      text: "@robbie_agh_bot hi",
+      text: "@nim_test_bot hi",
     });
     const harness = new ScriptedHarness("fake", [
       { type: "done", finalText: "hi" },
@@ -1254,7 +1254,7 @@ describe("runTelegramServer group addressing", () => {
       transport,
       oneShot: true,
     });
-    expect(harness.lastRequest?.userMessage).toBe("@robbie_agh_bot hi");
+    expect(harness.lastRequest?.userMessage).toBe("@nim_test_bot hi");
   });
 
   test("registers the real command menu at startup", async () => {
@@ -1286,19 +1286,19 @@ describe("runTelegramServer group addressing", () => {
       updateId: 1,
       chatId: -1001,
       fromUserId: 42,
-      fromUsername: "andrew",
+      fromUsername: "tester",
       chatType: "supergroup",
-      text: "robbie, status?",
+      text: "nim, status?",
     });
     const harness = new ScriptedHarness("fake", [
       { type: "done", finalText: "all good" },
     ]);
     await runTelegramServer({
-      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      config: baseConfig({ groupPersonaNames: ["nim", "pax", "vor"] }),
       memory,
       harnesses: [harness],
       agentDir,
-      persona: "robbie",
+      persona: "nim",
       transport,
       oneShot: true,
     });
@@ -1312,19 +1312,19 @@ describe("runTelegramServer group addressing", () => {
       updateId: 1,
       chatId: -1001,
       fromUserId: 42,
-      fromUsername: "andrew",
+      fromUsername: "tester",
       chatType: "supergroup",
-      text: "kai, status?",
+      text: "vor, status?",
     });
     const harness = new ScriptedHarness("fake", [
       { type: "done", finalText: "all good" },
     ]);
     await runTelegramServer({
-      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      config: baseConfig({ groupPersonaNames: ["nim", "pax", "vor"] }),
       memory,
       harnesses: [harness],
       agentDir,
-      persona: "robbie",
+      persona: "nim",
       transport,
       oneShot: true,
     });
@@ -1338,7 +1338,7 @@ describe("runTelegramServer group addressing", () => {
       updateId: 1,
       chatId: -1001,
       fromUserId: 42,
-      fromUsername: "andrew",
+      fromUsername: "tester",
       chatType: "supergroup",
       text: "anyone around?",
     });
@@ -1346,11 +1346,11 @@ describe("runTelegramServer group addressing", () => {
       { type: "done", finalText: "hi" },
     ]);
     await runTelegramServer({
-      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      config: baseConfig({ groupPersonaNames: ["nim", "pax", "vor"] }),
       memory,
       harnesses: [harness],
       agentDir,
-      persona: "robbie",
+      persona: "nim",
       transport,
       oneShot: true,
     });
@@ -1365,15 +1365,15 @@ describe("runTelegramServer group addressing", () => {
         updateId: 1,
         chatId: -1001,
         fromUserId: 42,
-        fromUsername: "andrew",
+        fromUsername: "tester",
         chatType: "supergroup",
-        text: "robbie, let's talk topic A",
+        text: "nim, let's talk topic A",
       },
       {
         updateId: 2,
         chatId: -1001,
         fromUserId: 42,
-        fromUsername: "andrew",
+        fromUsername: "tester",
         chatType: "supergroup",
         text: "and what about the edge cases?",
       },
@@ -1382,11 +1382,11 @@ describe("runTelegramServer group addressing", () => {
       { type: "done", finalText: "ok" },
     ]);
     await runTelegramServer({
-      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      config: baseConfig({ groupPersonaNames: ["nim", "pax", "vor"] }),
       memory,
       harnesses: [harness],
       agentDir,
-      persona: "robbie",
+      persona: "nim",
       transport,
       oneShot: true,
     });
@@ -1401,41 +1401,41 @@ describe("runTelegramServer group addressing", () => {
     const transport = new FakeTransport();
     transport.pendingUpdates.push(
       {
-        // Addressed to kai — robbie observes but stays silent.
+        // Addressed to vor — nim observes but stays silent.
         updateId: 1,
         chatId: -1001,
         fromUserId: 42,
-        fromUsername: "andrew",
+        fromUsername: "tester",
         chatType: "supergroup",
-        text: "kai, my take on topic A is X",
+        text: "vor, my take on topic A is X",
       },
       {
-        // Now robbie is addressed — should receive the kai-directed line
+        // Now nim is addressed — should receive the vor-directed line
         // as context.
         updateId: 2,
         chatId: -1001,
         fromUserId: 42,
-        fromUsername: "andrew",
+        fromUsername: "tester",
         chatType: "supergroup",
-        text: "robbie, what do you think of that?",
+        text: "nim, what do you think of that?",
       },
     );
     const harness = new ScriptedHarness("fake", [
       { type: "done", finalText: "here's my view" },
     ]);
     await runTelegramServer({
-      config: baseConfig({ groupPersonaNames: ["robbie", "lena", "kai"] }),
+      config: baseConfig({ groupPersonaNames: ["nim", "pax", "vor"] }),
       memory,
       harnesses: [harness],
       agentDir,
-      persona: "robbie",
+      persona: "nim",
       transport,
       oneShot: true,
     });
     expect(harness.invocations).toBe(1);
     const sent = harness.lastRequest?.userMessage ?? "";
     expect(sent).toContain("my take on topic A is X");
-    expect(sent).toContain("robbie, what do you think of that?");
+    expect(sent).toContain("nim, what do you think of that?");
   });
 });
 

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -27,7 +27,10 @@ import {
   extractReplyTo,
   formatReplyToContext,
   REPLY_TO_SNIPPET_MAX,
+  stripBotMention,
+  normalizeChatType,
 } from "../src/channels/telegram.ts";
+import { TELEGRAM_BOT_COMMANDS } from "../src/channels/commands.ts";
 import type { Config } from "../src/config.ts";
 import type {
   Harness,
@@ -99,6 +102,19 @@ class FakeTransport implements TelegramTransport {
     if (override instanceof Error) throw override;
     if (override) return override;
     return { data: this.fakeFileBytes, mime: "audio/ogg" };
+  }
+  /** Username returned by getMe — drives group @mention stripping. */
+  botUsername = "robbie_agh_bot";
+  /** Each setMyCommands call's payload, for assertions. */
+  registeredCommands: Array<Array<{ command: string; description: string }>> =
+    [];
+  async getMe(): Promise<{ ok: true; username: string } | { ok: false }> {
+    return { ok: true, username: this.botUsername };
+  }
+  async setMyCommands(
+    commands: Array<{ command: string; description: string }>,
+  ): Promise<void> {
+    this.registeredCommands.push(commands);
   }
 }
 
@@ -1031,6 +1047,163 @@ describe("runTelegramServer dispatch", () => {
     });
     expect(transport.sent).toEqual([{ chatId: 1001, text: "(error: boom)" }]);
     expect(await memory.recentTurns("phantom", "telegram:1001", 10)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group @mention handling + command-menu registration
+// ---------------------------------------------------------------------------
+
+describe("stripBotMention", () => {
+  test("strips a leading @username mention", () => {
+    expect(stripBotMention("@robbie_agh_bot hello there", "robbie_agh_bot")).toBe(
+      "hello there",
+    );
+  });
+
+  test("is case-insensitive on the username", () => {
+    expect(stripBotMention("@Robbie_AGH_Bot hi", "robbie_agh_bot")).toBe("hi");
+  });
+
+  test("strips a mid-string mention and collapses whitespace", () => {
+    expect(
+      stripBotMention("hey @robbie_agh_bot deploy now", "robbie_agh_bot"),
+    ).toBe("hey deploy now");
+  });
+
+  test("leaves the text untouched when the mention is absent", () => {
+    expect(stripBotMention("just a normal message", "robbie_agh_bot")).toBe(
+      "just a normal message",
+    );
+  });
+
+  test("does not strip a username that is a substring of a larger token", () => {
+    // word-boundary guard: an email-like token is not a Telegram mention.
+    expect(
+      stripBotMention("mail x@robbie_agh_bottle.com", "robbie_agh_bot"),
+    ).toBe("mail x@robbie_agh_bottle.com");
+  });
+
+  test("no-ops when the username is unknown", () => {
+    expect(stripBotMention("@robbie_agh_bot hi", undefined)).toBe(
+      "@robbie_agh_bot hi",
+    );
+  });
+});
+
+describe("normalizeChatType", () => {
+  test("passes through known chat types", () => {
+    expect(normalizeChatType("private")).toBe("private");
+    expect(normalizeChatType("group")).toBe("group");
+    expect(normalizeChatType("supergroup")).toBe("supergroup");
+    expect(normalizeChatType("channel")).toBe("channel");
+  });
+
+  test("returns undefined for unknown or missing types", () => {
+    expect(normalizeChatType("weird")).toBeUndefined();
+    expect(normalizeChatType(undefined)).toBeUndefined();
+  });
+});
+
+describe("parseGetUpdatesResult chatType", () => {
+  test("carries chat.type through as chatType", () => {
+    const r = parseGetUpdatesResult(
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: -100, type: "supergroup" },
+            from: { id: 42 },
+            text: "@robbie_agh_bot hi",
+          },
+        },
+      ],
+      0,
+    );
+    expect(r.updates[0]?.chatType).toBe("supergroup");
+  });
+
+  test("omits chatType when chat.type is absent", () => {
+    const r = parseGetUpdatesResult(
+      [{ update_id: 1, message: { chat: { id: 1 }, from: { id: 42 }, text: "hi" } }],
+      0,
+    );
+    expect(r.updates[0]).not.toHaveProperty("chatType");
+  });
+});
+
+describe("runTelegramServer group addressing", () => {
+  test("strips the bot @mention from a group message before dispatch", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: -1001,
+      fromUserId: 42,
+      fromUsername: "andrew",
+      chatType: "supergroup",
+      text: "@robbie_agh_bot deploy the thing",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "on it" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    // The harness sees the user's words without the addressing noise.
+    expect(harness.lastRequest?.userMessage).toBe("deploy the thing");
+  });
+
+  test("leaves DM text untouched even if it contains an @mention", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      chatType: "private",
+      text: "@robbie_agh_bot hi",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "hi" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.lastRequest?.userMessage).toBe("@robbie_agh_bot hi");
+  });
+
+  test("registers the real command menu at startup", async () => {
+    const transport = new FakeTransport();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "x" },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(transport.registeredCommands.length).toBeGreaterThanOrEqual(1);
+    expect(transport.registeredCommands[0]).toEqual(TELEGRAM_BOT_COMMANDS);
+    // Sanity: the menu has no ghost commands — every entry maps to a real
+    // handler name.
+    const names = TELEGRAM_BOT_COMMANDS.map((c) => c.command);
+    expect(names).toContain("status");
+    expect(names).not.toContain("activation");
   });
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -322,11 +322,13 @@ token = "desiree-token"
       token: "miles-token",
       pollTimeoutS: 25,
       allowedUserIds: [2, 3],
+      groupPersonaNames: [],
     });
     expect(c.channels.telegramPersonas!.desiree).toEqual({
       token: "desiree-token",
       pollTimeoutS: 30,
       allowedUserIds: [],
+      groupPersonaNames: [],
     });
   });
 
@@ -392,6 +394,7 @@ allowed_user_ids = [7]
       token: "env-only",
       pollTimeoutS: 30,
       allowedUserIds: [7],
+      groupPersonaNames: [],
     });
   });
 


### PR DESCRIPTION
## What

Fixes Telegram group behaviour for the multi-bot HQ (Robbie / Lena / Kai), plus the `/` command menu.

### The Telegram facts this is built on
- **Privacy mode ON** delivers a bot *only* slash commands, replies to its own messages, and service messages — **plain `@username` mentions in text are NOT delivered**. (Proven live: `@lena_oc_bot …` never reached the bot; `/c@lena_oc_bot …` did.)
- **Privacy mode OFF** delivers every *human* message to every bot.
- **A bot never sees another bot's messages** — privacy on or off. This is a hard Telegram platform rule, not a BotFather setting. So no cross-bot coordination is possible without an external shared store.

So the design runs with **privacy OFF** and gates *speaking* (not receiving) in software, using only the human message stream — which every bot sees identically, so **no shared state / no cross-machine service** (this repo is public).

### Group routing
1. A bot replies when its **persona name** (or its own **@username**) appears — case-insensitive, letter-boundary match, so `robbie` matches in `@robbie_agh_bot` and `Robbie,` but not `robbiee`.
2. **Multiple names** in one message → each named bot replies independently.
3. **No name** → continues the current thread: only the bot(s) **addressed last** reply (sticky). Talk to Robbie, keep going with no name, Robbie keeps answering; name Kai, now Kai's the active one.
4. **No name + brand-new chat** (nobody ever addressed) → **silence**.

### Context catch-up
Each bot keeps a rolling **20-message** per-chat buffer of human messages it *observed but didn't answer*, and forwards them as a context preamble the next time it **is** addressed. So if you discuss topic A with Kai, then ask Robbie about it, Robbie has your side of that thread. (Limit: it still can't see Kai's *reply* text — Telegram never delivers it.)

### Command menu
`setMyCommands` at startup registers only the 7 real commands, overwriting BotFather ghost entries (e.g. `/activation`).

## Config
New optional field `channels.telegram(.personas.<name>).group_persona_names` — the full list of persona names sharing a group, e.g. `["robbie","lena","kai"]`. Every bot needs the full list to tell "another bot was named" (go quiet) from "nobody named" (stay sticky). Env override: `PHANTOMBOT_TELEGRAM_GROUP_PERSONAS[_<PERSONA>]`. Empty → matches only the bot's own persona name.

## Deploy steps (operator)
1. In BotFather, **disable privacy** for each bot (`/setprivacy` → Disable).
2. **Remove + re-add** each bot to the group (required for the toggle + command cache to refresh).
3. Set `group_persona_names = ["robbie","lena","kai"]` for each bot.

## Tests
16 new tests (pure name-matchers, the decision table, and end-to-end gate + context-forwarding through `runTelegramServer`). Full suite **1063 pass / 0 fail**, typecheck clean.
