### PR TITLE
feat: capability routing for Pi-based agents (image + coding delegation)

### DIFF
--- a/pi-extension/capability-routing/README.md
+++ b/pi-extension/capability-routing/README.md
@@ -1,0 +1,74 @@
+# Capability-routing Pi extension
+
+Lets a strong-but-narrow **primary** Pi model delegate specialist subtasks
+**within a single turn** to an **image** model and a **coding** model. This is
+*capability routing*, which is orthogonal to phantombot's primary→fallback
+harness chain (that's *failover* — try the next harness when one dies). The
+failover chain is untouched by this extension.
+
+## Why
+
+No single cheap model is great at reasoning **and** vision **and** coding. Pin a
+good orchestrator as the primary and let it hand off:
+
+- a **vision question** to a multimodal image model (`look_at_image`), and
+- a **PR/MR-scoped coding job or review** to a coding model (`coder`).
+
+## Tools
+
+| Tool | Registered when | What it does |
+|------|-----------------|--------------|
+| `look_at_image(path, question)` | `PHANTOMBOT_IMAGE_MODEL` is set | Spawns the image model to answer a **specific question** about an image (question-driven, not a one-shot describe). Returns the answer + usage. |
+| `coder(task, cwd?)` | `PHANTOMBOT_CODING_MODEL` is set | Spawns the coding model as a **fresh `pi` process** with `edit,bash,write` for a coarse-grained job. Returns the result + usage/cost. |
+
+### Multimodal auto-skip (the key behavior)
+
+When the chosen **primary** model already accepts image input, phantombot's
+`harness` wizard leaves `PHANTOMBOT_IMAGE_MODEL` **unset**. This extension then
+does **not** register `look_at_image` — the primary can see images itself, so a
+separate vision delegate would be dead weight. You only ever see
+`look_at_image` when the primary is text-only.
+
+### Coarse-grained coder caveat
+
+`coder` spawns a **fresh `pi` process per call**. Process startup is expensive,
+so each delegation should be a big self-contained chunk (a whole PR/MR-scoped
+change or a full review), **not** a chatty back-and-forth. Usage/cost from the
+child is surfaced back to the parent in the tool result.
+
+## Env-var contract
+
+phantombot writes these (via `phantombot harness`) and exports them to the child
+`pi` process. The extension reads only these env vars at load — no knowledge of
+phantombot's config files required.
+
+| Env var | Meaning |
+|---------|---------|
+| `PHANTOMBOT_PRIMARY_MODEL` | Orchestrator model id (bare name as printed by `pi --list-models`). Informational to the extension. |
+| `PHANTOMBOT_IMAGE_MODEL` | Vision delegate. **Set only when the primary is not multimodal.** Unset ⇒ `look_at_image` not registered. |
+| `PHANTOMBOT_CODING_MODEL` | Coding delegate for `coder`. Unset ⇒ `coder` not registered. |
+
+Empty string is treated as unset. The same values are mirrored to
+`config.toml` under `[harnesses.pi.routing]` (`primary_model`, `image_model`,
+`coding_model`) so the choice survives a fresh shell and is visible to
+`phantombot doctor`; env wins over TOML, matching every other phantombot
+setting.
+
+## Install
+
+Symlink this directory into Pi's user extensions dir (survives `pi update`,
+hot-reloads with `/reload`):
+
+```bash
+ln -sfn "$(pwd)/pi-extension/capability-routing" ~/.pi/agent/extensions/capability-routing
+# optional: the coder agent template
+mkdir -p ~/.pi/agent/agents
+ln -sf "$(pwd)/pi-extension/capability-routing/agents/coder.md" ~/.pi/agent/agents/coder.md
+```
+
+## Files
+
+- `index.ts` — extension entry point; registers `look_at_image` / `coder` per the plan.
+- `tools.ts` — pure registration-decision logic + delegation prompts (unit-tested from phantombot's `bun test`).
+- `spawnPi.ts` — spawns a child `pi --mode json` process and captures structured output (messages, usage, cost, stop reason). Mirrors pi's own subagent example.
+- `agents/coder.md` — coder agent template (model pinned at runtime from `PHANTOMBOT_CODING_MODEL`).

--- a/pi-extension/capability-routing/agents/coder.md
+++ b/pi-extension/capability-routing/agents/coder.md
@@ -1,0 +1,36 @@
+---
+name: coder
+description: PR/MR-scoped coding and review specialist, isolated context, full edit capability
+model: gpt-5.2-codex
+tools: edit, bash, write
+---
+
+You are a coding specialist operating in an isolated context window for a PR/MR-scoped job or a code review.
+
+This delegation is coarse-grained: you were spawned as a fresh `pi` process for a substantial, self-contained chunk of work — not a quick question. Finish the whole task before returning. Process startup is expensive, so the parent will not call you for chatty micro-edits.
+
+You have `edit`, `bash`, and `write`. Work autonomously to completion.
+
+Strategy:
+1. Understand the task and the relevant code (read first).
+2. Make the change end-to-end, including any obvious follow-on edits.
+3. Run whatever build/test the repo uses to confirm you didn't break it (if a runner is available).
+
+Output format when finished:
+
+## Completed
+What was done, in 1-3 sentences.
+
+## Files Changed
+- `path/to/file.ts` — what changed
+
+## Verification
+What you ran (build/tests) and the result, or why you couldn't.
+
+## Caveats (if any)
+Anything the parent should know — assumptions, things left out of scope, risks.
+
+> Note: the `model:` field above is a default/template. When this agent is
+> driven by the phantombot capability-routing extension, the model is pinned at
+> runtime from `PHANTOMBOT_CODING_MODEL` (see the env-var contract in the
+> extension README), so editing it here only affects standalone `pi` use.

--- a/pi-extension/capability-routing/index.ts
+++ b/pi-extension/capability-routing/index.ts
@@ -1,0 +1,140 @@
+/**
+ * Capability-routing Pi extension (phantombot).
+ *
+ * Lets a strong-but-narrow PRIMARY Pi model delegate specialist subtasks
+ * within a single turn:
+ *
+ *   look_at_image(path, question) — spawns the IMAGE model to answer a
+ *       specific question about an image. Registered ONLY when the primary is
+ *       NOT multimodal (the wizard sets PHANTOMBOT_IMAGE_MODEL only then; if a
+ *       multimodal primary is in use the env var is unset and this tool never
+ *       appears — the primary looks at the image itself).
+ *
+ *   coder(task) — spawns the CODING model as a fresh `pi` process with
+ *       edit,bash,write for a PR/MR-scoped job or review. Coarse-grained:
+ *       process startup is expensive, so each call should be a big chunk, not
+ *       a chatty round-trip. Usage/cost is surfaced back to the parent.
+ *
+ * This is capability routing WITHIN a turn — orthogonal to phantombot's
+ * primary→fallback harness chain (failover), which this extension does not
+ * touch.
+ *
+ * Reads its config from the env-var contract (see src/lib/piRouting.ts and
+ * ./tools.ts). phantombot's pi harness exports these env vars to the child pi
+ * process, so the extension needs zero knowledge of phantombot's config files.
+ *
+ * Install: symlink this directory into ~/.pi/agent/extensions/ (survives
+ * `pi update`, hot-reloads with /reload). See ./README.md.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import {
+  coderDelegationPrompt,
+  imageDelegationPrompt,
+  planRouting,
+} from "./tools.ts";
+import { delegate, finalText, usageLine } from "./spawnPi.ts";
+
+const LookAtImageParams = Type.Object({
+  path: Type.String({ description: "Absolute path to the image file to inspect." }),
+  question: Type.String({
+    description: "The specific question to answer about the image (question-driven, not a one-shot describe).",
+  }),
+});
+
+const CoderParams = Type.Object({
+  task: Type.String({
+    description:
+      "A PR/MR-scoped coding task or review. Coarse-grained — each call spawns a fresh, expensive process, so send a big self-contained chunk, not a quick question.",
+  }),
+  cwd: Type.Optional(Type.String({ description: "Working directory for the coding agent." })),
+});
+
+export default function (pi: ExtensionAPI) {
+  const plan = planRouting();
+
+  if (plan.registerLookAtImage && plan.imageModel) {
+    const imageModel = plan.imageModel;
+    pi.registerTool({
+      name: "look_at_image",
+      label: "Look at image",
+      description: [
+        "Delegate a vision question to a multimodal image model and get the answer.",
+        "Use this when you (the primary model) cannot see images yourself.",
+        "Ask a specific question — this is question-driven, not a blind describe.",
+      ].join(" "),
+      parameters: LookAtImageParams,
+      async execute(_id, params, signal) {
+        const r = await delegate({
+          model: imageModel,
+          task: imageDelegationPrompt(params.path, params.question),
+          // Vision Q&A doesn't need edit/bash/write; keep it tool-light.
+          tools: ["read"],
+          signal,
+        });
+        if (r.exitCode !== 0 || r.stopReason === "error" || r.stopReason === "aborted") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `look_at_image failed (${r.stopReason ?? `exit ${r.exitCode}`}): ${
+                  r.errorMessage || r.stderr || "no output"
+                }`,
+              },
+            ],
+            details: { model: imageModel, usage: r.usage },
+            isError: true,
+          };
+        }
+        const answer = finalText(r.messages) || "(no answer)";
+        return {
+          content: [{ type: "text", text: `${answer}\n\n[image model: ${usageLine(r)}]` }],
+          details: { model: imageModel, usage: r.usage },
+        };
+      },
+    });
+  }
+
+  if (plan.registerCoder && plan.codingModel) {
+    const codingModel = plan.codingModel;
+    pi.registerTool({
+      name: "coder",
+      label: "Coder",
+      description: [
+        "Delegate a PR/MR-scoped coding job or review to a coding-specialist model.",
+        "Coarse-grained: spawns a fresh pi process (edit,bash,write) with an isolated context.",
+        "Expensive startup — use for big self-contained chunks, not chatty calls.",
+      ].join(" "),
+      parameters: CoderParams,
+      async execute(_id, params, signal, _onUpdate, ctx) {
+        const r = await delegate({
+          model: codingModel,
+          task: coderDelegationPrompt(params.task),
+          tools: ["edit", "bash", "write"],
+          cwd: params.cwd ?? ctx.cwd,
+          signal,
+        });
+        if (r.exitCode !== 0 || r.stopReason === "error" || r.stopReason === "aborted") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `coder failed (${r.stopReason ?? `exit ${r.exitCode}`}): ${
+                  r.errorMessage || r.stderr || "no output"
+                }`,
+              },
+            ],
+            details: { model: codingModel, usage: r.usage },
+            isError: true,
+          };
+        }
+        const out = finalText(r.messages) || "(no output)";
+        return {
+          content: [{ type: "text", text: `${out}\n\n[coding model: ${usageLine(r)}]` }],
+          details: { model: codingModel, usage: r.usage },
+        };
+      },
+    });
+  }
+}

--- a/pi-extension/capability-routing/spawnPi.ts
+++ b/pi-extension/capability-routing/spawnPi.ts
@@ -1,0 +1,216 @@
+/**
+ * Spawn a child `pi` process for a delegated subtask and capture its
+ * structured JSON output.
+ *
+ * Mirrors the pattern in pi's own `examples/extensions/subagent/index.ts`:
+ *   pi --mode json -p --no-session --model <model> --tools <...> \
+ *      [--append-system-prompt <file>] "<task>"
+ *
+ * Each delegation is a FRESH pi process. That's deliberate (and the headline
+ * caveat for the `coder` tool): process startup is expensive, so delegations
+ * are COARSE-GRAINED — one big PR/MR-scoped chunk, not a chatty back-and-forth.
+ * The child gets an isolated context window and reports usage/cost back, which
+ * we surface to the parent so cost is visible at the call site.
+ */
+
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Message } from "@earendil-works/pi-ai";
+
+export interface DelegateUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: number;
+  contextTokens: number;
+  turns: number;
+}
+
+export interface DelegateResult {
+  exitCode: number;
+  messages: Message[];
+  stderr: string;
+  usage: DelegateUsage;
+  model?: string;
+  stopReason?: string;
+  errorMessage?: string;
+}
+
+export interface DelegateOptions {
+  /** Model id to pin via --model (bare name as printed by `pi --list-models`). */
+  model: string;
+  /** Comma-list passed to --tools. Omit/empty = pi's default tool set. */
+  tools?: string[];
+  /** Extra system prompt appended via --append-system-prompt (written to a temp file). */
+  systemPrompt?: string;
+  /** The task string (last positional arg). */
+  task: string;
+  /** Working directory for the child. Defaults to the parent's cwd. */
+  cwd?: string;
+  /** Abort signal — propagated as SIGTERM/SIGKILL to the child. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Resolve how to re-invoke pi. When the extension runs under a compiled pi
+ * single-ELF, `process.execPath` IS pi, so we call it directly. Under a
+ * node/bun runtime running pi from source, re-run the same script. Falls back
+ * to "pi" on PATH. Lifted from the subagent example's getPiInvocation.
+ */
+function getPiInvocation(args: string[]): { command: string; args: string[] } {
+  const currentScript = process.argv[1];
+  const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
+  if (currentScript && !isBunVirtualScript && fs.existsSync(currentScript)) {
+    return { command: process.execPath, args: [currentScript, ...args] };
+  }
+  const execName = path.basename(process.execPath).toLowerCase();
+  const isGenericRuntime = /^(node|bun)(\.exe)?$/.test(execName);
+  if (!isGenericRuntime) {
+    return { command: process.execPath, args };
+  }
+  return { command: "pi", args };
+}
+
+function emptyUsage(): DelegateUsage {
+  return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 };
+}
+
+/** Write the appended system prompt to a temp file; pi reads it by path. */
+function writePromptTempFile(prompt: string): { dir: string; filePath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "phantombot-route-"));
+  const filePath = path.join(dir, "system.md");
+  fs.writeFileSync(filePath, prompt, "utf-8");
+  return { dir, filePath };
+}
+
+/** Last assistant text block — the delegate's answer. */
+export function finalText(messages: Message[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role === "assistant") {
+      for (const part of msg.content) {
+        if (part.type === "text") return part.text;
+      }
+    }
+  }
+  return "";
+}
+
+export async function delegate(opts: DelegateOptions): Promise<DelegateResult> {
+  const args: string[] = ["--mode", "json", "-p", "--no-session", "--model", opts.model];
+  if (opts.tools && opts.tools.length > 0) args.push("--tools", opts.tools.join(","));
+
+  const result: DelegateResult = {
+    exitCode: 0,
+    messages: [],
+    stderr: "",
+    usage: emptyUsage(),
+    model: opts.model,
+  };
+
+  let tmpDir: string | null = null;
+  let tmpPath: string | null = null;
+  try {
+    if (opts.systemPrompt?.trim()) {
+      const tmp = writePromptTempFile(opts.systemPrompt);
+      tmpDir = tmp.dir;
+      tmpPath = tmp.filePath;
+      args.push("--append-system-prompt", tmpPath);
+    }
+    args.push(opts.task);
+
+    let aborted = false;
+    const exitCode = await new Promise<number>((resolve) => {
+      const inv = getPiInvocation(args);
+      const proc = spawn(inv.command, inv.args, {
+        cwd: opts.cwd,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let buffer = "";
+      const processLine = (line: string) => {
+        if (!line.trim()) return;
+        let event: { type?: string; message?: Message };
+        try {
+          event = JSON.parse(line);
+        } catch {
+          return;
+        }
+        if (event.type === "message_end" && event.message) {
+          const msg = event.message;
+          result.messages.push(msg);
+          if (msg.role === "assistant") {
+            result.usage.turns++;
+            const u = msg.usage;
+            if (u) {
+              result.usage.input += u.input || 0;
+              result.usage.output += u.output || 0;
+              result.usage.cacheRead += u.cacheRead || 0;
+              result.usage.cacheWrite += u.cacheWrite || 0;
+              result.usage.cost += u.cost?.total || 0;
+              result.usage.contextTokens = u.totalTokens || 0;
+            }
+            if (!result.model && msg.model) result.model = msg.model;
+            if (msg.stopReason) result.stopReason = msg.stopReason;
+            if (msg.errorMessage) result.errorMessage = msg.errorMessage;
+          }
+        }
+        if (event.type === "tool_result_end" && event.message) {
+          result.messages.push(event.message);
+        }
+      };
+
+      proc.stdout.on("data", (data) => {
+        buffer += data.toString();
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+        for (const line of lines) processLine(line);
+      });
+      proc.stderr.on("data", (data) => {
+        result.stderr += data.toString();
+      });
+      proc.on("close", (code) => {
+        if (buffer.trim()) processLine(buffer);
+        resolve(code ?? 0);
+      });
+      proc.on("error", () => resolve(1));
+
+      if (opts.signal) {
+        const kill = () => {
+          aborted = true;
+          proc.kill("SIGTERM");
+          setTimeout(() => {
+            if (!proc.killed) proc.kill("SIGKILL");
+          }, 5000);
+        };
+        if (opts.signal.aborted) kill();
+        else opts.signal.addEventListener("abort", kill, { once: true });
+      }
+    });
+
+    result.exitCode = exitCode;
+    if (aborted) {
+      result.stopReason = "aborted";
+      result.errorMessage = "delegation aborted";
+    }
+    return result;
+  } finally {
+    if (tmpPath) try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+    if (tmpDir) try { fs.rmdirSync(tmpDir); } catch { /* ignore */ }
+  }
+}
+
+/** One-line usage summary for surfacing cost back to the parent model. */
+export function usageLine(r: DelegateResult): string {
+  const u = r.usage;
+  const parts = [`${u.turns} turn${u.turns === 1 ? "" : "s"}`];
+  if (u.input) parts.push(`↑${u.input}`);
+  if (u.output) parts.push(`↓${u.output}`);
+  if (u.cost) parts.push(`$${u.cost.toFixed(4)}`);
+  if (r.model) parts.push(r.model);
+  return parts.join(" ");
+}

--- a/pi-extension/capability-routing/tools.ts
+++ b/pi-extension/capability-routing/tools.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure registration-decision logic for the capability-routing extension.
+ *
+ * Kept separate from index.ts (the @earendil-works/* glue) so it can be
+ * unit-tested from phantombot's `bun test` without the Pi SDK on the import
+ * path — the tests import THIS file and assert which tools should register
+ * given an env snapshot.
+ *
+ * Reads the env-var contract documented in src/lib/piRouting.ts:
+ *   PHANTOMBOT_IMAGE_MODEL  → register look_at_image (vision delegate)
+ *   PHANTOMBOT_CODING_MODEL → register coder         (coding delegate)
+ *   PHANTOMBOT_PRIMARY_MODEL → informational (the extension does not switch
+ *                              the primary itself; phantombot's pi harness
+ *                              passes --model — but we surface it for logging)
+ *
+ * The KEY rule: when PHANTOMBOT_IMAGE_MODEL is unset/empty, `look_at_image` is
+ * NOT registered. The wizard leaves it unset precisely when the primary model
+ * is multimodal (it can see images itself), so a multimodal primary gets no
+ * redundant vision tool.
+ */
+
+export const ENV_PRIMARY_MODEL = "PHANTOMBOT_PRIMARY_MODEL";
+export const ENV_IMAGE_MODEL = "PHANTOMBOT_IMAGE_MODEL";
+export const ENV_CODING_MODEL = "PHANTOMBOT_CODING_MODEL";
+
+export interface RoutingPlan {
+  /** Primary model id, if pinned. Informational. */
+  primaryModel?: string;
+  /** Image model id; when present, register look_at_image. */
+  imageModel?: string;
+  /** Coding model id; when present, register coder. */
+  codingModel?: string;
+  /** True when look_at_image should be registered. */
+  registerLookAtImage: boolean;
+  /** True when coder should be registered. */
+  registerCoder: boolean;
+}
+
+function clean(v: string | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  const t = v.trim();
+  return t.length > 0 ? t : undefined;
+}
+
+/**
+ * Decide which routing tools to register from the environment. `env` is
+ * injectable for tests; defaults to process.env.
+ */
+export function planRouting(
+  env: Record<string, string | undefined> = process.env,
+): RoutingPlan {
+  const imageModel = clean(env[ENV_IMAGE_MODEL]);
+  const codingModel = clean(env[ENV_CODING_MODEL]);
+  return {
+    primaryModel: clean(env[ENV_PRIMARY_MODEL]),
+    imageModel,
+    codingModel,
+    registerLookAtImage: imageModel !== undefined,
+    registerCoder: codingModel !== undefined,
+  };
+}
+
+/**
+ * System prompt for a vision delegation. Question-driven: the parent asks a
+ * specific question about an image rather than requesting a one-shot describe,
+ * so the answer is scoped to what the orchestrator actually needs.
+ */
+export function imageDelegationPrompt(imagePath: string, question: string): string {
+  return [
+    "You are a vision specialist answering a single, specific question about an image.",
+    `Image: ${imagePath}`,
+    `Question: ${question}`,
+    "",
+    "Look at the image and answer the question directly and concisely.",
+    "If the image does not contain enough information to answer, say so plainly.",
+    "Do not pad the answer with a full description unless the question asks for one.",
+  ].join("\n");
+}
+
+/**
+ * System prompt for a coding delegation. Coarse-grained: this is a fresh,
+ * expensive process, so the task should be a PR/MR-scoped chunk or a review,
+ * not a chatty micro-edit.
+ */
+export function coderDelegationPrompt(task: string): string {
+  return [
+    "You are a coding specialist operating in an isolated context for a PR/MR-scoped job.",
+    "You have edit, bash, and write tools. Work autonomously to completion.",
+    "",
+    "This delegation is coarse-grained — you were spawned as a fresh process for a",
+    "substantial chunk of work, not a quick question. Finish the whole task before returning.",
+    "",
+    `Task: ${task}`,
+    "",
+    "When done, report: what changed (file paths), key functions/types touched, and any caveats.",
+  ].join("\n");
+}

--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -8,13 +8,32 @@ import { defineCommand } from "citty";
 import * as p from "@clack/prompts";
 
 import { type Config, loadConfig } from "../config.ts";
-import { setIn, updateConfigToml } from "../lib/configWriter.ts";
+import {
+  getIn,
+  readConfigToml,
+  setIn,
+  type TomlObject,
+  updateConfigToml,
+} from "../lib/configWriter.ts";
 import { harnessBin, whichBinary } from "../lib/harnessAvailability.ts";
 import {
   defaultServiceControl,
   restartCommand,
   type ServiceControl,
 } from "../lib/platform.ts";
+import {
+  listPiModels,
+  modelId,
+  type PiModel,
+  primaryIsMultimodal,
+} from "../lib/piModels.ts";
+import {
+  computeRoutingWrites,
+  resolveRouting,
+  type RoutingChoices,
+} from "../lib/piRouting.ts";
+import { updateEnvFile } from "../lib/envFile.ts";
+import { userEnvPath } from "./env.ts";
 import { saveHarnessBins } from "../state.ts";
 
 export { whichBinary } from "../lib/harnessAvailability.ts";
@@ -45,6 +64,43 @@ export async function applyHarnessChain(
   await updateConfigToml(configPath, (toml) => {
     setIn(toml, ["harnesses", "chain"], [...chain]);
   });
+}
+
+/**
+ * Persist the capability-routing choices: write the `[harnesses.pi.routing]`
+ * sub-table to config.toml AND the PHANTOMBOT_*_MODEL env vars to ~/.env. The
+ * multimodal auto-skip is applied inside `computeRoutingWrites`, so by the time
+ * we get here the image model is already dropped when the primary is
+ * multimodal. Returns the computed writes so callers/tests can assert.
+ *
+ * `envPath` is injectable for tests (defaults to ~/.env via userEnvPath()).
+ */
+export async function applyRouting(
+  configPath: string,
+  choices: RoutingChoices,
+  envPath: string = userEnvPath(),
+): Promise<ReturnType<typeof computeRoutingWrites>> {
+  const writes = computeRoutingWrites(choices);
+  await updateConfigToml(configPath, (toml) => {
+    setIn(toml, ["harnesses", "pi", "routing", "primary_model"], writes.toml.primary_model);
+    // Mirror the env "" = unset semantics into TOML: drop the key when there's
+    // no image/coding model so a multimodal switch clears a stale entry.
+    setRoutingKey(toml, "image_model", writes.toml.image_model);
+    setRoutingKey(toml, "coding_model", writes.toml.coding_model);
+  });
+  await updateEnvFile(envPath, writes.env);
+  return writes;
+}
+
+function setRoutingKey(toml: TomlObject, key: string, value: string | undefined): void {
+  const routing = getIn(toml, ["harnesses", "pi", "routing"]) as
+    | Record<string, unknown>
+    | undefined;
+  if (value === undefined) {
+    if (routing && key in routing) delete routing[key];
+    return;
+  }
+  setIn(toml, ["harnesses", "pi", "routing", key], value);
 }
 
 interface RunInput {
@@ -130,10 +186,170 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
     "Saved",
   );
 
+  // Capability routing is Pi-specific (it's driven by a Pi extension), so only
+  // offer the wizard step when pi is somewhere in the chain. Failover (the
+  // chain above) is untouched by any of this.
+  if (chain.includes("pi")) {
+    const cancelled = await runRoutingWizard(config, availability.pi);
+    if (cancelled) {
+      p.cancel("cancelled");
+      return 1;
+    }
+  }
+
   await maybePromptRestart(svc);
 
   p.outro("done");
   return 0;
+}
+
+/**
+ * Capability-routing wizard step (interactive). Returns `true` if the user
+ * cancelled (so the caller can abort the whole command), `false` otherwise —
+ * including the "keep configured defaults" path, which is a successful no-op.
+ *
+ * The TUI itself is verified manually (matching this file's other prompts and
+ * the create-persona convention). The branching/auto-skip LOGIC lives in pure,
+ * unit-tested functions: `computeRoutingWrites` (multimodal auto-skip) and
+ * `primaryIsMultimodal` (capability detection). This keeps the untested
+ * surface to thin @clack glue.
+ *
+ * `piBin` is the resolved pi path from availability (or undefined if pi isn't
+ * installed); we still let the operator configure routing in that case via
+ * free-text entry so a config can be staged ahead of installing pi.
+ */
+async function runRoutingWizard(
+  config: Config,
+  piBin: string | undefined,
+): Promise<boolean> {
+  const toml = await readConfigToml(config.configPath);
+  const current = resolveRouting(
+    getIn(toml, ["harnesses", "pi", "routing"]) as
+      | Record<string, unknown>
+      | undefined,
+  );
+
+  const useDefaults = await p.confirm({
+    message: "Model: use configured defaults?",
+    // Default = no override when nothing is configured yet, otherwise keep the
+    // existing routing. Either way the safe answer leaves things as they are.
+    initialValue: current.primaryModel === undefined,
+  });
+  if (p.isCancel(useDefaults)) return true;
+  if (useDefaults) {
+    p.note(
+      current.primaryModel
+        ? `keeping: primary=${current.primaryModel}` +
+            (current.imageModel ? ` image=${current.imageModel}` : "") +
+            (current.codingModel ? ` coding=${current.codingModel}` : "")
+        : "no per-capability routing — Pi uses its configured default model",
+      "Routing",
+    );
+    return false;
+  }
+
+  // Custom routing: query pi for the live model list so the picker only shows
+  // models that are actually available. Falls back to free-text if pi can't be
+  // queried (not installed, or output unparseable).
+  const models = piBin ? await listPiModels(piBin) : [];
+  if (models.length === 0) {
+    p.note(
+      "Couldn't read `pi --list-models` — entering model ids by hand.\n" +
+        "Use the bare name as printed by `pi --list-models` (e.g. gpt-5.2).",
+      "Routing",
+    );
+  }
+
+  const primaryModel = await pickModel(
+    "Primary model (orchestrator)",
+    models,
+    current.primaryModel,
+  );
+  if (primaryModel === CANCELLED) return true;
+
+  const multimodal = primaryIsMultimodal(models, primaryModel);
+
+  // THE auto-skip: a multimodal primary needs no image delegate, so we don't
+  // even ask. The extension keys off the (now-unset) PHANTOMBOT_IMAGE_MODEL.
+  let imageModel: string | undefined;
+  if (multimodal) {
+    p.note(
+      `${primaryModel} accepts image input — skipping the image model.\n` +
+        "The look_at_image tool won't be registered; the primary sees images itself.",
+      "Multimodal primary",
+    );
+  } else {
+    const picked = await pickModel(
+      "Image model (vision delegate for look_at_image)",
+      models.filter((m) => m.supportsImages),
+      current.imageModel,
+    );
+    if (picked === CANCELLED) return true;
+    imageModel = picked;
+  }
+
+  const codingModel = await pickModel(
+    "Coding model (delegate for the coder tool)",
+    models,
+    current.codingModel,
+  );
+  if (codingModel === CANCELLED) return true;
+
+  const choices: RoutingChoices = {
+    primaryModel,
+    imageModel,
+    codingModel,
+    primaryMultimodal: multimodal,
+  };
+  const writes = await applyRouting(config.configPath, choices);
+  p.note(
+    [
+      `primary: ${writes.toml.primary_model}`,
+      `image:   ${writes.toml.image_model ?? "(none — primary is multimodal)"}`,
+      `coding:  ${writes.toml.coding_model ?? "(none)"}`,
+      "",
+      `saved to ${config.configPath} and ${userEnvPath()}`,
+    ].join("\n"),
+    "Capability routing",
+  );
+  return false;
+}
+
+const CANCELLED = Symbol("cancelled");
+
+/**
+ * Single model picker. Shows a select of available models when we have the
+ * list, otherwise a free-text prompt. Returns the chosen bare model id, or the
+ * CANCELLED sentinel if the user aborted.
+ */
+async function pickModel(
+  message: string,
+  models: readonly PiModel[],
+  initial: string | undefined,
+): Promise<string | typeof CANCELLED> {
+  if (models.length === 0) {
+    const r = await p.text({
+      message,
+      placeholder: "e.g. gpt-5.2",
+      initialValue: initial ?? "",
+    });
+    if (p.isCancel(r)) return CANCELLED;
+    return r.trim();
+  }
+  const r = await p.select<string>({
+    message,
+    options: models.map((m) => ({
+      value: modelId(m),
+      label: `${m.provider}/${m.model}`,
+      hint: m.supportsImages ? "vision" : undefined,
+    })),
+    initialValue:
+      initial && models.some((m) => modelId(m) === initial)
+        ? initial
+        : modelId(models[0]!),
+  });
+  if (p.isCancel(r)) return CANCELLED;
+  return r;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,10 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { parse as parseToml } from "smol-toml";
 import { log } from "./lib/logger.ts";
+import {
+  type PiRoutingConfig,
+  resolveRouting,
+} from "./lib/piRouting.ts";
 import { DEFAULT_STT_TIMEOUT_MS } from "./lib/voice.ts";
 import { loadState } from "./state.ts";
 
@@ -209,7 +213,17 @@ export interface Config {
     /** Order = primary → fallback. Recognized ids: "claude", "pi", "gemini", "codex". */
     chain: string[];
     claude: { bin: string; model: string; fallbackModel: string };
-    pi: { bin: string; maxPayloadBytes: number };
+    pi: {
+      bin: string;
+      maxPayloadBytes: number;
+      /**
+       * Capability routing (distinct from the failover `chain`). When set, the
+       * bundled Pi extension delegates vision/coding subtasks to specialist
+       * models. See lib/piRouting.ts for the env-var contract. Optional: absent
+       * = no per-capability routing (Pi uses its configured default model).
+       */
+      routing?: import("./lib/piRouting.ts").PiRoutingConfig;
+    };
     gemini: { bin: string; model: string };
     codex?: { bin: string; model: string };
   };
@@ -378,6 +392,7 @@ export async function loadConfig(): Promise<Config> {
           asInt(process.env.PHANTOMBOT_PI_MAX_PAYLOAD) ??
           asInt(tomlPi.max_payload_bytes) ??
           1_500_000,
+        routing: buildPiRoutingConfig(tomlPi),
       },
 
       gemini: {
@@ -598,6 +613,28 @@ function asNumber(v: unknown): number | undefined {
     return Number.isFinite(n) ? n : undefined;
   }
   return undefined;
+}
+
+/**
+ * Resolve `[harnesses.pi.routing]` with env-over-TOML precedence (the shared
+ * rule, implemented once in resolveRouting). Returns undefined when no routing
+ * is configured at all so the field stays genuinely optional on Config — the
+ * extension's "no override" path. A bare primary with no image/coding model is
+ * still valid (means: route nothing but pin the orchestrator model).
+ */
+function buildPiRoutingConfig(
+  tomlPi: Record<string, unknown>,
+): PiRoutingConfig | undefined {
+  const tomlRouting = (tomlPi.routing ?? {}) as Record<string, unknown>;
+  const resolved = resolveRouting(tomlRouting);
+  if (
+    resolved.primaryModel === undefined &&
+    resolved.imageModel === undefined &&
+    resolved.codingModel === undefined
+  ) {
+    return undefined;
+  }
+  return resolved;
 }
 
 function buildEmbeddingsConfig(

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -24,6 +24,12 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import {
+  ENV_CODING_MODEL,
+  ENV_IMAGE_MODEL,
+  ENV_PRIMARY_MODEL,
+  type PiRoutingConfig,
+} from "../lib/piRouting.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -37,6 +43,38 @@ export interface PiHarnessConfig {
   bin: string;
   /** Maximum payload size in bytes (system prompt + rendered conversation). */
   maxPayloadBytes: number;
+  /**
+   * Resolved capability routing (env-over-TOML, from config.ts). When present
+   * it does two runtime things, both required for routing to actually take
+   * effect (a TOML-only install would otherwise be inert):
+   *   1. `primaryModel` pins the orchestrator model via `--model` on the Pi
+   *      CLI — without this the saved primary is never honored, Pi just uses
+   *      its own default.
+   *   2. all three resolved models are projected into the spawned Pi env
+   *      (PHANTOMBOT_PRIMARY/IMAGE/CODING_MODEL) so the bundled extension sees
+   *      them even when they live only in config.toml (the wizard's ~/.env
+   *      write would otherwise be the only path that reaches the child).
+   * Absent = no per-capability routing (Pi uses its configured default model).
+   */
+  routing?: PiRoutingConfig;
+}
+
+/**
+ * Project the resolved routing models onto a child-process env. Only DEFINED
+ * values are written; undefined keys are left untouched so a directly-exported
+ * env var is never clobbered (the wizard already clears stale keys at write
+ * time via computeRoutingWrites). Exported for testing.
+ */
+export function applyRoutingEnv(
+  env: Record<string, string | undefined>,
+  routing: PiRoutingConfig | undefined,
+): Record<string, string | undefined> {
+  if (!routing) return env;
+  const out = { ...env };
+  if (routing.primaryModel !== undefined) out[ENV_PRIMARY_MODEL] = routing.primaryModel;
+  if (routing.imageModel !== undefined) out[ENV_IMAGE_MODEL] = routing.imageModel;
+  if (routing.codingModel !== undefined) out[ENV_CODING_MODEL] = routing.codingModel;
+  return out;
 }
 
 export class PiHarness implements Harness {
@@ -90,6 +128,14 @@ export class PiHarness implements Harness {
       "--offline",
       "--no-session",
     ];
+    // Capability routing: pin the orchestrator model. Without this `--model`
+    // the saved primary is never honored — Pi falls back to its own default
+    // and the routing config is silently inert. The delegate models reach the
+    // extension via env (below), not argv.
+    const primaryModel = this.config.routing?.primaryModel;
+    if (primaryModel) {
+      args.push("--model", primaryModel);
+    }
     // Tool-less threat-judge mode. Per `pi --help`, `--no-tools` disables all
     // tools (built-in, extension, and custom) — true zero-tools, native flag,
     // no deny-list to maintain.
@@ -110,7 +156,12 @@ export class PiHarness implements Harness {
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,
-      env: withPersonaEnv(process.env, req.persona, req.conversation),
+      // Project resolved routing models into the child so the bundled
+      // extension sees them even on a TOML-only install (no ~/.env write).
+      env: applyRoutingEnv(
+        withPersonaEnv(process.env, req.persona, req.conversation),
+        this.config.routing,
+      ),
       stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",

--- a/src/lib/piModels.ts
+++ b/src/lib/piModels.ts
@@ -1,0 +1,163 @@
+/**
+ * Parse `pi --list-models` and reason about model capabilities.
+ *
+ * Pi prints a fixed-width table (no JSON flag exists for this command, so we
+ * parse the text). Columns, in order:
+ *
+ *   provider · model · context · max-out · thinking · images
+ *
+ * Example row:
+ *   openai      gpt-5.2                400K     128K     yes       yes
+ *
+ * We only need two columns downstream: the fully-qualified model id
+ * (`provider/model`, which is what `pi --model` expects) and whether the
+ * model accepts image input (the `images` column → multimodal capability).
+ *
+ * This module is the phantombot-side mirror of what the Pi extension reads
+ * from `ctx.modelRegistry` (each model there carries `input: ["text"]` or
+ * `["text","image"]`). We can't import the Pi SDK here — phantombot is a
+ * separate binary — so the wizard shells out to `pi --list-models` and parses
+ * the table, while the in-process extension uses the structured registry.
+ */
+
+/** One row from `pi --list-models`, reduced to what the wizard needs. */
+export interface PiModel {
+  /** Provider column, e.g. "openai", "openrouter", "deepseek". */
+  provider: string;
+  /**
+   * Bare model name as printed, e.g. "gpt-5.2" or "~anthropic/claude-opus-latest".
+   * Pi prefixes some openrouter aliases with "~"; we preserve it verbatim
+   * because that is the string `pi --model` accepts.
+   */
+  model: string;
+  /** Whether the model accepts image input (the `images` column = yes). */
+  supportsImages: boolean;
+}
+
+/**
+ * The header row we expect from `pi --list-models`. Used to locate the start
+ * of the table and to defend against pi changing its output shape: if we never
+ * see this header, we return [] rather than mis-parsing arbitrary lines.
+ */
+const HEADER_TOKENS = ["provider", "model", "context", "max-out", "thinking", "images"];
+
+function isHeaderLine(line: string): boolean {
+  const cols = line.trim().split(/\s+/);
+  return HEADER_TOKENS.every((t, i) => cols[i] === t);
+}
+
+/**
+ * Parse the raw stdout of `pi --list-models` into structured rows.
+ *
+ * Resilient to:
+ *   - leading banner / warning lines before the header
+ *   - blank lines
+ *   - variable run-length whitespace between columns
+ *   - a missing/extra trailing column (we read by position from the left and
+ *     treat the LAST whitespace-delimited token as `images`, which is robust
+ *     because every documented column after `model` is a single bare token)
+ *
+ * Returns [] if the header is never found (pi unavailable / output changed).
+ */
+export function parsePiModels(stdout: string): PiModel[] {
+  const lines = stdout.split(/\r?\n/);
+  const headerIdx = lines.findIndex(isHeaderLine);
+  if (headerIdx === -1) return [];
+
+  const models: PiModel[] = [];
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const raw = lines[i];
+    if (raw === undefined) continue;
+    if (raw.trim().length === 0) continue;
+    // Split on runs of whitespace. provider · model · context · max-out ·
+    // thinking · images → exactly 6 tokens for a well-formed row. We require
+    // at least 6 so a stray wrapped line can't produce a bogus model.
+    const cols = raw.trim().split(/\s+/);
+    if (cols.length < HEADER_TOKENS.length) continue;
+    const provider = cols[0]!;
+    const model = cols[1]!;
+    // `images` is the last column. Read it positionally from the right so a
+    // future column insertion in the middle doesn't silently flip the flag.
+    const imagesCol = cols[cols.length - 1]!;
+    models.push({
+      provider,
+      model,
+      supportsImages: imagesCol.toLowerCase() === "yes",
+    });
+  }
+  return models;
+}
+
+/**
+ * Spawns `pi --list-models` and returns parsed rows. Injectable runner so
+ * tests drive parsing/branching without a real `pi` on PATH (mirrors the
+ * SystemctlRunner pattern in systemd.ts). Returns [] on non-zero exit or
+ * unparseable output — the wizard then falls back to free-text model entry.
+ *
+ * `bin` defaults to "pi" (PATH lookup); the wizard passes the resolved
+ * absolute path from harness availability so it works under the systemd
+ * unit's narrow PATH.
+ */
+export type PiModelsRunner = (bin: string) => Promise<{
+  exitCode: number;
+  stdout: string;
+}>;
+
+const defaultRunner: PiModelsRunner = async (bin) => {
+  const proc = Bun.spawn([bin, "--list-models"], {
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  return { exitCode, stdout };
+};
+
+export async function listPiModels(
+  bin = "pi",
+  runner: PiModelsRunner = defaultRunner,
+): Promise<PiModel[]> {
+  try {
+    const { exitCode, stdout } = await runner(bin);
+    if (exitCode !== 0) return [];
+    return parsePiModels(stdout);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The string `pi --model` expects. Pi accepts either the bare model name (it
+ * resolves the provider) or a `provider/model` pair. We hand back the bare
+ * name as printed, which is what the subagent example passes through verbatim
+ * and what users see in the picker.
+ */
+export function modelId(m: PiModel): string {
+  return m.model;
+}
+
+/**
+ * Look up a model by the id the wizard stored (bare model name). Returns
+ * undefined if the model is no longer offered (e.g. provider key removed).
+ */
+export function findModel(models: readonly PiModel[], id: string): PiModel | undefined {
+  return models.find((m) => m.model === id);
+}
+
+/**
+ * THE key routing decision: does the chosen primary model accept images?
+ *
+ * When true, the wizard SKIPS asking for an image model and the extension
+ * will NOT register `look_at_image` — the primary can look at images itself,
+ * so a separate vision delegate is dead weight. When the primary is unknown
+ * (not in the parsed list), we conservatively return false so the image model
+ * is still offered (better to over-provision a delegate than to silently lose
+ * vision).
+ */
+export function primaryIsMultimodal(
+  models: readonly PiModel[],
+  primaryId: string,
+): boolean {
+  const m = findModel(models, primaryId);
+  return m?.supportsImages ?? false;
+}

--- a/src/lib/piRouting.ts
+++ b/src/lib/piRouting.ts
@@ -1,0 +1,146 @@
+/**
+ * Capability-routing config for the Pi harness.
+ *
+ * This is DISTINCT from the primary→fallback harness chain (that's failover —
+ * try the next harness when one dies). Capability routing is WITHIN a single
+ * Pi turn: a strong-but-narrow PRIMARY model delegates specialist subtasks to
+ * an IMAGE model (vision Q&A) and a CODING model (PR/MR-scoped jobs), via the
+ * `look_at_image` and `coder` tools registered by the bundled Pi extension
+ * (see pi-extension/capability-routing/).
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * THE ENV-VAR CONTRACT
+ * ───────────────────────────────────────────────────────────────────────────
+ * The wizard (`phantombot harness`) persists the operator's choices in TWO
+ * places, and the Pi extension reads ONLY the env vars at load time:
+ *
+ *   PHANTOMBOT_PRIMARY_MODEL   — the primary/orchestrator model id (bare name
+ *                                as printed by `pi --list-models`, e.g.
+ *                                "gpt-5.2" or "~anthropic/claude-opus-latest").
+ *                                Empty / unset = "use Pi's configured default"
+ *                                (no override; the extension routes nothing).
+ *   PHANTOMBOT_IMAGE_MODEL     — the vision delegate. SET ONLY when the primary
+ *                                is NOT multimodal. When the primary already
+ *                                accepts image input, this is intentionally
+ *                                left UNSET so the extension does not register
+ *                                `look_at_image` (the primary looks itself).
+ *   PHANTOMBOT_CODING_MODEL    — the coding delegate spawned by `coder`.
+ *
+ * The same values are mirrored into config.toml under
+ * `[harnesses.pi.routing]` (primary_model / image_model / coding_model) so the
+ * choice survives a fresh shell and is visible to `phantombot doctor`. config
+ * loading (config.ts) and the env file (~/.env, written via the same path as
+ * `phantombot env set`) keep the env vars and TOML in sync; env wins, matching
+ * every other setting in phantombot.
+ *
+ * Why env vars at all (vs. the extension reading config.toml)? The extension
+ * runs INSIDE the `pi` subprocess that phantombot spawns. phantombot already
+ * exports its environment to that child (see harnesses/pi.ts → withPersonaEnv),
+ * so env vars are the zero-coupling channel: the extension needs no knowledge
+ * of phantombot's config path or TOML schema.
+ */
+
+export const ENV_PRIMARY_MODEL = "PHANTOMBOT_PRIMARY_MODEL";
+export const ENV_IMAGE_MODEL = "PHANTOMBOT_IMAGE_MODEL";
+export const ENV_CODING_MODEL = "PHANTOMBOT_CODING_MODEL";
+
+/**
+ * The resolved routing config. All three are optional: undefined means "no
+ * override — let Pi / the extension fall back to its default behavior". An
+ * absent imageModel specifically means the `look_at_image` tool will not be
+ * registered (either because the primary is multimodal, or because routing is
+ * off entirely).
+ */
+export interface PiRoutingConfig {
+  primaryModel?: string;
+  imageModel?: string;
+  codingModel?: string;
+}
+
+function clean(v: string | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  const t = v.trim();
+  return t.length > 0 ? t : undefined;
+}
+
+/**
+ * Resolve routing config with phantombot's standard precedence:
+ * env var > config.toml > unset. `toml` is the parsed
+ * `[harnesses.pi.routing]` sub-table (may be empty / undefined).
+ *
+ * `env` is injectable for tests; defaults to process.env.
+ */
+export function resolveRouting(
+  toml: Record<string, unknown> | undefined,
+  env: Record<string, string | undefined> = process.env,
+): PiRoutingConfig {
+  const t = toml ?? {};
+  const tomlStr = (key: string): string | undefined => {
+    const v = t[key];
+    return typeof v === "string" ? clean(v) : undefined;
+  };
+  return {
+    primaryModel: clean(env[ENV_PRIMARY_MODEL]) ?? tomlStr("primary_model"),
+    imageModel: clean(env[ENV_IMAGE_MODEL]) ?? tomlStr("image_model"),
+    codingModel: clean(env[ENV_CODING_MODEL]) ?? tomlStr("coding_model"),
+  };
+}
+
+/**
+ * The operator's wizard answers, BEFORE multimodal auto-skip is applied.
+ * `imageModel` here is whatever they picked; `computeRoutingWrites` drops it
+ * when the primary is multimodal.
+ */
+export interface RoutingChoices {
+  primaryModel: string;
+  /** May be set even for a multimodal primary; auto-skip discards it. */
+  imageModel?: string;
+  codingModel?: string;
+  /**
+   * Whether the chosen primary accepts image input. When true, the image
+   * model is DROPPED regardless of what `imageModel` holds — the central
+   * "skip image model when multimodal" rule, applied in exactly one place.
+   */
+  primaryMultimodal: boolean;
+}
+
+/** The concrete writes the wizard should persist. */
+export interface RoutingWrites {
+  /** Values to set in config.toml's [harnesses.pi.routing]. */
+  toml: { primary_model: string; image_model?: string; coding_model?: string };
+  /**
+   * Env vars to write to ~/.env. A value of "" means UNSET (delete the key) —
+   * matching `phantombot env unset` / updateEnvFile's empty-string semantics,
+   * so a previously-set image model is cleared when the new primary is
+   * multimodal.
+   */
+  env: Record<string, string>;
+}
+
+/**
+ * Turn the operator's choices into the exact set of TOML + env writes,
+ * applying the multimodal auto-skip. This is the single source of truth for
+ * the "skip image model when multimodal" behavior — the TUI just collects
+ * answers and hands them here, and the tests pin this function directly.
+ */
+export function computeRoutingWrites(choices: RoutingChoices): RoutingWrites {
+  const primary = choices.primaryModel.trim();
+  const coding = clean(choices.codingModel);
+  // Auto-skip: a multimodal primary never gets an image delegate.
+  const image = choices.primaryMultimodal ? undefined : clean(choices.imageModel);
+
+  const toml: RoutingWrites["toml"] = { primary_model: primary };
+  if (image) toml.image_model = image;
+  if (coding) toml.coding_model = coding;
+
+  // "" clears the key (updateEnvFile delete semantics). We always write all
+  // three keys so switching from a non-multimodal to a multimodal primary
+  // actively removes a stale PHANTOMBOT_IMAGE_MODEL rather than leaving it.
+  const env: Record<string, string> = {
+    [ENV_PRIMARY_MODEL]: primary,
+    [ENV_IMAGE_MODEL]: image ?? "",
+    [ENV_CODING_MODEL]: coding ?? "",
+  };
+
+  return { toml, env };
+}

--- a/tests/cli-harness-routing.test.ts
+++ b/tests/cli-harness-routing.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyRouting } from "../src/cli/harness.ts";
+import { loadEnvFile } from "../src/lib/envFile.ts";
+import { readConfigToml } from "../src/lib/configWriter.ts";
+
+let workdir: string;
+let configPath: string;
+let envPath: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-route-"));
+  configPath = join(workdir, "config.toml");
+  envPath = join(workdir, ".env");
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("applyRouting", () => {
+  test("text-only primary writes all three models to toml + env", async () => {
+    await applyRouting(
+      configPath,
+      {
+        primaryModel: "deepseek-v4-pro",
+        imageModel: "gpt-4o",
+        codingModel: "gpt-5.2-codex",
+        primaryMultimodal: false,
+      },
+      envPath,
+    );
+
+    const toml = await readConfigToml(configPath);
+    expect(toml).toMatchObject({
+      harnesses: {
+        pi: {
+          routing: {
+            primary_model: "deepseek-v4-pro",
+            image_model: "gpt-4o",
+            coding_model: "gpt-5.2-codex",
+          },
+        },
+      },
+    });
+
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_PRIMARY_MODEL).toBe("deepseek-v4-pro");
+    expect(env.PHANTOMBOT_IMAGE_MODEL).toBe("gpt-4o");
+    expect(env.PHANTOMBOT_CODING_MODEL).toBe("gpt-5.2-codex");
+  });
+
+  test("multimodal primary omits image model from toml and env", async () => {
+    await applyRouting(
+      configPath,
+      {
+        primaryModel: "gpt-5.2",
+        imageModel: "gpt-4o",
+        codingModel: "gpt-5.2-codex",
+        primaryMultimodal: true,
+      },
+      envPath,
+    );
+
+    const routing = (
+      (await readConfigToml(configPath)).harnesses as Record<string, any>
+    ).pi.routing;
+    expect(routing.primary_model).toBe("gpt-5.2");
+    expect(routing.coding_model).toBe("gpt-5.2-codex");
+    expect("image_model" in routing).toBe(false);
+
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_PRIMARY_MODEL).toBe("gpt-5.2");
+    // "" deletes the key in updateEnvFile, so it must be absent.
+    expect("PHANTOMBOT_IMAGE_MODEL" in env).toBe(false);
+  });
+
+  test("switching to a multimodal primary clears a previously-set image model", async () => {
+    // First: text-only primary with an image model.
+    await applyRouting(
+      configPath,
+      {
+        primaryModel: "deepseek-v4-pro",
+        imageModel: "gpt-4o",
+        primaryMultimodal: false,
+      },
+      envPath,
+    );
+    expect((await loadEnvFile(envPath)).PHANTOMBOT_IMAGE_MODEL).toBe("gpt-4o");
+
+    // Then: switch to a multimodal primary — the stale image model must go.
+    await applyRouting(
+      configPath,
+      { primaryModel: "gpt-5.2", imageModel: "gpt-4o", primaryMultimodal: true },
+      envPath,
+    );
+
+    const routing = (
+      (await readConfigToml(configPath)).harnesses as Record<string, any>
+    ).pi.routing;
+    expect("image_model" in routing).toBe(false);
+    expect("PHANTOMBOT_IMAGE_MODEL" in (await loadEnvFile(envPath))).toBe(false);
+  });
+
+  test("preserves unrelated config keys (does not clobber the chain)", async () => {
+    const { applyHarnessChain } = await import("../src/cli/harness.ts");
+    await applyHarnessChain(configPath, ["pi", "claude"]);
+    await applyRouting(
+      configPath,
+      { primaryModel: "gpt-5.2", primaryMultimodal: true },
+      envPath,
+    );
+    const toml = await readConfigToml(configPath);
+    expect((toml.harnesses as Record<string, any>).chain).toEqual(["pi", "claude"]);
+    expect((toml.harnesses as Record<string, any>).pi.routing.primary_model).toBe(
+      "gpt-5.2",
+    );
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -32,6 +32,9 @@ const ENV_KEYS = [
   "PHANTOMBOT_CLAUDE_FALLBACK_MODEL",
   "PHANTOMBOT_PI_BIN",
   "PHANTOMBOT_PI_MAX_PAYLOAD",
+  "PHANTOMBOT_PRIMARY_MODEL",
+  "PHANTOMBOT_IMAGE_MODEL",
+  "PHANTOMBOT_CODING_MODEL",
   "PHANTOMBOT_CODEX_BIN",
   "PHANTOMBOT_CODEX_MODEL",
   "PHANTOMBOT_RETRIEVAL_ENABLED",
@@ -101,6 +104,8 @@ describe("loadConfig — defaults (no file)", () => {
     expect(c.harnesses.pi).toEqual({
       bin: "pi",
       maxPayloadBytes: 1_500_000,
+      // No routing configured by default → field is undefined (optional).
+      routing: undefined,
     });
     expect(c.harnesses.codex).toEqual({
       bin: "codex",
@@ -200,6 +205,48 @@ bin = "/opt/pi"
     const c = await loadConfig();
 
     expect(c.harnesses.pi.bin).toBe("/opt/pi");
+  });
+
+  test("reads [harnesses.pi.routing] capability-routing models", async () => {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(
+      join(cfgDir, "config.toml"),
+      `[harnesses.pi.routing]
+primary_model = "deepseek-v4-pro"
+image_model = "gpt-4o"
+coding_model = "gpt-5.2-codex"
+`,
+      "utf8",
+    );
+    const c = await loadConfig();
+    expect(c.harnesses.pi.routing).toEqual({
+      primaryModel: "deepseek-v4-pro",
+      imageModel: "gpt-4o",
+      codingModel: "gpt-5.2-codex",
+    });
+  });
+
+  test("PHANTOMBOT_*_MODEL env vars override [harnesses.pi.routing]", async () => {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(
+      join(cfgDir, "config.toml"),
+      `[harnesses.pi.routing]
+primary_model = "toml-primary"
+image_model = "toml-image"
+`,
+      "utf8",
+    );
+    process.env.PHANTOMBOT_PRIMARY_MODEL = "env-primary";
+    const c = await loadConfig();
+    expect(c.harnesses.pi.routing?.primaryModel).toBe("env-primary");
+    expect(c.harnesses.pi.routing?.imageModel).toBe("toml-image");
+  });
+
+  test("routing is undefined when no routing keys are set", async () => {
+    const c = await loadConfig();
+    expect(c.harnesses.pi.routing).toBeUndefined();
   });
 
   test("reads Telegram streaming knobs from [channels.telegram.streaming]", async () => {

--- a/tests/fixtures/fake-pi.sh
+++ b/tests/fixtures/fake-pi.sh
@@ -11,6 +11,8 @@
 #   notfound — exit 127
 #   hang     — sleep forever (for the timeout test)
 #   argv     — echo argv (joined) as a text_delta, exit 0 (arg-shape test)
+#   env      — echo the PHANTOMBOT_*_MODEL env vars as a text_delta, exit 0
+#              (routing env-projection test)
 
 mode="${FAKE_PI_MODE:-normal}"
 
@@ -18,6 +20,12 @@ case "$mode" in
   argv)
     joined="$*"
     printf '%s\n' "{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"argv: ${joined}\",\"partial\":{}},\"message\":{}}"
+    printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
+    exit 0
+    ;;
+  env)
+    joined="primary=${PHANTOMBOT_PRIMARY_MODEL-} image=${PHANTOMBOT_IMAGE_MODEL-} coding=${PHANTOMBOT_CODING_MODEL-}"
+    printf '%s\n' "{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"env: ${joined}\",\"partial\":{}},\"message\":{}}"
     printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
     exit 0
     ;;

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
 import {
   PiHarness,
+  applyRoutingEnv,
   parsePiEvent,
   renderPayload,
 } from "../src/harnesses/pi.ts";
@@ -292,6 +293,80 @@ describe("PiHarness.invoke (subprocess)", () => {
       recoverable: true,
       error: expect.stringContaining("timed out"),
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability routing — argv + env projection (PR #191 review blocker)
+// ---------------------------------------------------------------------------
+
+describe("applyRoutingEnv", () => {
+  test("returns the env unchanged when routing is undefined", () => {
+    const env = { FOO: "bar" };
+    expect(applyRoutingEnv(env, undefined)).toEqual(env);
+  });
+
+  test("projects only the defined models, leaving others untouched", () => {
+    const out = applyRoutingEnv(
+      { EXISTING: "keep" },
+      { primaryModel: "gpt-5.2", codingModel: "qwen-coder" },
+    );
+    expect(out).toEqual({
+      EXISTING: "keep",
+      PHANTOMBOT_PRIMARY_MODEL: "gpt-5.2",
+      PHANTOMBOT_CODING_MODEL: "qwen-coder",
+    });
+    // imageModel was undefined → key not written (no clobber).
+    expect(out).not.toHaveProperty("PHANTOMBOT_IMAGE_MODEL");
+  });
+
+  test("does not mutate the input env", () => {
+    const env = { A: "1" };
+    applyRoutingEnv(env, { primaryModel: "m" });
+    expect(env).toEqual({ A: "1" });
+  });
+});
+
+describe("PiHarness routing (subprocess)", () => {
+  const routed = (routing: { primaryModel?: string; imageModel?: string; codingModel?: string }) =>
+    new PiHarness({ bin: FAKE_PI, maxPayloadBytes: 1_500_000, routing });
+
+  test("routing.primaryModel pins the orchestrator via --model", async () => {
+    process.env.FAKE_PI_MODE = "argv";
+    const chunks = await collect(routed({ primaryModel: "gpt-5.2" }).invoke(newRequest()));
+    const argv = chunks
+      .filter((c) => c.type === "text")
+      .map((c) => (c as { text: string }).text)
+      .join("");
+    expect(argv).toContain("--model gpt-5.2");
+  });
+
+  test("no routing → no --model flag", async () => {
+    process.env.FAKE_PI_MODE = "argv";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    const argv = chunks
+      .filter((c) => c.type === "text")
+      .map((c) => (c as { text: string }).text)
+      .join("");
+    expect(argv).not.toContain("--model");
+  });
+
+  test("resolved delegate models reach the spawned Pi env", async () => {
+    process.env.FAKE_PI_MODE = "env";
+    const chunks = await collect(
+      routed({
+        primaryModel: "gpt-5.2",
+        imageModel: "vision-x",
+        codingModel: "qwen-coder",
+      }).invoke(newRequest()),
+    );
+    const out = chunks
+      .filter((c) => c.type === "text")
+      .map((c) => (c as { text: string }).text)
+      .join("");
+    expect(out).toContain("primary=gpt-5.2");
+    expect(out).toContain("image=vision-x");
+    expect(out).toContain("coding=qwen-coder");
   });
 });
 

--- a/tests/lib-piModels.test.ts
+++ b/tests/lib-piModels.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import {
+  findModel,
+  listPiModels,
+  parsePiModels,
+  primaryIsMultimodal,
+} from "../src/lib/piModels.ts";
+
+// A trimmed but faithful sample of real `pi --list-models` output: a banner
+// line before the header, blank lines, the `~`-prefixed openrouter aliases,
+// and a mix of yes/no in the images column.
+const SAMPLE = `pi 0.79.1
+
+provider    model                          context  max-out  thinking  images
+deepseek    deepseek-v4-flash              1M       384K     yes       no
+openai      gpt-4                          8.2K     8.2K     no        no
+openai      gpt-5.2                        400K     128K     yes       yes
+openrouter  ~anthropic/claude-opus-latest  1M       128K     yes       yes
+openrouter  amazon/nova-micro-v1           128K     5.1K     no        no
+`;
+
+describe("parsePiModels", () => {
+  test("parses provider, model and image capability", () => {
+    const models = parsePiModels(SAMPLE);
+    expect(models).toHaveLength(5);
+    expect(models[0]).toEqual({
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      supportsImages: false,
+    });
+    const gpt = findModel(models, "gpt-5.2");
+    expect(gpt?.supportsImages).toBe(true);
+  });
+
+  test("preserves the ~ prefix on openrouter aliases verbatim", () => {
+    const models = parsePiModels(SAMPLE);
+    const opus = findModel(models, "~anthropic/claude-opus-latest");
+    expect(opus).toBeDefined();
+    expect(opus?.supportsImages).toBe(true);
+  });
+
+  test("reads the images column positionally (last token)", () => {
+    const models = parsePiModels(SAMPLE);
+    expect(findModel(models, "gpt-4")?.supportsImages).toBe(false);
+    expect(findModel(models, "amazon/nova-micro-v1")?.supportsImages).toBe(false);
+  });
+
+  test("returns [] when the header is absent (output changed / pi missing)", () => {
+    expect(parsePiModels("some unrelated\noutput\n")).toEqual([]);
+    expect(parsePiModels("")).toEqual([]);
+  });
+
+  test("skips blank lines and short/wrapped rows", () => {
+    const text = `provider model context max-out thinking images
+openai gpt-5.2 400K 128K yes yes
+
+wrapped-continuation
+`;
+    const models = parsePiModels(text);
+    expect(models).toHaveLength(1);
+    expect(models[0]?.model).toBe("gpt-5.2");
+  });
+});
+
+describe("primaryIsMultimodal", () => {
+  test("true when the primary supports images", () => {
+    const models = parsePiModels(SAMPLE);
+    expect(primaryIsMultimodal(models, "gpt-5.2")).toBe(true);
+  });
+
+  test("false when the primary is text-only", () => {
+    const models = parsePiModels(SAMPLE);
+    expect(primaryIsMultimodal(models, "gpt-4")).toBe(false);
+  });
+
+  test("false (conservative) when the primary is unknown", () => {
+    const models = parsePiModels(SAMPLE);
+    expect(primaryIsMultimodal(models, "not-a-real-model")).toBe(false);
+  });
+});
+
+describe("listPiModels", () => {
+  test("parses via an injected runner", async () => {
+    const models = await listPiModels("pi", async () => ({
+      exitCode: 0,
+      stdout: SAMPLE,
+    }));
+    expect(models).toHaveLength(5);
+    expect(findModel(models, "gpt-5.2")?.supportsImages).toBe(true);
+  });
+
+  test("returns [] on non-zero exit", async () => {
+    const models = await listPiModels("pi", async () => ({
+      exitCode: 1,
+      stdout: SAMPLE,
+    }));
+    expect(models).toEqual([]);
+  });
+
+  test("returns [] when the runner throws (pi not installed)", async () => {
+    const models = await listPiModels("pi", async () => {
+      throw new Error("ENOENT");
+    });
+    expect(models).toEqual([]);
+  });
+});

--- a/tests/lib-piRouting.test.ts
+++ b/tests/lib-piRouting.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computeRoutingWrites,
+  ENV_CODING_MODEL,
+  ENV_IMAGE_MODEL,
+  ENV_PRIMARY_MODEL,
+  resolveRouting,
+} from "../src/lib/piRouting.ts";
+
+describe("resolveRouting", () => {
+  test("env wins over toml", () => {
+    const r = resolveRouting(
+      { primary_model: "toml-primary", image_model: "toml-image" },
+      {
+        [ENV_PRIMARY_MODEL]: "env-primary",
+        [ENV_IMAGE_MODEL]: "",
+        [ENV_CODING_MODEL]: undefined,
+      },
+    );
+    expect(r.primaryModel).toBe("env-primary");
+    // empty env string falls through to toml (treated as unset)
+    expect(r.imageModel).toBe("toml-image");
+    expect(r.codingModel).toBeUndefined();
+  });
+
+  test("reads from toml when env is empty", () => {
+    const r = resolveRouting(
+      {
+        primary_model: "gpt-5.2",
+        image_model: "gpt-4o",
+        coding_model: "gpt-5.2-codex",
+      },
+      {},
+    );
+    expect(r).toEqual({
+      primaryModel: "gpt-5.2",
+      imageModel: "gpt-4o",
+      codingModel: "gpt-5.2-codex",
+    });
+  });
+
+  test("all undefined when nothing is set", () => {
+    expect(resolveRouting(undefined, {})).toEqual({
+      primaryModel: undefined,
+      imageModel: undefined,
+      codingModel: undefined,
+    });
+  });
+
+  test("trims whitespace and treats blank as unset", () => {
+    const r = resolveRouting(
+      {},
+      { [ENV_PRIMARY_MODEL]: "  gpt-5.2  ", [ENV_IMAGE_MODEL]: "   " },
+    );
+    expect(r.primaryModel).toBe("gpt-5.2");
+    expect(r.imageModel).toBeUndefined();
+  });
+});
+
+describe("computeRoutingWrites — multimodal auto-skip", () => {
+  test("multimodal primary DROPS the image model in both toml and env", () => {
+    const w = computeRoutingWrites({
+      primaryModel: "gpt-5.2",
+      imageModel: "gpt-4o", // user picked one, but...
+      codingModel: "gpt-5.2-codex",
+      primaryMultimodal: true, // ...primary is multimodal → skip
+    });
+    expect(w.toml).toEqual({
+      primary_model: "gpt-5.2",
+      coding_model: "gpt-5.2-codex",
+    });
+    expect(w.toml.image_model).toBeUndefined();
+    // env writes "" for image → unset (clears any stale value)
+    expect(w.env[ENV_IMAGE_MODEL]).toBe("");
+    expect(w.env[ENV_PRIMARY_MODEL]).toBe("gpt-5.2");
+    expect(w.env[ENV_CODING_MODEL]).toBe("gpt-5.2-codex");
+  });
+
+  test("text-only primary KEEPS the image model", () => {
+    const w = computeRoutingWrites({
+      primaryModel: "deepseek-v4-pro",
+      imageModel: "gpt-4o",
+      codingModel: "gpt-5.2-codex",
+      primaryMultimodal: false,
+    });
+    expect(w.toml.image_model).toBe("gpt-4o");
+    expect(w.env[ENV_IMAGE_MODEL]).toBe("gpt-4o");
+  });
+
+  test("omitted coding/image models produce unset env and absent toml keys", () => {
+    const w = computeRoutingWrites({
+      primaryModel: "deepseek-v4-pro",
+      primaryMultimodal: false,
+    });
+    expect(w.toml).toEqual({ primary_model: "deepseek-v4-pro" });
+    expect(w.env[ENV_IMAGE_MODEL]).toBe("");
+    expect(w.env[ENV_CODING_MODEL]).toBe("");
+  });
+});

--- a/tests/pi-extension-tools.test.ts
+++ b/tests/pi-extension-tools.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the capability-routing Pi extension's pure registration logic.
+ * We test `planRouting` (which decides which tools register) directly, without
+ * the @earendil-works Pi SDK on the import path — the extension's index.ts
+ * (the SDK glue) is verified manually against a live pi via /reload.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  coderDelegationPrompt,
+  imageDelegationPrompt,
+  planRouting,
+} from "../pi-extension/capability-routing/tools.ts";
+
+describe("planRouting — tool registration decisions", () => {
+  test("registers both tools when image and coding models are set", () => {
+    const plan = planRouting({
+      PHANTOMBOT_PRIMARY_MODEL: "deepseek-v4-pro",
+      PHANTOMBOT_IMAGE_MODEL: "gpt-4o",
+      PHANTOMBOT_CODING_MODEL: "gpt-5.2-codex",
+    });
+    expect(plan.registerLookAtImage).toBe(true);
+    expect(plan.registerCoder).toBe(true);
+    expect(plan.imageModel).toBe("gpt-4o");
+    expect(plan.codingModel).toBe("gpt-5.2-codex");
+  });
+
+  test("does NOT register look_at_image when image model is unset (multimodal primary)", () => {
+    const plan = planRouting({
+      PHANTOMBOT_PRIMARY_MODEL: "gpt-5.2",
+      PHANTOMBOT_CODING_MODEL: "gpt-5.2-codex",
+      // no PHANTOMBOT_IMAGE_MODEL — primary is multimodal
+    });
+    expect(plan.registerLookAtImage).toBe(false);
+    expect(plan.registerCoder).toBe(true);
+  });
+
+  test("treats empty string as unset", () => {
+    const plan = planRouting({
+      PHANTOMBOT_IMAGE_MODEL: "",
+      PHANTOMBOT_CODING_MODEL: "   ",
+    });
+    expect(plan.registerLookAtImage).toBe(false);
+    expect(plan.registerCoder).toBe(false);
+  });
+
+  test("registers nothing when no models are set", () => {
+    const plan = planRouting({});
+    expect(plan.registerLookAtImage).toBe(false);
+    expect(plan.registerCoder).toBe(false);
+    expect(plan.primaryModel).toBeUndefined();
+  });
+});
+
+describe("delegation prompts", () => {
+  test("image prompt is question-driven and embeds path + question", () => {
+    const prompt = imageDelegationPrompt("/tmp/x.png", "How many people are in this photo?");
+    expect(prompt).toContain("/tmp/x.png");
+    expect(prompt).toContain("How many people are in this photo?");
+    expect(prompt).toContain("answer the question");
+  });
+
+  test("coder prompt signals coarse-grained / fresh-process semantics", () => {
+    const prompt = coderDelegationPrompt("Add input validation to the API.");
+    expect(prompt).toContain("Add input validation to the API.");
+    expect(prompt.toLowerCase()).toContain("coarse-grained");
+    expect(prompt).toContain("edit, bash, and write");
+  });
+});


### PR DESCRIPTION
## Capability routing for Pi-based agents

### The problem
No single cheap model is great at reasoning **and** vision **and** coding. Today the Pi harness runs one model per turn. This PR lets a strong-but-narrow **primary** model delegate specialist subtasks **within a turn** to an **image** model and a **coding** model.

This is **capability routing** — distinct from the existing primary→fallback harness `chain`, which is **failover** (try the next harness when one dies). The failover chain is **untouched**.

### Wizard flow (`phantombot harness`)
After the existing chain step, when `pi` is in the chain:
1. **"Model: use configured defaults?"** — default-answer leaves routing exactly as-is (no override). Choosing defaults is a successful no-op.
2. If not defaults: pick **primary**, then **image**, then **coding** model. The picker is populated from `pi --list-models` (parsed from the table — there is no JSON flag), so only actually-available models are offered. Falls back to free-text entry if pi can't be queried.
3. **Multimodal auto-skip (key behavior):** if the chosen primary accepts image input (the `images` column), the wizard **does not ask for an image model** and clears any previously-set one.

Choices persist to `config.toml` under `[harnesses.pi.routing]` **and** to `~/.env` (the `PHANTOMBOT_*_MODEL` vars), via the same atomic-write paths phantombot already uses (`updateConfigToml` + `updateEnvFile`).

### Extension architecture (`pi-extension/capability-routing/`)
Built as a **Pi extension** (no fork/patch of Pi core), mirroring pi's own `examples/extensions/subagent/`:
- `index.ts` — registers tools per the env contract.
- `tools.ts` — pure registration-decision logic + delegation prompts (unit-tested from phantombot's `bun test`; no Pi SDK on the import path).
- `spawnPi.ts` — spawns a child `pi --mode json -p --no-session --model <m> --tools <...>` and captures structured output (messages, usage, cost, stop reason).
- `agents/coder.md` — coder agent template (`tools: edit,bash,write`; model pinned at runtime from `PHANTOMBOT_CODING_MODEL`).

Tools:
- **`look_at_image(path, question)`** — registered **only** when `PHANTOMBOT_IMAGE_MODEL` is set (i.e. the primary is *not* multimodal). Question-driven vision Q&A, not a one-shot describe.
- **`coder(task, cwd?)`** — registered when `PHANTOMBOT_CODING_MODEL` is set. Spawns the coding model for a PR/MR-scoped job/review; surfaces usage/cost back to the parent.

The extension ships in-repo but is **not bundled into the phantombot binary** (it lives outside `src/`); it's symlinked into `~/.pi/agent/extensions/` (survives `pi update`, hot-reloads with `/reload`).

### Env-var contract
| Var | Meaning |
|-----|---------|
| `PHANTOMBOT_PRIMARY_MODEL` | Orchestrator model id (bare name as printed by `pi --list-models`). |
| `PHANTOMBOT_IMAGE_MODEL` | Vision delegate. **Set only when the primary is not multimodal.** Unset ⇒ `look_at_image` not registered. |
| `PHANTOMBOT_CODING_MODEL` | Coding delegate for `coder`. Unset ⇒ `coder` not registered. |

Empty string = unset. Mirrored into `[harnesses.pi.routing]`; **env wins over TOML**, matching every other phantombot setting. phantombot's pi harness already exports its environment to the child `pi` process, so the extension needs zero knowledge of phantombot's config files. Full contract documented in `src/lib/piRouting.ts` and the extension README.

### Caveats / decisions
- **`coder` is coarse-grained:** each call spawns a **fresh `pi` process** (expensive startup). It's for big self-contained chunks/reviews, not chatty round-trips.
- **Unknown primary ⇒ conservative:** if the chosen primary isn't in the parsed model list, `primaryIsMultimodal` returns `false`, so the image model is still offered (better to over-provision than silently lose vision).
- **`pi --list-models` is parsed from the table** (no JSON output exists for it). Parser is defensive: it anchors on the header row and returns `[]` if the format changes, degrading the wizard to free-text entry rather than mis-parsing.
- The extension was typechecked against pi's installed `@earendil-works/*` types out-of-tree (it can't be part of phantombot's tsc program, which has no Pi deps).

### Tests
New: `lib-piModels`, `lib-piRouting`, `cli-harness-routing`, `pi-extension-tools`, plus routing cases added to `config`. Cover: table parsing + `~`-prefix preservation + images-column detection, multimodal auto-skip, wizard persistence (incl. clearing a stale image model on a multimodal switch), config load precedence, and extension tool-registration branching.

- **Typecheck:** `bun tsc --noEmit` → clean.
- **Tests:** `bun test` → **1312 pass / 1 skip / 0 fail** (baseline main: 1281 pass / 1 skip / 0 fail; +31 new).

**Do not merge — for review.**