### PR TITLE
Delay automatic update notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ phantombot update --force --restart     # cron-friendly: no prompts, restart aft
 
 Updates download to `${binPath}.update.tmp`, SHA256-verify, atomically rename over the live binary, and clean up after themselves — no `.bak` files left in your install dir.
 
+The heartbeat checks for new releases automatically, but waits 72 hours after a release before sending the Telegram `/update` heads-up. Manual `phantombot update` and `/update` are immediate.
+
 ---
 
 ## Prerequisites

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -67,7 +67,8 @@ export async function runHeartbeatCli(
     indexPath: indexPath(persona),
     // Pass config + version so the heartbeat can hit GitHub for new
     // releases and dispatch a one-time Telegram notification when a
-    // newer version is out. See src/lib/updateNotify.ts.
+    // newer version has aged past the auto-notify delay. See
+    // src/lib/updateNotify.ts.
     config,
     currentVersion: VERSION,
   });

--- a/src/lib/githubReleases.ts
+++ b/src/lib/githubReleases.ts
@@ -36,6 +36,8 @@ export interface LatestRelease {
   version: string;
   /** The full tag, e.g. "v1.0.43". */
   tag: string;
+  /** ISO timestamp GitHub published the release. */
+  publishedAt?: string;
   /** GitHub release body text (release notes). May be empty. */
   body: string;
   /** The binary asset for the requested arch. */
@@ -161,6 +163,8 @@ export async function findLatestRelease(opts: {
     release: {
       version,
       tag,
+      publishedAt:
+        typeof body.published_at === "string" ? body.published_at : undefined,
       body: typeof body.body === "string" ? body.body : "",
       binary: {
         name: binary.name,
@@ -230,6 +234,7 @@ function buildHeaders(withAuth: boolean): Record<string, string> {
 
 interface GithubReleaseResponse {
   tag_name?: string;
+  published_at?: string;
   body?: string;
   assets?: Array<{
     name: string;

--- a/src/lib/updateNotify.ts
+++ b/src/lib/updateNotify.ts
@@ -12,8 +12,8 @@
  *      because by the time the new binary is live the old one is gone.
  *
  *   2. Heartbeat update check. The 30-minute heartbeat hits GitHub for the
- *      latest release; if newer than current, sends ONE Telegram message
- *      pointing the user at `/update`. Deduped via
+ *      latest release; if newer than current and at least 72 hours old,
+ *      sends ONE Telegram message pointing the user at `/update`. Deduped via
  *      ~/.config/phantombot/.last-update-notified so a user who's
  *      seen-but-not-yet-installed v1.0.99 isn't pinged every half hour.
  *
@@ -60,6 +60,8 @@ export function pendingUpdatePath(): string {
 export function lastNotifiedPath(): string {
   return join(xdgConfigHome(), "phantombot", ".last-update-notified");
 }
+
+export const AUTO_UPDATE_NOTIFY_DELAY_MS = 72 * 60 * 60 * 1000;
 
 /* -------------------------------------------------------------------------- *
  * Pending-update marker
@@ -162,12 +164,41 @@ export async function clearPendingUpdate(
  * Last-notified dedup file
  * -------------------------------------------------------------------------- */
 
-export async function readLastNotified(
-  path: string = lastNotifiedPath(),
-): Promise<string | undefined> {
+interface LastNotifiedState {
+  version: string;
+  firstSeenAt: string;
+  notifiedAt?: string;
+}
+
+function parseLastNotifiedState(text: string): LastNotifiedState | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  if (!trimmed.startsWith("{")) {
+    // Back-compat for the old plain-version dedup file. Treat it as already
+    // notified so existing installs do not get re-pinged after upgrading.
+    const legacyTime = new Date(0).toISOString();
+    return { version: trimmed, firstSeenAt: legacyTime, notifiedAt: legacyTime };
+  }
   try {
-    const text = (await readFile(path, "utf8")).trim();
-    return text.length > 0 ? text : undefined;
+    const parsed = JSON.parse(trimmed) as Partial<LastNotifiedState>;
+    if (
+      typeof parsed.version !== "string" ||
+      typeof parsed.firstSeenAt !== "string" ||
+      (parsed.notifiedAt !== undefined && typeof parsed.notifiedAt !== "string")
+    ) {
+      return undefined;
+    }
+    return parsed as LastNotifiedState;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readLastNotifiedState(
+  path: string = lastNotifiedPath(),
+): Promise<LastNotifiedState | undefined> {
+  try {
+    return parseLastNotifiedState(await readFile(path, "utf8"));
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     log.warn("updateNotify: failed to read last-notified", {
@@ -178,14 +209,32 @@ export async function readLastNotified(
   }
 }
 
-export async function writeLastNotified(
-  version: string,
+async function writeLastNotifiedState(
+  state: LastNotifiedState,
   path: string = lastNotifiedPath(),
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  await writeFile(tmp, version, "utf8");
+  await writeFile(tmp, JSON.stringify(state, null, 2), "utf8");
   await rename(tmp, path);
+}
+
+export async function readLastNotified(
+  path: string = lastNotifiedPath(),
+): Promise<string | undefined> {
+  const state = await readLastNotifiedState(path);
+  return state?.notifiedAt ? state.version : undefined;
+}
+
+export async function writeLastNotified(
+  version: string,
+  path: string = lastNotifiedPath(),
+): Promise<void> {
+  const now = new Date().toISOString();
+  await writeLastNotifiedState(
+    { version, firstSeenAt: now, notifiedAt: now },
+    path,
+  );
 }
 
 /* -------------------------------------------------------------------------- *
@@ -356,6 +405,7 @@ export async function runUpdateFlow(
 export interface CheckAndNotifyOnceInput {
   config: Config;
   currentVersion: string;
+  now?: Date;
   fetchImpl?: typeof fetch;
   transport?: TelegramTransport;
   lastNotifiedPath?: string;
@@ -365,12 +415,13 @@ export interface CheckAndNotifyOnceInput {
 
 export interface CheckAndNotifyOnceResult {
   /** "no_telegram" | "no_target" | "release_check_failed" | "already_current"
-   *  | "already_notified" | "no_allowed_users" | "notified" */
+   *  | "waiting_delay" | "already_notified" | "no_allowed_users" | "notified" */
   status:
     | "no_telegram"
     | "no_target"
     | "release_check_failed"
     | "already_current"
+    | "waiting_delay"
     | "already_notified"
     | "no_allowed_users"
     | "notified";
@@ -382,7 +433,9 @@ export interface CheckAndNotifyOnceResult {
 /**
  * Heartbeat-time update check. Idempotent: if the latest GitHub release
  * matches what we last notified about, this is a no-op — even across
- * restarts, because the last-notified version is on disk.
+ * restarts, because the last-notified version is on disk. New releases are
+ * held for 72 hours before the automatic Telegram heads-up; manual
+ * `phantombot update` and `/update` remain immediate.
  *
  * Failure modes are all logged and returned as a status string; we don't
  * throw, because a transient network blip mustn't take the heartbeat down.
@@ -409,14 +462,31 @@ export async function checkAndNotifyOnce(
     return { status: "release_check_failed", error: r.error };
   }
   const release = r.release;
+  const now = input.now ?? new Date();
 
   if (release.version === input.currentVersion) {
     return { status: "already_current", latestVersion: release.version };
   }
 
-  const lastNotified = await readLastNotified(input.lastNotifiedPath);
-  if (lastNotified === release.version) {
+  const state = await readLastNotifiedState(input.lastNotifiedPath);
+  if (state?.version === release.version && state.notifiedAt) {
     return { status: "already_notified", latestVersion: release.version };
+  }
+
+  const firstSeenAt =
+    (state?.version === release.version ? state.firstSeenAt : undefined) ??
+    release.publishedAt ??
+    now.toISOString();
+  const releaseAgeMs = now.getTime() - Date.parse(firstSeenAt);
+  if (
+    !Number.isFinite(releaseAgeMs) ||
+    releaseAgeMs < AUTO_UPDATE_NOTIFY_DELAY_MS
+  ) {
+    await writeLastNotifiedState(
+      { version: release.version, firstSeenAt },
+      input.lastNotifiedPath,
+    );
+    return { status: "waiting_delay", latestVersion: release.version };
   }
 
   if (tg.allowedUserIds.length === 0) {
@@ -448,7 +518,10 @@ export async function checkAndNotifyOnce(
   // Write the dedup marker even if some sends failed — otherwise a
   // partial-broadcast user gets re-notified forever. Better one missed
   // user than one re-pinged user.
-  await writeLastNotified(release.version, input.lastNotifiedPath);
+  await writeLastNotifiedState(
+    { version: release.version, firstSeenAt, notifiedAt: now.toISOString() },
+    input.lastNotifiedPath,
+  );
 
   log.info("updateNotify: heartbeat notified update available", {
     latestVersion: release.version,

--- a/tests/lib-githubReleases.test.ts
+++ b/tests/lib-githubReleases.test.ts
@@ -69,6 +69,7 @@ function authAwareFetch(
 
 const SAMPLE_RELEASE = {
   tag_name: "v1.0.43",
+  published_at: "2026-05-01T00:00:00Z",
   body: "Automated release for PR #43.",
   assets: [
     {
@@ -108,6 +109,7 @@ describe("findLatestRelease", () => {
     if (!r.ok) return;
     expect(r.release.version).toBe("1.0.43");
     expect(r.release.tag).toBe("v1.0.43");
+    expect(r.release.publishedAt).toBe("2026-05-01T00:00:00Z");
     expect(r.release.binary.name).toBe("phantombot-v1.0.43-linux-x64");
     expect(r.release.binary.url).toBe(
       "https://example/phantombot-v1.0.43-linux-x64",

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -232,6 +232,7 @@ describe("runHeartbeat update check hook", () => {
     const ASSET = `phantombot-${tag}-linux-x64`;
     const body = {
       tag_name: tag,
+      published_at: "2026-04-28T00:00:00Z",
       body: "test",
       assets: [
         { name: ASSET, browser_download_url: "x", size: 1 },

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -94,6 +94,7 @@ function fakeReleaseFetch(opts: {
   const status = opts.status ?? 200;
   const body = opts.releaseBody ?? {
     tag_name: "v1.0.99",
+    published_at: "2026-05-01T00:00:00Z",
     body: "test release",
     assets: [
       {
@@ -430,6 +431,7 @@ describe("checkAndNotifyOnce", () => {
     const r = await checkAndNotifyOnce({
       config: baseConfig(),
       currentVersion: "1.0.42",
+      now: new Date("2026-05-05T00:00:00Z"),
       fetchImpl: fakeReleaseFetch(),
       transport,
       lastNotifiedPath: lastNotifiedPathLocal,
@@ -442,6 +444,105 @@ describe("checkAndNotifyOnce", () => {
     expect(transport.sent.length).toBe(2);
     expect(transport.sent[0]!.text).toContain("v1.0.99");
     expect(transport.sent[0]!.text).toContain("/update");
+    expect(await readLastNotified(lastNotifiedPathLocal)).toBe("1.0.99");
+  });
+
+  test("update available but younger than 72 hours → records first seen without notifying", async () => {
+    const transport = new FakeTransport();
+    const r = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      now: new Date("2026-05-02T00:00:00Z"),
+      fetchImpl: fakeReleaseFetch({
+        releaseBody: {
+          tag_name: "v1.0.99",
+          published_at: "2026-05-01T00:00:00Z",
+          body: "test release",
+          assets: [
+            {
+              name: ASSET,
+              browser_download_url: "https://example/" + ASSET,
+              size: NEW_BYTES.byteLength,
+            },
+            {
+              name: "SHA256SUMS",
+              browser_download_url: "https://example/SHA256SUMS",
+              size: 256,
+            },
+          ],
+        },
+      }),
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.status).toBe("waiting_delay");
+    expect(r.latestVersion).toBe("1.0.99");
+    expect(transport.sent.length).toBe(0);
+    expect(await readLastNotified(lastNotifiedPathLocal)).toBeUndefined();
+  });
+
+  test("same pending release notifies after the 72-hour delay", async () => {
+    const first = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      now: new Date("2026-05-02T00:00:00Z"),
+      fetchImpl: fakeReleaseFetch({
+        releaseBody: {
+          tag_name: "v1.0.99",
+          body: "test release",
+          assets: [
+            {
+              name: ASSET,
+              browser_download_url: "https://example/" + ASSET,
+              size: NEW_BYTES.byteLength,
+            },
+            {
+              name: "SHA256SUMS",
+              browser_download_url: "https://example/SHA256SUMS",
+              size: 256,
+            },
+          ],
+        },
+      }),
+      transport: new FakeTransport(),
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(first.status).toBe("waiting_delay");
+
+    const transport = new FakeTransport();
+    const second = await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      now: new Date("2026-05-05T00:00:01Z"),
+      fetchImpl: fakeReleaseFetch({
+        releaseBody: {
+          tag_name: "v1.0.99",
+          body: "test release",
+          assets: [
+            {
+              name: ASSET,
+              browser_download_url: "https://example/" + ASSET,
+              size: NEW_BYTES.byteLength,
+            },
+            {
+              name: "SHA256SUMS",
+              browser_download_url: "https://example/SHA256SUMS",
+              size: 256,
+            },
+          ],
+        },
+      }),
+      transport,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(second.status).toBe("notified");
+    expect(transport.sent.length).toBe(2);
     expect(await readLastNotified(lastNotifiedPathLocal)).toBe("1.0.99");
   });
 


### PR DESCRIPTION
## Summary
- Delay heartbeat update notifications until a release is at least 72 hours old
- Keep manual `phantombot update` and Telegram `/update` immediate
- Store first-seen/notified update state while preserving old plain-version dedup files

## Verification
- `bun test`
- `bun run typecheck`
- `bun run build`