### PR TITLE
fix: bound Telegram + audio fetches with cancelling timeouts (#160, item c)

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -43,6 +43,7 @@ import {
 import { DEFAULT_STT_TIMEOUT_MS } from "../lib/voice.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
+import { timeoutSignal } from "../lib/fetchTimeout.ts";
 import type { ServiceControl } from "../lib/systemd.ts";
 import type { MemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
@@ -240,6 +241,26 @@ export interface TelegramTransport {
 }
 
 /**
+ * Hard timeouts for Telegram Bot API requests. Without these, a wedged
+ * upstream (a stalled file download, a control-plane call that never
+ * returns) hangs the per-chat serial chain indefinitely — the #135-class
+ * wedge. AbortSignal-backed (see lib/fetchTimeout.ts) so the socket is
+ * actually cancelled, not just a promise abandoned.
+ *
+ *   - CONTROL: sendMessage / sendVoice / sendChatAction / getFile /
+ *     getMe / setMyCommands / ackUpdates. These are small JSON or short
+ *     uploads; 30s is already pathological for them.
+ *   - DOWNLOAD: the file-body GET in downloadFile. Files can be up to the
+ *     ~20MB bot-API cap over a slow link, so it gets a longer ceiling —
+ *     but still bounded, so a non-voice attachment can't stall the chat
+ *     forever (it degrades to a graceful "download failed" instead).
+ *   - getUpdates is NOT covered here: it is a long-poll whose own
+ *     timeoutS bounds it, composed with the caller's /stop signal below.
+ */
+const TELEGRAM_CONTROL_TIMEOUT_MS = 30_000;
+const TELEGRAM_DOWNLOAD_TIMEOUT_MS = 120_000;
+
+/**
  * Real HTTP transport against api.telegram.org.
  */
 export class HttpTelegramTransport implements TelegramTransport {
@@ -253,11 +274,21 @@ export class HttpTelegramTransport implements TelegramTransport {
     const url = `https://api.telegram.org/bot${this.token}/getUpdates?offset=${offset}&timeout=${timeoutS}&allowed_updates=%5B%22message%22%5D`;
     let res: Response;
     try {
-      res = await fetch(url, { signal });
+      // Long-poll: bound by Telegram's own `timeout=` plus a margin for
+      // the round-trip, composed with the caller's /stop signal. If the
+      // poll overstays its own deadline (proxy/socket wedge), the timeout
+      // fires and we return empty so the loop re-polls cleanly.
+      res = await fetch(url, {
+        signal: timeoutSignal(timeoutS * 1000 + 10_000, signal),
+      });
     } catch (e) {
-      // AbortError is the expected path on Ctrl-C; just return empty so the
-      // caller's next signal check exits the loop.
-      if ((e as Error).name === "AbortError") {
+      // AbortError (Ctrl-C / external signal) and TimeoutError (poll
+      // overstayed) are both expected; return empty so the caller's next
+      // signal check exits the loop or it simply re-polls.
+      if (
+        (e as Error).name === "AbortError" ||
+        (e as Error).name === "TimeoutError"
+      ) {
         return { updates: [], nextOffset: offset };
       }
       log.warn("telegram: getUpdates fetch failed", {
@@ -292,7 +323,9 @@ export class HttpTelegramTransport implements TelegramTransport {
   async ackUpdates(offset: number): Promise<void> {
     const url = `https://api.telegram.org/bot${this.token}/getUpdates?offset=${offset}&timeout=0&limit=1&allowed_updates=%5B%22message%22%5D`;
     try {
-      const res = await fetch(url);
+      const res = await fetch(url, {
+        signal: timeoutSignal(TELEGRAM_CONTROL_TIMEOUT_MS),
+      });
       if (!res.ok) {
         log.warn("telegram: ackUpdates non-OK", {
           status: res.status,
@@ -329,6 +362,7 @@ export class HttpTelegramTransport implements TelegramTransport {
         text: html,
         parse_mode: "HTML",
       }),
+      signal: timeoutSignal(TELEGRAM_CONTROL_TIMEOUT_MS),
     });
     if (res.ok) return;
 
@@ -347,6 +381,7 @@ export class HttpTelegramTransport implements TelegramTransport {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ chat_id: chatId, text: safe }),
+        signal: timeoutSignal(TELEGRAM_CONTROL_TIMEOUT_MS),
       });
       if (!fallback.ok) {
         log.warn("telegram: plain-text fallback also failed", {
@@ -369,6 +404,7 @@ export class HttpTelegramTransport implements TelegramTransport {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ chat_id: chatId, action: "typing" }),
+      signal: timeoutSignal(TELEGRAM_CONTROL_TIMEOUT_MS),
     }).catch(() => {
       /* typing indicator is best-effort */
     });
@@ -380,6 +416,7 @@ export class HttpTelegramTransport implements TelegramTransport {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ chat_id: chatId, action: "record_voice" }),
+      signal: timeoutSignal(TELEGRAM_CONTROL_TIMEOUT_MS),
     }).catch(() => {});
   }
 
@@ -397,7 +434,11 @@ export class HttpTelegramTransport implements TelegramTransport {
     );
     const res = await fetch(
       `https://api.telegram.org/bot${this.token}/sendVoice`,
-      { method: "POST", body: form },
+      {
+        method: "POST",
+        body: form,
+        signal: timeoutSignal(TELEGRAM_DOWNLOAD_TIMEOUT_MS),
+      },
     );
     if (!res.ok) {
       log.warn("telegram: sendVoice non-OK", {
@@ -413,6 +454,7 @@ export class HttpTelegramTransport implements TelegramTransport {
     // Two-step: getFile to get file_path, then GET the file URL.
     const meta = await fetch(
       `https://api.telegram.org/bot${this.token}/getFile?file_id=${encodeURIComponent(fileId)}`,
+      { signal: timeoutSignal(TELEGRAM_CONTROL_TIMEOUT_MS) },
     );
     const metaBody = (await meta.json()) as {
       ok?: boolean;
@@ -421,8 +463,14 @@ export class HttpTelegramTransport implements TelegramTransport {
     if (!metaBody.ok || !metaBody.result?.file_path) {
       throw new Error(`getFile failed for ${fileId}`);
     }
+    // The file-body GET is the #135 wedge site: a non-voice attachment
+    // download that never returns would stall this chat's serial chain
+    // forever. The bounded signal makes a wedged download throw instead,
+    // which the caller catches and degrades to "[attachment download
+    // failed]".
     const file = await fetch(
       `https://api.telegram.org/file/bot${this.token}/${metaBody.result.file_path}`,
+      { signal: timeoutSignal(TELEGRAM_DOWNLOAD_TIMEOUT_MS) },
     );
     const data = Buffer.from(await file.arrayBuffer());
     const mime =
@@ -447,6 +495,7 @@ export class HttpTelegramTransport implements TelegramTransport {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ commands }),
+      signal: timeoutSignal(TELEGRAM_CONTROL_TIMEOUT_MS),
     }).catch((e) => {
       log.warn("telegram: setMyCommands fetch failed", {
         error: (e as Error).message,

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -8,6 +8,18 @@
 
 import type { Config } from "../config.ts";
 import type { VoiceProvider } from "./voice.ts";
+import { timeoutSignal } from "./fetchTimeout.ts";
+
+/**
+ * Hard ceiling for TTS/STT provider calls. Voice replies are short (the
+ * channel caps them to a few sentences) and STT runs on brief voice
+ * notes, so 60s is already pathological — but bounded, so a wedged
+ * provider returns a clean "network" error instead of stalling the
+ * chat's serial chain (the #135-class wedge). AbortSignal-backed, so the
+ * socket is actually cancelled. Tests inject a fetchImpl that ignores the
+ * signal, so this is transparent to them.
+ */
+const AUDIO_FETCH_TIMEOUT_MS = 60_000;
 
 export interface SynthesizedAudio {
   data: Buffer;
@@ -259,6 +271,7 @@ async function elevenlabsTts(
           style: cfg.style,
         },
       }),
+      signal: timeoutSignal(AUDIO_FETCH_TIMEOUT_MS),
     });
   } catch (e) {
     return { ok: false, error: `network: ${(e as Error).message}` };
@@ -295,6 +308,7 @@ async function openaiTts(
         speed: cfg.speed,
         response_format: "opus",
       }),
+      signal: timeoutSignal(AUDIO_FETCH_TIMEOUT_MS),
     });
   } catch (e) {
     return { ok: false, error: `network: ${(e as Error).message}` };
@@ -329,6 +343,7 @@ async function elevenlabsScribe(
       method: "POST",
       headers: { "xi-api-key": apiKey },
       body: form,
+      signal: timeoutSignal(AUDIO_FETCH_TIMEOUT_MS),
     });
   } catch (e) {
     return { ok: false, error: `network: ${(e as Error).message}` };
@@ -368,6 +383,7 @@ async function openaiWhisper(
         method: "POST",
         headers: { authorization: `Bearer ${apiKey}` },
         body: form,
+        signal: timeoutSignal(AUDIO_FETCH_TIMEOUT_MS),
       },
     );
   } catch (e) {

--- a/src/lib/fetchTimeout.ts
+++ b/src/lib/fetchTimeout.ts
@@ -1,0 +1,26 @@
+/**
+ * Compose a hard, socket-cancelling timeout into a fetch's AbortSignal.
+ *
+ * Why this exists instead of a Promise.race timeout wrapper: the
+ * withTimeout() helper in telegram.ts races a timer against the promise
+ * but, by its own admission, "cannot cancel the underlying request" — the
+ * socket stays open and the orphaned fetch keeps holding a connection
+ * until the OS eventually gives up. That is the #135-class wedge: a
+ * stalled upstream (Telegram file download, TTS/STT provider) hangs the
+ * caller indefinitely.
+ *
+ * AbortSignal.timeout() aborts the request ITSELF, releasing the socket,
+ * and AbortSignal.any() composes an optional external caller signal (e.g.
+ * a /stop AbortController) so EITHER the timeout OR the caller cancels the
+ * fetch. Whichever fires rejects the fetch with a TimeoutError /
+ * AbortError the call site already handles via its catch.
+ *
+ * Pass the returned signal as `signal` in a fetch init.
+ */
+export function timeoutSignal(
+  timeoutMs: number,
+  caller?: AbortSignal,
+): AbortSignal {
+  const deadline = AbortSignal.timeout(timeoutMs);
+  return caller ? AbortSignal.any([caller, deadline]) : deadline;
+}

--- a/src/lib/telegramApi.ts
+++ b/src/lib/telegramApi.ts
@@ -3,6 +3,11 @@
  * the `phantombot telegram` TUI to confirm the token works before saving.
  */
 
+import { timeoutSignal } from "./fetchTimeout.ts";
+
+/** getMe is a token-validation probe; a stalled call must not hang the TUI. */
+const GETME_TIMEOUT_MS = 15_000;
+
 export type GetMeResult =
   | { ok: true; username: string; firstName?: string; id: number }
   | { ok: false; error: string };
@@ -13,7 +18,9 @@ export async function telegramGetMe(
 ): Promise<GetMeResult> {
   let res: Response;
   try {
-    res = await fetchImpl(`https://api.telegram.org/bot${token}/getMe`);
+    res = await fetchImpl(`https://api.telegram.org/bot${token}/getMe`, {
+      signal: timeoutSignal(GETME_TIMEOUT_MS),
+    });
   } catch (e) {
     return { ok: false, error: `network: ${(e as Error).message}` };
   }

--- a/src/orchestrator/fallback.ts
+++ b/src/orchestrator/fallback.ts
@@ -149,6 +149,32 @@ export async function* runWithFallback(
     for await (const chunk of harness.invoke(req)) {
       if (chunk.type === "error") {
         if (chunk.recoverable && !isLast) {
+          // ─────────────────────────────────────────────────────────────
+          // INTENTIONAL, STREAMING-FIRST TRADE-OFF — do not "fix" this by
+          // buffering or by deleting already-sent text.
+          //
+          // If this harness streamed some text chunks before erroring, that
+          // text is ALREADY on the user's screen — we yield chunks live, the
+          // instant the harness produces them, because phantombot is a
+          // conversational agent and low-latency token streaming is the
+          // entire point of the experience. When we now fall through to the
+          // next harness, the user may briefly see a truncated partial reply
+          // followed by a fresh full reply from a different model.
+          //
+          // That is the ACCEPTED COST of streaming-first, exactly like the
+          // at-most-once Telegram offset trade-off elsewhere. The two
+          // "clean" alternatives are both worse:
+          //   1. Buffer-until-done before showing anything — kills live
+          //      streaming and the conversational feel. Non-starter.
+          //   2. Delete the already-sent bubbles on fall-through — a
+          //      behaviour-risky transport change, and yanking text a user
+          //      may have already read is its own jarring UX.
+          //
+          // A phantom is a conversation, not a transactional render that must
+          // commit atomically. A rare doubled/partial reply on a mid-stream
+          // harness failure is a calculated, acceptable price for fluid,
+          // immediate streaming. Re-litigate with Andrew before changing it.
+          // ─────────────────────────────────────────────────────────────
           log.warn(
             "orchestrator: harness recoverable error, falling through",
             {

--- a/tests/lib-fetchTimeout.test.ts
+++ b/tests/lib-fetchTimeout.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { timeoutSignal } from "../src/lib/fetchTimeout.ts";
+
+describe("timeoutSignal", () => {
+  test("returns a non-aborted signal initially", () => {
+    const sig = timeoutSignal(10_000);
+    expect(sig.aborted).toBe(false);
+  });
+
+  test("aborts itself after the timeout elapses", async () => {
+    const sig = timeoutSignal(5);
+    await new Promise((r) => setTimeout(r, 25));
+    expect(sig.aborted).toBe(true);
+    // AbortSignal.timeout() aborts with a TimeoutError DOMException.
+    expect((sig.reason as Error).name).toBe("TimeoutError");
+  });
+
+  test("an external caller abort propagates to the composed signal", () => {
+    const caller = new AbortController();
+    const sig = timeoutSignal(10_000, caller.signal);
+    expect(sig.aborted).toBe(false);
+    caller.abort(new Error("stop"));
+    expect(sig.aborted).toBe(true);
+  });
+
+  test("composed signal still fires on timeout when caller never aborts", async () => {
+    const caller = new AbortController();
+    const sig = timeoutSignal(5, caller.signal);
+    await new Promise((r) => setTimeout(r, 25));
+    expect(sig.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR B2 — transport resilience (#160, item c)

Third in the staged series after #163 (PR A) and #164 (PR B1). Adds hard, **socket-cancelling** timeouts to every Telegram Bot API and TTS/STT fetch that previously had none.

### The bug (#160 item c — fetch timeouts / #135-class wedge)
Only the `getUpdates` long-poll was cancelable. Every other network call — the `downloadFile` body GET especially — had no timeout. A wedged upstream (stalled file download, hung voice provider) stalled that chat's **serial** processing chain indefinitely. The existing `withTimeout` race wrapper can't help: by its own comment it "cannot cancel the underlying request" — the socket stays open.

### The fix
New `src/lib/fetchTimeout.ts` → `timeoutSignal(ms, caller?)`:
- composes `AbortSignal.timeout(ms)` with an optional caller signal (e.g. `/stop`) via `AbortSignal.any()`
- aborts the **request itself**, releasing the socket — not a promise abandoned around a live connection

Applied with per-site ceilings:
| Site | Timeout | Why |
|------|---------|-----|
| control plane (`sendMessage`, `sendVoice` action, `getFile`, `sendChatAction`, `setMyCommands`, `ackUpdates`) | 30s | small JSON / short calls |
| `downloadFile` body + `sendVoice` upload | 120s | up to ~20MB over a slow link |
| audio TTS/STT (eleven/openai) | 60s | short replies + brief notes |
| `getMe` (token probe) | 15s | must not hang the TUI |
| `getUpdates` | long-poll bound + 10s, composed with `/stop` | overstaying poll now cancels |

A wedged `downloadFile` now **throws**, which the caller already catches → degrades to `[attachment download failed]` instead of stalling the chat forever.

### Tests
- new `tests/lib-fetchTimeout.test.ts` (4 cases: not-aborted initially, self-aborts on timeout with `TimeoutError`, caller-abort propagates, timeout still fires when caller never aborts)
- `tsc` clean, **full suite 1175 pass / 0 fail** (+4)

### Scope note — item (d) deliberately not in this PR
#160 bundled **two** transport items. Item (c) — fetch timeouts — is the clean, mechanical win and is done here. Item (d) — *partial streamed text discarded on mid-stream harness failure* — is **not** a transport patch: streamed text is committed to Telegram live (great UX, low latency), so de-duping a fall-through partial requires either killing live streaming (buffer-until-done) or adding bubble-deletion machinery (a transport-interface change). That's a streaming-UX **design fork**, same shape as #159 — bringing it to Andrew rather than smuggling a behaviour-risky rewrite into a timeouts PR. **#160 stays open** pending that decision.

Closes nothing automatically — partial fix of #160.