### PR TITLE
fix(cli): clarify env set description (NAME=value entry in .env)

### DIFF
--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -136,7 +136,7 @@ export default defineCommand({
   },
   subCommands: {
     set: defineCommand({
-      meta: { name: "set", description: "Set NAME=value in ~/.env." },
+      meta: { name: "set", description: "Add or update the NAME=value entry in ~/.env." },
       args: {
         name: { type: "positional", required: true, description: "Env var name (e.g. GITHUB_TOKEN)" },
         value: { type: "positional", required: true, description: "Value to store" },


### PR DESCRIPTION
The previous description, "Set NAME=value in ~/.env.", placed the = next to the command name. On a quick read of the help output, 'set NAME=value' can be misinterpreted as the invocation 'env set NAME=value', when set actually receives NAME and value as two separate positional arguments. The = originates from the .env file format (dotenv stores each line as NAME=value), not from the command syntax.

The revised wording keeps = solely where it applies: describing the entry written to the file, rather than the manner in which the command is invoked, thereby preventing the misreading.