### PR TITLE
harness: trim CLI pre-prompting noise (claude/gemini/codex/pi)

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -221,6 +221,26 @@ export class ClaudeHarness implements Harness {
       "--no-session-persistence",
       "--permission-mode", "bypassPermissions",
       "--model", this.config.model,
+      // Pre-prompting trim (phantombot supplies persona / memory / scheduling
+      // itself, so Claude Code's daily-driver scaffolding is pure noise here):
+      //   --disallowedTools Workflow
+      //     Drops the Workflow tool from the available set. The "you typed
+      //     'workflow', use the Workflow tool" system nudge ONLY fires because
+      //     that tool is loaded — removing the tool kills the nudge at source.
+      //     (We deny by name rather than via the --settings deny-list because
+      //     disallowedTools removes it from the advertised surface, which is
+      //     what actually suppresses the injected reminder.)
+      //   --disable-slash-commands
+      //     Suppresses the entire injected "available skills" block
+      //     (deep-research / loop / schedule / verify / code-review / …).
+      //   --exclude-dynamic-system-prompt-sections
+      //     Explicitly drops the per-machine cwd/env/git cruft. --system-prompt
+      //     already drops most of it; this is the canonical belt-and-suspenders.
+      // NB: MCP connectors (Gmail / Calendar / Drive) are tools, not skills or
+      // Workflow, so they are UNAFFECTED — Andrew uses those and they stay.
+      "--disallowedTools", "Workflow",
+      "--disable-slash-commands",
+      "--exclude-dynamic-system-prompt-sections",
     ];
     if (this.config.fallbackModel) {
       args.push("--fallback-model", this.config.fallbackModel);

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -3,9 +3,13 @@
  *
  * Uses `codex exec --json` for non-interactive JSONL streaming. We run in
  * YOLO mode (`--dangerously-bypass-approvals-and-sandbox`) and with
- * `--ephemeral --ignore-user-config --ignore-rules` so phantombot-managed
- * persona/memory stays authoritative and Codex local memory/rules do not leak
- * into agent behavior.
+ * `--ephemeral --ignore-rules` so phantombot-managed persona/memory stays
+ * authoritative and Codex's local rules/memory do not leak into agent
+ * behavior. We deliberately let user config (~/.codex/config.toml) load on
+ * normal turns so MCP connectors (Google Workspace, etc.) remain available.
+ * The tool-less threat judge is the exception — it keeps `--ignore-user-config`
+ * (see PHANTOMBOT_JUDGE_CODEX_FLAGS) for maximum isolation when reading
+ * untrusted input.
  */
 
 import { access, constants } from "node:fs/promises";
@@ -186,7 +190,13 @@ export function renderStdinPayload(req: HarnessRequest): string {
 export const PHANTOMBOT_INJECTED_CODEX_FLAGS = [
   "--dangerously-bypass-approvals-and-sandbox",
   "--ephemeral",
-  "--ignore-user-config",
+  // NOTE: we intentionally do NOT pass `--ignore-user-config` on normal turns.
+  // Codex's MCP connectors (Gmail / Google Calendar / Google Drive, etc.) are
+  // configured in ~/.codex/config.toml; --ignore-user-config would skip that
+  // file entirely and silently disable every connector. Andrew wants those
+  // Workspace connectors available, so user config loads. We still keep
+  // `--ignore-rules` below so Codex's local AGENTS.md / project rules / memory
+  // do NOT leak into behavior — phantombot's persona stays authoritative.
   "--ignore-rules",
 ] as const;
 

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -110,6 +110,15 @@ export class GeminiHarness implements Harness {
     const args: string[] = [
       "-p", req.userMessage,
       "-o", "stream-json",
+      // Skip gemini-cli's per-session workspace-trust handshake. In headless
+      // mode the trust prompt can stall startup; phantombot already runs on a
+      // trusted host. Safe for both normal and judge (read-only) modes.
+      // NB: we deliberately keep `-o stream-json` (NOT `-o text`) — the
+      // stream-json event feed is what drives heartbeats / wedge detection;
+      // collapsing to text would blind the channel layer (see header comment).
+      // We also do NOT pass `-e` (extension pinning) so any Workspace
+      // connector extensions Andrew configures keep loading.
+      "--skip-trust",
     ];
     // Tool-less threat-judge mode → `--approval-mode plan` (per `gemini
     // --help`: "plan (read-only mode)"). The judge may read but cannot act.

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -78,6 +78,18 @@ export class PiHarness implements Harness {
       "--print",
       "--mode", "json",
       "--system-prompt", req.systemPrompt,
+      // Pre-prompting trim:
+      //   --offline   Disables Pi's STARTUP network operations (telemetry,
+      //               update checks) only — NOT the model API call. The
+      //               OpenRouter model request still goes out, so the
+      //               (intentional) OpenRouter fallback is unaffected. Same as
+      //               PI_OFFLINE=1.
+      //   --no-session  Ephemeral: don't write a session file. Phantombot owns
+      //               conversation state, so Pi's own session store is dead
+      //               weight.
+      // We leave tools / skills / extensions ENABLED so connectors survive.
+      "--offline",
+      "--no-session",
     ];
     // Tool-less threat-judge mode. Per `pi --help`, `--no-tools` disables all
     // tools (built-in, extension, and custom) — true zero-tools, native flag,

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -370,6 +370,23 @@ describe("ClaudeHarness subprocess invocation passes injected settings", () => {
       .join("");
     expect(texts).not.toContain("--tools");
   });
+
+  test("pre-prompting trim flags ride along on every turn", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });
+    const chunks = await collect(h.invoke(newRequest()));
+    const texts = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    // Workflow tool removed (kills the "you typed 'workflow'…" nudge at source).
+    expect(texts).toContain("--disallowedTools");
+    expect(texts).toContain("Workflow");
+    // Skills block suppressed.
+    expect(texts).toContain("--disable-slash-commands");
+    // Per-machine dynamic sections dropped.
+    expect(texts).toContain("--exclude-dynamic-system-prompt-sections");
+  });
 });
 
 describe("ClaudeHarness.available", () => {

--- a/tests/harnesses-codex.test.ts
+++ b/tests/harnesses-codex.test.ts
@@ -116,6 +116,29 @@ describe("CodexHarness.invoke", () => {
     expect(argv).not.toContain("read-only");
   });
 
+  test("a normal turn LOADS user config (no --ignore-user-config) so MCP connectors work, but keeps --ignore-rules", async () => {
+    process.env.FAKE_CODEX_MODE = "argv";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const argv = chunks
+      .filter((c) => c.type === "text")
+      .map((c) => (c as { text: string }).text)
+      .join("");
+    // Workspace connectors live in ~/.codex/config.toml — must NOT be skipped.
+    expect(argv).not.toContain("--ignore-user-config");
+    // Persona stays authoritative: local rules/memory still ignored.
+    expect(argv).toContain("--ignore-rules");
+  });
+
+  test("the tool-less judge stays fully isolated (--ignore-user-config)", async () => {
+    process.env.FAKE_CODEX_MODE = "argv";
+    const chunks = await collect(mkHarness().invoke(newRequest({ toolsMode: "none" })));
+    const argv = chunks
+      .filter((c) => c.type === "text")
+      .map((c) => (c as { text: string }).text)
+      .join("");
+    expect(argv).toContain("--ignore-user-config");
+  });
+
   test("non-zero exit -> recoverable error", async () => {
     process.env.FAKE_CODEX_MODE = "error";
     const chunks = await collect(mkHarness().invoke(newRequest()));

--- a/tests/harnesses-gemini.test.ts
+++ b/tests/harnesses-gemini.test.ts
@@ -350,6 +350,8 @@ describe("GeminiHarness.invoke (end-to-end via fake-gemini.sh)", () => {
     expect(text1.text).toContain("-o");
     expect(text1.text).toContain("stream-json");
     expect(text1.text).toContain("-y");
+    // Workspace-trust handshake skipped for headless startup.
+    expect(text1.text).toContain("--skip-trust");
     expect(text1.text).not.toContain("-m");
 
     // With model.

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -232,6 +232,19 @@ describe("PiHarness.invoke (subprocess)", () => {
     expect(argv).not.toContain("--no-tools");
   });
 
+  test("pre-prompting trim flags ride along on every turn", async () => {
+    process.env.FAKE_PI_MODE = "argv";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const argv = chunks
+      .filter((c) => c.type === "text")
+      .map((c) => (c as { text: string }).text)
+      .join("");
+    // Startup network ops off (telemetry/update checks) — model call unaffected.
+    expect(argv).toContain("--offline");
+    // Ephemeral: phantombot owns conversation state.
+    expect(argv).toContain("--no-session");
+  });
+
   test("non-zero exit emits recoverable error", async () => {
     process.env.FAKE_PI_MODE = "error";
     const chunks = await collect(mkHarness().invoke(newRequest()));


### PR DESCRIPTION
## What
Trim the per-invocation "pre-prompting" scaffolding from each wrapped CLI. Phantombot already provides persona, memory and scheduling, so Claude Code / Gemini / Codex / Pi's daily-driver extras are pure noise (and latency). Strip them **without** breaking OAuth/Max billing or the Google Workspace MCP connectors Andrew uses.

## Per-harness changes
| CLI | Added | Why |
|-----|-------|-----|
| **claude** | `--disallowedTools Workflow`, `--disable-slash-commands`, `--exclude-dynamic-system-prompt-sections` | Removes the Workflow tool (kills the "you typed 'workflow'…" nudge at its source), drops the injected skills block, drops per-machine cwd/env/git cruft. |
| **gemini** | `--skip-trust` | Skips the headless workspace-trust handshake. |
| **codex** | **removed** `--ignore-user-config` on normal turns (kept `--ignore-rules`) | Lets `~/.codex/config.toml` MCP connectors (Google Workspace) load while keeping persona authoritative. |
| **pi** | `--offline`, `--no-session` | Disables startup-only network ops (telemetry/update checks) + session persistence. |

## Deliberate non-changes (deviations from the original verbal plan — flagging these)
- **Gemini stays on `-o stream-json`, NOT `-o text`.** The harness depends on the stream-json event feed for heartbeats / wedge detection; collapsing to text would blind the channel layer. So I did *not* make that switch.
- **Gemini `usageStatisticsEnabled: false`** is the real speed win, but it's a `~/.gemini/settings.json` edit, **not** a CLI flag — so it's not in this code PR. I'll apply it as a host-config change (this box + Lena/Kai/Jake) once you're happy.
- **Codex was already fully stripped** (`--ignore-user-config` was always passed), so its Workspace connectors were *never* loading under phantombot. This PR is what actually enables them. The tool-less **threat judge keeps full isolation** (`--ignore-user-config` retained on that path).
- **OAuth/Max preserved everywhere.** No `--bare` (Claude), no API-key forcing. MCP connectors preserved on Claude (untouched), Gemini (extensions default), Codex (user config now loads), Pi (tools/skills/extensions left on).

## Tests
- New argv assertions in all four harness test files.
- `bun test` harness suites: **98 pass / 0 fail**. `bun tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
