### PR TITLE
Remove PhantomOps link from website

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -18,7 +18,6 @@
             </div>
             <div class="links">
                 <a href="https://github.com/phantomyard/phantombot">GitHub</a>
-                <a href="https://phantomops.app">PhantomOps</a>
             </div>
         </nav>
     </header>


### PR DESCRIPTION
## Summary
- Remove the PhantomOps link from the Phantombot website nav
- Leave the rest of the website unchanged

## Verification
- rg -n "phantomops\.app|PhantomOps" www || true