### PR TITLE
fix(nightly,tick,ask): resolve harness bins under systemd; populate MEMORY.md

### DIFF
--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -31,6 +31,7 @@ import { existsSync } from "node:fs";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
+import { resolveHarnessBinsForConfig } from "../lib/harnessAvailability.ts";
 import type { Harness } from "../harnesses/types.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { openMemoryStore, type MemoryStore } from "../memory/store.ts";
@@ -88,7 +89,7 @@ export async function runAsk(input: RunAskInput): Promise<number> {
     return 2;
   }
 
-  const config = input.config ?? (await loadConfig());
+  let config = input.config ?? (await loadConfig());
   const persona = input.persona ?? config.defaultPersona;
   const agentDir = personaDir(config, persona);
   if (!existsSync(agentDir)) {
@@ -98,7 +99,15 @@ export async function runAsk(input: RunAskInput): Promise<number> {
     return 2;
   }
 
-  const harnesses = input.harnesses ?? buildHarnessChain(config, err);
+  // Resolve harness binaries against the live filesystem like `run` does, so
+  // an `ask` invoked from a systemd context (e.g. a command-task that shells
+  // out to `phantombot ask`) doesn't hit `exit 127` on a PATH-relative `pi`
+  // that lives outside the unit's narrow Environment=PATH (issue #181 §1).
+  let harnesses = input.harnesses;
+  if (!harnesses) {
+    ({ config } = await resolveHarnessBinsForConfig(config, { err }));
+    harnesses = buildHarnessChain(config, err);
+  }
   if (harnesses.length === 0) {
     err.write(
       "phantombot ask: no harnesses configured. Run `phantombot harness` to pick at least one.\n",

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -25,11 +25,9 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
-import { ClaudeHarness } from "../harnesses/claude.ts";
-import { PiHarness } from "../harnesses/pi.ts";
-import { GeminiHarness } from "../harnesses/gemini.ts";
-import { CodexHarness } from "../harnesses/codex.ts";
+import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import type { Harness } from "../harnesses/types.ts";
+import { resolveHarnessBinsForConfig } from "../lib/harnessAvailability.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import {
@@ -111,13 +109,19 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
 
-  const config = input.config ?? (await loadConfig());
+  let config = input.config ?? (await loadConfig());
   const persona = input.persona ?? config.defaultPersona;
   const dir = personaDir(config, persona);
   if (!existsSync(dir)) {
     err.write(`persona '${persona}' not found at ${dir}\n`);
     return 2;
   }
+
+  // Resolve harness binaries against the live filesystem the same way the
+  // long-running `run` daemon does. Without this the nightly oneshot relied
+  // solely on the systemd unit's narrow Environment=PATH and a PATH-relative
+  // `pi` could fail with `exit 127` every night (issue #181 §1).
+  ({ config } = await resolveHarnessBinsForConfig(config, { err }));
 
   const harnesses = buildHarnessChain(config, err);
   if (harnesses.length === 0) {
@@ -256,18 +260,6 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
   } finally {
     await memory.close();
   }
-}
-
-function buildHarnessChain(config: Config, err: WriteSink): Harness[] {
-  const out: Harness[] = [];
-  for (const id of config.harnesses.chain) {
-    if (id === "claude") out.push(new ClaudeHarness(config.harnesses.claude));
-    else if (id === "pi") out.push(new PiHarness(config.harnesses.pi));
-    else if (id === "gemini") out.push(new GeminiHarness(config.harnesses.gemini));
-    else if (id === "codex") out.push(new CodexHarness(config.harnesses.codex ?? { bin: "codex", model: "" }));
-    else err.write(`warning: unknown harness '${id}', skipping\n`);
-  }
-  return out;
 }
 
 export default defineCommand({

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -21,10 +21,7 @@ import {
 } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import {
-  applyResolvedHarnessBins,
-  checkConfiguredHarnesses,
-  missingHarnesses,
-  resolvedHarnessBins,
+  resolveHarnessBinsForConfig,
   type HarnessAvailability,
 } from "../lib/harnessAvailability.ts";
 import type { WriteSink } from "../lib/io.ts";
@@ -38,7 +35,6 @@ import {
 } from "../lib/runLock.ts";
 import { notifyPostRestartIfPending } from "../lib/updateNotify.ts";
 import { openMemoryStore } from "../memory/store.ts";
-import { saveHarnessBins } from "../state.ts";
 import { VERSION } from "../version.ts";
 import { runDoctor } from "./doctor.ts";
 
@@ -186,20 +182,14 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     return 2;
   }
 
-  const harnessChecks =
-    input.checkHarnesses === false
-      ? []
-      : input.checkHarnesses
-        ? await input.checkHarnesses(config)
-        : await checkConfiguredHarnesses(config);
+  let missingHarnessBins: HarnessAvailability[] = [];
   if (input.checkHarnesses !== false) {
-    const resolved = resolvedHarnessBins(harnessChecks);
-    if (Object.keys(resolved).length > 0) {
-      await saveHarnessBins(resolved);
-      config = applyResolvedHarnessBins(config, harnessChecks);
-    }
+    const resolution = await resolveHarnessBinsForConfig(config, {
+      ...(input.checkHarnesses ? { check: input.checkHarnesses } : {}),
+    });
+    config = resolution.config;
+    missingHarnessBins = resolution.missing;
   }
-  const missingHarnessBins = missingHarnesses(harnessChecks);
   if (missingHarnessBins.length > 0) {
     log.error("run: configured harness binary not found", {
       missing: missingHarnessBins.map((h) => ({ id: h.id, bin: h.bin })),

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -38,6 +38,7 @@ import { spawn } from "node:child_process";
 
 import { type Config, loadConfig, personaDir, xdgStateHome } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
+import { resolveHarnessBinsForConfig } from "../lib/harnessAvailability.ts";
 import type { Harness, HarnessChunk } from "../harnesses/types.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
@@ -75,7 +76,7 @@ export interface RunTickInput {
 export async function runTick(input: RunTickInput = {}): Promise<number> {
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
-  const config = input.config ?? (await loadConfig());
+  let config = input.config ?? (await loadConfig());
   const now = input.now ?? new Date();
 
   // Record that the tick timer fired — even if the body exits early
@@ -164,7 +165,16 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
             runError = `command exited ${result.exitCode}`;
           }
         } else {
-          harnesses ??= buildHarnessChain(config, err);
+          if (!harnesses) {
+            // Resolve harness binaries against the live filesystem the same
+            // way the `run` daemon does — the tick oneshot otherwise relied
+            // solely on the systemd unit's narrow Environment=PATH, so a
+            // PATH-relative `pi` could fail with `exit 127` (issue #181 §1).
+            // Done lazily (only when an agent-backed task is actually due) so
+            // a tick with no agent work doesn't pay the filesystem search.
+            ({ config } = await resolveHarnessBinsForConfig(config, { err }));
+            harnesses = buildHarnessChain(config, err);
+          }
           if (harnesses.length === 0) {
             throw new Error("no harnesses configured");
           }

--- a/src/lib/harnessAvailability.ts
+++ b/src/lib/harnessAvailability.ts
@@ -2,6 +2,9 @@ import { access, constants, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Config } from "../config.ts";
+import { log } from "./logger.ts";
+import { saveHarnessBins } from "../state.ts";
+import type { WriteSink } from "./io.ts";
 
 export type KnownHarnessId = "claude" | "pi" | "gemini" | "codex";
 
@@ -182,6 +185,57 @@ export function resolvedHarnessBins(
       .filter((h) => h.resolved)
       .map((h) => [h.id, h.resolved!]),
   );
+}
+
+/**
+ * Resolve every configured harness binary against the live filesystem,
+ * persist the resolved absolute paths to state, and return a config whose
+ * harness bins point at those absolute paths.
+ *
+ * Why this exists as a shared helper: the long-running `run` daemon already
+ * did this inline, but the systemd ONESHOTS (`nightly`, `tick`) and `ask`
+ * did not — they built their harness chain straight off `loadConfig()`. A
+ * PATH-relative bin like `pi` then relied solely on the unit's narrow
+ * `Environment=PATH=` (PHANTOMBOT_SERVICE_PATH). If `pi` lives anywhere
+ * outside those dirs — a versioned nvm/fnm/volta/.bun path that only the
+ * broad `harnessSearchPath()` covers — the oneshot spawned `pi` and got
+ * `exit 127` (command not found) every single night, while the interactive
+ * daemon (which DID resolve) worked fine. That divergence was phantombot
+ * issue #181 §1. Routing all four entry points through this one helper
+ * means a oneshot resolves binaries exactly the way the daemon does.
+ *
+ * `check` is injectable for tests; `persist` defaults to true (cheap write
+ * that keeps state.json's resolved bins fresh for the next loadConfig).
+ */
+export async function resolveHarnessBinsForConfig(
+  config: Config,
+  opts: {
+    check?: (c: Config) => Promise<HarnessAvailability[]>;
+    persist?: boolean;
+    err?: WriteSink;
+  } = {},
+): Promise<{ config: Config; missing: HarnessAvailability[] }> {
+  const checks = opts.check
+    ? await opts.check(config)
+    : await checkConfiguredHarnesses(config);
+  const resolved = resolvedHarnessBins(checks);
+  let next = config;
+  if (Object.keys(resolved).length > 0) {
+    if (opts.persist !== false) await saveHarnessBins(resolved);
+    next = applyResolvedHarnessBins(config, checks);
+  }
+  const missing = missingHarnesses(checks);
+  if (missing.length > 0) {
+    log.warn("harness binary not found on PATH or search path", {
+      missing: missing.map((h) => ({ id: h.id, bin: h.bin })),
+    });
+    opts.err?.write(
+      "warning: configured harness binary not found:\n" +
+        missing.map((h) => `  ${h.id}: '${h.bin}'`).join("\n") +
+        "\n",
+    );
+  }
+  return { config: next, missing };
 }
 
 export function applyResolvedHarnessBins(

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -339,7 +339,7 @@ Re-read today's daily file for durable knowledge (procedures, configs, runbooks,
   c) Otherwise create a new atomic note in the right kb/<category>/ subdir from a kb/templates/ scaffold. Frontmatter required: type, tags, created, updated. Link related notes with [[wikilinks]].
 Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
 Finish with \`phantombot memory index --rebuild\` so new notes get embeddings.`,
-  compress: (today) => `STAGE: MAINTAIN MEMORY.md
+  compress: (today) => `STAGE: COMPRESS / MAINTAIN MEMORY.md
 MEMORY.md is the always-in-context orientation layer. Your job here is to MAINTAIN it — both fill and trim — not just trim.
   1. Read MEMORY.md (use your Read tool). If it has no "## Recent" section, add one.
   2. FILL: from today's daily file (memory/${today}.md) and the items you promoted/distilled in earlier stages, add a few SHORT orientation bullets under "## Recent" — only durable, still-relevant facts worth having in context every turn (current focus, active projects, fresh standing facts). One line each. Do not copy whole entries; summarise and link to the KB note or drawer that holds the detail.

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -282,8 +282,10 @@ PHASE 3 — Feed the KB
   Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
   Run \`phantombot memory index --rebuild\` at the end so new notes have embeddings.
 
-PHASE 4 — Compress MEMORY.md
-  MEMORY.md should stay short (orientation layer only). If it's bloated, move detail into the relevant KB note(s) and leave a short pointer. Clear items from "## Recent" that you've now distilled to a permanent home.
+PHASE 4 — Maintain MEMORY.md
+  MEMORY.md is the always-in-context orientation layer — MAINTAIN it (fill AND trim), don't only trim.
+    - FILL: read MEMORY.md; if there is no "## Recent" section, add one. From today's daily file and what you promoted/distilled above, add a few SHORT orientation bullets (one line each) for durable, still-relevant facts worth having in context every turn. Summarise and point to the KB note / drawer that holds the detail — don't paste whole entries.
+    - TRIM: keep MEMORY.md short. Remove "## Recent" bullets that are now stale or fully distilled to a permanent home (leave a pointer if useful). If a section bloated into long-form prose, move detail into the relevant KB note(s) and leave a short pointer.
 
 PHASE 5 — State report
   Write your summary to memory/.nightly-state.json (overwrite). Include:
@@ -337,8 +339,12 @@ Re-read today's daily file for durable knowledge (procedures, configs, runbooks,
   c) Otherwise create a new atomic note in the right kb/<category>/ subdir from a kb/templates/ scaffold. Frontmatter required: type, tags, created, updated. Link related notes with [[wikilinks]].
 Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
 Finish with \`phantombot memory index --rebuild\` so new notes get embeddings.`,
-  compress: () => `STAGE: COMPRESS MEMORY.md
-MEMORY.md should stay short (orientation layer only). If it is bloated, move detail into the relevant KB note(s) and leave a short pointer. Clear items from "## Recent" that have now been distilled to a permanent home.`,
+  compress: (today) => `STAGE: MAINTAIN MEMORY.md
+MEMORY.md is the always-in-context orientation layer. Your job here is to MAINTAIN it — both fill and trim — not just trim.
+  1. Read MEMORY.md (use your Read tool). If it has no "## Recent" section, add one.
+  2. FILL: from today's daily file (memory/${today}.md) and the items you promoted/distilled in earlier stages, add a few SHORT orientation bullets under "## Recent" — only durable, still-relevant facts worth having in context every turn (current focus, active projects, fresh standing facts). One line each. Do not copy whole entries; summarise and link to the KB note or drawer that holds the detail.
+  3. TRIM: MEMORY.md must stay short. Remove "## Recent" bullets that are now stale or have a permanent home in a drawer/KB note (leave a short pointer if useful). If any section has bloated into long-form prose, move that detail into the relevant KB note and leave a one-line pointer.
+If today's daily file is missing or empty and nothing has changed, say so and make no edits.`,
   state: (today) => `STAGE: STATE REPORT
 Write memory/.nightly-state.json (overwrite). Include:
   last_run         (ISO 8601 timestamp — now)

--- a/tests/lib-harnessAvailability.test.ts
+++ b/tests/lib-harnessAvailability.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { expandSystemdPath, whichBinary, checkConfiguredHarnesses } from "../src/lib/harnessAvailability.ts";
+import {
+  expandSystemdPath,
+  whichBinary,
+  checkConfiguredHarnesses,
+  resolveHarnessBinsForConfig,
+  type HarnessAvailability,
+} from "../src/lib/harnessAvailability.ts";
 import type { Config } from "../src/config.ts";
 
 describe("expandSystemdPath", () => {
@@ -97,5 +103,53 @@ describe("checkConfiguredHarnesses", () => {
         source: "path",
       },
     ]);
+  });
+});
+
+describe("resolveHarnessBinsForConfig", () => {
+  // The whole point of issue #181 §1: the systemd oneshots (nightly/tick/ask)
+  // must resolve a PATH-relative `pi` to its absolute path the way `run`
+  // does, instead of handing the bare "pi" to the spawn and getting exit 127.
+  const baseConfig = {
+    harnesses: {
+      chain: ["claude", "pi"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi", maxPayloadBytes: 1000 },
+      gemini: { bin: "gemini", model: "" },
+    },
+  } as unknown as Config;
+
+  test("rewrites config bins to the resolved absolute paths", async () => {
+    const check = async (): Promise<HarnessAvailability[]> => [
+      { id: "claude", bin: "claude", resolved: "/abs/claude", source: "path" },
+      { id: "pi", bin: "pi", resolved: "/abs/pi", source: "search" },
+    ];
+
+    const { config, missing } = await resolveHarnessBinsForConfig(baseConfig, {
+      check,
+      persist: false,
+    });
+
+    expect(config.harnesses.claude.bin).toBe("/abs/claude");
+    expect(config.harnesses.pi.bin).toBe("/abs/pi");
+    expect(missing).toHaveLength(0);
+    // copy-on-write — the input config is never mutated
+    expect(baseConfig.harnesses.pi.bin).toBe("pi");
+  });
+
+  test("reports an unresolvable binary as missing and leaves its bin alone", async () => {
+    const check = async (): Promise<HarnessAvailability[]> => [
+      { id: "claude", bin: "claude", resolved: "/abs/claude", source: "path" },
+      { id: "pi", bin: "pi" }, // not found anywhere
+    ];
+
+    const { config, missing } = await resolveHarnessBinsForConfig(baseConfig, {
+      check,
+      persist: false,
+    });
+
+    expect(config.harnesses.claude.bin).toBe("/abs/claude");
+    expect(config.harnesses.pi.bin).toBe("pi");
+    expect(missing.map((m) => m.id)).toEqual(["pi"]);
   });
 });

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -290,7 +290,19 @@ describe("buildNightlyStagePrompt", () => {
     expect(bodies[0]).toContain("DAY ESSENCE");
     expect(bodies[1]).toContain("PROMOTE TO DRAWERS");
     expect(bodies[2]).toContain("FEED THE KB");
-    expect(bodies[3]).toContain("COMPRESS MEMORY.md");
+    expect(bodies[3]).toContain("MAINTAIN MEMORY.md");
     expect(bodies[4]).toContain("STATE REPORT");
+  });
+
+  // Issue #181 §4: MEMORY.md was never populated because the old stage only
+  // ever TRIMMED. The maintain stage must also instruct the agent to FILL the
+  // "## Recent" orientation section, otherwise MEMORY.md stays at template.
+  test("the MEMORY.md stage instructs filling, not only trimming", () => {
+    const body = buildNightlyStagePrompt("robbie", "2026-05-18", "compress");
+    expect(body).toContain("FILL");
+    expect(body).toContain("## Recent");
+    expect(body).toMatch(/maintain/i);
+    // and still keeps the trim half
+    expect(body).toContain("TRIM");
   });
 });


### PR DESCRIPTION
Follow-up to #182 — the two remaining points from #181 that were left out of the focus PR because they're env/prompt-shaped rather than the clean deterministic bugs.

## §1 — `pi exited with code 127` under systemd

**Root cause.** The long-running `run` daemon resolves each configured harness binary against the live filesystem via the broad `harnessSearchPath()` (covering `~/.local/bin`, nvm/fnm/volta/`.bun`/`.npm-global`, versioned node dirs, …) and rewrites PATH-relative bins like `pi` to their absolute path. The systemd **oneshots** (`nightly`, `tick`) and `ask` did **not** — they built their harness chain straight off `loadConfig()`. So a PATH-relative `pi` relied solely on the unit's narrow `Environment=PATH` (`PHANTOMBOT_SERVICE_PATH`). When `pi` lives outside those dirs, the oneshot spawned a bare `pi`, got **exit 127**, and (since 127 is treated as terminal) the nightly stage failed every night — while the interactive daemon, which *did* resolve, worked fine. Classic "works interactively, 127 under systemd" PATH divergence.

**Fix.** Extract the resolve → persist → apply logic into a shared `resolveHarnessBinsForConfig()` and route `run`/`nightly`/`tick`/`ask` through it, so an oneshot resolves binaries exactly the way the daemon does. `nightly` also drops its own duplicate `buildHarnessChain` and uses the shared one. In `tick` the resolve is lazy (only when an agent-backed task is actually due) so an idle per-minute tick doesn't pay the filesystem search.

## §4 — MEMORY.md never filled (stayed at template)

The compress stage only ever **trimmed** — nothing ever **populated** the `## Recent` orientation layer it kept trying to clear, so MEMORY.md never grew past the template. Reworked the stage (and the monolithic `PHASE 4`) into **maintain**: distil a few short durable orientation bullets into `## Recent` **and** trim the stale ones. This is a prompt change, so it's inherently fuzzier than §1 — the test asserts the instruction now tells the agent to fill, not only trim.

## Tests
- `resolveHarnessBinsForConfig` rewrites config bins to resolved absolute paths and is copy-on-write; reports an unresolvable binary as `missing` and leaves its bin untouched.
- The maintain stage prompt instructs filling `## Recent` (not only trimming).
- Suite green on touched modules. The ~14 pre-existing failures (`runUpdate`, `runImportPersona`, `healDefaultPersona`) are environmental (network/systemd/bun-on-PATH on a dev Mac) and fail identically on clean `main` — none touch the modules changed here.

Refs #181. Leaves #181 fully addressed across #182 + this PR.