### PR TITLE
feat(phantomchat): stream reply as progress bubbles like Telegram

### DIFF
--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -3,18 +3,22 @@
  *
  * The phantomchat analogue of `runTelegramServer`: consume the channel's
  * inbound stream (`channel.listen()`), apply the AUTH GATE, run the
- * channel-agnostic `runTurn`, accumulate the full reply, and publish it back
- * as a NIP-17 DM. It runs ALONGSIDE the Telegram listeners (see cli/run.ts).
+ * channel-agnostic `runTurn`, and stream the reply back as a sequence of
+ * NIP-17 bubbles. It runs ALONGSIDE the Telegram listeners (see cli/run.ts).
  *
  * Differences from Telegram, by design:
- *   - No streaming / segmenting. Nostr DMs are single messages, so we
- *     accumulate the whole reply and send it once (toolNarration OFF).
- *   - No slash commands, groups, voice, or attachments.
+ *   - Same streaming model as Telegram: the reply is split into markdown-aware
+ *     bubbles by the shared StreamSegmenter and progress narration
+ *     ("checking your calendar…") is sent as its own bubbles before tool calls
+ *     (toolNarration ON), so the user sees live progress instead of one long
+ *     wait. Each bubble is its own NIP-17 wrap.
+ *   - No slash commands, voice, or attachments (groups ARE supported).
  *   - The trust perimeter gates on the CRYPTOGRAPHIC sender (rumor.pubkey,
  *     surfaced as `senderId`), never on the envelope `from` field.
  */
 
 import type { Config } from "../../config.ts";
+import { DEFAULT_TELEGRAM_STREAMING } from "../../config.ts";
 import type { Harness } from "../../harnesses/types.ts";
 import type { WriteSink } from "../../lib/io.ts";
 import { log } from "../../lib/logger.ts";
@@ -25,6 +29,10 @@ import { makeScreener } from "../../orchestrator/screen.ts";
 import { makeTurnIndexer } from "../../orchestrator/turnIndexer.ts";
 import { TELEGRAM_REPLY_INSTRUCTION, voiceUnavailableMessage } from "../core/prompts.ts";
 import type { Channel, ChannelMessage } from "../core/types.ts";
+import {
+  splitIntoSegments,
+  StreamSegmenter,
+} from "../streamSegmenter.ts";
 import type { PhantomchatTransport } from "./transport.ts";
 import { sttSupport, transcribe } from "../../lib/audio.ts";
 import { DEFAULT_STT_TIMEOUT_MS } from "../../lib/voice.ts";
@@ -37,6 +45,12 @@ import { join } from "node:path";
 // Don't download absurdly large attachments. The harness reads from the inbox;
 // a multi-hundred-MB blob would blow memory + disk for little benefit.
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+// Local sleep — spaces out consecutive bubbles so the PWA renders them as a
+// readable sequence rather than a single burst (mirrors core/engine.ts).
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 // Map a mime type to a file extension for the inbox filename (the envelope
 // carries no original name). Falls back to the mime subtype, then the kind.
@@ -344,10 +358,27 @@ export async function runPhantomchatServer(
       ? `phantomchat:group:${msg.groupId}`
       : `phantomchat:${senderHex}`;
 
-    let reply = "";
-    // Typing indicator. Unlike Telegram's streaming engine (which refreshes the
-    // indicator on every chunk), this loop sends a single message at the end —
-    // so we drive the typing tick ourselves. The PWA shows three-dots on each
+    const streaming =
+      input.config.telegramStreaming ?? DEFAULT_TELEGRAM_STREAMING;
+    const segmenterOptions = {
+      maxSentences: streaming.bubbleMaxSentences,
+      maxChars: streaming.bubbleMaxChars,
+    };
+    // Streaming accumulators — mirror core/engine.ts so the PWA gets the same
+    // progressive bubbles Telegram does. `streamedReply` is the running sum of
+    // text chunks; `consumedReplyChars` is the prefix already delivered as a
+    // final bubble OR classified as progress narration and dropped from the
+    // answer; `narrationBuffer` holds classified narration awaiting the timed
+    // flush; `finalSegmenter` is the markdown-aware live splitter.
+    let streamedReply = "";
+    let consumedReplyChars = 0;
+    let narrationBuffer = "";
+    let finalSegmenter = new StreamSegmenter(segmenterOptions);
+    let finalCandidateText = "";
+    let finalCandidateSentChars = 0;
+    let finalReply: string | undefined;
+    let lastNarrationFlushAt = Date.now();
+    // Typing indicator. The PWA shows three-dots on each
     // ephemeral kind-20001 event and auto-expires it after ~6s, so we refresh
     // every 2s for the whole turn. A plain interval (rather than per-chunk)
     // keeps the dots alive through long tool-call gaps where runTurn emits no
@@ -374,7 +405,63 @@ export async function runPhantomchatServer(
         ? void transport.sendGroupTyping(msg.groupId, groupTypingMembers!)
         : void transport.sendTyping(senderHex);
     const firstTypingTick = setTimeout(sendTypingTick, 0);
-    const typingTimer = setInterval(sendTypingTick, 2000);
+
+    // Publish one chat bubble — a progress/narration line or a slice of the
+    // final answer — routed to the group broadcast or the 1:1 DM exactly like
+    // the final reply path. groupTypingMembers is the same set the reply path
+    // broadcasts to (inbound p-tags ∪ { sender }). Best-effort: a failed bubble
+    // is logged, not thrown, so one dropped progress line never aborts the turn.
+    const sendBubble = async (text: string): Promise<void> => {
+      if (text.trim().length === 0) return;
+      try {
+        if (msg.groupId) {
+          await transport.sendGroupMessage(
+            msg.groupId,
+            groupTypingMembers!,
+            text,
+          );
+        } else {
+          // transport.sendMessage NIP-17-wraps the plaintext to `senderHex`
+          // and publishes both wraps. conversationId === recipient hex pubkey.
+          await transport.sendMessage(senderHex, text);
+        }
+      } catch (e) {
+        log.warn("phantomchat: bubble send failed", {
+          error: (e as Error).message,
+          sender: senderHex.slice(0, 12) + "…",
+        });
+      }
+    };
+
+    // Flush coalesced progress narration on a clock (like core/engine.ts), not
+    // on every tool boundary — tool boundaries classify preceding text as
+    // narration; this decides when that text becomes a bubble. Driven by both
+    // the typing interval below and the chunk boundaries in the loop.
+    const flushNarration = async (force = false): Promise<void> => {
+      if (narrationBuffer.trim().length === 0) return;
+      const now = Date.now();
+      if (!force && now - lastNarrationFlushAt < streaming.narrationFlushMs) {
+        return;
+      }
+      const pending = narrationBuffer;
+      narrationBuffer = "";
+      lastNarrationFlushAt = now;
+      await sendBubble(pending);
+    };
+
+    const resetFinalCandidate = (): void => {
+      finalSegmenter = new StreamSegmenter(segmenterOptions);
+      finalCandidateText = "";
+      finalCandidateSentChars = 0;
+    };
+
+    // Refresh the typing dots every 2s AND flush any pending narration, so a
+    // long tool run (during which runTurn emits no chunks) still surfaces the
+    // "working on…" line buffered before the tool started.
+    const typingTimer = setInterval(() => {
+      sendTypingTick();
+      void flushNarration();
+    }, 2000);
     try {
       for await (const chunk of runTurn({
         persona: input.persona,
@@ -416,12 +503,42 @@ export async function runPhantomchatServer(
         // is on a phone-style chat client here too. No voice overlay (Nostr
         // DMs are text only).
         systemPromptSuffix: TELEGRAM_REPLY_INSTRUCTION,
-        // No live stream to fill: we send one message at the end, so pre-tool
-        // narration would just bloat the reply.
-        toolNarration: false,
+        // Pre-tool narration ON: the user now sees streamed bubbles, so a
+        // "checking your calendar…" line before a tool call usefully fills the
+        // silence — same as Telegram's text-out path.
+        toolNarration: true,
       })) {
-        if (chunk.type === "text") reply += chunk.text;
-        if (chunk.type === "done") reply = chunk.finalText;
+        if (chunk.type === "text") {
+          streamedReply += chunk.text;
+          finalCandidateText += chunk.text;
+          // Markdown-aware splitter: emit only completed sentence/block
+          // boundaries as bubbles; partial text stays buffered until it is.
+          const { segments } = finalSegmenter.push(chunk.text);
+          for (const segment of segments) {
+            await sendBubble(segment);
+            consumedReplyChars += segment.length;
+            finalCandidateSentChars += segment.length;
+            if (streaming.bubbleDelayMs > 0) {
+              await sleep(streaming.bubbleDelayMs);
+            }
+          }
+        }
+        if (chunk.type === "heartbeat") {
+          // Tool completed or model is thinking — a chance to surface narration.
+          await flushNarration();
+        }
+        if (chunk.type === "progress") {
+          // A tool is about to run. Text emitted since the last boundary that
+          // the splitter hasn't already sent as a final bubble is progress
+          // narration ("checking your calendar…"): buffer it for the timed
+          // flush, then consume it so it is not duplicated in the final answer.
+          const unsent = finalCandidateText.slice(finalCandidateSentChars);
+          if (unsent.trim().length > 0) narrationBuffer += unsent;
+          consumedReplyChars = streamedReply.length;
+          resetFinalCandidate();
+          await flushNarration();
+        }
+        if (chunk.type === "done") finalReply = chunk.finalText;
       }
     } catch (e) {
       log.warn("phantomchat: turn failed", {
@@ -443,38 +560,37 @@ export async function runPhantomchatServer(
       }
     }
 
-    const finalReply = reply.trim();
-    if (finalReply.length === 0) return;
+    // After live streaming, send only what the user hasn't seen yet. If the
+    // consumed prefix matches the authoritative reply, send just the suffix; if
+    // the harness reformatted (prefix mismatch), send the whole thing, accepting
+    // some duplication over truncating. Mirrors core/engine.ts. Empty outText is
+    // intentional silence — progress/final bubbles already delivered everything,
+    // or the reply was genuinely empty (original behaviour: stay silent).
+    //
+    // sendBubble routes group-broadcast vs 1:1 DM exactly like the old single-
+    // shot path did: a group reply is reconstructed from the inbound rumor
+    // (inbound p-tags ∪ { sender }) since the bridge holds no group DB, and
+    // sendGroupMessage adds our self-wrap and defensively drops our own hex.
+    const fullReply = finalReply ?? streamedReply;
+    let outText: string;
+    if (fullReply.trim().length === 0) {
+      outText = "";
+    } else if (
+      consumedReplyChars > 0 &&
+      fullReply.startsWith(streamedReply.slice(0, consumedReplyChars))
+    ) {
+      outText = fullReply.slice(consumedReplyChars);
+    } else {
+      outText = fullReply;
+    }
+    if (outText.trim().length === 0) return;
 
-    try {
-      if (msg.groupId) {
-        // GROUP REPLY. Broadcast back into the group instead of DMing the
-        // sender (the HQ bug was replying 1:1). The bridge holds no group DB, so
-        // the outbound member set is reconstructed from the inbound rumor:
-        //
-        //   full group  = inbound p-tags ∪ { sender }      (the PWA omits the
-        //                                                    sender from its own
-        //                                                    p-tags)
-        //   others (us excluded) = full group \ { us }
-        //
-        // wrapGroupMessage adds OUR self-wrap, so we pass it everyone-but-us.
-        // (sendGroupMessage defensively drops our own hex if it appears here.)
-        const others = new Set<string>(msg.groupMemberHexes ?? []);
-        // Add the original sender back: the PWA omits the sender from its own
-        // p-tags, so without this the sender wouldn't receive our reply.
-        others.add(senderHex.toLowerCase());
-        const memberHexes = [...others];
-        await transport.sendGroupMessage(msg.groupId, memberHexes, finalReply);
-      } else {
-        // transport.sendMessage NIP-17-wraps the plaintext to `senderHex` and
-        // publishes both wraps. conversationId === recipient hex pubkey.
-        await transport.sendMessage(senderHex, finalReply);
+    const finalSegments = splitIntoSegments(outText, segmenterOptions);
+    for (let i = 0; i < finalSegments.length; i++) {
+      await sendBubble(finalSegments[i]!);
+      if (i < finalSegments.length - 1 && streaming.bubbleDelayMs > 0) {
+        await sleep(streaming.bubbleDelayMs);
       }
-    } catch (e) {
-      log.warn("phantomchat: reply publish failed", {
-        error: (e as Error).message,
-        sender: senderHex.slice(0, 12) + "…",
-      });
     }
   };
 

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -13,7 +13,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
 
-import { type Config } from "../src/config.ts";
+import {
+  type Config,
+  DEFAULT_TELEGRAM_STREAMING,
+  type TelegramStreamingSettings,
+} from "../src/config.ts";
 import type { Harness, HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
 import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
 import { createPhantomchatChannel } from "../src/channels/phantomchat/channel.ts";
@@ -139,6 +143,12 @@ async function runOnce(opts: {
   text: string;
   tofu?: boolean;
   persistTrust?: (senderHex: string) => Promise<void>;
+  // Override the streaming config (bubble sizing / delays). Streaming tests set
+  // bubbleMaxSentences=1 + bubbleDelayMs=0 + narrationFlushMs=0 so each sentence
+  // is its own bubble and narration flushes at once — deterministic and fast.
+  streaming?: TelegramStreamingSettings;
+  // How long to let listen() enqueue + the handler drain before aborting.
+  waitMs?: number;
 }): Promise<FakePool> {
   const botHex = getPublicKey(opts.botSk);
   const pool = new FakePool();
@@ -165,9 +175,12 @@ async function runOnce(opts: {
   });
   const { wraps } = wrapNip17Message(opts.senderSk, botHex, envelope);
 
+  const config = baseConfig();
+  if (opts.streaming) config.telegramStreaming = opts.streaming;
+
   const ac = new AbortController();
   const serverPromise = runPhantomchatServer({
-    config: baseConfig(),
+    config,
     memory,
     harnesses: [opts.harness],
     agentDir,
@@ -185,7 +198,7 @@ async function runOnce(opts: {
   pool.feed(wraps[0] as NTNostrEvent);
   // Give the microtask queue a tick so the channel enqueues the message before
   // we abort the listen loop.
-  await new Promise((r) => setTimeout(r, 80));
+  await new Promise((r) => setTimeout(r, opts.waitMs ?? 80));
   ac.abort();
   await serverPromise;
 
@@ -793,5 +806,223 @@ describe("phantomchat group routing (HQ bug)", () => {
     expect(replyWrap).toBeDefined();
     const reply = await unwrapV2(replyWrap! as NTNostrEvent, senderSk);
     expect(reply.tags.find((t) => t[0] === "group")).toBeUndefined();
+  });
+});
+
+/**
+ * Streaming progress bubbles (PR #197). The phantomchat channel now consumes
+ * runTurn's chunks the way Telegram does: text is split into markdown-aware
+ * bubbles by the shared StreamSegmenter, pre-tool narration is flushed as its
+ * own bubble, and the post-loop send emits only the not-yet-seen suffix.
+ *
+ * The existing auth/group tests above use single-`done` scripts, which produce
+ * exactly one bubble through the same path. These exercise the multi-chunk
+ * streaming behaviour directly. All use a 1-sentence-per-bubble config with no
+ * delays so each sentence is its own bubble and narration flushes at once —
+ * deterministic and fast.
+ */
+const STREAM_ONE_PER_SENTENCE: TelegramStreamingSettings = {
+  ...DEFAULT_TELEGRAM_STREAMING,
+  bubbleMaxSentences: 1,
+  bubbleDelayMs: 0,
+  narrationFlushMs: 0,
+};
+
+/** Trimmed contents of the v2 reply bubbles a DM recipient can unwrap, in order. */
+async function dmBubbles(
+  pool: FakePool,
+  recipientSk: Uint8Array,
+): Promise<string[]> {
+  const v2 = pool.published.filter(
+    (e) =>
+      e.kind === 1059 && e.tags.some((t) => t[0] === "v" && t[1] === "pc-v2"),
+  );
+  const out: string[] = [];
+  for (const w of v2) {
+    const r = await unwrapV2(w as NTNostrEvent, recipientSk);
+    out.push(r.content.trim());
+  }
+  return out;
+}
+
+describe("phantomchat streaming bubbles", () => {
+  test("multi-sentence reply streams as one bubble per sentence", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "First sentence. Second sentence. Third sentence." },
+      {
+        type: "done",
+        finalText: "First sentence. Second sentence. Third sentence.",
+      },
+    ]);
+
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "go",
+      streaming: STREAM_ONE_PER_SENTENCE,
+      waitMs: 150,
+    });
+
+    expect(await dmBubbles(pool, senderSk)).toEqual([
+      "First sentence.",
+      "Second sentence.",
+      "Third sentence.",
+    ]);
+  });
+
+  test("text before a progress chunk is flushed as a separate narration bubble", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    // "Checking your calendar" has no sentence terminator, so the segmenter
+    // never sends it as a final bubble. The progress chunk classifies it as
+    // narration and the (unthrottled) flush sends it as its own bubble.
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "Checking your calendar" },
+      { type: "progress", note: "running calendar tool" },
+      { type: "text", text: "You are free at 3pm." },
+      {
+        type: "done",
+        finalText: "Checking your calendarYou are free at 3pm.",
+      },
+    ]);
+
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "am I free at 3?",
+      streaming: STREAM_ONE_PER_SENTENCE,
+      waitMs: 150,
+    });
+
+    // Narration bubble first, answer second — and the narration is consumed,
+    // not duplicated into the final answer.
+    expect(await dmBubbles(pool, senderSk)).toEqual([
+      "Checking your calendar",
+      "You are free at 3pm.",
+    ]);
+  });
+
+  test("final send emits only the unseen suffix (no duplicated bubbles)", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    // "First. " is streamed live; the done chunk's authoritative finalText is
+    // longer. The post-loop send must emit only "Second.", not the whole reply.
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "First. " },
+      { type: "done", finalText: "First. Second." },
+    ]);
+
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "go",
+      streaming: STREAM_ONE_PER_SENTENCE,
+      waitMs: 150,
+    });
+
+    expect(await dmBubbles(pool, senderSk)).toEqual(["First.", "Second."]);
+  });
+
+  test("group reply streams as multiple group broadcasts", async () => {
+    const andrewSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const memberSk = generateSecretKey();
+    const andrewHex = getPublicKey(andrewSk);
+    const botHex = getPublicKey(botSk);
+    const memberHex = getPublicKey(memberSk);
+    const groupId = "hq-stream-test";
+
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "Hello team. Working on it now." },
+      { type: "done", finalText: "Hello team. Working on it now." },
+    ]);
+
+    const pool = new FakePool();
+    const transport = new SimplePoolPhantomchatTransport(
+      botSk,
+      ["wss://test.relay"],
+      pool,
+    );
+    const channel = createPhantomchatChannel({
+      secretKey: botSk,
+      publicKeyHex: botHex,
+      transport,
+    });
+
+    const payload = JSON.stringify({
+      content: "status?",
+      type: "text",
+      id: `grp-${Date.now()}-stream`,
+      timestamp: Date.now(),
+    });
+    const { wraps } = wrapGroupMessage(
+      andrewSk,
+      [botHex, memberHex],
+      payload,
+      groupId,
+    );
+    let inboundForBot: NTNostrEvent | undefined;
+    for (const w of wraps) {
+      try {
+        unwrapNip17Message(w as NTNostrEvent, botSk);
+        inboundForBot = w as NTNostrEvent;
+        break;
+      } catch {
+        /* not ours */
+      }
+    }
+    expect(inboundForBot).toBeDefined();
+
+    const config = baseConfig();
+    config.telegramStreaming = STREAM_ONE_PER_SENTENCE;
+
+    const ac = new AbortController();
+    const serverPromise = runPhantomchatServer({
+      config,
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      channel,
+      secretKey: botSk,
+      allowedHex: [andrewHex],
+      oneShot: true,
+      signal: ac.signal,
+    });
+    pool.feed(inboundForBot!);
+    await new Promise((r) => setTimeout(r, 150));
+    ac.abort();
+    await serverPromise;
+
+    // Two sentences → two group broadcasts. Each broadcast is one wrap per
+    // OTHER member (Andrew + member) + Lena's self-wrap = 3 wraps, so two
+    // broadcasts = 6 kind-1059 reply wraps.
+    const replyWraps = pool.published.filter((e) => e.kind === 1059);
+    expect(replyWraps.length).toBe(6);
+
+    // Andrew can unwrap exactly one wrap per broadcast; the two he reads are
+    // the two sentences, in order, each carrying the group tag.
+    const andrewContents: string[] = [];
+    for (const w of replyWraps) {
+      try {
+        const m = unwrapNip17Message(w as NTNostrEvent, andrewSk);
+        expect(m.tags.find((t) => t[0] === "group")).toEqual([
+          "group",
+          groupId,
+        ]);
+        andrewContents.push(JSON.parse(m.content).content.trim());
+      } catch {
+        /* not for Andrew */
+      }
+    }
+    expect(andrewContents).toEqual(["Hello team.", "Working on it now."]);
   });
 });


### PR DESCRIPTION
## Problem

On Telegram the bot streams **progress bubbles** — completed sentences land as they're written, and pre-tool "checking your calendar…" lines fill the gaps. On PhantomChat the same agent showed **one long typing indicator followed by one long reply**.

Both channels run the same `runTurn` engine; they just consumed its output differently. The phantomchat channel (`channels/phantomchat/server.ts`) accumulated every chunk and published a single NIP-17 message at the end (`toolNarration: false`). The Telegram channel (`channels/core/engine.ts`) already streams that output through the shared `StreamSegmenter`. The segmenter, the `telegramStreaming` config, and the chunk protocol were all already shared — only the phantomchat consumer hadn't adopted them.

## Change

Ported the Telegram streaming model into `channels/phantomchat/server.ts`:

- **`toolNarration: true`** — `runTurn` emits pre-tool narration text + `progress` chunks.
- **Live segmentation** — `text` chunks feed a `StreamSegmenter`; each completed sentence/block is published immediately as its own bubble, spaced by `bubbleDelayMs`.
- **Narration bubbles** — text preceding a tool call is classified as progress narration, buffered, and flushed on the `narrationFlushMs` clock (also driven by the existing 2s typing tick so it surfaces during long tool gaps).
- **Suffix-only final send** — after streaming, only the not-yet-seen tail is sent, using the engine's prefix-match dedup, so nothing duplicates.
- A **`sendBubble()`** helper routes every bubble through the existing **group-broadcast vs 1:1 DM** paths, so groups still work (one NIP-17 wrap per bubble).

Typing-indicator, auth gate, and STOP behavior are unchanged. The two channels now share the segmenter and `telegramStreaming` config, so they stay in lockstep.

## Behavior notes

- Single-`done`-chunk replies still produce exactly **one** bubble (text with no sentence terminator never flushes mid-stream), so existing assertions hold; multi-sentence / tool-using turns now stream progressively.
- This publishes **one gift-wrap per bubble** (and per group member), so a chatty multi-step turn produces more relay traffic than the old single-shot path. The `bubbleMaxChars` / `bubbleMaxSentences` / `bubbleDelayMs` knobs in `telegramStreaming` tune granularity.

## Testing

- `npm run typecheck` — clean
- `bun test` — **1461 pass, 1 skip, 0 fail** (phantomchat server/channel/transport/cli suites included)