### PR TITLE
fix(prompts): make "ask to confirm" actually end the turn

### DIFF
--- a/src/channels/core/prompts.ts
+++ b/src/channels/core/prompts.ts
@@ -53,6 +53,12 @@ sentences and ask the user to confirm or adjust:
 - Anything involving git, build, or deploy operations
 - Anything where you're going to spawn more than one tool call
 
+When you ask, STOP. End the turn on the question itself — write
+nothing after it. Do NOT answer your own question, and do NOT fall
+back to a "safe default" and proceed anyway. Asking hands control
+back to the user; the next move is theirs. Wait for their actual
+reply before doing the work.
+
 Telegram round-trips are slow and tokens aren't free — confirming up
 front beats producing the wrong thing minutes later. For
 straightforward questions, just answer.`;


### PR DESCRIPTION
## Problem

The **"Confirm before long jobs"** block tells the agent to ask the user for confirmation, but nothing instructs it to end the turn on that question. On agentic harnesses (Claude Code and the like) the autonomy pressure wins mid-turn: the model writes the question *and* then answers it itself ("no answer → safe default") within the same turn. The user does see the question, but never gets a chance to reply — the work has already started.

Seen in practice: a bot announced "One more thing I want to know from you:" and then immediately flushed "No answer — I'll go with the safe default…" as a separate message.

## Fix

Make the turn boundary explicit in `TELEGRAM_REPLY_INSTRUCTION` (`src/channels/core/prompts.ts`):

- stop on the question, write nothing after it;
- no self-answering;
- no "safe default" escape hatch to proceed anyway.

Asking hands control back to the user; the next move is theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
