### PR TITLE
feat(phantomchat): transcribe incoming voice notes (STT) — step 2

### DIFF
--- a/src/channels/core/types.ts
+++ b/src/channels/core/types.ts
@@ -129,6 +129,8 @@ export interface ChannelMessage {
     ivHex: string;
     mimeType: string;
     durationS?: number;
+    /** Plaintext byte size from the envelope (used to skip oversized downloads). */
+    size?: number;
   };
 }
 

--- a/src/channels/core/types.ts
+++ b/src/channels/core/types.ts
@@ -111,6 +111,25 @@ export interface ChannelMessage {
    * application-level delivery receipts (e.g. Telegram, which has its own).
    */
   messageId?: string;
+  /**
+   * INBOUND MEDIA (optional; currently only the phantomchat channel sets it).
+   *
+   * A voice note / attachment the sender wrapped as an AES-256-GCM encrypted
+   * file stored on Blossom; the key/iv travel inside the gift-wrap envelope.
+   * For a pure voice note `text` is empty and the turn driver (phantomchat
+   * server) fetches+decrypts the file and transcribes it into the user message
+   * before running the turn — mirroring the Telegram voice→STT path in
+   * core/engine. Absent for plain text messages.
+   */
+  media?: {
+    kind: "voice" | "image" | "video" | "file";
+    url: string;
+    sha256: string;
+    keyHex: string;
+    ivHex: string;
+    mimeType: string;
+    durationS?: number;
+  };
 }
 
 /**

--- a/src/channels/phantomchat/blossomFetch.ts
+++ b/src/channels/phantomchat/blossomFetch.ts
@@ -1,0 +1,59 @@
+/*
+ * PhantomChat media: fetch a file from Blossom and AES-256-GCM decrypt it.
+ *
+ * Counterpart to the PWA's encrypt path (phantomchat/src/lib/phantomchat/
+ * file-crypto.ts). The PWA encrypts with Web Crypto `AES-GCM`:
+ *   - 256-bit key (32 bytes), 96-bit IV (12 bytes), both hex on the wire
+ *   - Web Crypto APPENDS the 128-bit (16-byte) auth tag to the ciphertext
+ *     (output is ciphertext‖tag), whereas Node's GCM wants the tag supplied
+ *     separately — so we split the trailing 16 bytes and `setAuthTag`.
+ * The encrypted bytes live at a Blossom URL; the key/iv travel inside the
+ * NIP-17 gift-wrap envelope, so only the recipient can decrypt.
+ */
+import { createDecipheriv, createHash } from "node:crypto";
+
+const GCM_TAG_BYTES = 16;
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+
+export async function fetchAndDecryptBlossom(
+  url: string,
+  keyHex: string,
+  ivHex: string,
+  opts?: { expectedSha256Hex?: string; signal?: AbortSignal },
+): Promise<Buffer> {
+  const key = Buffer.from(keyHex, "hex");
+  const iv = Buffer.from(ivHex, "hex");
+  if (key.length !== KEY_BYTES) {
+    throw new Error(`blossom: bad key length ${key.length} (want ${KEY_BYTES})`);
+  }
+  if (iv.length !== IV_BYTES) {
+    throw new Error(`blossom: bad iv length ${iv.length} (want ${IV_BYTES})`);
+  }
+
+  const res = await fetch(url, { signal: opts?.signal });
+  if (!res.ok) {
+    throw new Error(`blossom fetch ${url}: HTTP ${res.status}`);
+  }
+  const ciphertext = Buffer.from(await res.arrayBuffer());
+
+  // Blossom is content-addressed by sha256 of the (encrypted) bytes. Verifying
+  // it catches a corrupt/tampered/wrong-blob fetch before we waste a GCM auth
+  // failure on it (and before STT spends a paid API call on garbage).
+  if (opts?.expectedSha256Hex) {
+    const got = createHash("sha256").update(ciphertext).digest("hex");
+    if (got !== opts.expectedSha256Hex.toLowerCase()) {
+      throw new Error("blossom: sha256 mismatch (corrupt or tampered file)");
+    }
+  }
+
+  if (ciphertext.length < GCM_TAG_BYTES) {
+    throw new Error("blossom: ciphertext shorter than the GCM auth tag");
+  }
+  const tag = ciphertext.subarray(ciphertext.length - GCM_TAG_BYTES);
+  const body = ciphertext.subarray(0, ciphertext.length - GCM_TAG_BYTES);
+
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(body), decipher.final()]);
+}

--- a/src/channels/phantomchat/channel.ts
+++ b/src/channels/phantomchat/channel.ts
@@ -226,16 +226,46 @@ export function createPhantomchatChannel(
         //   - Legacy PhantomChat JSON envelope {type, content, id, nonce}.
         //   - Standard NIP-17: rumor.content IS the plain message text (what
         //     0xchat/Amethyst and the aligned PWA send). Resolved below.
-        let envelope: {id?: unknown; type?: unknown; content?: unknown; nonce?: unknown} | null = null;
+        let parsedContent: any = null;
         try {
-          const parsed = JSON.parse(rumor.content);
-          // Only OUR envelope has a string `type`. A plain-text body that happens
-          // to be JSON without a `type` falls through to the plain-text path.
-          if (parsed && typeof parsed === "object" && typeof parsed.type === "string") {
-            envelope = parsed;
-          }
+          const p = JSON.parse(rumor.content);
+          if (p && typeof p === "object") parsedContent = p;
         } catch {
           // not JSON → standard NIP-17 plain-text message (handled below)
+        }
+        // Only OUR text envelope has a string `type`. A plain-text body that
+        // happens to be JSON without a `type` falls through to the plain-text path.
+        const envelope: {id?: unknown; type?: unknown; content?: unknown; nonce?: unknown} | null =
+          parsedContent && typeof parsedContent.type === "string" ? parsedContent : null;
+
+        // Media envelope (voice / image / file): the PWA wraps an encrypted
+        // Blossom file as {url, sha256, key, iv, mediaType, duration, waveform}.
+        // It carries no `type`, so it isn't caught above — detect it here so the
+        // server fetches+decrypts (and, for voice, transcribes) instead of
+        // running a turn on the raw metadata JSON.
+        let media: ChannelMessage["media"] | undefined;
+        if (
+          parsedContent &&
+          typeof parsedContent.url === "string" &&
+          typeof parsedContent.sha256 === "string" &&
+          typeof parsedContent.key === "string" &&
+          typeof parsedContent.iv === "string" &&
+          typeof parsedContent.mediaType === "string"
+        ) {
+          const mt = parsedContent.mediaType;
+          media = {
+            kind: mt === "voice" || mt === "image" || mt === "video" ? mt : "file",
+            url: parsedContent.url,
+            sha256: parsedContent.sha256,
+            keyHex: parsedContent.key,
+            ivHex: parsedContent.iv,
+            mimeType:
+              typeof parsedContent.mimeType === "string"
+                ? parsedContent.mimeType
+                : "application/octet-stream",
+            durationS:
+              typeof parsedContent.duration === "number" ? parsedContent.duration : undefined,
+          };
         }
 
         // (6) LIVE-GATE. On (re)connect the relays replay up to 49h of stored
@@ -262,7 +292,13 @@ export function createPhantomchatChannel(
         // Resolve the message text + id from whichever shape arrived.
         let text: string;
         let messageId: string | undefined;
-        if (envelope) {
+        if (media) {
+          // Voice / media: no text body — the server fetches+decrypts (and, for
+          // voice, transcribes) before running the turn. Key the delivery
+          // receipt off the rumor id, same as a standard NIP-17 message.
+          text = "";
+          messageId = rumor.id;
+        } else if (envelope) {
           // Legacy envelope: only `text` envelopes become turns (reactions/etc. drop).
           if (envelope.type !== "text" || typeof envelope.content !== "string") {
             return;
@@ -309,6 +345,7 @@ export function createPhantomchatChannel(
             text,
             groupId,
             groupMemberHexes: memberHexes,
+            ...(media ? { media } : {}),
           });
           wake?.();
           return;
@@ -327,6 +364,7 @@ export function createPhantomchatChannel(
           senderId: senderHex,
           text,
           ...(messageId ? { messageId } : {}),
+          ...(media ? { media } : {}),
         });
         wake?.();
       };

--- a/src/channels/phantomchat/channel.ts
+++ b/src/channels/phantomchat/channel.ts
@@ -78,6 +78,11 @@ export const BACKFILL_POLL_MS = 15_000;
  */
 export const BACKFILL_POLL_WINDOW_SEC = 90;
 
+// Envelope `type` values that carry a Blossom file rather than plain text
+// (see chat-api.sendFileMessage / GroupAPI.sendFile in the PWA). Matches the
+// PWA's ChatMessageType media kinds.
+const MEDIA_ENVELOPE_TYPES = new Set(["voice", "image", "video", "gif", "file"]);
+
 /**
  * The application-level message envelope carried INSIDE a rumor's `content`,
  * as a JSON string. This is the wire contract with the PWA: the rumor content
@@ -235,38 +240,53 @@ export function createPhantomchatChannel(
         }
         // Only OUR text envelope has a string `type`. A plain-text body that
         // happens to be JSON without a `type` falls through to the plain-text path.
-        const envelope: {id?: unknown; type?: unknown; content?: unknown; nonce?: unknown} | null =
+        const envelope: {id?: unknown; type?: unknown; content?: unknown; nonce?: unknown; fileMetadata?: unknown} | null =
           parsedContent && typeof parsedContent.type === "string" ? parsedContent : null;
 
-        // Media envelope (voice / image / file): the PWA wraps an encrypted
-        // Blossom file as {url, sha256, key, iv, mediaType, duration, waveform}.
-        // It carries no `type`, so it isn't caught above — detect it here so the
-        // server fetches+decrypts (and, for voice, transcribes) instead of
-        // running a turn on the raw metadata JSON.
+        // Media envelope. The PWA wraps media in the SAME typed envelope as
+        // text, with `type` = the media kind (voice/image/video/gif/file). Two
+        // wire shapes (see chat-api.sendFileMessage and GroupAPI.sendFile):
+        //   - DM:    envelope.content is a JSON STRING of the file metadata
+        //            ({url, sha256, key, iv, mediaType, duration, ...}).
+        //   - Group: envelope.fileMetadata is the metadata OBJECT
+        //            ({url, sha256, keyHex, ivHex, ...}); envelope.content is
+        //            the caption.
+        // Detect it BEFORE the `type !== "text"` reject below, else real voice
+        // notes / attachments are dropped. Accept both key/iv and keyHex/ivHex.
         let media: ChannelMessage["media"] | undefined;
-        if (
-          parsedContent &&
-          typeof parsedContent.url === "string" &&
-          typeof parsedContent.sha256 === "string" &&
-          typeof parsedContent.key === "string" &&
-          typeof parsedContent.iv === "string" &&
-          typeof parsedContent.mediaType === "string"
-        ) {
-          const mt = parsedContent.mediaType;
-          media = {
-            kind: mt === "voice" || mt === "image" || mt === "video" ? mt : "file",
-            url: parsedContent.url,
-            sha256: parsedContent.sha256,
-            keyHex: parsedContent.key,
-            ivHex: parsedContent.iv,
-            mimeType:
-              typeof parsedContent.mimeType === "string"
-                ? parsedContent.mimeType
-                : "application/octet-stream",
-            durationS:
-              typeof parsedContent.duration === "number" ? parsedContent.duration : undefined,
-            size: typeof parsedContent.size === "number" ? parsedContent.size : undefined,
-          };
+        let mediaCaption = "";
+        if (envelope && MEDIA_ENVELOPE_TYPES.has(envelope.type as string)) {
+          let fm: any = null;
+          if (envelope.fileMetadata && typeof envelope.fileMetadata === "object") {
+            fm = envelope.fileMetadata; // group
+            if (typeof envelope.content === "string") mediaCaption = envelope.content;
+          } else if (typeof envelope.content === "string") {
+            try {
+              fm = JSON.parse(envelope.content); // DM (content is the metadata JSON string)
+            } catch {
+              fm = null;
+            }
+            if (fm && typeof fm.caption === "string") mediaCaption = fm.caption;
+          }
+          if (fm && typeof fm.url === "string" && typeof fm.sha256 === "string") {
+            const keyHex =
+              typeof fm.keyHex === "string" ? fm.keyHex : typeof fm.key === "string" ? fm.key : "";
+            const ivHex =
+              typeof fm.ivHex === "string" ? fm.ivHex : typeof fm.iv === "string" ? fm.iv : "";
+            if (keyHex && ivHex) {
+              const mt = typeof fm.mediaType === "string" ? fm.mediaType : (envelope.type as string);
+              media = {
+                kind: mt === "voice" || mt === "image" || mt === "video" ? mt : "file",
+                url: fm.url,
+                sha256: fm.sha256,
+                keyHex,
+                ivHex,
+                mimeType: typeof fm.mimeType === "string" ? fm.mimeType : "application/octet-stream",
+                durationS: typeof fm.duration === "number" ? fm.duration : undefined,
+                size: typeof fm.size === "number" ? fm.size : undefined,
+              };
+            }
+          }
         }
 
         // (6) LIVE-GATE. On (re)connect the relays replay up to 49h of stored
@@ -294,11 +314,13 @@ export function createPhantomchatChannel(
         let text: string;
         let messageId: string | undefined;
         if (media) {
-          // Voice / media: no text body — the server fetches+decrypts (and, for
-          // voice, transcribes) before running the turn. Key the delivery
-          // receipt off the rumor id, same as a standard NIP-17 message.
-          text = "";
-          messageId = rumor.id;
+          // Media: the body text is the caption (empty for a bare voice note);
+          // the server fetches+decrypts (and, for voice, transcribes) before the
+          // turn. Receipt off the envelope's app id (what the PWA's file
+          // delivery tracker keys on), falling back to the rumor id.
+          text = mediaCaption;
+          messageId =
+            typeof envelope!.id === "string" && envelope!.id ? (envelope!.id as string) : rumor.id;
         } else if (envelope) {
           // Legacy envelope: only `text` envelopes become turns (reactions/etc. drop).
           if (envelope.type !== "text" || typeof envelope.content !== "string") {

--- a/src/channels/phantomchat/channel.ts
+++ b/src/channels/phantomchat/channel.ts
@@ -265,6 +265,7 @@ export function createPhantomchatChannel(
                 : "application/octet-stream",
             durationS:
               typeof parsedContent.duration === "number" ? parsedContent.duration : undefined,
+            size: typeof parsedContent.size === "number" ? parsedContent.size : undefined,
           };
         }
 

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -23,9 +23,24 @@ import { runTurn } from "../../orchestrator/turn.ts";
 import { makeRetriever } from "../../orchestrator/retrieval.ts";
 import { makeScreener } from "../../orchestrator/screen.ts";
 import { makeTurnIndexer } from "../../orchestrator/turnIndexer.ts";
-import { TELEGRAM_REPLY_INSTRUCTION } from "../core/prompts.ts";
+import { TELEGRAM_REPLY_INSTRUCTION, voiceUnavailableMessage } from "../core/prompts.ts";
 import type { Channel, ChannelMessage } from "../core/types.ts";
 import type { PhantomchatTransport } from "./transport.ts";
+import { sttSupport, transcribe } from "../../lib/audio.ts";
+import { DEFAULT_STT_TIMEOUT_MS } from "../../lib/voice.ts";
+import { fetchAndDecryptBlossom } from "./blossomFetch.ts";
+
+// Bound the voice fetch+decrypt+transcribe step. A hung Blossom fetch or STT
+// request would otherwise never settle and wedge this peer's serial turn chain
+// forever (the Telegram engine guards its STT the same way).
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
 
 export interface RunPhantomchatServerInput {
   config: Config;
@@ -145,6 +160,77 @@ export async function runPhantomchatServer(
       void transport.sendDeliveryReceipt(senderHex, msg.messageId);
     }
 
+    // ===================== VOICE / MEDIA → TEXT =====================
+    // A voice note arrives as an encrypted Blossom file (msg.media) with an
+    // empty text body. Fetch + AES-256-GCM decrypt + transcribe so the turn
+    // reasons over the words — mirroring the Telegram voice→STT path
+    // (core/engine.processChatMessage). Done AFTER the auth gate so we never
+    // spend a paid STT call (or de-stealth) on a dropped stranger. Other media
+    // kinds carry no transcript yet, so the turn sees a short marker.
+    let userMessage = msg.text;
+    if (msg.media) {
+      const m = msg.media;
+      if (m.kind === "voice") {
+        const stt = sttSupport(input.config);
+        if (!stt.ok) {
+          log.warn("phantomchat: voice note but STT unavailable", {
+            persona: input.persona,
+            reason: stt.reason,
+          });
+          await transport
+            .sendMessage(senderHex, voiceUnavailableMessage(stt))
+            .catch(() => {});
+          return;
+        }
+        try {
+          const r = await withTimeout(
+            (async () => {
+              const audio = await fetchAndDecryptBlossom(m.url, m.keyHex, m.ivHex, {
+                expectedSha256Hex: m.sha256,
+                signal: input.signal,
+              });
+              return transcribe(input.config, audio, m.mimeType);
+            })(),
+            input.config.voice.sttTimeoutMs ?? DEFAULT_STT_TIMEOUT_MS,
+          );
+          if (!r.ok) {
+            log.error("phantomchat: STT failed", {
+              persona: input.persona,
+              error: r.error,
+            });
+            await transport
+              .sendMessage(
+                senderHex,
+                "🎙️ I couldn’t make out that voice note — the audio may be unclear or too quiet. Please try again, or type your message.",
+              )
+              .catch(() => {});
+            return;
+          }
+          userMessage = r.text;
+          log.info("phantomchat: STT ok", {
+            persona: input.persona,
+            transcriptChars: r.text.length,
+          });
+        } catch (e) {
+          log.error("phantomchat: voice pipeline error", {
+            persona: input.persona,
+            error: (e as Error).message,
+          });
+          await transport
+            .sendMessage(
+              senderHex,
+              "⚠️ Something went wrong processing that voice note. Please try again in a moment, or type your message.",
+            )
+            .catch(() => {});
+          return;
+        }
+      } else {
+        // image / video / file — no extraction yet. Give the turn a marker so it
+        // can acknowledge instead of running on empty text.
+        userMessage = msg.text?.trim() ? msg.text : `[sent a ${m.kind}]`;
+      }
+    }
+
     // A sender that PASSES the allowlist is a trusted principal — exactly the
     // same trust grant Telegram's allowlisted users get. This selects the
     // trusted SECURITY_PERIMETER prompt block and skips the threat screen.
@@ -194,7 +280,7 @@ export async function runPhantomchatServer(
       for await (const chunk of runTurn({
         persona: input.persona,
         conversation: conversationKey,
-        userMessage: msg.text,
+        userMessage,
         agentDir: input.agentDir,
         harnesses,
         memory: input.memory,

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -29,6 +29,35 @@ import type { PhantomchatTransport } from "./transport.ts";
 import { sttSupport, transcribe } from "../../lib/audio.ts";
 import { DEFAULT_STT_TIMEOUT_MS } from "../../lib/voice.ts";
 import { fetchAndDecryptBlossom } from "./blossomFetch.ts";
+import { inboxDir } from "../telegram/parse.ts";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// Don't download absurdly large attachments. The harness reads from the inbox;
+// a multi-hundred-MB blob would blow memory + disk for little benefit.
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+// Map a mime type to a file extension for the inbox filename (the envelope
+// carries no original name). Falls back to the mime subtype, then the kind.
+function extForMime(mime: string, kind: string): string {
+  const m = ((mime || "").split(";")[0] ?? "").trim().toLowerCase();
+  const map: Record<string, string> = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "video/mp4": "mp4",
+    "video/webm": "webm",
+    "video/quicktime": "mov",
+    "audio/ogg": "ogg",
+    "audio/mpeg": "mp3",
+    "audio/wav": "wav",
+    "application/pdf": "pdf",
+  };
+  if (map[m]) return map[m];
+  const sub = m.includes("/") ? m.slice(m.indexOf("/") + 1) : "";
+  return /^[a-z0-9]{1,8}$/.test(sub) ? sub : kind === "image" ? "jpg" : kind === "video" ? "mp4" : "bin";
+}
 
 // Bound the voice fetch+decrypt+transcribe step. A hung Blossom fetch or STT
 // request would otherwise never settle and wedge this peer's serial turn chain
@@ -225,9 +254,50 @@ export async function runPhantomchatServer(
           return;
         }
       } else {
-        // image / video / file — no extraction yet. Give the turn a marker so it
-        // can acknowledge instead of running on empty text.
-        userMessage = msg.text?.trim() ? msg.text : `[sent a ${m.kind}]`;
+        // image / video / file: fetch + AES-GCM decrypt + save to the per-chat
+        // inbox, then hand the harness "[attached: <abs-path>]" so it can read
+        // the file — mirrors the Telegram attachment path
+        // (core/engine.processChatMessage). The harness decides what to do.
+        const caption = msg.text?.trim() ? msg.text + "\n\n" : "";
+        if (m.size !== undefined && m.size > MAX_ATTACHMENT_BYTES) {
+          log.warn("phantomchat: attachment over cap — not downloading", {
+            persona: input.persona,
+            kind: m.kind,
+            size: m.size,
+          });
+          userMessage = `${caption}[sent a ${m.kind} (~${Math.round(m.size / 1024 / 1024)} MB) — too large to fetch]`;
+        } else {
+          const convId = `phantomchat-${msg.groupId ? `group-${msg.groupId}` : senderHex}`;
+          try {
+            const data = await withTimeout(
+              fetchAndDecryptBlossom(m.url, m.keyHex, m.ivHex, {
+                expectedSha256Hex: m.sha256,
+                signal: input.signal,
+              }),
+              input.config.voice.sttTimeoutMs ?? DEFAULT_STT_TIMEOUT_MS,
+            );
+            const dir = inboxDir(convId);
+            await mkdir(dir, { recursive: true });
+            const path = join(dir, `${m.sha256.slice(0, 16)}.${extForMime(m.mimeType, m.kind)}`);
+            await writeFile(path, data);
+            log.info("phantomchat: attachment saved", {
+              persona: input.persona,
+              kind: m.kind,
+              path,
+              bytes: data.byteLength,
+            });
+            userMessage = `${caption}[attached: ${path}]`;
+          } catch (e) {
+            log.error("phantomchat: attachment download failed", {
+              persona: input.persona,
+              kind: m.kind,
+              error: (e as Error).message,
+            });
+            userMessage = caption
+              ? msg.text!
+              : `[sent a ${m.kind}, but it couldn’t be downloaded]`;
+          }
+        }
       }
     }
 

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -189,6 +189,20 @@ export async function runPhantomchatServer(
       void transport.sendDeliveryReceipt(senderHex, msg.messageId);
     }
 
+    // Route a short user-facing notice to the SAME place a reply would go: into
+    // the group when the message arrived via a group (reconstructing the member
+    // set exactly like the reply path), else a 1:1 DM. Without this, a group
+    // voice/media failure (STT unavailable/failed/errored) would surface
+    // privately to the sender instead of in the group conversation.
+    const sendNotice = (text: string): Promise<void> => {
+      if (msg.groupId) {
+        const others = new Set<string>(msg.groupMemberHexes ?? []);
+        others.add(senderHex.toLowerCase());
+        return transport.sendGroupMessage(msg.groupId, [...others], text);
+      }
+      return transport.sendMessage(senderHex, text);
+    };
+
     // ===================== VOICE / MEDIA → TEXT =====================
     // A voice note arrives as an encrypted Blossom file (msg.media) with an
     // empty text body. Fetch + AES-256-GCM decrypt + transcribe so the turn
@@ -206,9 +220,7 @@ export async function runPhantomchatServer(
             persona: input.persona,
             reason: stt.reason,
           });
-          await transport
-            .sendMessage(senderHex, voiceUnavailableMessage(stt))
-            .catch(() => {});
+          await sendNotice(voiceUnavailableMessage(stt)).catch(() => {});
           return;
         }
         try {
@@ -227,12 +239,9 @@ export async function runPhantomchatServer(
               persona: input.persona,
               error: r.error,
             });
-            await transport
-              .sendMessage(
-                senderHex,
-                "🎙️ I couldn’t make out that voice note — the audio may be unclear or too quiet. Please try again, or type your message.",
-              )
-              .catch(() => {});
+            await sendNotice(
+              "🎙️ I couldn’t make out that voice note — the audio may be unclear or too quiet. Please try again, or type your message.",
+            ).catch(() => {});
             return;
           }
           userMessage = r.text;
@@ -245,12 +254,9 @@ export async function runPhantomchatServer(
             persona: input.persona,
             error: (e as Error).message,
           });
-          await transport
-            .sendMessage(
-              senderHex,
-              "⚠️ Something went wrong processing that voice note. Please try again in a moment, or type your message.",
-            )
-            .catch(() => {});
+          await sendNotice(
+            "⚠️ Something went wrong processing that voice note. Please try again in a moment, or type your message.",
+          ).catch(() => {});
           return;
         }
       } else {

--- a/tests/channels-phantomchat-blossom.test.ts
+++ b/tests/channels-phantomchat-blossom.test.ts
@@ -1,0 +1,60 @@
+/*
+ * blossomFetch decrypt must round-trip the PWA's Web Crypto AES-GCM encrypt.
+ * The PWA (phantomchat file-crypto.ts) encrypts with Web Crypto, which APPENDS
+ * the 16-byte GCM tag to the ciphertext; this asserts the bot's node:crypto
+ * decrypt (which splits the tag) recovers the exact plaintext.
+ */
+import { describe, expect, test } from "bun:test";
+import { fetchAndDecryptBlossom } from "../src/channels/phantomchat/blossomFetch.ts";
+
+function toHex(bytes: Uint8Array): string {
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+describe("blossomFetch — AES-256-GCM decrypt (PWA round-trip)", () => {
+  test("decrypts a Web-Crypto-encrypted blob (tag appended) back to plaintext", async () => {
+    const plaintext = new TextEncoder().encode("fake ogg/opus voice bytes 🎙️ test");
+    const key = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const cryptoKey = await crypto.subtle.importKey("raw", key, { name: "AES-GCM" }, false, [
+      "encrypt",
+    ]);
+    // Web Crypto output is ciphertext‖tag — exactly what the PWA uploads.
+    const ct = new Uint8Array(
+      await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, plaintext),
+    );
+    const sha256 = toHex(new Uint8Array(await crypto.subtle.digest("SHA-256", ct)));
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(ct, { status: 200 })) as unknown as typeof fetch;
+    try {
+      const out = await fetchAndDecryptBlossom(
+        "https://blossom.example/x",
+        toHex(key),
+        toHex(iv),
+        { expectedSha256Hex: sha256 },
+      );
+      expect(new Uint8Array(out)).toEqual(new Uint8Array(plaintext));
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("rejects a sha256 mismatch before attempting decryption", async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(new Uint8Array([1, 2, 3, 4]), { status: 200 })) as unknown as typeof fetch;
+    try {
+      await expect(
+        fetchAndDecryptBlossom(
+          "https://blossom.example/x",
+          "00".repeat(32),
+          "00".repeat(12),
+          { expectedSha256Hex: "deadbeef" },
+        ),
+      ).rejects.toThrow(/sha256 mismatch/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});

--- a/tests/channels-phantomchat-channel.test.ts
+++ b/tests/channels-phantomchat-channel.test.ts
@@ -377,7 +377,7 @@ describe("phantomchat channel — catch-up poll", () => {
 });
 
 describe("phantomchat channel — voice / media intake", () => {
-  test("a voice envelope surfaces as a media message, not a turn over raw JSON", async () => {
+  test("a DM voice envelope (metadata JSON in content) surfaces as media, not raw JSON", async () => {
     const { ourPub, pool, channel } = setup();
     const ac = new AbortController();
 
@@ -388,8 +388,9 @@ describe("phantomchat channel — voice / media intake", () => {
 
     await new Promise((r) => setTimeout(r, 10));
 
-    // The PWA's voice envelope: an encrypted Blossom file, no `type` field.
-    const voiceEnvelope = {
+    // Real DM wire shape (chat-api.sendFileMessage → sendMessage): a typed
+    // envelope whose `content` is the file-metadata JSON STRING (key/iv).
+    const fileMeta = {
       url: "https://blossom.primal.net/b8447b96c67839dc9aa4632408a0d35375",
       sha256: "b8447b96c67839dc9aa4632408a0d35375ad6d9c0f42ee6057a5be47eb074b03",
       mimeType: "audio/ogg",
@@ -400,7 +401,14 @@ describe("phantomchat channel — voice / media intake", () => {
       duration: 9,
       waveform: [0, 0, 8, 255, 255],
     };
-    const { wrap } = wrapEnvelopeToUs(ourPub, voiceEnvelope);
+    const { wrap } = wrapEnvelopeToUs(ourPub, {
+      id: "chat-99-0",
+      from: "peer",
+      to: ourPub,
+      type: "voice",
+      content: JSON.stringify(fileMeta),
+      timestamp: Date.now(),
+    });
     pool.feed(wrap);
 
     await new Promise((r) => setTimeout(r, 30));
@@ -410,23 +418,22 @@ describe("phantomchat channel — voice / media intake", () => {
     expect(got.length).toBe(1);
     const m = got[0]!;
     // Surfaced as MEDIA (so the server transcribes), NOT a turn over the JSON.
-    expect(m.text).toBe("");
+    expect(m.text).toBe(""); // bare voice note has no caption
     expect(m.media).toBeDefined();
     expect(m.media!.kind).toBe("voice");
-    expect(m.media!.url).toBe(voiceEnvelope.url);
-    expect(m.media!.sha256).toBe(voiceEnvelope.sha256);
-    expect(m.media!.keyHex).toBe(voiceEnvelope.key);
-    expect(m.media!.ivHex).toBe(voiceEnvelope.iv);
+    expect(m.media!.url).toBe(fileMeta.url);
+    expect(m.media!.sha256).toBe(fileMeta.sha256);
+    expect(m.media!.keyHex).toBe(fileMeta.key); // accepts `key`
+    expect(m.media!.ivHex).toBe(fileMeta.iv); // accepts `iv`
     expect(m.media!.mimeType).toBe("audio/ogg");
     expect(m.media!.durationS).toBe(9);
-    // Keyed by the rumor id for the delivery receipt.
-    expect(typeof m.messageId).toBe("string");
-    expect(m.messageId!.length).toBe(64);
+    // Receipt keyed off the envelope's app id (PWA file delivery tracker).
+    expect(m.messageId).toBe("chat-99-0");
   });
 });
 
 describe("phantomchat channel — attachment (non-voice) intake", () => {
-  test("an image envelope surfaces as media kind=image with size, not raw JSON", async () => {
+  test("a group image envelope (fileMetadata object + caption) surfaces as media", async () => {
     const { ourPub, pool, channel } = setup();
     const ac = new AbortController();
     const got: ChannelMessage[] = [];
@@ -435,18 +442,24 @@ describe("phantomchat channel — attachment (non-voice) intake", () => {
     })();
     await new Promise((r) => setTimeout(r, 10));
 
-    const imgEnvelope = {
-      url: "https://blossom.primal.net/deadbeefimg",
-      sha256: "deadbeef00000000000000000000000000000000000000000000000000000000",
-      mimeType: "image/jpeg",
-      size: 845123,
-      key: "11".repeat(32),
-      iv: "22".repeat(12),
-      mediaType: "image",
-      width: 1200,
-      height: 800,
-    };
-    const { wrap } = wrapEnvelopeToUs(ourPub, imgEnvelope);
+    // Real group wire shape (GroupAPI.sendFile): `fileMetadata` OBJECT
+    // (keyHex/ivHex), with the caption in `content`.
+    const { wrap } = wrapEnvelopeToUs(ourPub, {
+      id: "grp-123-abc",
+      type: "image",
+      content: "check this out",
+      timestamp: Date.now(),
+      fileMetadata: {
+        url: "https://blossom.primal.net/deadbeefimg",
+        sha256: "deadbeef00000000000000000000000000000000000000000000000000000000",
+        mimeType: "image/jpeg",
+        size: 845123,
+        keyHex: "11".repeat(32),
+        ivHex: "22".repeat(12),
+        width: 1200,
+        height: 800,
+      },
+    });
     pool.feed(wrap);
 
     await new Promise((r) => setTimeout(r, 30));
@@ -455,10 +468,11 @@ describe("phantomchat channel — attachment (non-voice) intake", () => {
 
     expect(got.length).toBe(1);
     const m = got[0]!;
-    expect(m.text).toBe("");
+    expect(m.text).toBe("check this out"); // caption preserved
     expect(m.media?.kind).toBe("image");
-    expect(m.media?.url).toBe(imgEnvelope.url);
-    expect(m.media?.keyHex).toBe(imgEnvelope.key);
+    expect(m.media?.url).toBe("https://blossom.primal.net/deadbeefimg");
+    expect(m.media?.keyHex).toBe("11".repeat(32)); // accepts `keyHex`
+    expect(m.media?.ivHex).toBe("22".repeat(12));
     expect(m.media?.size).toBe(845123);
   });
 });

--- a/tests/channels-phantomchat-channel.test.ts
+++ b/tests/channels-phantomchat-channel.test.ts
@@ -375,3 +375,52 @@ describe("phantomchat channel — catch-up poll", () => {
     expect(received).toContain("recovered by poll");
   });
 });
+
+describe("phantomchat channel — voice / media intake", () => {
+  test("a voice envelope surfaces as a media message, not a turn over raw JSON", async () => {
+    const { ourPub, pool, channel } = setup();
+    const ac = new AbortController();
+
+    const got: ChannelMessage[] = [];
+    const pump = (async () => {
+      for await (const msg of channel.listen!(ac.signal)) got.push(msg);
+    })();
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The PWA's voice envelope: an encrypted Blossom file, no `type` field.
+    const voiceEnvelope = {
+      url: "https://blossom.primal.net/b8447b96c67839dc9aa4632408a0d35375",
+      sha256: "b8447b96c67839dc9aa4632408a0d35375ad6d9c0f42ee6057a5be47eb074b03",
+      mimeType: "audio/ogg",
+      size: 26050,
+      key: "2d3574e50d989038d2b377601485960210a2f381068a49446b40f2e754f9adb8",
+      iv: "7bab87dee86e940684b2ff88",
+      mediaType: "voice",
+      duration: 9,
+      waveform: [0, 0, 8, 255, 255],
+    };
+    const { wrap } = wrapEnvelopeToUs(ourPub, voiceEnvelope);
+    pool.feed(wrap);
+
+    await new Promise((r) => setTimeout(r, 30));
+    ac.abort();
+    await pump;
+
+    expect(got.length).toBe(1);
+    const m = got[0]!;
+    // Surfaced as MEDIA (so the server transcribes), NOT a turn over the JSON.
+    expect(m.text).toBe("");
+    expect(m.media).toBeDefined();
+    expect(m.media!.kind).toBe("voice");
+    expect(m.media!.url).toBe(voiceEnvelope.url);
+    expect(m.media!.sha256).toBe(voiceEnvelope.sha256);
+    expect(m.media!.keyHex).toBe(voiceEnvelope.key);
+    expect(m.media!.ivHex).toBe(voiceEnvelope.iv);
+    expect(m.media!.mimeType).toBe("audio/ogg");
+    expect(m.media!.durationS).toBe(9);
+    // Keyed by the rumor id for the delivery receipt.
+    expect(typeof m.messageId).toBe("string");
+    expect(m.messageId!.length).toBe(64);
+  });
+});

--- a/tests/channels-phantomchat-channel.test.ts
+++ b/tests/channels-phantomchat-channel.test.ts
@@ -424,3 +424,41 @@ describe("phantomchat channel — voice / media intake", () => {
     expect(m.messageId!.length).toBe(64);
   });
 });
+
+describe("phantomchat channel — attachment (non-voice) intake", () => {
+  test("an image envelope surfaces as media kind=image with size, not raw JSON", async () => {
+    const { ourPub, pool, channel } = setup();
+    const ac = new AbortController();
+    const got: ChannelMessage[] = [];
+    const pump = (async () => {
+      for await (const msg of channel.listen!(ac.signal)) got.push(msg);
+    })();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const imgEnvelope = {
+      url: "https://blossom.primal.net/deadbeefimg",
+      sha256: "deadbeef00000000000000000000000000000000000000000000000000000000",
+      mimeType: "image/jpeg",
+      size: 845123,
+      key: "11".repeat(32),
+      iv: "22".repeat(12),
+      mediaType: "image",
+      width: 1200,
+      height: 800,
+    };
+    const { wrap } = wrapEnvelopeToUs(ourPub, imgEnvelope);
+    pool.feed(wrap);
+
+    await new Promise((r) => setTimeout(r, 30));
+    ac.abort();
+    await pump;
+
+    expect(got.length).toBe(1);
+    const m = got[0]!;
+    expect(m.text).toBe("");
+    expect(m.media?.kind).toBe("image");
+    expect(m.media?.url).toBe(imgEnvelope.url);
+    expect(m.media?.keyHex).toBe(imgEnvelope.key);
+    expect(m.media?.size).toBe(845123);
+  });
+});

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -678,6 +678,91 @@ describe("phantomchat group routing (HQ bug)", () => {
     expect(typingEvents.some((e) => e.content === "stop")).toBe(true);
   });
 
+  test("group voice note with STT unavailable: failure notice broadcasts to the GROUP, not a DM", async () => {
+    // Regression (review #187): the voice STT error paths early-returned with a
+    // 1:1 DM to the sender, so a group voice-note failure surfaced privately
+    // instead of in the group. The notice must go back into the group.
+    const andrewSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const memberSk = generateSecretKey();
+    const andrewHex = getPublicKey(andrewSk);
+    const botHex = getPublicKey(botSk);
+    const memberHex = getPublicKey(memberSk);
+    const groupId = "hq-voice-fail";
+
+    // The turn must NOT run — STT-unavailable returns before the harness.
+    const harness = new ScriptedHarness("fake", [{ type: "done", finalText: "should not run" }]);
+    const pool = new FakePool();
+    const transport = new SimplePoolPhantomchatTransport(botSk, ["wss://test.relay"], pool);
+    const channel = createPhantomchatChannel({ secretKey: botSk, publicKeyHex: botHex, transport });
+
+    // A GROUP voice note in the GroupAPI.sendFile shape (fileMetadata object).
+    const payload = JSON.stringify({
+      content: "",
+      type: "voice",
+      id: `grp-${Date.now()}-voice`,
+      timestamp: Date.now(),
+      fileMetadata: {
+        url: "https://blossom.primal.net/voicenote",
+        sha256: "ab".repeat(32),
+        keyHex: "11".repeat(32),
+        ivHex: "22".repeat(12),
+        mimeType: "audio/ogg",
+        size: 26050,
+        duration: 9,
+      },
+    });
+    const { wraps } = wrapGroupMessage(andrewSk, [botHex, memberHex], payload, groupId);
+    let inboundForBot: NTNostrEvent | undefined;
+    for (const w of wraps) {
+      try {
+        unwrapNip17Message(w as NTNostrEvent, botSk);
+        inboundForBot = w as NTNostrEvent;
+        break;
+      } catch {
+        /* not ours */
+      }
+    }
+    expect(inboundForBot).toBeDefined();
+
+    const ac = new AbortController();
+    const serverPromise = runPhantomchatServer({
+      config: baseConfig(), // voice.provider = "none" → STT unavailable
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      channel,
+      allowedHex: [andrewHex],
+      oneShot: true,
+      signal: ac.signal,
+    });
+    pool.feed(inboundForBot!);
+    await new Promise((r) => setTimeout(r, 100));
+    ac.abort();
+    await serverPromise;
+
+    // No turn ran (STT unavailable → early return).
+    expect(harness.invocations).toBe(0);
+
+    // The notice is a GROUP broadcast — 3 kind-1059 wraps (Andrew + member +
+    // Lena's self-wrap) carrying the group tag — NOT a 1:1 DM (2 wraps, no tag).
+    const replyWraps = pool.published.filter((e) => e.kind === 1059);
+    expect(replyWraps.length).toBe(3);
+    let andrewNotice: ReturnType<typeof unwrapNip17Message> | undefined;
+    for (const w of replyWraps) {
+      try {
+        andrewNotice = unwrapNip17Message(w as NTNostrEvent, andrewSk);
+        break;
+      } catch {
+        /* not for Andrew */
+      }
+    }
+    expect(andrewNotice).toBeDefined();
+    expect(andrewNotice!.tags.find((t) => t[0] === "group")).toEqual(["group", groupId]);
+    expect(JSON.parse(andrewNotice!.content).content.length).toBeGreaterThan(0);
+  });
+
   test("a plain DM still replies 1:1 (no group tag → unchanged DM behaviour)", async () => {
     const senderSk = generateSecretKey();
     const botSk = generateSecretKey();


### PR DESCRIPTION
**Step 2: a voice note from the PWA reaches the bot and gets transcribed (STT) instead of producing a garbage reply.**

## The bug
The phantomchat channel was text-only. A PWA voice note arrives as a kind-14 rumor whose content is the media envelope `{url, sha256, key, iv, mediaType:"voice", duration, waveform}` — which has **no `type` field**, so it fell through to the plain-text path and the bot ran a turn over the **raw metadata JSON**. (The note *was* delivered — the ✓✓ — the bot just couldn't read it.)

## What this does (mirrors the Telegram voice→STT path)
- **`blossomFetch.ts`** (new): fetch the encrypted file from Blossom + **AES-256-GCM decrypt**. Counterpart to the PWA's Web Crypto encrypt — splits the trailing 16-byte GCM tag Web Crypto appends, verifies the content-addressed sha256. Round-trip tested against a real Web Crypto encrypt.
- **`ChannelMessage.media`** (new optional field): carries the envelope from channel → turn driver.
- **`channel.ts`**: detect the media envelope → surface a media `ChannelMessage` (empty text), keyed by rumor id for the delivery receipt.
- **`server.ts`**: **after the auth gate** (never transcribe a dropped stranger), fetch+decrypt+`transcribe()` (reusing `lib/audio.ts` — the same STT as Telegram), timeout-bounded; run the turn over the transcript. STT-unavailable / failure / error each send a clear notice and skip. Non-voice media get a `[sent a <kind>]` marker for now.

## Scope
- `capabilities.voice` stays **false** — that governs *outgoing* voice (TTS reply), which is **step 3**. This is incoming STT only; the bot replies in **text**.
- **Runtime prerequisite:** STT runs only when a voice provider is configured for the personas (`[voice] provider = openai|elevenlabs` + `PHANTOMBOT_OPENAI_API_KEY` / `PHANTOMBOT_ELEVENLABS_API_KEY` on the Lena box). Without it, it replies "voice unavailable" and skips — same as Telegram.

## Tests
`bun tsc` clean; **1274 pass** (added a Blossom AES-GCM round-trip test and a channel voice-intake test). Deploy to the Lena box is manual.