### PR TITLE
fix(pi): handle pi 0.79.x renamed stream events (toolcall_*/toolName)

### DIFF
--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -152,11 +152,12 @@ export function renderPayload(req: HarnessRequest): string {
 /**
  * Translate one pi stream-json line into a HarnessChunk.
  *
- * Schema (verified against pi v0.67.x with `--mode json`):
+ * Schema (verified against pi v0.79.x with `--mode json`; older v0.67.x
+ * event names — `tool_use_*`, `tool_name` — still accepted as fallback):
  *
  *   {"type":"message_update",
  *    "assistantMessageEvent":{
- *       "type":"text_delta"|"thinking_delta"|"tool_use_*"|...,
+ *       "type":"text_delta"|"thinking_delta"|"toolcall_*"|...,
  *       "contentIndex": N,
  *       "delta": "...",     // for *_delta events
  *       "partial": {...},
@@ -176,9 +177,10 @@ export function renderPayload(req: HarnessRequest): string {
  * time, that's pi actually thinking — the indicator vanishing means the
  * model has gone silent (and may be wedged on a tool call).
  *
- * tool_use_* event types inside assistantMessageEvent → `progress`
- * so the channel layer flushes narration into a bubble before the tool
- * runs. thinking_delta + other event types → `heartbeat`.
+ * toolcall_* (pi ≥0.79; formerly tool_use_*) event types inside
+ * assistantMessageEvent → `progress` so the channel layer flushes narration
+ * into a bubble before the tool runs. thinking_delta + other event types →
+ * `heartbeat`.
  *
  * Exported for testing.
  */
@@ -191,7 +193,14 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
   // flushes any buffered narration into a bubble before the tool
   // runs (keeping the user oriented during the silence).
   if (obj.type === "tool_execution_start") {
-    const toolName = typeof obj.tool_name === "string" ? obj.tool_name : undefined;
+    // pi 0.79.x renamed this field `tool_name` → `toolName` (camelCase).
+    // Accept both so the adapter works across pi versions.
+    const toolName =
+      typeof obj.toolName === "string"
+        ? obj.toolName
+        : typeof obj.tool_name === "string"
+          ? obj.tool_name
+          : undefined;
     return { type: "progress", note: toolName ? `tool: ${toolName}` : "tool" };
   }
 
@@ -209,12 +218,15 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
   }
 
   if (typeof ame.type === "string") {
-    // tool_use_* assistantMessageEvent: the model has decided to call
+    // toolcall_* assistantMessageEvent: the model has decided to call
     // a tool — emit `progress` so the channel layer flushes narration
     // into a bubble before the tool runs. Previously these were mapped
     // to heartbeats, which kept the typing indicator alive but never
     // triggered a bubble flush (defeating the purpose of PR #74).
-    if (ame.type.startsWith("tool_use")) {
+    //
+    // pi 0.79.x renamed these events `tool_use_*` → `toolcall_*`. Match
+    // both prefixes so narration surfaces across pi versions.
+    if (ame.type.startsWith("toolcall") || ame.type.startsWith("tool_use")) {
       return { type: "progress", note: "tool" };
     }
     // thinking_delta + anything else → heartbeat.
@@ -235,8 +247,13 @@ function piActivity(parsed: unknown, chunk: HarnessChunk): HarnessActivity {
   if (obj.type === "tool_execution_start") return "tool";
   const ame = obj.assistantMessageEvent;
   if (isObject(ame) && typeof ame.type === "string") {
-    if (ame.type === "tool_use_end") return "productive";
-    if (ame.type.startsWith("tool_use")) return "tool";
+    // pi 0.79.x: `tool_use_*` → `toolcall_*`. Accept both.
+    if (ame.type === "toolcall_end" || ame.type === "tool_use_end") {
+      return "productive";
+    }
+    if (ame.type.startsWith("toolcall") || ame.type.startsWith("tool_use")) {
+      return "tool";
+    }
   }
   return chunk.type === "heartbeat" ? "model" : "productive";
 }

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -92,7 +92,15 @@ describe("parsePiEvent", () => {
     expect(JSON.stringify(c)).not.toContain("internal reasoning");
   });
 
-  test("emits progress for tool_execution_start (top-level event)", () => {
+  test("emits progress for tool_execution_start (pi 0.79.x toolName field)", () => {
+    const c = parsePiEvent({
+      type: "tool_execution_start",
+      toolName: "bash",
+    });
+    expect(c).toEqual({ type: "progress", note: "tool: bash" });
+  });
+
+  test("emits progress for tool_execution_start (legacy 0.67.x tool_name field)", () => {
     const c = parsePiEvent({
       type: "tool_execution_start",
       tool_name: "run_shell_command",
@@ -100,13 +108,22 @@ describe("parsePiEvent", () => {
     expect(c).toEqual({ type: "progress", note: "tool: run_shell_command" });
   });
 
-  test("emits progress for tool_execution_start without a tool_name", () => {
+  test("emits progress for tool_execution_start without a tool name", () => {
     const c = parsePiEvent({ type: "tool_execution_start" });
     expect(c).toEqual({ type: "progress", note: "tool" });
   });
 
-  test("emits progress for tool_use assistantMessageEvent (not heartbeat)", () => {
-    for (const ameType of ["tool_use_start", "tool_use_end", "tool_use"]) {
+  test("emits progress for toolcall_* / tool_use_* assistantMessageEvent (not heartbeat)", () => {
+    for (const ameType of [
+      // pi 0.79.x names
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      // legacy 0.67.x names (still accepted)
+      "tool_use_start",
+      "tool_use_end",
+      "tool_use",
+    ]) {
       expect(
         parsePiEvent({
           type: "message_update",


### PR DESCRIPTION
## What

pi **0.79.x** renamed its `--mode json` stream events. The phantombot Pi adapter (`src/harnesses/pi.ts`) was written against **0.67.x** and no longer recognised the new names:

| Old (0.67.x) | New (0.79.x) |
|---|---|
| `assistantMessageEvent.type` = `tool_use_*` | `toolcall_*` (`toolcall_start` / `toolcall_delta` / `toolcall_end`) |
| `tool_execution_start.tool_name` | `tool_execution_start.toolName` |

Because the adapter only matched the old names, on current pi:
- tool-call `assistantMessageEvent`s fell through to the `heartbeat` branch, so narration was **never flushed into a bubble** before a tool ran (defeating PR #74);
- `tool_execution_start` progress notes always rendered as a nameless **`tool`** instead of `tool: <name>`.

This surfaced while testing the `moonshotai/kimi-k2.7-code` OpenRouter model on Lena: long tool-heavy turns showed "constant thinking, no output" with zero visibility into what the agent was doing.

## Fix

Accept **both** the new and legacy event names so the adapter works across pi versions:
- `parsePiEvent`: read `toolName` with `tool_name` fallback; match `toolcall*` **or** `tool_use*` prefixes.
- `piActivity`: treat `toolcall_end`/`tool_use_end` as productive and `toolcall*`/`tool_use*` as tool activity.
- Refreshed the schema docstrings (0.67.x → 0.79.x, old names noted as fallback).

Functionally this was **cosmetic** — turns still completed — but it restores mid-turn visibility into tool activity.

## Verification

- Schema confirmed against **pi 0.79.1** with a forced bash tool call (`toolcall_*` events + `toolName` field observed directly).
- New/updated unit tests cover both new and legacy names.
- `bun tsc --noEmit` clean.
- Full suite: **1309 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
