### PR TITLE
fix: auth-family env leak (#157) + sqlite busy_timeout (#158)

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -40,10 +40,11 @@
  *      subscription path. Don't add it back unless that changes upstream.
  *
  * Auth model under phantombot:
- *   ANTHROPIC_API_KEY is filtered out of the subprocess env so claude
- *   resolves credentials from ~/.claude/.credentials.json (the OAuth
+ *   The entire ANTHROPIC_* / CLAUDE_CODE_* auth+routing namespace is
+ *   filtered out of the subprocess env (see filterAuthEnv) so claude
+ *   resolves credentials only from ~/.claude/.credentials.json (the OAuth
  *   path that backs Claude Max). Phantombot does not hold or pass any
- *   API keys.
+ *   API keys, auth tokens, or base-URL overrides.
  */
 
 import { access, constants } from "node:fs/promises";
@@ -96,8 +97,9 @@ export class ClaudeHarness implements Harness {
     // Shell-exported keys remain sticky — see envBootstrap.ts header.
     await reloadEnvFiles();
 
-    // OAuth-on-host: don't leak ANTHROPIC_API_KEY into the subprocess env,
-    // so claude resolves credentials from ~/.claude/.credentials.json.
+    // OAuth-on-host: don't leak any ANTHROPIC_* / CLAUDE_CODE_* auth or
+    // routing var into the subprocess env (reloadEnvFiles just re-sourced
+    // ~/.env), so claude resolves credentials from ~/.claude/.credentials.json.
     const env = withPersonaEnv(filterAuthEnv(process.env), req.persona);
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
@@ -221,16 +223,43 @@ export const PHANTOMBOT_INJECTED_CLAUDE_SETTINGS = {
 } as const;
 
 /**
- * Strip ANTHROPIC_API_KEY from the inherited env so the subprocess uses
- * OAuth credentials at ~/.claude/.credentials.json. Exported for testing.
+ * Prefixes whose entire namespace is treated as authentication/routing
+ * config for the claude subprocess. Anything matching one of these is
+ * dropped from the inherited env UNLESS it is explicitly allow-listed in
+ * AUTH_ENV_ALLOW below.
+ *
+ * Denylisting individual names (the old behaviour, which only stripped
+ * ANTHROPIC_API_KEY) is fragile: ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL,
+ * CLAUDE_CODE_OAUTH_TOKEN, CLAUDE_CODE_USE_BEDROCK, etc. all silently flip
+ * claude off the Max-subscription OAuth path. reloadEnvFiles() re-sources
+ * ~/.env into process.env right before this runs, so a stray
+ * `phantombot env set ANTHROPIC_AUTH_TOKEN …` would leak straight through.
+ * Allow-listing the namespace closes the whole family at once.
+ */
+const AUTH_ENV_PREFIXES = ["ANTHROPIC_", "CLAUDE_CODE_"] as const;
+
+/**
+ * Known-safe vars inside the auth namespace that may still pass through to
+ * the subprocess. Empty today — the codebase reads none of these itself,
+ * and the claude subprocess must take its credentials only from
+ * ~/.claude/.credentials.json. Add a name here only with a clear reason.
+ */
+const AUTH_ENV_ALLOW = new Set<string>([]);
+
+/**
+ * Strip the entire ANTHROPIC_* / CLAUDE_CODE_* auth+routing namespace from
+ * the inherited env so the subprocess uses OAuth credentials at
+ * ~/.claude/.credentials.json. Exported for testing.
  */
 export function filterAuthEnv(
   source: NodeJS.ProcessEnv,
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(source)) {
-    if (k === "ANTHROPIC_API_KEY") continue;
-    if (v !== undefined) out[k] = v;
+    if (v === undefined) continue;
+    const inAuthNamespace = AUTH_ENV_PREFIXES.some((p) => k.startsWith(p));
+    if (inAuthNamespace && !AUTH_ENV_ALLOW.has(k)) continue;
+    out[k] = v;
   }
   return out;
 }

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -156,6 +156,9 @@ export class MemoryIndex {
   constructor(private readonly db: Database) {
     db.exec(SCHEMA);
     db.exec("PRAGMA journal_mode = WAL");
+    // Shared across processes (tick reindex vs. run query): block-and-retry
+    // on a busy writer instead of an immediate SQLITE_BUSY throw. See store.ts.
+    db.exec("PRAGMA busy_timeout = 5000");
   }
 
   static async open(indexPath: string): Promise<MemoryIndex> {

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -154,11 +154,11 @@ CREATE TABLE IF NOT EXISTS turn_index_state (
 
 export class MemoryIndex {
   constructor(private readonly db: Database) {
+    // Pragmas must already be applied on `db` before this runs (see open()).
+    // busy_timeout in particular has to be set before the very first
+    // statement, or schema setup itself can throw SQLITE_BUSY when another
+    // process touches the index DB concurrently.
     db.exec(SCHEMA);
-    db.exec("PRAGMA journal_mode = WAL");
-    // Shared across processes (tick reindex vs. run query): block-and-retry
-    // on a busy writer instead of an immediate SQLITE_BUSY throw. See store.ts.
-    db.exec("PRAGMA busy_timeout = 5000");
   }
 
   static async open(indexPath: string): Promise<MemoryIndex> {
@@ -166,6 +166,13 @@ export class MemoryIndex {
       await mkdir(dirname(indexPath), { recursive: true });
     }
     const db = new Database(indexPath, { create: true });
+    // Apply pragmas BEFORE constructing (which runs schema setup). The index
+    // DB is shared across processes (tick reindex vs. run query); without
+    // busy_timeout the first concurrent writer — including schema setup —
+    // gets an immediate SQLITE_BUSY throw instead of block-and-retry.
+    // See store.ts for the same ordering.
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec("PRAGMA busy_timeout = 5000");
     return new MemoryIndex(db);
   }
 

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -567,5 +567,8 @@ export async function openTaskStore(path: string): Promise<TaskStore> {
   }
   const db = new Database(path, { create: true });
   db.exec("PRAGMA journal_mode = WAL");
+  // Shared DB across processes (tick vs. run): block-and-retry on a busy
+  // writer instead of throwing SQLITE_BUSY immediately. See store.ts.
+  db.exec("PRAGMA busy_timeout = 5000");
   return new TaskStore(db, /* ownsConnection */ true);
 }

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -346,9 +346,13 @@ export async function openMemoryStore(path: string): Promise<MemoryStore> {
     await mkdir(dirname(path), { recursive: true });
   }
   const db = new Database(path, { create: true });
-  // WAL keeps reads non-blocking even though phantombot is single-process —
-  // useful if `phantombot history` is run while a `phantombot chat` REPL is open.
+  // WAL keeps reads non-blocking, but the file is in fact shared across
+  // processes — `phantombot run` persists turns while `phantombot tick`
+  // records task runs against the same DB. WAL permits one writer at a
+  // time; without busy_timeout a concurrent writer gets an immediate
+  // SQLITE_BUSY throw. busy_timeout makes it block-and-retry instead.
   db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 5000");
   db.exec("PRAGMA foreign_keys = ON");
   return new SqliteMemoryStore(db);
 }

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -79,6 +79,28 @@ describe("filterAuthEnv", () => {
     expect(out.HOME).toBe("/home/test");
   });
 
+  test("strips the whole ANTHROPIC_* / CLAUDE_CODE_* auth family", () => {
+    const out = filterAuthEnv({
+      ANTHROPIC_API_KEY: "sk-redacted",
+      ANTHROPIC_AUTH_TOKEN: "tok-redacted",
+      ANTHROPIC_BASE_URL: "https://proxy.example",
+      ANTHROPIC_CUSTOM_HEADERS: "X-Foo: bar",
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-redacted",
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      PATH: "/usr/bin",
+      HOME: "/home/test",
+    });
+    expect(out).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(out).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
+    expect(out).not.toHaveProperty("ANTHROPIC_BASE_URL");
+    expect(out).not.toHaveProperty("ANTHROPIC_CUSTOM_HEADERS");
+    expect(out).not.toHaveProperty("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(out).not.toHaveProperty("CLAUDE_CODE_USE_BEDROCK");
+    // Non-auth env passes through untouched.
+    expect(out.PATH).toBe("/usr/bin");
+    expect(out.HOME).toBe("/home/test");
+  });
+
   test("drops undefined values (NodeJS.ProcessEnv allows them)", () => {
     const out = filterAuthEnv({
       DEFINED: "yes",

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -36,6 +36,24 @@ async function note(rel: string, content: string) {
   await writeFile(join(personaDir, rel), content);
 }
 
+describe("MemoryIndex.open", () => {
+  test("applies busy_timeout before schema setup (file-backed)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "phantombot-mi-open-"));
+    const index = await MemoryIndex.open(join(dir, "index.sqlite"));
+    try {
+      // busy_timeout is connection-scoped (not persisted to the file), so we
+      // read it back off the index's own db handle. If it were still set after
+      // db.exec(SCHEMA), the first schema statements would be unprotected.
+      const db = (index as unknown as { db: { query: (sql: string) => { get: () => Record<string, number> } } }).db;
+      const row = db.query("PRAGMA busy_timeout").get();
+      expect(Object.values(row)[0]).toBe(5000);
+    } finally {
+      index.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("sanitizeFtsQuery", () => {
   test("strips special chars and quotes each token", () => {
     expect(sanitizeFtsQuery('hello world')).toBe('"hello" "world"');


### PR DESCRIPTION
**PR A** of the codebase-health triage — the two cheap, high-value fixes. Both verified against current `main` before changing. Closes #157, closes #158.

## #157 — auth-family env leak (security/billing) 🔴
`filterAuthEnv` stripped only `ANTHROPIC_API_KEY`. The rest of the auth/routing namespace — `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_CUSTOM_HEADERS`, `CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CODE_USE_BEDROCK`, … — passed straight through. Since `invoke()` runs `reloadEnvFiles()` immediately before filtering, a stray `phantombot env set ANTHROPIC_AUTH_TOKEN …` (or any exported family member) would silently flip claude off the Max-subscription OAuth path onto token/proxy billing — the exact failure the OAuth-only invariant exists to prevent.

**Fix:** swap the single-name denylist for a **namespace allowlist** — drop every `ANTHROPIC_*` / `CLAUDE_CODE_*` var unless explicitly allow-listed (`AUTH_ENV_ALLOW`, empty today since the codebase reads none of them). Closes the whole family at once and is future-proof against new auth vars.

## #158 — sqlite `busy_timeout` missing (data-loss) 🔴
`memory.sqlite` is shared across processes (`run` persists turns while `tick` records task runs / reindexes). WAL is on but `busy_timeout` was 0, so a second concurrent writer gets an immediate `SQLITE_BUSY` throw instead of blocking. Intermittent, hard-to-repro write failures.

**Fix:** `PRAGMA busy_timeout = 5000` on all three openers (memory store, task store, memory index).

## Validation
- `bun tsc --noEmit` ✅ clean
- `bun test` ✅ **1168 pass, 1 skip, 0 fail** (incl. new full-auth-family test)
- Two commits, one per issue.

Deliberately scoped tiny — the data-integrity cluster (#159/#160) and security hardening (#161) follow as separate PRs.