### PR TITLE
feat(harness): expose persona as PHANTOMBOT_PERSONA env to subprocesses

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -48,7 +48,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
-import { reloadEnvFiles } from "../lib/envBootstrap.ts";
+import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
   type HarnessActivity,
@@ -99,7 +99,7 @@ export class ClaudeHarness implements Harness {
 
     // OAuth-on-host: don't leak ANTHROPIC_API_KEY into the subprocess env,
     // so claude resolves credentials from ~/.claude/.credentials.json.
-    const env = filterAuthEnv(process.env);
+    const env = withPersonaEnv(filterAuthEnv(process.env), req.persona);
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -10,7 +10,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
-import { reloadEnvFiles } from "../lib/envBootstrap.ts";
+import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
   type HarnessActivity,
@@ -51,7 +51,7 @@ export class CodexHarness implements Harness {
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,
-      env: process.env,
+      env: withPersonaEnv(process.env, req.persona),
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -38,7 +38,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
-import { reloadEnvFiles } from "../lib/envBootstrap.ts";
+import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
   type HarnessActivity,
@@ -129,7 +129,7 @@ export class GeminiHarness implements Harness {
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,
-      env: process.env,
+      env: withPersonaEnv(process.env, req.persona),
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -24,7 +24,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
-import { reloadEnvFiles } from "../lib/envBootstrap.ts";
+import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   createKillCoordinator,
   type HarnessActivity,
@@ -92,7 +92,7 @@ export class PiHarness implements Harness {
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,
-      env: process.env,
+      env: withPersonaEnv(process.env, req.persona),
       stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -22,6 +22,15 @@ export interface HarnessRequest {
   userMessage: string;
   /** Prior turns of this conversation, oldest first. May be empty. */
   history: HistoryTurn[];
+  /**
+   * Persona key for THIS turn (e.g. "burt"). Exposed to the subprocess as
+   * the `PHANTOMBOT_PERSONA` env var so tools can self-identify without a
+   * hardcoded name — this is the single source of truth for "which bot am
+   * I". Per-turn, not global: a host running multiple personas gets the
+   * right identity on every spawn. Optional — degraded paths (e.g. the
+   * no-tools recovery reply) may omit it.
+   */
+  persona?: string;
   /** Subprocess working directory. Defaults to the agent dir. */
   workingDir?: string;
   /**

--- a/src/lib/envBootstrap.ts
+++ b/src/lib/envBootstrap.ts
@@ -255,3 +255,21 @@ export async function reloadEnvFiles(
 
   return { updated, removed };
 }
+
+/**
+ * Return a copy of `base` with `PHANTOMBOT_PERSONA` set to the turn's persona
+ * key, so the spawned harness subprocess can self-identify (e.g. bot-inbox
+ * defaults its `--from` to it). Per-spawn and copy-on-write: we never mutate
+ * the caller's env (notably the global `process.env`). When `persona` is
+ * empty/undefined the base is returned untouched — degraded paths that don't
+ * carry a persona just don't get the var.
+ *
+ * One helper, shared by all four harnesses, so the var name can't drift.
+ */
+export function withPersonaEnv<T extends NodeJS.ProcessEnv>(
+  base: T,
+  persona: string | undefined,
+): T {
+  if (!persona) return base;
+  return { ...base, PHANTOMBOT_PERSONA: persona };
+}

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -169,6 +169,7 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
     systemPrompt,
     userMessage: input.userMessage,
     history,
+    persona: input.persona,
     workingDir: input.workingDir ?? homedir(),
     idleTimeoutMs: input.idleTimeoutMs,
     hardTimeoutMs: input.hardTimeoutMs,

--- a/tests/lib-envBootstrap.test.ts
+++ b/tests/lib-envBootstrap.test.ts
@@ -22,6 +22,7 @@ import { join } from "node:path";
 import {
   preloadEnvFiles,
   reloadEnvFiles,
+  withPersonaEnv,
 } from "../src/lib/envBootstrap.ts";
 
 let workdir: string;
@@ -311,5 +312,33 @@ describe("reloadEnvFiles — mtime stat cache", () => {
     await reloadEnvFiles({ files: [path], env, tracked, statCache });
     expect(env.FOO).toBe("resurrected");
     expect(statCache.get(path)!.parsed.FOO).toBe("resurrected");
+  });
+});
+
+describe("withPersonaEnv", () => {
+  test("sets PHANTOMBOT_PERSONA to the persona key", () => {
+    const base: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+    const out = withPersonaEnv(base, "burt");
+    expect(out.PHANTOMBOT_PERSONA).toBe("burt");
+    expect(out.PATH).toBe("/usr/bin");
+  });
+
+  test("does not mutate the input env (copy-on-write)", () => {
+    const base: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+    const out = withPersonaEnv(base, "robbie");
+    expect(out).not.toBe(base);
+    expect(base.PHANTOMBOT_PERSONA).toBeUndefined();
+  });
+
+  test("returns the base untouched when persona is undefined", () => {
+    const base: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+    const out = withPersonaEnv(base, undefined);
+    expect(out).toBe(base);
+    expect(out.PHANTOMBOT_PERSONA).toBeUndefined();
+  });
+
+  test("returns the base untouched when persona is empty", () => {
+    const base: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+    expect(withPersonaEnv(base, "")).toBe(base);
   });
 });


### PR DESCRIPTION
## What

Passes the per-turn persona to every harness subprocess via `PHANTOMBOT_PERSONA`, so tools (like bot-inbox) can derive their bot identity without a separate config var.

## Why

bot-inbox (phantomtools) needs a `--from`. Rather than introducing a new `$BOT_NAME`, we lift the persona phantombot already knows — at the right layer, and automatically correct if the host ever runs multiple personas.

## Changes

- Added `persona?` to `HarnessRequest`, set from `turn.ts` (the chokepoint that tick/ask/nightly all flow through)
- New `withPersonaEnv()` helper in `envBootstrap.ts` (copy-on-write, doesn't touch `process.env`) — all 4 harnesses use it so the var name can't drift
- All 4 harnesses (claude/codex/gemini/pi) set `PHANTOMBOT_PERSONA`
- Recovery (no-tools path) deliberately left untouched; the field is optional

## Multi-persona

The persona is passed **per-invoke**, not as a global env var — each subprocess gets the identity of that turn.

## Tests

120/120 pass, typecheck clean (+4 unit tests).