### PR TITLE
docs(readme): reflect channel core/adapter split (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,11 +782,20 @@ immediate.
 Telegram getUpdates
         |
         v
-Telegram adapter
+Telegram adapter  (channels/telegram)
+        |
+        |-- transport: HTTP getUpdates / sendMessage
+        |-- parse: raw update -> ChannelMessage
+        |-- convert numeric chat/user ids -> string at the boundary
+        |-- encrypt / decrypt seam (identity pass-through today)
+        |
+        v
+Channel core  (channels/core, channel-blind)
         |
         |-- slash command handler
         |-- group routing gate
         |-- attachment / voice handling
+        |-- streaming turn engine + server loop
         |
         v
 Turn coordinator
@@ -794,6 +803,7 @@ Turn coordinator
         |-- load persona markdown
         |-- load rolling conversation context
         |-- retrieve memory / KB hits
+        |-- threat-screen untrusted input (see Security)
         |
         v
 Harness chain: pi -> claude -> gemini -> codex
@@ -807,6 +817,13 @@ Persist turn and send Telegram reply
 
 Tool execution happens inside the harness. Phantombot only coordinates the
 turn, memory, channel behavior, and runtime services.
+
+The channel layer is split into a channel-blind core and per-platform
+adapters. The core deals only in string `conversationId` / `senderId` ids and
+plaintext `ChannelMessage`s; each adapter converts its platform's native id
+types and (in future) decrypts on ingest / encrypts on egress at its own
+boundary. Telegram is the only adapter today; the encrypt/decrypt hooks are
+identity pass-throughs and there is no Matrix or crypto code yet.
 
 ## Build From Source
 
@@ -852,6 +869,9 @@ phantombot/
     importer/
     orchestrator/
     channels/
+      core/        channel-blind types, routing, prompts, turn engine
+      telegram/    Telegram adapter: transport, parse, channel
+      telegram.ts  backward-compat barrel re-export
     cli/
     harnesses/
     lib/


### PR DESCRIPTION
Syncs `README.md` with the post-#168 channel layer (companion to the AGENTS.md sync in #169).

## What changed
- **Architecture diagram** — splits the old monolithic "Telegram adapter" into the channel-blind **core** (`channels/core`: slash commands, group routing, streaming turn engine + server loop) and the **Telegram adapter** (`channels/telegram`: transport, parse, numeric→string id conversion at the boundary, identity encrypt/decrypt seam). Adds the threat-screen step to the turn coordinator.
- **Project Layout** — expands the flat `channels/` entry into `core/`, `telegram/`, and the `telegram.ts` backward-compat barrel.
- Adds a short prose note on the core/adapter contract: string `conversationId`/`senderId` ids + plaintext `ChannelMessage` in the core; adapters convert ids and (in future) handle crypto at their own boundary.

**Docs only — no code changes.** Reflects merged #168. No Matrix or crypto code exists yet; the encrypt/decrypt hooks are identity pass-throughs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)