### PR TITLE
Make harness idle timeout phase-aware

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -314,6 +314,9 @@ export function renderStdinPayload(req: HarnessRequest): string {
  * informally: each line has a `type` (system / user / assistant / result)
  * and a `message` payload. The assistant content is an array of blocks
  * with their own `type`: `text`, `thinking`, `tool_use`, `tool_result`.
+ * Claude reports tool results in user-typed messages; we surface those as
+ * heartbeats too so the timeout coordinator can clear the tool-running latch
+ * without flushing user-visible narration.
  *
  * Channel layers want three distinct signals from us:
  *   - `text` blocks → user-visible reply (concatenate, surface verbatim).
@@ -336,12 +339,20 @@ export function renderStdinPayload(req: HarnessRequest): string {
 export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   if (typeof parsed !== "object" || parsed === null) return undefined;
   const obj = parsed as Record<string, unknown>;
-  if (obj.type !== "assistant") return undefined;
 
   const message = obj.message as Record<string, unknown> | undefined;
   if (!message) return undefined;
   const content = message.content;
   if (!Array.isArray(content)) return undefined;
+
+  if (obj.type !== "assistant") {
+    return content.some((part) => {
+      if (typeof part !== "object" || part === null) return false;
+      return (part as Record<string, unknown>).type === "tool_result";
+    })
+      ? { type: "heartbeat" }
+      : undefined;
+  }
 
   let text = "";
   let toolName: string | undefined;

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -51,6 +51,7 @@ import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { reloadEnvFiles } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
+  type HarnessActivity,
   killCauseToErrorChunk,
 } from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
@@ -158,15 +159,13 @@ export class ClaudeHarness implements Harness {
             parsed = JSON.parse(trimmed);
           } catch {
             // Not stream-json — surface as out-of-band progress note.
-            killer.touch(); // non-JSON line is real output
+            killer.touch("productive"); // non-JSON line is real output
             yield { type: "progress", note: trimmed };
             continue;
           }
           const c = parseStreamJson(parsed);
           if (c) {
-            // Only reset the idle window on productive chunks; heartbeats
-            // keep the UI typing indicator alive but must not extend idle.
-            if (c.type !== "heartbeat") killer.touch();
+            killer.touch(claudeActivity(parsed, c));
             if (c.type === "text") finalText += c.text;
             yield c;
           }
@@ -363,6 +362,32 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   if (toolName) return { type: "progress", note: `tool: ${toolName}` };
   if (sawOtherNonText) return { type: "heartbeat" };
   return undefined;
+}
+
+function claudeActivity(
+  parsed: unknown,
+  chunk: HarnessChunk,
+): HarnessActivity {
+  if (chunk.type === "text" || chunk.type === "done") return "productive";
+  if (typeof parsed !== "object" || parsed === null) {
+    return chunk.type === "heartbeat" ? "model" : "productive";
+  }
+  const obj = parsed as Record<string, unknown>;
+  const message = obj.message as Record<string, unknown> | undefined;
+  const content = message?.content;
+  if (Array.isArray(content)) {
+    let hasToolUse = false;
+    let hasToolResult = false;
+    for (const part of content) {
+      if (typeof part !== "object" || part === null) continue;
+      const type = (part as Record<string, unknown>).type;
+      hasToolUse ||= type === "tool_use";
+      hasToolResult ||= type === "tool_result";
+    }
+    if (hasToolUse) return "tool";
+    if (hasToolResult) return "productive";
+  }
+  return chunk.type === "heartbeat" ? "model" : "productive";
 }
 
 async function consumeStderr(

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -197,6 +197,8 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
     if (typeof it.type === "string" && it.type.includes("tool")) {
       return { type: "progress", note: "tool" };
     }
+    // Non-tool starts are still useful liveness signals while the model is
+    // preparing output, but they should not flush user-visible narration.
     return { type: "heartbeat" };
   }
   if (type === "item.completed") {

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -13,6 +13,7 @@ import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { reloadEnvFiles } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
+  type HarnessActivity,
   killCauseToErrorChunk,
 } from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
@@ -96,15 +97,13 @@ export class CodexHarness implements Harness {
           try {
             parsed = JSON.parse(trimmed);
           } catch {
-            killer.touch(); // non-JSON line is real output
+            killer.touch("productive"); // non-JSON line is real output
             yield { type: "progress", note: trimmed.slice(0, 200) };
             continue;
           }
           const c = parseCodexEvent(parsed);
           if (!c) continue;
-          // Only reset the idle window on productive chunks; heartbeats
-          // keep the UI typing indicator alive but must not extend idle.
-          if (c.type !== "heartbeat") killer.touch();
+          killer.touch(codexActivity(parsed, c));
           if (c.type === "text") finalText += c.text;
           if (c.type === "done") {
             usageMeta = c.meta;
@@ -191,6 +190,15 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
   if (typeof parsed !== "object" || parsed === null) return undefined;
   const obj = parsed as Record<string, unknown>;
   const type = obj.type;
+  if (type === "item.started") {
+    const item = obj.item;
+    if (typeof item !== "object" || item === null) return undefined;
+    const it = item as Record<string, unknown>;
+    if (typeof it.type === "string" && it.type.includes("tool")) {
+      return { type: "progress", note: "tool" };
+    }
+    return { type: "heartbeat" };
+  }
   if (type === "item.completed") {
     const item = obj.item;
     if (typeof item !== "object" || item === null) return undefined;
@@ -212,6 +220,29 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
     return { type: "done", finalText: "", meta: undefined };
   }
   return undefined;
+}
+
+function codexActivity(
+  parsed: unknown,
+  chunk: HarnessChunk,
+): HarnessActivity {
+  if (chunk.type === "text" || chunk.type === "done") return "productive";
+  if (typeof parsed !== "object" || parsed === null) {
+    return chunk.type === "heartbeat" ? "model" : "productive";
+  }
+  const obj = parsed as Record<string, unknown>;
+  const item = obj.item;
+  const itemType =
+    typeof item === "object" && item !== null
+      ? (item as Record<string, unknown>).type
+      : undefined;
+  if (obj.type === "item.started" && typeof itemType === "string" && itemType.includes("tool")) {
+    return "tool";
+  }
+  if (obj.type === "item.completed" && typeof itemType === "string" && itemType.includes("tool")) {
+    return "productive";
+  }
+  return chunk.type === "heartbeat" ? "model" : "productive";
 }
 
 async function consumeStderr(

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -41,6 +41,7 @@ import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { reloadEnvFiles } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
+  type HarnessActivity,
   killCauseToErrorChunk,
 } from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
@@ -210,15 +211,13 @@ export class GeminiHarness implements Harness {
             log.debug("gemini: non-JSON stdout line", {
               line: trimmed.slice(0, 200),
             });
-            killer.touch(); // non-JSON line is real output
+            killer.touch("productive"); // non-JSON line is real output
             yield { type: "progress", note: trimmed.slice(0, 200) };
             continue;
           }
           const c = parseGeminiEvent(parsed);
           if (!c) continue;
-          // Only reset the idle window on productive chunks; heartbeats
-          // keep the UI typing indicator alive but must not extend idle.
-          if (c.type !== "heartbeat") killer.touch();
+          killer.touch(geminiActivity(parsed, c));
           if (c.type === "text") finalText += c.text;
           if (c.type === "done") {
             // gemini's `result` event carries the authoritative stats.
@@ -235,8 +234,10 @@ export class GeminiHarness implements Harness {
       const tail = buffer.trim();
       if (tail) {
         try {
-          const c = parseGeminiEvent(JSON.parse(tail));
+          const parsed = JSON.parse(tail);
+          const c = parseGeminiEvent(parsed);
           if (c) {
+            killer.touch(geminiActivity(parsed, c));
             if (c.type === "text") finalText += c.text;
             if (c.type === "done") resultMeta = c.meta;
             else yield c;
@@ -368,6 +369,20 @@ export function parseGeminiEvent(parsed: unknown): HarnessChunk | undefined {
   }
 
   return undefined;
+}
+
+function geminiActivity(
+  parsed: unknown,
+  chunk: HarnessChunk,
+): HarnessActivity {
+  if (chunk.type === "text" || chunk.type === "done") return "productive";
+  if (typeof parsed !== "object" || parsed === null) {
+    return chunk.type === "heartbeat" ? "model" : "productive";
+  }
+  const type = (parsed as Record<string, unknown>).type;
+  if (type === "tool_use") return "tool";
+  if (type === "tool_result") return "productive";
+  return chunk.type === "heartbeat" ? "model" : "productive";
 }
 
 /**

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -27,6 +27,7 @@ import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { reloadEnvFiles } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
+  type HarnessActivity,
   killCauseToErrorChunk,
 } from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
@@ -130,15 +131,13 @@ export class PiHarness implements Harness {
           try {
             parsed = JSON.parse(trimmed);
           } catch {
-            killer.touch(); // non-JSON line is real output
+            killer.touch("productive"); // non-JSON line is real output
             yield { type: "progress", note: trimmed };
             continue;
           }
           const c = parsePiEvent(parsed);
           if (c) {
-            // Only reset the idle window on productive chunks; heartbeats
-            // keep the UI typing indicator alive but must not extend idle.
-            if (c.type !== "heartbeat") killer.touch();
+            killer.touch(piActivity(parsed, c));
             if (c.type === "text") finalText += c.text;
             yield c;
           }
@@ -272,6 +271,21 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
   }
 
   return undefined;
+}
+
+function piActivity(parsed: unknown, chunk: HarnessChunk): HarnessActivity {
+  if (chunk.type === "text" || chunk.type === "done") return "productive";
+  if (typeof parsed !== "object" || parsed === null) {
+    return chunk.type === "heartbeat" ? "model" : "productive";
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.type === "tool_execution_start") return "tool";
+  const ame = obj.assistantMessageEvent;
+  if (isObject(ame) && typeof ame.type === "string") {
+    if (ame.type === "tool_use_end") return "productive";
+    if (ame.type.startsWith("tool_use")) return "tool";
+  }
+  return chunk.type === "heartbeat" ? "model" : "productive";
 }
 
 function isObject(v: unknown): v is Record<string, unknown> {

--- a/src/lib/harnessRunner.ts
+++ b/src/lib/harnessRunner.ts
@@ -4,7 +4,7 @@
  * Every harness (claude/gemini/pi) needs the same machinery:
  *
  *   - spawn the binary in a fresh process group (so grandchildren die too)
- *   - run an idle timer that resets on every chunk from stdout
+ *   - run an idle timer that resets on useful activity from stdout
  *   - run a hard wall-clock timer that never resets
  *   - listen for an external AbortSignal (the user typed /stop)
  *   - on any of those firing, SIGTERM → 5s grace → SIGKILL the whole group
@@ -21,7 +21,7 @@
  *   });
  *   try {
  *     for await (const chunk of proc.stdout) {
- *       runner.touch();   // resets idle timer
+ *       runner.touch("productive"); // resets idle timer
  *       // ...emit chunks...
  *     }
  *   } finally {
@@ -35,6 +35,7 @@ import { killProcessGroup } from "./processGroup.ts";
 import { log } from "./logger.ts";
 
 export type KillCause = "timeout" | "idle" | "aborted" | undefined;
+export type HarnessActivity = "model" | "tool" | "productive";
 
 export interface KillCoordinatorOpts {
   proc: Subprocess<
@@ -55,8 +56,15 @@ export interface KillCoordinatorOpts {
 }
 
 export interface KillCoordinator {
-  /** Reset the idle timer. Call after every emitted chunk. */
-  touch(): void;
+  /**
+   * Record subprocess activity.
+   *
+   * - productive: visible text, completed tool output, non-JSON stdout, done
+   * - model: model-side thinking/progress while no tool is known to be running
+   * - tool: tool invocation/start; later generic model heartbeats do not extend
+   *   the idle window until productive output arrives
+   */
+  touch(activity?: HarnessActivity): void;
   /** Stop all timers and detach signal listener. Idempotent. */
   dispose(): Promise<void>;
   /** Why the process was killed, if it was. undefined = exited normally. */
@@ -69,6 +77,7 @@ export function createKillCoordinator(
   const graceMs = opts.graceMs ?? 5000;
   let cause: KillCause;
   let disposed = false;
+  let toolRunning = false;
 
   const triggerKill = (newCause: Exclude<KillCause, undefined>): void => {
     if (cause || disposed) return;
@@ -101,8 +110,15 @@ export function createKillCoordinator(
   }
 
   return {
-    touch(): void {
+    touch(activity: HarnessActivity = "productive"): void {
       if (cause || disposed) return;
+      if (activity === "tool") {
+        toolRunning = true;
+      } else if (activity === "productive") {
+        toolRunning = false;
+      } else if (toolRunning) {
+        return;
+      }
       clearTimeout(idleTimer);
       idleTimer = setTimeout(
         () => triggerKill("idle"),

--- a/tests/fixtures/fake-claude.sh
+++ b/tests/fixtures/fake-claude.sh
@@ -12,6 +12,9 @@
 #   hang     — sleep forever (used for the timeout test)
 #   argv     — emit argv as a single assistant text event (so the test can
 #              inspect what flags the harness passed), then exit 0
+#   posttool_thinking — tool_use -> user tool_result -> spaced thinking
+#              heartbeats -> final text. Proves user-side tool_result clears
+#              the tool-running idle latch.
 
 mode="${FAKE_CLAUDE_MODE:-normal}"
 
@@ -48,6 +51,19 @@ case "$mode" in
     payload="${payload//\\/\\\\}"
     payload="${payload//\"/\\\"}"
     printf '%s\n' "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"${payload}\"}]}}"
+    printf '%s\n' '{"type":"result"}'
+    exit 0
+    ;;
+  posttool_thinking)
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}'
+    sleep 0.1
+    printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"abc","content":"done"}]}}'
+    sleep 0.45
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"still working"}]}}'
+    sleep 0.45
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"still working"}]}}'
+    sleep 0.45
+    printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"finished"}]}}'
     printf '%s\n' '{"type":"result"}'
     exit 0
     ;;

--- a/tests/fixtures/fake-codex.sh
+++ b/tests/fixtures/fake-codex.sh
@@ -6,10 +6,12 @@
 #   notfound   -> exit 127
 #   hang       -> sleep forever
 #   argv       -> echo argv in an agent message
-#   heartbeats -> stream turn.started heartbeats spaced under the idle
-#                 window for ~3s, then a late agent_message + turn.completed.
-#                 Used to prove heartbeats do NOT reset the idle timer: the
-#                 harness must idle-kill long before the late finish lands.
+#   heartbeats -> stream model heartbeats spaced under the idle window for
+#                 ~3s, then an agent_message + turn.completed. Used to prove
+#                 model-side activity can keep a genuinely busy turn alive.
+#   tool-heartbeats -> start a tool, then stream heartbeats spaced under the
+#                 idle window before a late finish. Used to prove generic
+#                 heartbeat noise does NOT keep a tool-stuck turn alive.
 #   productive -> stream agent_message text spaced under the idle window,
 #                 then turn.completed. Used to prove productive output DOES
 #                 keep resetting the idle timer, so the turn finishes cleanly.
@@ -39,6 +41,17 @@ case "$mode" in
     ;;
   heartbeats)
     printf '%s\n' '{"type":"turn.started"}'
+    for i in $(seq 1 15); do
+      printf '%s\n' '{"type":"item.completed","item":{"id":"hb'"$i"'","type":"reasoning","text":"thinking"}}'
+      sleep 0.2
+    done
+    printf '%s\n' '{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"late finish"}}'
+    printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+    exit 0
+    ;;
+  tool-heartbeats)
+    printf '%s\n' '{"type":"turn.started"}'
+    printf '%s\n' '{"type":"item.started","item":{"id":"tool1","type":"tool_call","name":"shell"}}'
     for i in $(seq 1 15); do
       printf '%s\n' '{"type":"item.completed","item":{"id":"hb'"$i"'","type":"reasoning","text":"thinking"}}'
       sleep 0.2

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -110,9 +110,14 @@ describe("parseStreamJson", () => {
     expect(c).toEqual({ type: "text", text: "hello world" });
   });
 
-  test("returns undefined for non-assistant events", () => {
+  test("returns undefined for non-assistant events without tool results", () => {
     expect(parseStreamJson({ type: "system" })).toBeUndefined();
-    expect(parseStreamJson({ type: "user" })).toBeUndefined();
+    expect(
+      parseStreamJson({
+        type: "user",
+        message: { content: [{ type: "text", text: "not surfaced" }] },
+      }),
+    ).toBeUndefined();
     expect(parseStreamJson({ type: "result" })).toBeUndefined();
   });
 
@@ -137,6 +142,16 @@ describe("parseStreamJson", () => {
   test("heartbeat for tool_result blocks (no flush)", () => {
     const c = parseStreamJson({
       type: "assistant",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: "abc", content: "done" }],
+      },
+    });
+    expect(c).toEqual({ type: "heartbeat" });
+  });
+
+  test("heartbeat for user-side tool_result blocks so idle latch clears", () => {
+    const c = parseStreamJson({
+      type: "user",
       message: {
         content: [{ type: "tool_result", tool_use_id: "abc", content: "done" }],
       },
@@ -266,6 +281,20 @@ describe("ClaudeHarness.invoke (subprocess)", () => {
       type: "error",
       recoverable: true,
       error: expect.stringContaining("timed out"),
+    });
+  });
+
+  test("user-side tool_result clears tool latch so post-tool thinking can keep the turn alive", async () => {
+    process.env.FAKE_CLAUDE_MODE = "posttool_thinking";
+    const chunks = await collect(
+      mkHarness().invoke(newRequest({ idleTimeoutMs: 700, hardTimeoutMs: 5_000 })),
+    );
+
+    expect(chunks.some((c) => c.type === "error")).toBe(false);
+    expect(chunks).toContainEqual({ type: "text", text: "finished" });
+    expect(chunks.at(-1)).toMatchObject({
+      type: "done",
+      finalText: "finished",
     });
   });
 });

--- a/tests/harnesses-codex.test.ts
+++ b/tests/harnesses-codex.test.ts
@@ -66,6 +66,13 @@ describe("parseCodexEvent", () => {
     expect(parseCodexEvent({ type: "turn.started" })).toEqual({ type: "heartbeat" });
   });
 
+  test("item.started tool -> progress", () => {
+    expect(parseCodexEvent({
+      type: "item.started",
+      item: { type: "tool_call", name: "shell" },
+    })).toEqual({ type: "progress", note: "tool" });
+  });
+
   test("turn.completed -> done-shaped stats carrier", () => {
     const c = parseCodexEvent({ type: "turn.completed", usage: { output_tokens: 2 } });
     expect(c?.type).toBe("done");
@@ -114,22 +121,33 @@ describe("CodexHarness.invoke", () => {
     expect(err.error).toContain("timed out");
   });
 
-  // Regression for #123: heartbeats (streamed reasoning) must NOT reset the
-  // idle timer. The fixture emits heartbeats spaced under the idle window for
-  // ~3s before a late agent_message. With the pre-fix touch()-on-every-chunk
-  // behaviour those heartbeats kept postponing the idle kill, so the wedged
-  // turn ran to completion. With the fix the idle timer fires regardless of
-  // heartbeats, so we get an idle error and never reach the late finish.
-  test("repeated heartbeats do not reset idle -> idle-killed before finish", async () => {
+  test("model heartbeats reset idle -> completes", async () => {
     process.env.FAKE_CODEX_MODE = "heartbeats";
     const chunks = await collect(
       mkHarness().invoke(
         newRequest({ idleTimeoutMs: 800, hardTimeoutMs: 10_000 }),
       ),
     );
-    // Heartbeats really did stream through (otherwise the test is vacuous)...
     expect(chunks.some((c) => c.type === "heartbeat")).toBe(true);
-    // ...yet the turn was idle-killed before the late agent_message landed.
+    expect(chunks.some((c) => c.type === "error")).toBe(false);
+    const done = chunks.find((c) => c.type === "done");
+    if (done?.type !== "done") throw new Error("expected done chunk");
+    expect(done.finalText).toContain("late finish");
+  });
+
+  // Regression for #123: after a tool has started, generic heartbeat noise
+  // must NOT keep a stuck turn alive forever. The fixture emits heartbeats
+  // spaced under the idle window after the tool-start signal; the harness must
+  // idle-kill before the late agent_message lands.
+  test("tool-phase heartbeats do not reset idle -> idle-killed before finish", async () => {
+    process.env.FAKE_CODEX_MODE = "tool-heartbeats";
+    const chunks = await collect(
+      mkHarness().invoke(
+        newRequest({ idleTimeoutMs: 800, hardTimeoutMs: 10_000 }),
+      ),
+    );
+    expect(chunks.some((c) => c.type === "heartbeat")).toBe(true);
+    expect(chunks.some((c) => c.type === "progress")).toBe(true);
     expect(chunks.some((c) => c.type === "done")).toBe(false);
     expect(
       chunks.some((c) => c.type === "text" && c.text.includes("late finish")),


### PR DESCRIPTION
## Summary
- let model-side heartbeat/thinking activity reset the idle timer before a tool is known to be running
- keep tool execution bounded by ignoring generic heartbeats until productive output arrives
- add Codex fixture coverage for both model-heartbeat survival and tool-phase heartbeat timeout regression

## Verification
- `bun run typecheck`
- `bun test`
- `bun run build`