### PR TITLE
fix(telegram): handle /start before harness fallback

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -2,7 +2,7 @@
  * Slash command dispatcher for chat channels.
  *
  * Sits BEFORE the LLM in the message loop. Catches in-band control commands
- * (`/stop`, `/reset`, `/status`, `/harness`, `/help`) and handles them in the
+ * (`/start`, `/stop`, `/reset`, `/status`, `/harness`, `/help`) and handles them in the
  * channel layer so they keep working even when the LLM is hung on a
  * subprocess tool call — that was the failure mode that motivated this
  * module: PhantomBot's old design routed every message through the harness,
@@ -15,7 +15,7 @@
  * the reply text back to the user.
  *
  * Recognized vs unknown:
- *   - `/stop`, `/reset`, `/status`, `/harness`, `/help` → handled here.
+ *   - `/start`, `/stop`, `/reset`, `/status`, `/harness`, `/help` → handled here.
  *   - Any other `/foo` → returned as null, channel falls through to runTurn
  *     so the LLM can interpret it (some personas use `/remember`, etc.).
  */
@@ -123,6 +123,7 @@ export const TELEGRAM_BOT_COMMANDS: Array<{
   command: string;
   description: string;
 }> = [
+  { command: "start", description: "Show this command list" },
   { command: "stop", description: "Abort the current turn" },
   { command: "reset", description: "Clear this chat's history" },
   { command: "status", description: "Show harness, uptime, context usage" },
@@ -209,6 +210,7 @@ export async function handleSlashCommand(
       return await handleUpdate(ctx);
     case "/restart":
       return handleRestart(ctx);
+    case "/start":
     case "/help":
       return { reply: HELP };
     default:

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -2872,6 +2872,33 @@ describe("runTelegramServer slash commands", () => {
     expect(transport.sent[0]!.text).toContain("/status");
   });
 
+  test("/start is handled by the channel layer (no harness fallback slash-command leak)", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      conversationId: "1001",
+      senderId: "42",
+      text: "/start",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: 'Unknown command: /start' },
+    ]);
+    await runTelegramServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+    expect(harness.invocations).toBe(0);
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]!.text).toContain("/start");
+    expect(transport.sent[0]!.text).toContain("/help");
+    expect(transport.sent[0]!.text).not.toContain("Unknown command");
+  });
+
   test("group: /cmd@otherbot is ignored — a state-changing command doesn't fan out to every bot", async () => {
     // Privacy-off groups deliver every slash command to every bot. A
     // /reset addressed to another bot must NOT clear this bot's history.


### PR DESCRIPTION
## Summary
- Add `/start` to the Telegram command menu and channel-level slash handler
- Return the normal help text for `/start`, matching Telegram Start-button expectations
- Add a regression test proving `/start` never reaches the harness fallback path

Fixes #174.

## Verification
- `/home/kai/.bun/bin/bun test tests/channels-telegram.test.ts --timeout 30000`
- `/home/kai/.bun/bin/bun test`
- `/home/kai/.bun/bin/bun tsc --noEmit`