### PR TITLE
docs: sync AGENTS.md with current architecture (#167)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,13 +66,31 @@ phantombot/
 │   ├── importer/
 │   │   └── openclaw.ts       # OpenClaw → phantombot persona import
 │   ├── orchestrator/
-│   │   ├── turn.ts           # one-turn coordinator (persona → memory → harness → persist)
-│   │   └── fallback.ts       # harness chain (primary → fallback)
-│   ├── channels/
-│   │   └── telegram.ts       # Telegram adapter (HttpTelegramTransport + long-poll loop)
+│   │   ├── turn.ts           # one-turn coordinator (persona → memory → screen → harness → persist)
+│   │   ├── fallback.ts       # harness chain (primary → fallback)
+│   │   ├── screen.ts         # makeScreener: threat-screen wiring for UNTRUSTED turns (see "Security perimeter")
+│   │   ├── retrieval.ts      # makeRetriever: semantic recall of prior turns/memory for the prompt
+│   │   ├── recovery.ts       # generateRecoveryReply: graceful user-facing message on harness failure
+│   │   └── turnIndexer.ts    # makeTurnIndexer: embeds persisted turns for later retrieval
+│   ├── channels/             # channel-agnostic core + per-channel adapters (see "Channel layer")
+│   │   ├── core/
+│   │   │   ├── types.ts      # Channel / ChannelTransport / ChannelMessage + capabilities + encrypt/decrypt seam
+│   │   │   ├── engine.ts     # the streaming turn engine + server loop (channel-blind)
+│   │   │   ├── routing.ts    # group-reply decision logic (pure)
+│   │   │   └── prompts.ts    # channel-layer prompt suffixes (VOICE_REPLY_INSTRUCTION, capture nudge, …)
+│   │   ├── telegram/
+│   │   │   ├── transport.ts  # HttpTelegramTransport (HTTP client; Number(conversationId) at the API boundary)
+│   │   │   ├── parse.ts      # update parsing → ChannelMessage (String(chat.id) on ingest)
+│   │   │   └── channel.ts    # Telegram adapter: capabilities + identity encrypt/decrypt (no crypto)
+│   │   ├── telegram.ts       # backward-compat barrel re-export (preserves the old public surface)
+│   │   ├── telegramFormat.ts # markdown → Telegram HTML
+│   │   ├── streamSegmenter.ts # splits a streaming reply into Telegram-sized segments (fence/table/list-aware)
+│   │   └── commands.ts       # slash-command handling (/stop, /update, …)
 │   ├── cli/                  # one file per Citty subcommand
 │   │   ├── index.ts          # dispatcher; subcommand registration list lives here
 │   │   ├── run.ts            # the long-running listener
+│   │   ├── ask.ts            # phantombot ask (programmatic single turn — an UNTRUSTED entry point; screened)
+│   │   ├── init.ts           # phantombot init (first-run setup)
 │   │   ├── install.ts uninstall.ts
 │   │   ├── update.ts         # phantombot update (consumes the GH releases feed)
 │   │   ├── env.ts            # phantombot env (manages ~/.env)
@@ -93,39 +111,76 @@ phantombot/
 │   │   ├── buildChain.ts     # build Harness[] from config — single source of truth (was duplicated in run.ts + tick.ts)
 │   │   ├── claude.ts         # Bun.spawn `claude --print --output-format stream-json …` (OAuth-only; ANTHROPIC_API_KEY filtered)
 │   │   ├── pi.ts             # Bun.spawn `pi --print --mode json …` (OAuth on host; ARG_MAX guard)
-│   │   └── gemini.ts         # Bun.spawn `gemini -p <user_msg> -o text -y` (stdin = system + history; v1 text mode)
+│   │   ├── gemini.ts         # Bun.spawn `gemini -p <user_msg> -o text -y` (stdin = system + history; v1 text mode)
+│   │   └── codex.ts          # Bun.spawn `codex …` (OpenAI Codex CLI harness)
 │   └── lib/
-│       ├── logger.ts io.ts configWriter.ts envFile.ts
-│       ├── systemd.ts        # unit generators + install/uninstall + ensureUnitCurrent
+│       ├── logger.ts io.ts configWriter.ts envFile.ts format.ts
+│       ├── threatJudge.ts    # tool-less untrusted-input judge (see "Security perimeter")
+│       ├── redact.ts         # secret redaction for log lines + task_runs audit table
+│       ├── platform.ts       # cross-platform service-manager router (systemd ↔ launchd)
+│       ├── systemd.ts        # Linux unit generators + install/uninstall + ensureUnitCurrent
+│       ├── launchd.ts        # macOS LaunchAgent (plist) generators + install/uninstall (mirrors systemd.ts)
+│       ├── envBootstrap.ts   # self-load ~/.env + .config/.env at startup; reloadEnvFiles() before each spawn
+│       ├── harnessRunner.ts  # shared spawn/kill/idle-timeout/abort coordination for all harnesses
+│       ├── harnessAvailability.ts cooldown.ts  # binary-on-PATH detection + per-harness fast-fallback cooldown
 │       ├── tasks.ts          # task store (bun:sqlite tasks table) + CRUD
-│       ├── cronSchedule.ts   # cron-parser wrapper + review-interval defaults
+│       ├── cronSchedule.ts scheduleParser.ts   # cron-parser wrapper + duration→cron + review-interval defaults
+│       ├── timerHealth.ts    # timer fire-markers (heartbeat/tick) so doctor can flag silent timers
+│       ├── processGroup.ts fetchTimeout.ts      # process-group helpers + fetch with timeout
 │       ├── binaryUpdate.ts   # phantombot update: download + sha256 + atomic swap
-│       ├── githubReleases.ts # phantombot update: latest-release discovery
+│       ├── githubReleases.ts updateNotify.ts    # latest-release discovery + post-update notify
 │       ├── audio.ts          # TTS/STT dispatch (ElevenLabs/OpenAI/Azure Edge)
-│       ├── voice.ts telegramApi.ts personaScaffold.ts personaTemplate.ts personaArchive.ts
+│       ├── voice.ts telegramApi.ts personaScaffold.ts personaTemplate.ts personaArchive.ts personaDefault.ts
 │       ├── memoryIndex.ts heartbeat.ts nightly.ts embedJob.ts geminiEmbed.ts
 │       └── runLock.ts        # single-instance lock (prevents two `phantombot run` on one box)
 ├── agents/
 │   └── phantom/              # placeholder persona used by tests
-└── tests/                    # bun test, ~430 tests across ~50 files
+└── tests/                    # bun test, ~1180 tests across ~79 files
 ```
 
 ## Architecture at a glance
 
 - **Citty CLI dispatcher** (`src/cli/index.ts`) → subcommand → orchestrator (for turn-spending commands like `run`, `ask`, `tick`, `nightly`).
-- **One-turn coordinator** (`src/orchestrator/turn.ts`) loads persona files, loads recent turns from memory, builds system prompt, runs the harness chain, and persists the user+assistant turns on success.
-- **Harness chain** (`src/orchestrator/fallback.ts`) tries primary; if it returns a recoverable error, falls through to the next.
-- **Channels listen** (`src/channels/telegram.ts`); `phantombot run` is the long-running process.
+- **One-turn coordinator** (`src/orchestrator/turn.ts`) loads persona files, loads recent turns from memory, builds system prompt, **screens untrusted input** (`screen.ts`), runs the harness chain, and persists the user+assistant turns on success.
+- **Harness chain** (`src/orchestrator/fallback.ts` + `lib/harnessRunner.ts`) tries primary; if it returns a recoverable error, falls through to the next (with per-harness cooldown for fast fallback).
+- **Security perimeter** (`lib/threatJudge.ts` + `orchestrator/screen.ts`) — trusted principals act directly; untrusted input is judged in code before any capable harness sees it. See "Security perimeter".
+- **Channels** are a channel-agnostic core + thin per-channel adapters (`src/channels/core/` + `src/channels/telegram/`); `phantombot run` is the long-running process. See "Channel layer".
+- **Env bootstrap** (`lib/envBootstrap.ts`) self-sources the `.env` files at startup (required on macOS, no-op on Linux) and re-sources before each harness spawn so `phantombot env set` takes effect mid-session.
 - **Tick fires scheduled tasks** (`src/cli/tick.ts`); 1-minute systemd timer; lockfile prevents overlap; missed runs are skipped, not piled up.
 - **Heartbeat is mechanical** (no LLM); **nightly is cognitive** (LLM-driven distillation).
+
+## Channel layer (core + adapters)
+
+As of #168 the channel layer is split into a **channel-agnostic core** and **thin per-channel adapters**, so a second transport (Matrix, Slack, …) is a small adapter rather than a fork of the engine.
+
+- **`src/channels/core/`** is channel-blind. `engine.ts` holds the streaming turn engine + server loop (moved verbatim out of the old `telegram.ts`); `routing.ts` is the pure group-reply decision; `prompts.ts` holds the channel-layer prompt suffixes (`VOICE_REPLY_INSTRUCTION`, the capture nudge, the voice-unavailable message); `types.ts` defines the contract: `Channel` / `ChannelTransport` / `ChannelMessage`, a `ChannelCapabilities` object (`voice` / `typing` / `attachments` / `encryption`), and `encrypt`/`decrypt` hook signatures.
+- **`src/channels/telegram/`** is the first adapter: `transport.ts` (HTTP client), `parse.ts` (update → `ChannelMessage`), `channel.ts` (capabilities + encrypt/decrypt).
+- **`src/channels/telegram.ts`** is now a **backward-compat barrel** that re-exports the core + adapter symbols under their old names, so importers and the test suite kept their surface unchanged across the refactor.
+
+Two invariants worth knowing before you touch this:
+
+1. **IDs are channel-neutral strings.** The core speaks `conversationId: string` / `senderId: string`. Telegram's numeric ids are normalized at the adapter boundary only — `String(chat.id)` on ingest (`parse.ts`), and `Number(conversationId)` right before the Telegram API call (`transport.ts`). Don't reintroduce a numeric id into the core contract; Matrix/Slack ids aren't numbers. The numeric update-notify recipient ids (`updateNotify.ts`, `notify.ts`) and the slash-command logging id are separate, Telegram-specific, and converted at their own boundary.
+2. **The encrypt/decrypt seam is placed but empty.** Telegram's `encrypt`/`decrypt` are identity pass-throughs (Telegram bots have no E2EE) with `encryption: false`. They return `T | Promise<T>` so async crypto (Matrix Megolm) can slot in later with no signature change. There is deliberately **zero crypto code and zero Matrix code** — the actual Matrix adapter + E2EE are parked for the community discussion in issue #154.
+
+## Security perimeter — trusted vs untrusted input
+
+Phantombot runs a **two-tier perimeter**, enforced in code (not by trusting a model's say-so — the bug that prompted this design was a model *claiming* it had notified/recorded when it hadn't).
+
+- **Trusted** input — an authenticated Telegram principal — is acted on directly. The principal *is* the gate; no screening.
+- **Untrusted** input — email, web, Twilio, webhooks, raw `phantombot ask`, any future app — is read by a **tool-less threat judge** (`lib/threatJudge.ts`) before any capable harness runs. `orchestrator/screen.ts` (`makeScreener`, wired into `turn.ts` like `makeRetriever`) does the side-effecting orchestration around the pure judge: it first **briefs** the judge with semantic recall from the threat-relevant drawers (`decisions` = prior rulings, `people` = known senders, `norms` = what's routine), then the judge returns a 0–100 threat score. Below threshold → green-lit silently; at/above → the untrusted turn is **HELD** (does nothing) and surfaced to the principal.
+- A **ruling is only recorded from a trusted turn** — the judge and the untrusted turn never write decisions. When the principal concludes, the ruling (with its weight) is captured to the `decisions` drawer so the next similar screening recalls it.
+
+If you add a new untrusted entry point (a new inbound channel, a new `ask`-style API), it MUST route through the screener — don't let untrusted content reach a harness unscreened.
 
 ## Persona model — single at runtime
 
 **One persona is active at a time.** This surprises people. The persona "library" on disk (under `~/.local/share/phantombot/personas/`) can have many directories, but `phantombot run` binds to one — `config.defaultPersona` — and the `runLock` (`src/lib/runLock.ts`) prevents two `phantombot run` processes from coexisting on the same box. If a feature needs "different personas for different chats" or "two personas at once," that's a real architectural change (per-persona Telegram tokens, per-persona XDG dirs, lifted runLock) — not a config knob. The README's [Personas](README.md#personas) section is the authoritative explanation; if you change this model, update both.
 
-## Systemd model
+## Service model (systemd + launchd)
 
-`phantombot install` creates **four** systemd-user units:
+Phantombot ships on **Linux (systemd --user)** and **macOS (launchd, per-user LaunchAgents)**. `lib/platform.ts` is the single router that decides which backend to talk to; `lib/systemd.ts` and `lib/launchd.ts` are the two backends behind a common `ServiceControl` surface (each takes an injectable runner — `SystemctlRunner` / `LaunchctlRunner` — so tests never touch the real service manager). The four logical units are identical across platforms; only the unit-file shape and control verbs differ.
+
+On Linux, `phantombot install` creates **four** systemd-user units:
 
 | Unit | Cadence | What it does |
 |---|---|---|
@@ -142,6 +197,8 @@ EnvironmentFile=-%h/.env                        # user's general credentials
 ```
 
 Leading `-` makes both optional (no error if either file is absent). The merged `process.env` is what spawned harnesses inherit, so the agent finds credentials without re-reading either file.
+
+**macOS has no `EnvironmentFile=` equivalent.** launchd plists can't source a file, so on macOS `lib/envBootstrap.ts` self-loads both `.env` files into `process.env` at startup (existing values win, so nothing already set is clobbered). On Linux this is a cheap no-op because systemd already sourced them. Either way, harnesses also call `reloadEnvFiles()` before each spawn so a freshly-written `phantombot env set` secret is visible mid-session without a restart.
 
 Service units also set a deterministic `PATH` that includes `~/.local/bin` plus stable user harness shim locations such as `~/.local/share/pi-node/bin` and `~/.local/share/pi-node/current/bin`. Do not rely on interactive shell startup files for service harness discovery. When Phantombot finds a harness in PATH or common npm/pi-node versioned locations, it saves the absolute path in `state.json` and executes that path directly on later starts. `phantombot run` must never fail startup just because a harness binary is missing; log loudly, keep the headless service alive, and let `phantombot doctor` report/repair the configured chain.
 
@@ -199,9 +256,9 @@ Every merged PR auto-releases `v1.0.<PR_NUMBER>`. The workflow at `.github/workf
 7. **Creating/importing/restoring a persona on a fresh box without setting it as default** — the built-in fallback `default_persona = "phantom"` doesn't have a directory; `phantombot run` would fail with "persona 'phantom' not found." Every persona-producing path (`runImportPersona`, `runImportFromPath`, `runRestoreArchive`, `applyPersona`) calls `adoptAsDefaultIfMissing` from `src/lib/personaDefault.ts` so the new persona becomes default when there's no working default. If you add another persona-producing path, call it too — and add a `state.json` isolation `beforeEach` to its tests so they don't pollute the real `~/.local/share/phantombot/state.json`.
 8. **`install.sh` piped to `sh` runs without a TTY** — interactive @clack TUIs would misbehave. The script detects this with `[ -t 0 ] && [ -t 1 ]` before launching the persona TUI, and prints the next-step hint instead. If you add interactive setup steps to the install flow, repeat the check.
 9. **Adding a new harness — three places that must be touched, not one.** `src/harnesses/buildChain.ts` (factory: instantiate the wrapper class), `src/cli/harness.ts` (`SUPPORTED_HARNESSES` for the TUI + `detectAvailability` for the binary-on-PATH check), and `src/config.ts` (Config type slot + loader for `[harnesses.<id>]`). Plus inline test fixtures across ~12 files that have a literal Config object. If you forget any, typecheck + tests catch it — but it's tedious; the buildChain.ts extraction was specifically to retire the *fourth* duplicate that was about to land with each new harness.
-10. **Channel-specific behavior belongs in the channel layer, not in personas.** Brevity for voice replies, formatting for Slack, etc. should be appended to the system prompt at the channel boundary (see `VOICE_REPLY_INSTRUCTION` in `src/channels/telegram.ts`, passed via `runTurn`'s `systemPromptSuffix`). Putting "be brief on voice" in a persona's BOOT.md/SOUL.md throttles text replies too — and persists across all the persona's contexts where verbosity is fine. Channel-layer suffixes are scoped to the turn that needs them.
+10. **Channel-specific behavior belongs in the channel layer, not in personas.** Brevity for voice replies, formatting for Slack, etc. should be appended to the system prompt at the channel boundary (see `VOICE_REPLY_INSTRUCTION` in `src/channels/core/prompts.ts`, passed via `runTurn`'s `systemPromptSuffix`). Putting "be brief on voice" in a persona's BOOT.md/SOUL.md throttles text replies too — and persists across all the persona's contexts where verbosity is fine. Channel-layer suffixes are scoped to the turn that needs them.
 
-11. **Reply modality is mirror-input by default, with a per-message text override available.** `processChatMessage` in `src/channels/telegram.ts` picks the wire format (sendMessage vs sendVoice) via `replyModalityOverride()` from `src/lib/audio.ts`: when the user's message (post-STT, so voice transcripts count) contains an explicit directive like *"reply in text"*, *"no voice"*, or *"send a voice note"*, that wins; otherwise modality mirrors input. The override is parsed by a small, deliberately conservative regex set — anchored on reply-verbs and unmistakable shorthand, no bare-noun matches ("text message to John" must not trigger). Voice is still capped by `ttsSupported(config)`: an override asking for voice when no TTS provider is configured degrades to text gracefully, same as the original no-TTS fallback. If you extend the regex set, add cases to `replyModalityOverride` in `tests/lib-audio.test.ts` AND to the three end-to-end scenarios in `tests/channels-telegram.test.ts` (voice-in→text, text-in→voice, text-in→voice-without-TTS).
+11. **Reply modality is mirror-input by default, with a per-message text override available.** `processChatMessage` in `src/channels/core/engine.ts` picks the wire format (sendMessage vs sendVoice) via `replyModalityOverride()` from `src/lib/audio.ts`: when the user's message (post-STT, so voice transcripts count) contains an explicit directive like *"reply in text"*, *"no voice"*, or *"send a voice note"*, that wins; otherwise modality mirrors input. The override is parsed by a small, deliberately conservative regex set — anchored on reply-verbs and unmistakable shorthand, no bare-noun matches ("text message to John" must not trigger). Voice is still capped by `ttsSupported(config)`: an override asking for voice when no TTS provider is configured degrades to text gracefully, same as the original no-TTS fallback. If you extend the regex set, add cases to `replyModalityOverride` in `tests/lib-audio.test.ts` AND to the three end-to-end scenarios in `tests/channels-telegram.test.ts` (voice-in→text, text-in→voice, text-in→voice-without-TTS).
 
 12. **`GITHUB_TOKEN` for `phantombot update` isn't always safe to send.** GitHub App installation tokens are scoped to a single org's repos; using one against the public `phantomyard/phantombot` releases endpoint returns 401 even though the endpoint is anonymously reachable. `findLatestRelease` in `src/lib/githubReleases.ts` therefore retries once *without* the auth header on 401/403 before failing, and the final error mentions org-scoping explicitly. If you add another auth'd GitHub API call (e.g. for changelog fetch, asset metadata, etc.), reuse the `buildHeaders(withAuth)` helper and replicate the unauth-retry path — otherwise users with org-scoped tokens hit a dead end on what should be a public read. See issue #115 / PR #120.
 


### PR DESCRIPTION
Closes #167 — the do-last docs catch-up, now that the channel abstraction (#168) has landed.

**Docs-only. No code change.** Brings `AGENTS.md` back in sync with the tree; whole subsystems had drifted out of the docs.

### What changed
- **Channel layer (new section)** — documents the post-#168 `core/` (engine/routing/prompts/types) + `telegram/` adapter split, the backward-compat barrel, the **string-id-in-core** invariant (Telegram converts at its boundary), and the **empty encrypt/decrypt seam** (zero crypto/Matrix code — parked in #154).
- **Security perimeter (new section)** — the two-tier trusted/untrusted model: `lib/threatJudge.ts` + `orchestrator/screen.ts`, briefing from the `decisions`/`people`/`norms` drawers, the held-request flow, and the rule that rulings are recorded only from a trusted turn.
- **Service model (renamed from "Systemd model")** — adds the macOS **launchd** backend, the `platform.ts` router, and why macOS self-sources env via `envBootstrap` (no `EnvironmentFile=` on launchd).
- **Repo layout refresh** — `channels/`, `orchestrator/` (screen/recovery/retrieval/turnIndexer), `harnesses/` (codex), the `lib/` inventory (threatJudge, redact, platform, launchd, envBootstrap, harnessRunner, cooldown, timerHealth, …), `cli/` (ask, init), and the test count (~430 → ~1180).
- **Stale ref fixes** — pitfalls #10/#11 pointed at `src/channels/telegram.ts`; now `core/prompts.ts` and `core/engine.ts`.

### Not in scope
No `README.md` change — this PR documents already-merged behaviour, it doesn't introduce any. If README has its own drift that's a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)