### PR TITLE
fix(memory): surface nightly errors in doctor + stop double-bullet drawer entries

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -84,6 +84,12 @@ export interface DoctorReport {
   nightly: {
     last_run?: string;
     last_status?: string;
+    /**
+     * Error messages from the last run, if any. Persisted in
+     * `.nightly-state.json` but historically dropped here, so a failing
+     * stage was invisible to `doctor` (it only showed `last_status`).
+     */
+    errors?: string[];
     /** Hours since the last run, or null if it never ran. */
     age_hours: number | null;
     stale: boolean;
@@ -386,6 +392,9 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     nightly: {
       last_run: state.last_run,
       last_status: state.last_status,
+      ...(state.errors && state.errors.length > 0
+        ? { errors: state.errors }
+        : {}),
       age_hours: ageHours === null ? null : Math.round(ageHours * 10) / 10,
       stale: needed,
       ...(progress
@@ -449,8 +458,13 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   // Human summary.
   const tick = (ok: boolean) => (ok ? "ok" : "WARN");
   out.write(`phantombot doctor — persona '${persona}'\n`);
+  // A non-ok status is a warning even when the run isn't stale: a stage
+  // can fail today yet still be "recent", which previously slipped past
+  // the staleness-only marker.
+  const statusBad =
+    state.last_status === "error" || state.last_status === "partial";
   out.write(
-    `  nightly: ${tick(!needed)} — ` +
+    `  nightly: ${tick(!needed && !statusBad)} — ` +
       (state.last_run
         ? `last run ${state.last_run} (${report.nightly.age_hours}h ago), status '${
             state.last_status ?? "unknown"
@@ -458,6 +472,11 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
         : "never run") +
       "\n",
   );
+  if (state.errors && state.errors.length > 0) {
+    for (const e of state.errors) {
+      out.write(`    error: ${e}\n`);
+    }
+  }
   if (progress) {
     out.write(
       `  checkpoint: ${progress.status} for ${progress.date} — ` +

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -191,7 +191,11 @@ export async function promoteTaggedLines(
     const tag = m[1]!.toLowerCase();
     const drawer = TAG_TO_DRAWER[tag];
     if (!drawer) continue;
-    const cleanLine = raw.trim();
+    // Strip any leading list bullet the daily line already carries. Daily
+    // captures are written as `- [tag] …`, and TAG_PATTERN matches that
+    // (`-?`). Without stripping it here, the `- ` we prepend below would
+    // produce malformed double-bullet drawer entries (`- - [tag] …`).
+    const cleanLine = raw.trim().replace(/^[-*]\s+/, "");
     const existing = await loadDrawer(drawer);
     if (existing.includes(cleanLine)) continue;
 

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -147,6 +147,39 @@ describe("runDoctor", () => {
     expect(code).toBe(1);
   });
 
+  test("surfaces the nightly errors array (human + json) and flags WARN on non-ok status", async () => {
+    // A fresh run (not stale) that still recorded a failing stage. Status
+    // is non-ok and errors is populated — both must reach the operator.
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "partial",
+      errors: ["stage 'essence': pi exited with code 127"],
+    });
+    const out = new CaptureStream();
+    await runDoctor({ config, out, spawnRepair: () => {} });
+    expect(out.text).toContain("pi exited with code 127");
+    // Non-ok status downgrades the nightly line to WARN even when recent.
+    expect(out.text).toMatch(/nightly: WARN/);
+
+    const jsonOut = new CaptureStream();
+    await runDoctor({ config, json: true, out: jsonOut, spawnRepair: () => {} });
+    const report = JSON.parse(jsonOut.text);
+    expect(report.nightly.errors).toEqual([
+      "stage 'essence': pi exited with code 127",
+    ]);
+  });
+
+  test("omits the errors field when the last run was clean", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({ config, json: true, out, spawnRepair: () => {} });
+    const report = JSON.parse(out.text);
+    expect(report.nightly.errors).toBeUndefined();
+  });
+
   test("json mode emits a parseable report", async () => {
     await writeState({
       last_run: new Date().toISOString(),

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -99,6 +99,41 @@ describe("promoteTaggedLines", () => {
     ).toBe(1);
   });
 
+  test("strips the daily line's leading bullet (no `- - [tag]` double-bullet)", async () => {
+    // Real daily captures are written as `- [tag] …`. TAG_PATTERN matches
+    // the leading dash, so the drawer append must not blindly prepend
+    // another bullet.
+    await file(
+      "memory/2026-05-02.md",
+      [
+        "# 2026-05-02",
+        "",
+        "- [decision] Pin bun to 1.1.x in CI",
+        "- [norm] Nightly deploys at 03:00 are routine",
+      ].join("\n"),
+    );
+    for (const d of ["decisions.md", "norms.md"]) {
+      await file(`memory/${d}`, `# ${d}\n\n## (no entries yet)\n`);
+    }
+
+    const r = await promoteTaggedLines(personaDir, "2026-05-02");
+    expect(r.map((p) => p.line)).toEqual([
+      "[decision] Pin bun to 1.1.x in CI",
+      "[norm] Nightly deploys at 03:00 are routine",
+    ]);
+
+    const decisions = await readFile(
+      join(personaDir, "memory/decisions.md"),
+      "utf8",
+    );
+    expect(decisions).toContain("- [decision] Pin bun to 1.1.x in CI");
+    expect(decisions).not.toContain("- - [decision]");
+
+    const norms = await readFile(join(personaDir, "memory/norms.md"), "utf8");
+    expect(norms).toContain("- [norm] Nightly deploys at 03:00 are routine");
+    expect(norms).not.toContain("- - [norm]");
+  });
+
   test("returns [] when today's daily file is missing", async () => {
     expect(await promoteTaggedLines(personaDir, "2026-05-02")).toEqual([]);
   });


### PR DESCRIPTION
Closes part of #181 — the two deterministic, in-repo bugs.

## What was broken
**1. `doctor` hid nightly failures.** `.nightly-state.json` carries an `errors` array, but `runDoctor` loaded the state and only ever printed `last_status`. A run that failed a stage (e.g. `essence: pi exited with code 127`) showed up as a bare status with no detail — and a *recent* run with a non-ok status still rendered `nightly: ok` because the marker keyed purely on staleness.

**2. Drawer entries got double-bulleted.** `TAG_PATTERN` matches an optional leading bullet (`-?`), so a real daily capture written as `- [tag] …` kept its dash in `cleanLine`; the append step then prepended another `- `, yielding malformed `- - [decision] …` / `- - [norm] …` lines. The existing tests only fed dash-less lines, so it never tripped.

## Changes
- **`doctor.ts`**: add `errors` to `DoctorReport.nightly`, print each as an `error:` line, and downgrade the nightly line to `WARN` when `last_status` is `error`/`partial` (even if recent).
- **`heartbeat.ts`** (`promoteTaggedLines`): strip a leading list bullet before re-prefixing, so drawer entries are always single-bulleted.

## Tests
- heartbeat: daily lines with leading bullets no longer produce `- - [tag]`.
- doctor: errors array surfaces in both human + JSON output and flags `WARN`; omitted when the run was clean.

Full suite: the only failures are pre-existing and environmental (`update`/`importPersona`/`healDefaultPersona` — network + systemd, fail identically on clean `main` in this sandbox). All heartbeat + doctor tests pass.

## Out of scope (left in #181 for follow-up)
- `essence` `pi exited with code 127` under systemd — a PATH/env/cwd difference, not a code bug per se.
- `MEMORY.md` never populated — driven by the nightly *prompt*, not deterministic code.