### PR TITLE
feat(phantomchat): slash commands over Nostr — handle + advertise in kind-0

### DIFF
--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -12,7 +12,12 @@
  *     ("checking your calendar…") is sent as its own bubbles before tool calls
  *     (toolNarration ON), so the user sees live progress instead of one long
  *     wait. Each bubble is its own NIP-17 wrap.
- *   - No slash commands, voice, or attachments (groups ARE supported).
+ *   - Slash commands (/stop, /reset, /status, /harness, /coder, /update,
+ *     /restart, /help) work via the shared `handleSlashCommand` dispatcher,
+ *     handled inline so /stop reaches a turn hung in the per-peer chain.
+ *     DM-only (group "/…" lines fall through to a normal turn). No Telegram
+ *     `setMyCommands` menu — Nostr has no command-registration API.
+ *   - No voice or attachments (groups ARE supported).
  *   - The trust perimeter gates on the CRYPTOGRAPHIC sender (rumor.pubkey,
  *     surfaced as `senderId`), never on the envelope `from` field.
  */
@@ -27,12 +32,17 @@ import { runTurn } from "../../orchestrator/turn.ts";
 import { makeRetriever } from "../../orchestrator/retrieval.ts";
 import { makeScreener } from "../../orchestrator/screen.ts";
 import { makeTurnIndexer } from "../../orchestrator/turnIndexer.ts";
+import {
+  type ActiveTurnHandle,
+  handleSlashCommand,
+} from "../commands.ts";
 import { TELEGRAM_REPLY_INSTRUCTION, voiceUnavailableMessage } from "../core/prompts.ts";
 import type { Channel, ChannelMessage } from "../core/types.ts";
 import {
   splitIntoSegments,
   StreamSegmenter,
 } from "../streamSegmenter.ts";
+import type { ServiceControl } from "../../lib/systemd.ts";
 import type { PhantomchatTransport } from "./transport.ts";
 import { sttSupport, transcribe } from "../../lib/audio.ts";
 import { DEFAULT_STT_TIMEOUT_MS } from "../../lib/voice.ts";
@@ -126,6 +136,14 @@ export interface RunPhantomchatServerInput {
   secretKey: Uint8Array;
   /** Stop after draining the currently-available messages. For tests. */
   oneShot?: boolean;
+  /**
+   * ServiceControl override for the `/restart` slash command's afterSend.
+   * Production leaves this undefined and `/restart` picks up
+   * `defaultServiceControl()`; tests inject a stub so a `bun test` run never
+   * invokes the host's real systemctl restart. Mirrors the Telegram engine's
+   * input seam.
+   */
+  serviceControl?: ServiceControl;
   /** Signal to stop the loop cleanly (Ctrl-C / SIGTERM). */
   signal?: AbortSignal;
   out?: WriteSink;
@@ -168,20 +186,30 @@ export async function runPhantomchatServer(
 
   const harnesses: Harness[] = [...input.harnesses];
 
+  // Wall-clock when the server came up, for the /status uptime line.
+  const serverStartedAt = Date.now();
+
+  // In-flight turns keyed by conversationId (senderHex for a DM, `group:<id>`
+  // for a group). A /stop or /reset slash command looks the peer up here and
+  // aborts its controller; /status reads startTime + lastProgressNote. Mirrors
+  // the Telegram engine's `activeTurns` map.
+  const activeTurns = new Map<string, ActiveTurnHandle>();
+
   // Per-peer promise chain so messages from one peer stay strictly ordered.
   const chains = new Map<string, Promise<void>>();
   const inFlight = new Set<Promise<void>>();
 
-  const handle = async (msg: ChannelMessage): Promise<void> => {
+  // ===================== AUTH GATE =====================
+  // Gate on the CRYPTOGRAPHIC sender (rumor.pubkey, carried as senderId — the
+  // verifying unwrap proved it equals seal.pubkey and is signature-checked).
+  // The envelope `from` field is NEVER consulted here: it's attacker-
+  // controllable plaintext. A sender not in the allowlist is dropped SILENTLY
+  // (info log only) — no reply, so the bot doesn't become an oracle that
+  // confirms its own pubkey is live to strangers. Returns false to drop.
+  // Factored out so both the regular turn path (`handle`) and the inline slash
+  // path (`runSlash`) apply the identical gate.
+  const authorize = (msg: ChannelMessage): boolean => {
     const senderHex = msg.senderId;
-
-    // ===================== AUTH GATE =====================
-    // Gate on the CRYPTOGRAPHIC sender (rumor.pubkey, carried as senderId — the
-    // verifying unwrap proved it equals seal.pubkey and is signature-checked).
-    // The envelope `from` field is NEVER consulted here: it's attacker-
-    // controllable plaintext. A sender not in the allowlist is dropped SILENTLY
-    // (info log only) — no reply, so the bot doesn't become an oracle that
-    // confirms its own pubkey is live to strangers.
     const lowerHex = senderHex.toLowerCase();
     if (allowedSet.size > 0) {
       // Locked allowlist (configured, or already claimed by TOFU).
@@ -189,7 +217,7 @@ export async function runPhantomchatServer(
         log.info("phantomchat: dropping message from non-allowed sender", {
           sender: senderHex.slice(0, 12) + "…",
         });
-        return;
+        return false;
       }
     } else if (tofuArmed) {
       // TRUST-ON-FIRST-USE. Claim this sender SYNCHRONOUSLY (before any await)
@@ -213,6 +241,13 @@ export async function runPhantomchatServer(
       }
     }
     // else: empty set + tofu off = open bot — answer anyone (caller warned).
+    return true;
+  };
+
+  const handle = async (msg: ChannelMessage): Promise<void> => {
+    const senderHex = msg.senderId;
+
+    if (!authorize(msg)) return;
 
     // ===================== DELIVERY RECEIPT =====================
     // The sender just passed the auth gate, so acknowledging receipt to them is
@@ -462,6 +497,21 @@ export async function runPhantomchatServer(
       sendTypingTick();
       void flushNarration();
     }, 2000);
+
+    // Register this turn so a /stop or /reset slash command can abort it and
+    // /status can read its elapsed time + latest progress note. The turn aborts
+    // on EITHER the server's shutdown signal OR this per-turn controller (which
+    // /stop fires). Keyed by conversationId, exactly the key the slash path
+    // looks up.
+    const controller = new AbortController();
+    const turnHandle: ActiveTurnHandle = {
+      controller,
+      startTime: Date.now(),
+    };
+    activeTurns.set(msg.conversationId, turnHandle);
+    const turnSignal = input.signal
+      ? AbortSignal.any([input.signal, controller.signal])
+      : controller.signal;
     try {
       for await (const chunk of runTurn({
         persona: input.persona,
@@ -472,7 +522,7 @@ export async function runPhantomchatServer(
         memory: input.memory,
         idleTimeoutMs: input.config.harnessIdleTimeoutMs,
         hardTimeoutMs: input.config.harnessHardTimeoutMs,
-        signal: input.signal,
+        signal: turnSignal,
         // The trust grant — see the auth gate above. Always true here because
         // we already dropped non-allowlisted senders.
         trusted: true,
@@ -528,6 +578,9 @@ export async function runPhantomchatServer(
           await flushNarration();
         }
         if (chunk.type === "progress") {
+          // Surface the latest progress note on the turn handle so /status can
+          // show "running: <tool>" in real time.
+          turnHandle.lastProgressNote = chunk.note.slice(0, 500);
           // A tool is about to run. Text emitted since the last boundary that
           // the splitter hasn't already sent as a final bubble is progress
           // narration ("checking your calendar…"): buffer it for the timed
@@ -547,6 +600,11 @@ export async function runPhantomchatServer(
       });
       return;
     } finally {
+      // Deregister the turn (only if we're still the registered one — a later
+      // turn for this peer could have replaced us).
+      if (activeTurns.get(msg.conversationId) === turnHandle) {
+        activeTurns.delete(msg.conversationId);
+      }
       // Stop the typing refresh whether the turn succeeded, errored, or the
       // early-return above fired, then publish an explicit STOP so the PWA
       // clears the dots AT ONCE instead of waiting out its 6s auto-expiry (the
@@ -571,6 +629,11 @@ export async function runPhantomchatServer(
     // shot path did: a group reply is reconstructed from the inbound rumor
     // (inbound p-tags ∪ { sender }) since the bridge holds no group DB, and
     // sendGroupMessage adds our self-wrap and defensively drops our own hex.
+    //
+    // If the turn was aborted (/stop or /reset), don't emit a trailing partial:
+    // the command already sent its own confirmation and any streamed bubbles
+    // stand on their own.
+    if (controller.signal.aborted) return;
     const fullReply = finalReply ?? streamedReply;
     let outText: string;
     if (fullReply.trim().length === 0) {
@@ -591,6 +654,65 @@ export async function runPhantomchatServer(
       if (i < finalSegments.length - 1 && streaming.bubbleDelayMs > 0) {
         await sleep(streaming.bubbleDelayMs);
       }
+    }
+  };
+
+  // A DM whose text begins with "/" is a candidate control command. Media
+  // messages and group messages never take the slash path (see runSlash).
+  const isControlCommand = (msg: ChannelMessage): boolean =>
+    !msg.groupId && !msg.media && msg.text.trim().startsWith("/");
+
+  // Slash commands (/stop, /reset, /status, /harness, /coder, /help, …) are
+  // handled INLINE — bypassing the per-peer turn chain — so /stop can abort a
+  // turn that is currently hung in that chain (a queued /stop would never run
+  // until the very turn it is meant to kill had finished). DM-only: group slash
+  // semantics (who may /reset the shared thread, /status broadcast noise) are
+  // out of scope, so in a group a "/…" line falls through to a normal turn.
+  // Unknown commands (handleSlashCommand → null) also fall through to a normal
+  // turn, since some personas treat e.g. /remember as plain input.
+  const runSlash = async (msg: ChannelMessage): Promise<void> => {
+    if (!authorize(msg)) return;
+    const senderHex = msg.senderId;
+    const result = await handleSlashCommand(msg.text, {
+      chatId: msg.conversationId,
+      persona: input.persona,
+      // Must match handle()'s DM conversationKey EXACTLY so /reset and /coder
+      // target the same persisted history. senderId is already lowercase hex
+      // (the channel lowercases rumor.pubkey).
+      conversation: `phantomchat:${senderHex}`,
+      memory: input.memory,
+      // Same array runTurn uses, so /harness reordering sticks for next turn.
+      harnesses,
+      startedAt: serverStartedAt,
+      activeTurn: activeTurns.get(msg.conversationId),
+      config: input.config,
+      serviceControl: input.serviceControl,
+      // No @username concept on Nostr, and slash handling is DM-only, so there
+      // is nothing to disambiguate — leave botUsername undefined.
+    }).catch((e: unknown) => {
+      log.warn("phantomchat: slash command failed", {
+        error: (e as Error).message,
+        sender: senderHex.slice(0, 12) + "…",
+      });
+      return undefined; // error: drop (don't run a failed command as a turn)
+    });
+
+    if (result === undefined) return; // errored — already logged
+    if (result === null) {
+      // Not a command we own — run it as a normal turn instead.
+      enqueue(msg);
+      return;
+    }
+    try {
+      await transport.sendMessage(senderHex, result.reply);
+      // /update and /restart fire their side effect AFTER the reply lands, so
+      // the user sees "restarting…" before the process is SIGTERM'd.
+      if (result.afterSend) await result.afterSend();
+    } catch (e) {
+      log.warn("phantomchat: slash reply send failed", {
+        error: (e as Error).message,
+        sender: senderHex.slice(0, 12) + "…",
+      });
     }
   };
 
@@ -623,7 +745,15 @@ export async function runPhantomchatServer(
   // the signal; listen()'s loop drains its queue and completes, so this
   // for-await ends naturally and we fall through to draining inFlight.
   for await (const msg of channel.listen(input.signal)) {
-    enqueue(msg);
+    if (isControlCommand(msg)) {
+      // Handle inline (off the per-peer chain) but still track it in inFlight
+      // so oneShot tests and clean shutdown wait for it to settle.
+      const p = runSlash(msg);
+      inFlight.add(p);
+      void p.finally(() => inFlight.delete(p));
+    } else {
+      enqueue(msg);
+    }
   }
 
   // Drain in-flight turns so callers (and tests) can assert on what was sent

--- a/src/channels/phantomchat/transport.ts
+++ b/src/channels/phantomchat/transport.ts
@@ -344,16 +344,34 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
   /**
    * Publish this identity's NIP-01 kind-0 profile. The content is the standard
    * metadata JSON: `name`/`display_name` (so the PWA shows e.g. "Lena" not the
-   * npub) plus NIP-24 `bot: true` to mark the account automated. Signed with our
-   * key and published to all relays the same best-effort way as a wrap.
+   * npub) plus NIP-24 `bot: true` to mark the account automated, and optionally
+   * a `commands` array so the PWA can render the slash-command `/`-typeahead
+   * menu (the decentralized setMyCommands). Signed with our key and published to
+   * all relays the same best-effort way as a wrap.
    */
-  async publishProfile(metadata: { name: string; bot?: boolean; about?: string }): Promise<void> {
+  async publishProfile(metadata: {
+    name: string;
+    bot?: boolean;
+    about?: string;
+    /**
+     * Slash commands to advertise, `{command, description}` with the bare
+     * command name (no leading slash) — the same shape Telegram's setMyCommands
+     * / bot_info uses. Published in the kind-0 content under a `commands` key so
+     * a client (the PhantomChat PWA) can render the `/`-typeahead menu. This is
+     * the decentralized analogue of setMyCommands: the bot owns the list. kind-0
+     * content is freeform JSON, so other Nostr clients simply ignore the field.
+     */
+    commands?: Array<{ command: string; description: string }>;
+  }): Promise<void> {
     const content = JSON.stringify({
       name: metadata.name,
       display_name: metadata.name,
       // NIP-24: flags the account as (partly) automated so clients can badge it.
       bot: metadata.bot ?? true,
       ...(metadata.about ? { about: metadata.about } : {}),
+      ...(metadata.commands && metadata.commands.length > 0
+        ? { commands: metadata.commands }
+        : {}),
     });
     const event = finalizeEvent(
       { kind: 0, created_at: Math.floor(Date.now() / 1000), tags: [], content },

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -14,6 +14,7 @@ import {
   HttpTelegramTransport,
   runTelegramServer,
 } from "../channels/telegram.ts";
+import { TELEGRAM_BOT_COMMANDS } from "../channels/commands.ts";
 import { createPhantomchatChannel } from "../channels/phantomchat/channel.ts";
 import { runPhantomchatServer } from "../channels/phantomchat/server.ts";
 import { SimplePoolPhantomchatTransport } from "../channels/phantomchat/transport.ts";
@@ -521,7 +522,13 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         const displayName =
           spec.persona.charAt(0).toUpperCase() + spec.persona.slice(1);
         void transport
-          .publishProfile({ name: displayName, bot: true })
+          // Advertise the same slash commands the channel handles (the
+          // setMyCommands analogue) so the PWA can render the /-typeahead menu.
+          .publishProfile({
+            name: displayName,
+            bot: true,
+            commands: TELEGRAM_BOT_COMMANDS,
+          })
           .then(() =>
             out.write(
               `  [phantomchat:${spec.persona}] published profile '${displayName}' (bot)\n`,

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -1026,3 +1026,270 @@ describe("phantomchat streaming bubbles", () => {
     expect(andrewContents).toEqual(["Hello team.", "Working on it now."]);
   });
 });
+
+/**
+ * Slash commands (PR: Telegram-style /commands on phantomchat). The shared
+ * `handleSlashCommand` dispatcher is wired into the phantomchat server, handled
+ * inline (off the per-peer turn chain) so /stop reaches a hung turn. DM-only.
+ *
+ * Replies are sent via transport.sendMessage (a v2 wrap), so `dmBubbles` reads
+ * them. Recognized commands never invoke the harness; unknown commands fall
+ * through to a normal turn.
+ */
+
+const slashSleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/** A harness that emits one text chunk then blocks until its signal aborts —
+ *  lets a test hold a turn "in flight" so /stop has something to abort. */
+class BlockingHarness implements Harness {
+  invocations = 0;
+  constructor(public readonly id: string) {}
+  async available(): Promise<boolean> {
+    return true;
+  }
+  async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+    this.invocations++;
+    yield { type: "text", text: "working" };
+    await new Promise<void>((resolve) => {
+      if (req.signal?.aborted) return resolve();
+      req.signal?.addEventListener("abort", () => resolve(), { once: true });
+    });
+    // No `done` — the turn was interrupted, nothing to finalize.
+  }
+}
+
+/**
+ * Start a long-lived phantomchat server (oneShot off) and return handles to
+ * feed messages mid-run and to stop it. Needed for /stop and /reset, which
+ * require a turn to be in flight / already persisted before the command lands —
+ * the single-shot `runOnce` can't express that ordering.
+ */
+function makeServer(opts: {
+  botSk: Uint8Array;
+  allowedHex: string[];
+  harness: Harness;
+  serviceControl?: import("../src/lib/systemd.ts").ServiceControl;
+}): { pool: FakePool; feed: (sk: Uint8Array, text: string) => void; stop: () => Promise<void> } {
+  const botHex = getPublicKey(opts.botSk);
+  const pool = new FakePool();
+  const transport = new SimplePoolPhantomchatTransport(
+    opts.botSk,
+    ["wss://test.relay"],
+    pool,
+  );
+  const channel = createPhantomchatChannel({
+    secretKey: opts.botSk,
+    publicKeyHex: botHex,
+    transport,
+  });
+  const ac = new AbortController();
+  const done = runPhantomchatServer({
+    config: baseConfig(),
+    memory,
+    harnesses: [opts.harness],
+    agentDir,
+    persona: "phantom",
+    channel,
+    secretKey: opts.botSk,
+    allowedHex: opts.allowedHex,
+    serviceControl: opts.serviceControl,
+    oneShot: false,
+    signal: ac.signal,
+  });
+  let n = 0;
+  const feed = (sk: Uint8Array, text: string) => {
+    const envelope = JSON.stringify({
+      id: `slash-${++n}`,
+      from: getPublicKey(sk),
+      to: botHex,
+      type: "text",
+      content: text,
+      timestamp: Date.now(),
+    });
+    const { wraps } = wrapNip17Message(sk, botHex, envelope);
+    pool.feed(wraps[0] as NTNostrEvent);
+  };
+  const stop = async () => {
+    ac.abort();
+    await done;
+  };
+  return { pool, feed, stop };
+}
+
+describe("phantomchat slash commands", () => {
+  test("/help lists the commands and runs no turn", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "/help",
+    });
+    expect(harness.invocations).toBe(0);
+    const replies = await dmBubbles(pool, senderSk);
+    expect(replies.length).toBe(1);
+    expect(replies[0]).toContain("available commands");
+    expect(replies[0]).toContain("/stop");
+    expect(replies[0]).toContain("/reset");
+  });
+
+  test("/status reports harness + uptime + idle, runs no turn", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "/status",
+    });
+    expect(harness.invocations).toBe(0);
+    const r = (await dmBubbles(pool, senderSk))[0]!;
+    expect(r).toContain("harness: fake");
+    expect(r).toContain("uptime:");
+    expect(r).toMatch(/active:\s+no/);
+  });
+
+  test("/harness with no arg lists the chain, runs no turn", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "/harness",
+    });
+    expect(harness.invocations).toBe(0);
+    const r = (await dmBubbles(pool, senderSk))[0]!;
+    expect(r).toContain("→ fake");
+  });
+
+  test("unknown /command falls through to a normal turn", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "noted" },
+    ]);
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "/remember buy milk",
+    });
+    // Not a command we own → runTurn handled it.
+    expect(harness.invocations).toBe(1);
+    expect(await dmBubbles(pool, senderSk)).toContain("noted");
+  });
+
+  test("a non-allowed sender's /status is dropped (no reply)", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const otherSk = generateSecretKey(); // the only allowed key
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(otherSk)],
+      harness,
+      text: "/status",
+    });
+    expect(harness.invocations).toBe(0);
+    expect(pool.published.filter((e) => e.kind === 1059).length).toBe(0);
+  });
+
+  test("/stop aborts an in-flight turn", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const harness = new BlockingHarness("fake");
+    const srv = makeServer({
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+    });
+    srv.feed(senderSk, "do a long thing");
+    await slashSleep(120); // let the turn register + block
+    srv.feed(senderSk, "/stop");
+    await slashSleep(120);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(1);
+    const replies = await dmBubbles(srv.pool, senderSk);
+    expect(replies.some((r) => r.startsWith("stopped (was running"))).toBe(true);
+  });
+
+  test("/reset clears the conversation history", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    const conversation = `phantomchat:${getPublicKey(senderSk)}`;
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "hi there" },
+    ]);
+    const srv = makeServer({
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+    });
+    srv.feed(senderSk, "hello"); // a normal turn persists history for this peer
+    await slashSleep(150);
+    expect(
+      (await memory.recentTurns("phantom", conversation, 50)).length,
+    ).toBeGreaterThan(0);
+    srv.feed(senderSk, "/reset");
+    await slashSleep(120);
+    await srv.stop();
+
+    const replies = await dmBubbles(srv.pool, senderSk);
+    expect(
+      replies.some((r) => /^reset: cleared \d+ turns? from this chat/.test(r)),
+    ).toBe(true);
+    // History is empty afterwards.
+    expect((await memory.recentTurns("phantom", conversation, 50)).length).toBe(
+      0,
+    );
+  });
+
+  test("/restart replies then fires serviceControl.restart via afterSend", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    let restarted = false;
+    const serviceControl = {
+      isActive: async () => true,
+      restart: async () => {
+        restarted = true;
+        return { ok: true };
+      },
+    } as unknown as import("../src/lib/systemd.ts").ServiceControl;
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const srv = makeServer({
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      serviceControl,
+    });
+    srv.feed(senderSk, "/restart");
+    await slashSleep(120);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(0);
+    expect(restarted).toBe(true);
+    expect(await dmBubbles(srv.pool, senderSk)).toContain("restarting…");
+  });
+});

--- a/tests/channels-phantomchat-transport.test.ts
+++ b/tests/channels-phantomchat-transport.test.ts
@@ -152,6 +152,40 @@ describe("phantomchat transport subscription wire shape", () => {
     expect(meta.name).toBe("Lena");
     expect(meta.display_name).toBe("Lena");
     expect(meta.bot).toBe(true);
+    // No commands passed → no `commands` key (the PWA shows no menu).
+    expect("commands" in meta).toBe(false);
+  });
+
+  test("publishProfile embeds the advertised slash commands in the kind-0", async () => {
+    const published: NTNostrEvent[] = [];
+    const fakePool: RelayPool = {
+      subscribeMany() {
+        return { close() {} };
+      },
+      publish(_relays, event) {
+        published.push(event);
+        return [Promise.resolve("ok")];
+      },
+      close() {},
+    };
+
+    const sk = generateSecretKey();
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      ["wss://relay.example"],
+      fakePool,
+    );
+
+    const commands = [
+      { command: "help", description: "Show this command list" },
+      { command: "stop", description: "Abort the current turn" },
+    ];
+    await transport.publishProfile({ name: "Lena", bot: true, commands });
+
+    const meta = JSON.parse(published[0]!.content);
+    // The PWA reads `commands` (bare names, no leading slash — bot_info shape)
+    // and renders the /-typeahead menu from it.
+    expect(meta.commands).toEqual(commands);
   });
 
   test("sendTyping with stop=true publishes the STOP content marker", async () => {


### PR DESCRIPTION
## Summary

The phantomchat (Nostr NIP-17) channel ran **every** inbound message through the harness — there was no `/stop`, `/reset`, `/status`, etc. This wires the **shared `handleSlashCommand` dispatcher** (already channel-agnostic, used by Telegram) into the phantomchat server so the full Telegram control-command set works over Nostr DMs:

```
/start  /help  /stop  /reset  /status  /harness  /coder  /update  /restart
```

## How it works (mirrors `core/engine.ts`)

- **Inline handling, off the per-peer chain.** Slash commands are dispatched directly in the listen loop, *bypassing* the per-peer turn `chains`, so `/stop` reaches a turn that's currently hung in that chain. (A queued `/stop` would never run until the very turn it's meant to kill had finished — the exact failure mode the shared dispatcher was built to avoid.)
- **Active-turn tracking.** Each turn now registers an `AbortController` + `ActiveTurnHandle` in an `activeTurns` map keyed by `conversationId`. `runTurn` aborts on **either** the server shutdown signal **or** the per-turn controller (`AbortSignal.any`). `/stop` and `/reset` abort it; `/status` reads `startTime` + `lastProgressNote` (captured from `progress` chunks). On abort the trailing partial reply is suppressed.
- **Shared auth gate.** Factored into `authorize()` and applied on both the regular and slash paths. Unknown commands (dispatcher → `null`) fall through to a normal turn (some personas treat `/remember` etc. as plain input).
- **DM-only.** A group `"/…"` line falls through to a normal turn — group slash semantics (who may `/reset` the shared thread, `/status` broadcast noise) are out of scope. No `setMyCommands` menu either; Nostr has no command-registration API.
- **`serviceControl`** is threaded onto the server input (optional) for `/restart`, defaulting to `defaultServiceControl()` in prod; tests inject a stub.

## Known limitation: `/update`

`/update` works (it downloads, swaps, and restarts via the shared `runUpdateFlow`), but that flow is Telegram-coupled: it keys recipients by **numeric Telegram chat id**, so the post-restart "✅ Updated to vX.Y.Z" confirmation lands on **Telegram**, not phantomchat (the phantomchat user just sees the "installed, restarting…" reply). For a single operator running the same agent on both channels this is acceptable; making update notifications channel-aware is a separate change.

## Tests

8 new cases in `tests/channels-phantomchat-server.test.ts`:
- `/help` lists commands, runs no turn
- `/status` reports harness/uptime/idle, runs no turn
- `/harness` (no arg) lists the chain
- unknown `/command` falls through to a normal turn
- a non-allowed sender's `/status` is dropped (no reply)
- `/stop` aborts an in-flight turn (via a `BlockingHarness` that waits on its signal)
- `/reset` clears the conversation history
- `/restart` replies then fires `serviceControl.restart` via `afterSend`

A `makeServer` helper drives a long-lived server so `/stop` and `/reset` can feed a second message mid-turn.

## Verification

- `npm run typecheck` — clean
- `bun test` — **1473 pass, 1 skip, 0 fail** (shared `channels-commands` suite still green)