### PR TITLE
fix(harness): 5-min idle timeout + recover failed turns with a real reply, never a raw error

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -45,6 +45,7 @@ import { log } from "../lib/logger.ts";
 import type { ServiceControl } from "../lib/systemd.ts";
 import type { MemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
+import { generateRecoveryReply } from "../orchestrator/recovery.ts";
 import { makeRetriever } from "../orchestrator/retrieval.ts";
 import { makeTurnIndexer } from "../orchestrator/turnIndexer.ts";
 import {
@@ -1893,21 +1894,48 @@ async function processChatMessage(
     return;
   }
 
-  // The authoritative full reply: prefer the harness's `done.finalText`
-  // (which may have been reformatted), fall back to whatever streamed.
-  const fullReply = finalReply ?? streamedReply;
+  // The harness chain failed with a (recoverable) diagnostic — almost
+  // always a wedged tool call tripping the idle timeout. We NEVER show the
+  // raw internal string: it's English-only and reads like a crash. Instead
+  // re-prompt the chain ONCE for a short, language-matched human reply
+  // ("hit a snag, mind trying again?") and deliver that like any normal
+  // message. If even the recovery turn can't produce text, we stay silent —
+  // the diagnostic is already in the journal.
+  let recoveryText: string | undefined;
+  if (errored) {
+    log.error("telegram: turn failed; generating recovery reply", {
+      chatId: msg.chatId,
+      error: errored,
+    });
+    recoveryText = await generateRecoveryReply({
+      harnesses,
+      userMessage: msg.text,
+      personaName: input.persona,
+      signal: controller.signal,
+    });
+  }
+  // True only when the turn failed AND recovery couldn't produce anything.
+  // `errored` itself is left intact so the telemetry below still records
+  // that the underlying turn failed.
+  const unrecoverable = !!errored && !recoveryText;
+
+  // The authoritative full reply: a recovery message if we made one, else
+  // the harness's done.finalText (possibly reformatted), else whatever
+  // streamed live.
+  const fullReply = recoveryText ?? finalReply ?? streamedReply;
 
   // Compute what still needs to be sent after live streaming:
-  //   - error: surface the diagnostic
+  //   - unrecoverable failure: stay silent (diagnostic is logged, never shown)
   //   - consumed prefix matches: send only the suffix (the part the user
   //     hasn't seen yet, after live final bubbles and classified narration)
-  //   - consumed prefix doesn't match (harness reformatted): send the
-  //     full reply. We accept some duplication over silently truncating.
+  //   - consumed prefix doesn't match (harness reformatted, or a recovery
+  //     reply unrelated to the streamed text): send the full reply. We
+  //     accept some duplication over silently truncating.
   //   - nothing came back AND nothing visible was sent: "(no reply)"
   //   - nothing came back BUT progress/final bubbles landed: stay silent
   let outText: string;
-  if (errored) {
-    outText = `(error: ${errored})`;
+  if (unrecoverable) {
+    outText = "";
   } else if (fullReply.length === 0) {
     // Empty reply: in a DM the "(no reply)" placeholder is a useful signal
     // that the turn produced nothing. In a GROUP it's pure noise — a bot
@@ -1930,16 +1958,16 @@ async function processChatMessage(
     outText = fullReply;
   }
 
-  // Voice in → voice out (when TTS is configured AND no error).
-  // Text in → text out, always. The reply lands as a fresh message,
-  // so Telegram pushes a notification — important when the user kicked
-  // off a long job and walked away from the chat.
+  // Voice in → voice out (when TTS is configured AND we have something to
+  // say — including a recovery reply). Text in → text out, always. The
+  // reply lands as a fresh message, so Telegram pushes a notification —
+  // important when the user kicked off a long job and walked away.
   //
   // Voice-out synthesizes the full reply, split into short clips. Text
   // streaming is disabled for voice, so there is nothing to dedupe.
   let sentAsVoice = false;
   try {
-    if (willReplyWithVoice && !errored && fullReply.length > 0) {
+    if (willReplyWithVoice && !unrecoverable && fullReply.length > 0) {
       const voiceSegments = splitIntoSegments(fullReply, {
         maxSentences: streaming.voiceMaxSentences,
         maxChars: streaming.bubbleMaxChars,
@@ -1964,13 +1992,11 @@ async function processChatMessage(
       }
     } else if (outText.length > 0) {
       // Empty outText is intentional silence: streaming/progress bubbles
-      // already delivered all useful output. Otherwise, split the remaining
-      // final reply into markdown-safe Telegram bubbles.
-      if (errored) {
-        await sendTextSegment(outText, "error");
-      } else {
-        await sendFinalSegments(outText);
-      }
+      // already delivered all useful output, or the turn failed
+      // unrecoverably (diagnostic logged, nothing shown). Otherwise, split
+      // the remaining final reply — a normal answer or a recovery message —
+      // into markdown-safe Telegram bubbles.
+      await sendFinalSegments(outText);
     }
   } catch (e) {
     log.error("telegram: send failed", {
@@ -1992,6 +2018,9 @@ async function processChatMessage(
     inputModality: isVoice ? "voice" : "text",
     modalityOverride: modalityOverride ?? "none",
     ok: !errored,
+    // Turn failed at the harness level but a language-matched recovery
+    // reply was generated and delivered instead of a raw diagnostic.
+    recovered: !!errored && !unrecoverable,
   });
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -273,15 +273,22 @@ export async function loadConfig(): Promise<Config> {
     // the OLD semantics for an unmodified legacy config we map
     // turn_timeout_s to BOTH ceilings: idle == hard == legacy value.
     // That way a `turn_timeout_s = 600` config still tolerates 10
-    // minutes of silence, the way it used to. New configs that want the
-    // safer 120s-idle behavior set harness_idle_timeout_s explicitly.
+    // minutes of silence, the way it used to. New configs that want a
+    // different idle window set harness_idle_timeout_s explicitly.
+    //
+    // Default is 300s (5 min). Modern agent turns legitimately go quiet
+    // for minutes at a time — a single tool call can fan out to many
+    // sub-agents, or run a long build/search — so the old 120s default
+    // killed genuinely-working turns as if they were wedged. 5 min sits
+    // well under the 60-min hard cap and gives real work room to breathe
+    // while still catching a truly stuck subprocess.
     harnessIdleTimeoutMs:
       asInt(process.env.PHANTOMBOT_HARNESS_IDLE_TIMEOUT_MS) ??
       (asInt(toml.harness_idle_timeout_s) !== undefined
         ? asInt(toml.harness_idle_timeout_s)! * 1000
         : undefined) ??
       legacyTurnTimeoutMs(toml) ??
-      120_000,
+      300_000,
 
     harnessHardTimeoutMs:
       asInt(process.env.PHANTOMBOT_HARNESS_HARD_TIMEOUT_MS) ??

--- a/src/orchestrator/recovery.ts
+++ b/src/orchestrator/recovery.ts
@@ -1,0 +1,126 @@
+/**
+ * Post-failure recovery reply.
+ *
+ * When the harness chain is exhausted on a *recoverable* failure — most
+ * often a wedged tool call tripping the idle timeout — the channel must
+ * NOT surface the raw internal diagnostic (e.g. "claude timed out after
+ * 300000ms with no output ..."). Those strings are English-only and read
+ * to the user like a crash.
+ *
+ * Instead we re-prompt the chain ONCE for a short, human reply that tells
+ * the user, in the language of their own message, that the turn hit a snag
+ * and to try again. Because it's a real model reply rather than a hardcoded
+ * constant, it matches the conversation's language and the persona's tone —
+ * which is the whole point: a canned English line is fine for English
+ * speakers and alienating for everyone else.
+ *
+ * Guarantees:
+ *   - Bounded: short idle/hard caps so a second wedge can't double the
+ *     latency the user already sat through on the failed turn.
+ *   - Fresh chain: runs with its own CooldownStore so the failed turn's
+ *     cooldown bookkeeping doesn't force recovery onto the weakest harness.
+ *   - Non-recursive: a single runWithFallback pass. If it also fails we
+ *     return undefined and the caller stays silent — the original
+ *     diagnostic is already in the journal via the orchestrator's logs.
+ *   - Tool-free by instruction: the prompt forbids tools, so recovery
+ *     won't re-trigger the same wedged call.
+ */
+
+import { homedir } from "node:os";
+
+import { runWithFallback } from "./fallback.ts";
+import type { Harness } from "../harnesses/types.ts";
+import { CooldownStore } from "../lib/cooldown.ts";
+import { log } from "../lib/logger.ts";
+
+/**
+ * Bounded budget for the recovery turn. It only has to emit a sentence or
+ * two, so keep it tight — the user has already waited out the failed turn's
+ * full idle window and we don't want to compound that.
+ */
+const RECOVERY_IDLE_TIMEOUT_MS = 30_000;
+const RECOVERY_HARD_TIMEOUT_MS = 60_000;
+
+export interface RecoveryReplyInput {
+  /** The harness chain the failed turn used. */
+  harnesses: Harness[];
+  /** The user's original message — carries the language to mirror. */
+  userMessage: string;
+  /** Persona display name, for light tone framing. Optional. */
+  personaName?: string;
+  /** Subprocess working dir. Defaults to the running user's home. */
+  workingDir?: string;
+  /** Abort signal — a new inbound message should cancel recovery too. */
+  signal?: AbortSignal;
+}
+
+function recoverySystemPrompt(personaName?: string): string {
+  const who = personaName
+    ? `You are ${personaName}, the user's personal assistant.`
+    : `You are the user's personal assistant.`;
+  return [
+    who,
+    "",
+    "Your previous attempt to answer the user's last message got stuck on",
+    "an internal step and was aborted before you could reply. Nothing was",
+    "sent to them yet.",
+    "",
+    "Write a brief, warm reply — one or two sentences — telling the user you",
+    "hit a snag and didn't get through this time, and asking them to try",
+    "again. Reply in the SAME LANGUAGE as the user's message below.",
+    "",
+    "Hard rules:",
+    "- Do NOT use any tools. Just write the message.",
+    "- Do NOT mention timeouts, subprocesses, errors, or any technical detail.",
+    "- Do NOT try to answer their actual question — you don't have an answer.",
+    "- Keep it short and human; no long apologies.",
+  ].join("\n");
+}
+
+/**
+ * Generate the recovery message. Returns the trimmed text, or undefined if
+ * even the recovery turn failed (caller then stays silent).
+ */
+export async function generateRecoveryReply(
+  input: RecoveryReplyInput,
+): Promise<string | undefined> {
+  if (input.signal?.aborted) return undefined;
+  if (input.harnesses.length === 0) return undefined;
+
+  let text = "";
+  try {
+    for await (const chunk of runWithFallback(
+      input.harnesses,
+      {
+        systemPrompt: recoverySystemPrompt(input.personaName),
+        userMessage: input.userMessage,
+        history: [],
+        workingDir: input.workingDir ?? homedir(),
+        idleTimeoutMs: RECOVERY_IDLE_TIMEOUT_MS,
+        hardTimeoutMs: RECOVERY_HARD_TIMEOUT_MS,
+        signal: input.signal,
+      },
+      // Fresh cooldown state: the failed turn just marked harnesses down,
+      // and we want recovery to try the primary harness first rather than
+      // inherit that penalty.
+      { cooldown: new CooldownStore() },
+    )) {
+      if (chunk.type === "text") text += chunk.text;
+      if (chunk.type === "done") {
+        if (chunk.finalText.length > 0) text = chunk.finalText;
+      }
+      if (chunk.type === "error") {
+        log.warn("recovery: reply generation failed", { error: chunk.error });
+        return undefined;
+      }
+    }
+  } catch (e) {
+    log.warn("recovery: reply generation threw", {
+      error: (e as Error).message,
+    });
+    return undefined;
+  }
+
+  const trimmed = text.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -1028,7 +1028,7 @@ describe("runTelegramServer dispatch", () => {
     });
   });
 
-  test("on harness error sends an error message and does not persist", async () => {
+  test("on unrecoverable harness error: never shows the raw diagnostic, does not persist", async () => {
     const transport = new FakeTransport();
     transport.pendingUpdates.push({
       updateId: 1,
@@ -1036,6 +1036,8 @@ describe("runTelegramServer dispatch", () => {
       fromUserId: 42,
       text: "hi",
     });
+    // This harness fails on every invoke, so the recovery re-prompt fails
+    // too. The user must NOT see the internal "boom" string; we stay silent.
     const harness = new ScriptedHarness("fake", [
       { type: "error", error: "boom", recoverable: false },
     ]);
@@ -1048,7 +1050,64 @@ describe("runTelegramServer dispatch", () => {
       transport,
       oneShot: true,
     });
-    expect(transport.sent).toEqual([{ chatId: 1001, text: "(error: boom)" }]);
+    expect(transport.sent).toEqual([]);
+    expect(
+      transport.sent.some((s) => /boom|error|timed out/i.test(s.text)),
+    ).toBe(false);
+    expect(await memory.recentTurns("phantom", "telegram:1001", 10)).toEqual([]);
+  });
+
+  test("on harness failure: surfaces a language-matched recovery reply, not the raw error", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      chatId: 1001,
+      fromUserId: 42,
+      text: "hola, ¿cómo estás?",
+    });
+    // First invoke (the real turn) fails; the recovery re-prompt is a
+    // second invoke that succeeds with a human reply. A stateful harness
+    // models exactly that.
+    let calls = 0;
+    const harness: Harness = {
+      id: "flaky",
+      available: async () => true,
+      async *invoke() {
+        calls++;
+        if (calls === 1) {
+          yield {
+            type: "error",
+            error: "flaky timed out after 300000ms",
+            recoverable: true,
+          };
+          return;
+        }
+        yield { type: "text", text: "¡Uy, me atasqué! ¿Lo intentamos otra vez?" };
+        yield {
+          type: "done",
+          finalText: "¡Uy, me atasqué! ¿Lo intentamos otra vez?",
+        };
+      },
+    };
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(calls).toBe(2);
+    expect(transport.sent).toEqual([
+      { chatId: 1001, text: "¡Uy, me atasqué! ¿Lo intentamos otra vez?" },
+    ]);
+    // The raw diagnostic is never shown.
+    expect(transport.sent.some((s) => /timed out|error:/i.test(s.text))).toBe(
+      false,
+    );
+    // A failed-but-recovered turn still leaves no history (the original
+    // question went unanswered, so the user can retry cleanly).
     expect(await memory.recentTurns("phantom", "telegram:1001", 10)).toEqual([]);
   });
 });
@@ -2379,9 +2438,11 @@ describe("runTelegramServer narration flush (text-out)", () => {
     expect(transport.sent.map((s) => s.text)).toEqual([]);
   });
 
-  test("error after short narration: error message still surfaces", async () => {
+  test("error after short narration: raw diagnostic is never surfaced", async () => {
     // Narration may or may not have reached the timer before the tool
-    // blows up. The error diagnostic still has to surface.
+    // blows up. Either way the raw internal diagnostic must NOT reach the
+    // user — the recovery re-prompt fails too here (same scripted harness),
+    // so the turn stays silent rather than printing "(error: boom)".
     class ErrorAfterToolHarness implements Harness {
       readonly id = "error-after-tool";
       async available(): Promise<boolean> {
@@ -2411,7 +2472,9 @@ describe("runTelegramServer narration flush (text-out)", () => {
       oneShot: true,
     });
 
-    expect(transport.sent.map((s) => s.text)).toEqual(["(error: boom)"]);
+    expect(
+      transport.sent.some((s) => /boom|error:/i.test(s.text)),
+    ).toBe(false);
   });
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -88,7 +88,7 @@ describe("loadConfig — defaults (no file)", () => {
   test("returns built-in defaults when no config file exists", async () => {
     const c = await loadConfig();
     expect(c.defaultPersona).toBe("phantom");
-    expect(c.harnessIdleTimeoutMs).toBe(120_000);
+    expect(c.harnessIdleTimeoutMs).toBe(300_000);
     expect(c.harnessHardTimeoutMs).toBe(3_600_000);
     expect(c.harnesses.chain).toEqual(["claude"]);
     expect(c.harnesses.claude).toEqual({

--- a/tests/orchestrator-recovery.test.ts
+++ b/tests/orchestrator-recovery.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the post-failure recovery reply.
+ *
+ * When the harness chain fails, the channel re-prompts once for a short,
+ * language-matched human reply instead of surfacing the raw diagnostic.
+ * generateRecoveryReply is the unit that produces that text.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { generateRecoveryReply } from "../src/orchestrator/recovery.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessRequest,
+} from "../src/harnesses/types.ts";
+
+class FakeHarness implements Harness {
+  invocations = 0;
+  lastRequest?: HarnessRequest;
+  constructor(
+    public readonly id: string,
+    private readonly script: HarnessChunk[],
+  ) {}
+  async available(): Promise<boolean> {
+    return true;
+  }
+  async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    this.invocations++;
+    this.lastRequest = req;
+    for (const c of this.script) yield c;
+  }
+}
+
+describe("generateRecoveryReply", () => {
+  test("returns the harness's recovery text", async () => {
+    const harness = new FakeHarness("fake", [
+      { type: "text", text: "Hit a snag — mind trying again?" },
+      { type: "done", finalText: "Hit a snag — mind trying again?" },
+    ]);
+    const out = await generateRecoveryReply({
+      harnesses: [harness],
+      userMessage: "what's my balance?",
+      personaName: "Robbie",
+    });
+    expect(out).toBe("Hit a snag — mind trying again?");
+    expect(harness.invocations).toBe(1);
+  });
+
+  test("trims whitespace and prefers final text", async () => {
+    const harness = new FakeHarness("fake", [
+      { type: "text", text: "partial" },
+      { type: "done", finalText: "  Final clean reply.  " },
+    ]);
+    const out = await generateRecoveryReply({
+      harnesses: [harness],
+      userMessage: "hi",
+    });
+    expect(out).toBe("Final clean reply.");
+  });
+
+  test("passes the original user message through (for language matching)", async () => {
+    const harness = new FakeHarness("fake", [
+      { type: "done", finalText: "ok" },
+    ]);
+    await generateRecoveryReply({
+      harnesses: [harness],
+      userMessage: "hola, ¿cómo estás?",
+    });
+    expect(harness.lastRequest?.userMessage).toBe("hola, ¿cómo estás?");
+    // Recovery runs with no history and a tool-forbidding system prompt.
+    expect(harness.lastRequest?.history).toEqual([]);
+    expect(harness.lastRequest?.systemPrompt).toContain("Do NOT use any tools");
+  });
+
+  test("returns undefined when the recovery turn itself errors", async () => {
+    const harness = new FakeHarness("fake", [
+      { type: "error", error: "still broken", recoverable: true },
+    ]);
+    const out = await generateRecoveryReply({
+      harnesses: [harness],
+      userMessage: "hi",
+    });
+    expect(out).toBeUndefined();
+  });
+
+  test("returns undefined for an empty reply", async () => {
+    const harness = new FakeHarness("fake", [
+      { type: "done", finalText: "   " },
+    ]);
+    const out = await generateRecoveryReply({
+      harnesses: [harness],
+      userMessage: "hi",
+    });
+    expect(out).toBeUndefined();
+  });
+
+  test("returns undefined with no harnesses", async () => {
+    const out = await generateRecoveryReply({
+      harnesses: [],
+      userMessage: "hi",
+    });
+    expect(out).toBeUndefined();
+  });
+
+  test("returns undefined immediately if already aborted", async () => {
+    const harness = new FakeHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const out = await generateRecoveryReply({
+      harnesses: [harness],
+      userMessage: "hi",
+      signal: AbortSignal.abort(),
+    });
+    expect(out).toBeUndefined();
+    expect(harness.invocations).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

Two complaints about how a wedged/failed turn looks to the user:

1. **2-min idle timeout is too aggressive.** Modern agent turns legitimately go quiet for minutes — one tool call can fan out to many sub-agents or run a long build/search. The old 120s default killed genuinely-working turns as if they were stuck.
2. **The raw diagnostic leaks to the user.** `(error: claude timed out after 120000ms with no output ...)` is internal English-only text that reads like a crash, and is alienating to non-English speakers.

## What

**1. Idle timeout default 120s → 300s** (`src/config.ts`). Shipped as a *code default* so every agent inherits it on `phantombot update` with **no config.toml edits**; `config.toml` stays a per-agent override. 5 min sits well under the 60-min hard cap.

**2. Recover with a real, language-matched reply** (`src/orchestrator/recovery.ts`, wired into `src/channels/telegram.ts`). When the chain fails, instead of rendering the raw string we re-prompt the chain **once** for a short human reply ("hit a snag, mind trying again?") in the **language of the user's message**, and deliver it like a normal message (text or voice). The raw diagnostic is logged to the journal only.

Recovery is:
- **bounded** (30s idle / 60s hard) so a second wedge can't double the latency the user already waited through
- **fresh-cooldown** so it tries the primary harness first, not the just-failed fallback
- **tool-free by instruction** so it won't re-trigger the wedged call
- **non-recursive** — returns `undefined` on failure, and the channel then stays *silent* rather than showing an error string

Telemetry: the telegram `complete` log keeps `ok:!errored` and adds `recovered:<bool>`, so a recovered turn is still visibly a failed turn.

## Tests

- New `tests/orchestrator-recovery.test.ts` (7 cases: success, trim/prefer-final, language pass-through + tool-free prompt, error→undefined, empty→undefined, no-harnesses, pre-aborted).
- Updated `tests/config.test.ts` (default now 300s; legacy alias unchanged) and `tests/channels-telegram.test.ts` (raw diagnostic never surfaced; recovery reply surfaced instead).
- Full suite green (1090 pass / 0 fail), typecheck clean, arm64 compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)