### PR TITLE
feat(turn-index): time-based + forced flush for sub-threshold tails (#189)

### DIFF
--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -14,6 +14,8 @@ import { runHeartbeat } from "../lib/heartbeat.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import { currentPlatform } from "../lib/platform.ts";
+import { openMemoryStore } from "../memory/store.ts";
+import { flushDueConversationTurns } from "../orchestrator/turnIndexer.ts";
 import {
   BunSystemctlRunner,
   buildSystemctlEnv,
@@ -72,6 +74,37 @@ export async function runHeartbeatCli(
     config,
     currentVersion: VERSION,
   });
+
+  // Drain sub-threshold conversation turn tails on the heartbeat's regular
+  // cadence. The live service only flushes a conversation when a new message
+  // crosses the 20-turn batch, so a quiet conversation stuck below it (e.g.
+  // 19 turns) would stay unembedded for days — recent chat goes invisible to
+  // recall. This time-based sweep (flushAfterHours) closes that gap for every
+  // conversation, mechanically, with no LLM call. Wrapped in try/catch so a
+  // turn-flush hiccup never breaks the primary heartbeat work.
+  try {
+    const turnIndexing = config.retrieval?.turnIndexing;
+    if (config.retrieval?.enabled && turnIndexing?.enabled) {
+      const store = await openMemoryStore(config.memoryDbPath);
+      try {
+        const flush = await flushDueConversationTurns({
+          config,
+          persona,
+          memory: store,
+          settings: turnIndexing,
+        });
+        if (flush.triggered > 0) {
+          log.info("heartbeat: flushed conversation turn tails", { ...flush });
+        }
+      } finally {
+        await store.close();
+      }
+    }
+  } catch (e) {
+    log.warn("heartbeat: turn-flush sweep threw unexpectedly", {
+      error: (e as Error).message,
+    });
+  }
 
   // Self-heal systemd units on the heartbeat's regular cadence. This
   // is the long-uptime cure for the broken-symlink class of bug — a

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -39,6 +39,7 @@ import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import { MemoryIndex, type Scope } from "../lib/memoryIndex.ts";
 import { openMemoryStore } from "../memory/store.ts";
+import { flushDueConversationTurns } from "../orchestrator/turnIndexer.ts";
 
 function resolvePersonaDir(config: Config, persona?: string): {
   persona: string;
@@ -221,6 +222,13 @@ export interface RunIndexInput extends RunMemoryInput {
 export interface RunIndexInputV2 extends RunIndexInput {
   /** Skip the embedding pass even when a provider is configured. */
   noEmbed?: boolean;
+  /**
+   * Force-flush unindexed conversation turn tails across ALL conversations
+   * instead of (re)building the notes/KB index. This is the operator
+   * backfill path for the time-based turn flush — drains tails that are
+   * below the 20-turn batch and haven't aged into the heartbeat window yet.
+   */
+  flushTurns?: boolean;
 }
 
 export async function runMemoryIndex(
@@ -234,6 +242,40 @@ export async function runMemoryIndex(
   if (!existsSync(dir)) {
     err.write(`persona '${persona}' not found at ${dir}\n`);
     return 2;
+  }
+
+  // `--turns`: force-flush conversation turn tails instead of the notes/KB
+  // index. Separate path — the FTS/embed work below is for memory/ + kb/
+  // files, which never touches the raw-turn index.
+  if (input.flushTurns) {
+    const turnIndexing = config.retrieval?.turnIndexing;
+    if (!config.retrieval?.enabled || !turnIndexing?.enabled) {
+      out.write(`turn indexing is disabled in config; nothing to flush\n`);
+      return 0;
+    }
+    const store = await openMemoryStore(config.memoryDbPath);
+    try {
+      const r = await flushDueConversationTurns({
+        config,
+        persona,
+        memory: store,
+        settings: turnIndexing,
+        force: true,
+      });
+      out.write(
+        `turn flush for '${persona}': ` +
+          `${r.triggered}/${r.conversations} conversation(s) flushed, ` +
+          `${r.indexed} turn(s) indexed` +
+          (r.embedded > 0 ? `, ${r.embedded} embedded` : "") +
+          (r.embeddingFailures > 0
+            ? `, ${r.embeddingFailures} embed failure(s)`
+            : "") +
+          `\n`,
+      );
+    } finally {
+      await store.close();
+    }
+    return 0;
   }
 
   const ix = await MemoryIndex.open(input.indexPath ?? memoryIndexPath(persona));
@@ -511,12 +553,14 @@ const indexCmd = defineCommand({
     persona: { type: "string", description: "Persona name." },
     rebuild: { type: "boolean", description: "Drop and re-index from scratch.", default: false },
     "no-embed": { type: "boolean", description: "Skip embedding pass (FTS only).", default: false },
+    turns: { type: "boolean", description: "Force-flush unindexed conversation turn tails (all conversations) instead of the notes/KB index.", default: false },
   },
   async run({ args }) {
     process.exitCode = await runMemoryIndex({
       persona: args.persona ? String(args.persona) : undefined,
       rebuild: Boolean(args.rebuild),
       noEmbed: Boolean(args["no-embed"]),
+      flushTurns: Boolean(args.turns),
     });
   },
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,12 +107,24 @@ export interface TurnIndexingSettings {
   interval: number;
   /** Max raw turn rows read from memory in one SQLite page. */
   batchSize: number;
+  /**
+   * Time-based safety net. Flush a conversation's unindexed tail when its
+   * oldest unindexed turn has aged past this many hours, even if the
+   * user-turn count hasn't reached `interval`. This drains sub-threshold
+   * tails (e.g. a conversation stuck at 19 turns) so recent chat stays
+   * semantically recallable instead of going invisible for days. The live
+   * service only flushes on a new message crossing the batch; the 30-min
+   * heartbeat applies this time-based drain across all conversations. Set
+   * to 0 to disable the time-based flush (count trigger only).
+   */
+  flushAfterHours: number;
 }
 
 export const DEFAULT_TURN_INDEXING: TurnIndexingSettings = {
   enabled: true,
   interval: 20,
   batchSize: 200,
+  flushAfterHours: 2,
 };
 
 /**
@@ -511,10 +523,16 @@ function buildTurnIndexingConfig(
     asInt(process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_BATCH_SIZE) ??
     asInt(tomlTurnIndexing.batch_size) ??
     DEFAULT_TURN_INDEXING.batchSize;
+  const flushAfterHours =
+    asInt(process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS) ??
+    asInt(tomlTurnIndexing.flush_after_hours) ??
+    DEFAULT_TURN_INDEXING.flushAfterHours;
   return {
     enabled,
     interval: Math.max(1, Math.min(10_000, interval)),
     batchSize: Math.max(1, Math.min(5_000, batchSize)),
+    // 0 disables the time-based flush; otherwise clamp to a sane 1h..1yr.
+    flushAfterHours: Math.max(0, Math.min(8_760, flushAfterHours)),
   };
 }
 

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -95,6 +95,12 @@ export interface MemoryStore {
   ): Promise<Turn[]>;
   /** Count user turns in a conversation. Used by predictable indexing triggers. */
   countUserTurns(persona: string, conversation: string): Promise<number>;
+  /**
+   * Distinct conversation keys that have at least one turn for this persona,
+   * sorted. Used by the turn-index sweep (heartbeat + `memory index --turns`)
+   * to find every conversation that might have an unindexed tail.
+   */
+  listConversations(persona: string): Promise<string[]>;
   /** Delete all turns for a (persona, conversation) pair. Used by /reset. */
   deleteConversation(persona: string, conversation: string): Promise<number>;
   /**
@@ -193,6 +199,7 @@ class SqliteMemoryStore implements MemoryStore {
   private appendCaptureStmt;
   private lastCaptureStmt;
   private countUserTurnsStmt;
+  private listConversationsStmt;
   private countTurnsSinceStmt;
   private countCapturesSinceStmt;
   private appendPairTxn;
@@ -259,6 +266,10 @@ class SqliteMemoryStore implements MemoryStore {
     this.countUserTurnsStmt = db.prepare(
       `SELECT COUNT(*) AS n FROM turns
        WHERE persona = ? AND conversation = ? AND role = 'user'`,
+    );
+    this.listConversationsStmt = db.prepare(
+      `SELECT DISTINCT conversation FROM turns
+       WHERE persona = ? ORDER BY conversation`,
     );
     this.countTurnsSinceStmt = db.prepare(
       `SELECT COUNT(*) AS n FROM turns
@@ -359,6 +370,13 @@ class SqliteMemoryStore implements MemoryStore {
       n: number;
     };
     return row.n;
+  }
+
+  async listConversations(persona: string): Promise<string[]> {
+    const rows = this.listConversationsStmt.all(persona) as Array<{
+      conversation: string;
+    }>;
+    return rows.map((r) => r.conversation);
   }
 
   async appendCapture(input: AppendCaptureInput): Promise<void> {

--- a/src/orchestrator/turnIndexer.ts
+++ b/src/orchestrator/turnIndexer.ts
@@ -29,6 +29,12 @@ export interface IndexConversationTurnsInput {
   conversation: string;
   memory: MemoryStore;
   settings: TurnIndexingSettings;
+  /**
+   * Force a flush of any unindexed tail regardless of the count or time
+   * triggers. Used by the operator backfill path (`memory index --turns`).
+   * A no-op when there is no unindexed tail.
+   */
+  force?: boolean;
 }
 
 export interface IndexConversationTurnsResult {
@@ -57,7 +63,36 @@ export async function indexConversationTurnsIfDue(
     ix = await MemoryIndex.open(memoryIndexPath(input.persona));
     const state = ix.turnIndexState(input.persona, input.conversation);
     const previousUserTurnsIndexed = state?.userTurnsIndexed ?? 0;
-    const due = userTurns - previousUserTurnsIndexed >= input.settings.interval;
+    const lastTurnId = state?.lastTurnId ?? 0;
+
+    // Primary trigger: enough new user turns have accrued (the batch).
+    let due = userTurns - previousUserTurnsIndexed >= input.settings.interval;
+
+    // Secondary triggers — only consulted when the count batch hasn't
+    // fired. Both need to know whether an unindexed tail actually exists,
+    // and (for the time trigger) how old its oldest turn is. One cheap
+    // single-row read of the head-of-tail answers both.
+    if (!due && (input.force || input.settings.flushAfterHours > 0)) {
+      const head = await input.memory.turnsAfterId(
+        input.persona,
+        input.conversation,
+        lastTurnId,
+        1,
+      );
+      if (head.length > 0) {
+        if (input.force) {
+          // Operator backfill: flush the tail unconditionally.
+          due = true;
+        } else {
+          // Time-based safety net: flush once the oldest unindexed turn has
+          // aged past flushAfterHours, even below the count threshold — so a
+          // conversation stuck at e.g. 19 turns still becomes recallable.
+          const ageMs = Date.now() - head[0]!.createdAt.getTime();
+          if (ageMs >= input.settings.flushAfterHours * 3_600_000) due = true;
+        }
+      }
+    }
+
     if (!due) {
       return {
         triggered: false,
@@ -164,6 +199,85 @@ export function makeTurnIndexer(
       memory,
       settings: turnIndexing,
     }).then(() => undefined);
+}
+
+export interface FlushDueConversationsInput {
+  config: Config;
+  persona: string;
+  memory: MemoryStore;
+  settings: TurnIndexingSettings;
+  /** Force-flush every conversation's tail regardless of count/age. */
+  force?: boolean;
+}
+
+export interface FlushDueConversationsResult {
+  /** How many conversations were scanned. */
+  conversations: number;
+  /** How many actually flushed a tail (triggered). */
+  triggered: number;
+  indexed: number;
+  embedded: number;
+  embeddingFailures: number;
+}
+
+/**
+ * Sweep every conversation for one persona and flush any tail that is due —
+ * by the count batch, by age (flushAfterHours), or unconditionally when
+ * `force` is set. This is the box-level drain the live service can't do on
+ * its own: the service only flushes a conversation when a new message in it
+ * crosses the batch, so a quiet sub-threshold tail would otherwise stay
+ * unembedded indefinitely. Called by the 30-min heartbeat (time-based) and
+ * `phantombot memory index --turns` (operator backfill, force).
+ *
+ * Never throws: indexConversationTurnsIfDue swallows its own errors per
+ * conversation, and a failure to enumerate conversations is logged and
+ * returns an empty summary. Safe to run from the mechanical heartbeat.
+ */
+export async function flushDueConversationTurns(
+  input: FlushDueConversationsInput,
+): Promise<FlushDueConversationsResult> {
+  const summary: FlushDueConversationsResult = {
+    conversations: 0,
+    triggered: 0,
+    indexed: 0,
+    embedded: 0,
+    embeddingFailures: 0,
+  };
+  if (!input.settings.enabled) return summary;
+
+  let conversations: string[];
+  try {
+    conversations = await input.memory.listConversations(input.persona);
+  } catch (e) {
+    log.warn("turn-index sweep: failed to list conversations", {
+      persona: input.persona,
+      error: (e as Error).message,
+    });
+    return summary;
+  }
+  summary.conversations = conversations.length;
+
+  for (const conversation of conversations) {
+    const r = await indexConversationTurnsIfDue({
+      config: input.config,
+      persona: input.persona,
+      conversation,
+      memory: input.memory,
+      settings: input.settings,
+      force: input.force,
+    });
+    if (r?.triggered) {
+      summary.triggered++;
+      summary.indexed += r.indexed;
+      summary.embedded += r.embedded;
+      summary.embeddingFailures += r.embeddingFailures;
+    }
+  }
+
+  if (summary.triggered > 0) {
+    log.info("turn-index sweep: flushed conversation tails", { ...summary });
+  }
+  return summary;
 }
 
 async function embedTurn(

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -41,6 +41,7 @@ const ENV_KEYS = [
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_ENABLED",
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_INTERVAL",
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_BATCH_SIZE",
+  "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS",
   "PHANTOMBOT_STATE",
   "XDG_CONFIG_HOME",
   "XDG_DATA_HOME",
@@ -535,12 +536,14 @@ limit = 5
 enabled = false
 interval = 30
 batch_size = 400
+flush_after_hours = 6
 `);
     const c = await loadConfig();
     expect(c.retrieval!.turnIndexing).toEqual({
       enabled: false,
       interval: 30,
       batchSize: 400,
+      flushAfterHours: 6,
     });
   });
 
@@ -550,15 +553,18 @@ batch_size = 400
 enabled = false
 interval = 30
 batch_size = 400
+flush_after_hours = 6
 `);
     process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_ENABLED = "true";
     process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_INTERVAL = "20";
     process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_BATCH_SIZE = "50";
+    process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS = "1";
     const c = await loadConfig();
     expect(c.retrieval!.turnIndexing).toEqual({
       enabled: true,
       interval: 20,
       batchSize: 50,
+      flushAfterHours: 1,
     });
   });
 

--- a/tests/orchestrator-turnIndexer.test.ts
+++ b/tests/orchestrator-turnIndexer.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,6 +16,7 @@ import {
 import { MemoryIndex } from "../src/lib/memoryIndex.ts";
 import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
 import {
+  flushDueConversationTurns,
   indexConversationTurnsIfDue,
   makeTurnIndexer,
 } from "../src/orchestrator/turnIndexer.ts";
@@ -104,7 +106,12 @@ describe("indexConversationTurnsIfDue", () => {
     // A held-episode quarantined user turn must never be indexed/embedded, but
     // it still counts as processed so the cursor moves past it; a following
     // embeddable turn IS indexed. Use interval 1 so a single user turn triggers.
-    const settings = { enabled: true, interval: 1, batchSize: 200 };
+    const settings = {
+      enabled: true,
+      interval: 1,
+      batchSize: 200,
+      flushAfterHours: 0,
+    };
 
     // Quarantined raw payload (would otherwise FTS-match "Etna secret").
     await memory.appendTurn({
@@ -166,6 +173,158 @@ describe("indexConversationTurnsIfDue", () => {
     expect(result?.indexed).toBe(40);
     expect(result?.previousUserTurnsIndexed).toBe(20);
     expect(result?.userTurns).toBe(40);
+  });
+});
+
+describe("time-based and forced flush", () => {
+  // These tests need to age turns into the past. The store auto-stamps
+  // created_at to "now", so we use a file-backed DB and backdate every row
+  // via a second connection — the only way to simulate a stale tail.
+  async function openFileStore(): Promise<{ store: MemoryStore; path: string }> {
+    const path = join(workdir, `mem-${Math.random().toString(36).slice(2)}.sqlite`);
+    return { store: await openMemoryStore(path), path };
+  }
+
+  async function appendUserPair(
+    store: MemoryStore,
+    conversation: string,
+    i: number,
+  ): Promise<void> {
+    await store.appendTurn({
+      persona: "phantom",
+      conversation,
+      role: "user",
+      text: `aged turn ${i} Vesuvius pension`,
+    });
+    await store.appendTurn({
+      persona: "phantom",
+      conversation,
+      role: "assistant",
+      text: `assistant turn ${i}`,
+    });
+  }
+
+  function backdateAllTurns(path: string, hoursAgo: number): void {
+    const raw = new Database(path);
+    const ts = new Date(Date.now() - hoursAgo * 3_600_000).toISOString();
+    raw.prepare("UPDATE turns SET created_at = ?").run(ts);
+    raw.close();
+  }
+
+  test("flushes a sub-threshold tail older than flushAfterHours without a 20th message", async () => {
+    const { store, path } = await openFileStore();
+    try {
+      // 19 user turns — one short of the 20-turn batch.
+      for (let i = 1; i <= 19; i++) await appendUserPair(store, "telegram:2002", i);
+      backdateAllTurns(path, 3); // age the whole tail 3h into the past
+
+      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, flushAfterHours: 2 };
+      const result = await indexConversationTurnsIfDue({
+        config: baseConfig(),
+        persona: "phantom",
+        conversation: "telegram:2002",
+        memory: store,
+        settings,
+      });
+
+      expect(result?.triggered).toBe(true);
+      expect(result?.indexed).toBe(38); // 19 user + 19 assistant rows
+      const ix = await MemoryIndex.open(memoryIndexPath("phantom"));
+      expect(
+        ix.search("Vesuvius pension", { scope: "turns" }).length,
+      ).toBeGreaterThan(0);
+      ix.close();
+    } finally {
+      await store.close();
+    }
+  });
+
+  test("does NOT flush a fresh sub-threshold tail (younger than flushAfterHours)", async () => {
+    const { store } = await openFileStore();
+    try {
+      for (let i = 1; i <= 19; i++) await appendUserPair(store, "telegram:2003", i);
+      // No backdating: the tail is brand new, so the 2h window hasn't elapsed.
+      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, flushAfterHours: 2 };
+      const result = await indexConversationTurnsIfDue({
+        config: baseConfig(),
+        persona: "phantom",
+        conversation: "telegram:2003",
+        memory: store,
+        settings,
+      });
+
+      expect(result?.triggered).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+
+  test("flushAfterHours = 0 disables the time-based flush", async () => {
+    const { store, path } = await openFileStore();
+    try {
+      for (let i = 1; i <= 19; i++) await appendUserPair(store, "telegram:2004", i);
+      backdateAllTurns(path, 100); // very old, but time flush is disabled
+      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, flushAfterHours: 0 };
+      const result = await indexConversationTurnsIfDue({
+        config: baseConfig(),
+        persona: "phantom",
+        conversation: "telegram:2004",
+        memory: store,
+        settings,
+      });
+
+      expect(result?.triggered).toBe(false);
+    } finally {
+      await store.close();
+    }
+  });
+
+  test("force flushes a fresh sub-threshold tail regardless of count or age", async () => {
+    const { store } = await openFileStore();
+    try {
+      for (let i = 1; i <= 5; i++) await appendUserPair(store, "telegram:2005", i);
+      const result = await indexConversationTurnsIfDue({
+        config: baseConfig(),
+        persona: "phantom",
+        conversation: "telegram:2005",
+        memory: store,
+        settings: DEFAULT_RETRIEVAL.turnIndexing,
+        force: true,
+      });
+
+      expect(result?.triggered).toBe(true);
+      expect(result?.indexed).toBe(10);
+    } finally {
+      await store.close();
+    }
+  });
+
+  test("flushDueConversationTurns sweeps every conversation (force backfill)", async () => {
+    const { store } = await openFileStore();
+    try {
+      for (let i = 1; i <= 3; i++) await appendUserPair(store, "telegram:3001", i);
+      for (let i = 1; i <= 4; i++) await appendUserPair(store, "telegram:3002", i);
+
+      // listConversations underpins the sweep.
+      expect(await store.listConversations("phantom")).toEqual([
+        "telegram:3001",
+        "telegram:3002",
+      ]);
+
+      const summary = await flushDueConversationTurns({
+        config: baseConfig(),
+        persona: "phantom",
+        memory: store,
+        settings: DEFAULT_RETRIEVAL.turnIndexing,
+        force: true,
+      });
+
+      expect(summary.conversations).toBe(2);
+      expect(summary.triggered).toBe(2);
+      expect(summary.indexed).toBe(14); // (3 + 4) pairs × 2 rows
+    } finally {
+      await store.close();
+    }
   });
 });
 


### PR DESCRIPTION
Closes #189.

## Problem
Conversation turn-indexing was **count-driven only**: a flush happened only when a new message arrived in a conversation *and* the unindexed user-turn count had crossed 20. Any tail below 20 stayed unembedded indefinitely — so recent chat wasn't semantically recallable until the next message tipped it past the threshold. Observed on Lena (2026-06-20): her DM sat at 19 unindexed turns with the last index event 2+ days earlier → presented as the agent "forgetting" recent chat. Two other conversations were similarly stuck (13, 16).

`phantombot memory index` and `phantombot heartbeat` were notes/KB only (turns: 0), and there was no force-flush path.

## Fix — three layers, all opt-out via config
1. **Time-based flush** (`indexConversationTurnsIfDue`): when the count batch hasn't fired, flush the tail if its **oldest unindexed turn** has aged past `retrieval.turn_indexing.flush_after_hours`. Default **2h**; `0` disables (count-only). Env override `PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS`, TOML `flush_after_hours`. One cheap single-row head-of-tail read drives the decision.
2. **Heartbeat sweep**: the 30-min mechanical heartbeat now drains aged tails across **every** conversation for the persona via the new `flushDueConversationTurns()` + `MemoryStore.listConversations()`. No LLM; wrapped in try/catch so a hiccup never breaks the heartbeat. This is the box-level drain the live service can't do (it only flushes a conversation on a new message).
3. **Operator backfill**: `phantombot memory index --turns` force-flushes all conversation tails immediately (debug/backfill).

Applies to all agents (Robbie, Lena, Kai, Jake).

## Acceptance (from the issue)
- ✅ A sub-threshold tail gets indexed within the time window without a 20th message — heartbeat sweep, time-based.
- ✅ Manual force-flush path exists — `memory index --turns`.

## Files
- `src/config.ts` — `flushAfterHours` field + default (2) + env/TOML wiring + clamp (0..8760).
- `src/orchestrator/turnIndexer.ts` — time/force due logic + `flushDueConversationTurns` sweep.
- `src/memory/store.ts` — `listConversations(persona)`.
- `src/cli/heartbeat.ts` — wire the sweep into the timer path.
- `src/cli/memory.ts` — `index --turns` force-flush path.
- Tests: time trigger (positive / fresh-negative / disabled), force, sweep + `listConversations`; config env+TOML.

## Verification
- `bun tsc --noEmit` clean.
- `bun test` — **1281 pass, 1 skip, 0 fail** (89 files). Existing count-path behaviour unchanged.

## Notes for review
- Default window is **2h** (per Andrew). Tune via TOML/env without a code change.
- The heartbeat sweep is deliberately mechanical (no embeddings beyond what the indexer already does) — consistent with "heartbeat is mechanical, nightly is cognitive."
