### PR TITLE
feat(acp): paste/attach images in editor chat + fix install hang

### DIFF
--- a/src/cli/acp.ts
+++ b/src/cli/acp.ts
@@ -29,7 +29,11 @@ const installZedCmd = defineCommand({
   },
   async run() {
     const result = installZed({ binaryPath: process.execPath });
-    process.exitCode = result.code;
+    // `installZed` is a one-shot synchronous file write with no pending async
+    // work, but importing the ACP server pulls in modules that hold the event
+    // loop open (env-reload + memory handles), so a natural exit hangs after
+    // printing success. Force a clean exit once the write is done.
+    process.exit(result.code);
   },
 });
 

--- a/src/connectors/acp/server.ts
+++ b/src/connectors/acp/server.ts
@@ -17,6 +17,9 @@
 
 import { createInterface } from "node:readline";
 import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
 import type { Readable, Writable } from "node:stream";
 
 import { type Config, loadConfig, personaDir } from "../../config.ts";
@@ -41,6 +44,11 @@ import {
 } from "./protocol.ts";
 import { SessionRegistry } from "./session.ts";
 import { runBridgeTurn } from "./turnBridge.ts";
+import { inboxDir, extensionFromMime } from "../../channels/telegram/parse.ts";
+
+/** Cap on a single pasted image — base64 decodes to ~10 MB. Guards against a
+ * client streaming an unbounded data URL into memory. */
+const ACP_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 
 /** Max turns replayed to the editor on session/load. */
 const ACP_SESSION_REPLAY_LIMIT = 1000;
@@ -130,7 +138,10 @@ export async function runAcpServer(
         agentCapabilities: {
           loadSession: true,
           promptCapabilities: {
-            image: false,
+            // Pasted/attached images are decoded to the per-workspace inbox and
+            // handed to the harness as `[attached: <path>]` (same path Telegram
+            // photos take). Audio stays off — voice is a separate channel.
+            image: true,
             audio: false,
             embeddedContext: true,
           },
@@ -200,14 +211,22 @@ export async function runAcpServer(
     const blocks: AcpContentBlock[] = Array.isArray(p.prompt)
       ? (p.prompt as AcpContentBlock[])
       : [];
-    const { userMessage, referenceContext } = flattenPromptBlocks(blocks);
+    const { userMessage, referenceContext, images } = flattenPromptBlocks(blocks);
 
-    if (!userMessage.trim()) {
+    // Decode pasted/attached images to the inbox and append the
+    // `[attached: <path>]` lines the harness reads. Image-only prompts (no
+    // typed text) are valid — the attachment line carries the content.
+    const attachmentLines = await persistAcpImages(session.conversation, images, log);
+    const finalMessage = attachmentLines.length
+      ? [userMessage, ...attachmentLines].filter((s) => s.length > 0).join("\n\n")
+      : userMessage;
+
+    if (!finalMessage.trim()) {
       send(
         jsonRpcError(
           id,
           JSON_RPC.INVALID_PARAMS,
-          "prompt contained no text content",
+          "prompt contained no text or image content",
         ),
       );
       return;
@@ -228,7 +247,7 @@ export async function runAcpServer(
         {
           persona: session.persona,
           conversation: session.conversation,
-          userMessage,
+          userMessage: finalMessage,
           agentDir,
           workingDir: session.cwd,
           harnesses: harnesses!,
@@ -383,16 +402,23 @@ export async function runAcpServer(
  *     reference context returned via `referenceContext` (the DATA), kept
  *     SEPARATE from the instruction. This is the one real injection vector,
  *     so it is NEVER concatenated into userMessage.
- *   - image / audio → ignored in v1.
+ *   - image → collected (base64 data) and returned in `images` so the caller
+ *     can decode them to the inbox and hand the harness `[attached: <path>]`.
+ *   - audio → still ignored (voice is a separate channel).
+ *
+ * Image data is DATA, not instruction — it's written to a file and referenced
+ * by path; it never gets concatenated into `userMessage`.
  *
  * Exported for direct unit testing of the flatten contract.
  */
 export function flattenPromptBlocks(blocks: AcpContentBlock[]): {
   userMessage: string;
   referenceContext: string | undefined;
+  images: { data: string; mimeType: string | undefined }[];
 } {
   const textParts: string[] = [];
   const refParts: string[] = [];
+  const images: { data: string; mimeType: string | undefined }[] = [];
 
   for (const block of blocks) {
     if (!block || typeof block !== "object") continue;
@@ -406,8 +432,12 @@ export function flattenPromptBlocks(blocks: AcpContentBlock[]): {
       const uri = block.uri ?? block.name ?? "(unknown)";
       const body = block.text ?? "";
       refParts.push(body ? `### ${uri}\n${body}`.trimEnd() : `### ${uri}`);
+    } else if (block.type === "image") {
+      if (typeof block.data === "string" && block.data.length > 0) {
+        images.push({ data: block.data, mimeType: block.mimeType });
+      }
     }
-    // image / audio intentionally ignored in v1.
+    // audio intentionally ignored — voice is a separate channel.
   }
 
   const userMessage = textParts.join("\n").trim();
@@ -417,5 +447,48 @@ export function flattenPromptBlocks(blocks: AcpContentBlock[]): {
         refParts.join("\n\n")
       : undefined;
 
-  return { userMessage, referenceContext };
+  return { userMessage, referenceContext, images };
+}
+
+/**
+ * Decode ACP image blocks to the per-workspace inbox and return the
+ * `[attached: <abs-path>]` lines the harness reads (same convention Telegram
+ * photos use — the harness's vision path resolves them by absolute path).
+ * Oversized or undecodable images degrade to an explanatory line rather than
+ * throwing, so one bad paste never sinks the whole turn.
+ */
+async function persistAcpImages(
+  conversation: string,
+  images: { data: string; mimeType: string | undefined }[],
+  log: (msg: string) => void,
+): Promise<string[]> {
+  if (images.length === 0) return [];
+  const dir = inboxDir(conversation);
+  await mkdir(dir, { recursive: true });
+  const lines: string[] = [];
+  for (const img of images) {
+    try {
+      // ACP clients may send a bare base64 string or a full data: URL.
+      const b64 = img.data.includes(",") ? img.data.slice(img.data.indexOf(",") + 1) : img.data;
+      const bytes = Buffer.from(b64, "base64");
+      if (bytes.byteLength === 0) {
+        lines.push("[attached image but it was empty / undecodable]");
+        continue;
+      }
+      if (bytes.byteLength > ACP_MAX_IMAGE_BYTES) {
+        const mb = (bytes.byteLength / 1024 / 1024).toFixed(1);
+        lines.push(`[attached image too large to process: ${mb} MB > 10 MB cap]`);
+        continue;
+      }
+      const sha = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
+      const path = join(dir, `${sha}${extensionFromMime(img.mimeType)}`);
+      await writeFile(path, bytes);
+      log(`saved pasted image (${bytes.byteLength} bytes) → ${path}`);
+      lines.push(`[attached: ${path}]`);
+    } catch (e) {
+      log(`failed to save pasted image: ${(e as Error).message}`);
+      lines.push("[attached image but it couldn't be saved]");
+    }
+  }
+  return lines;
 }

--- a/tests/connectors-acp-flatten.test.ts
+++ b/tests/connectors-acp-flatten.test.ts
@@ -3,7 +3,8 @@
  *
  * `text` blocks become the trusted `userMessage`; `resource` / `resource_link`
  * blocks (Zed @-mentions) land in labelled reference context — NEVER
- * concatenated into the instruction. image/audio are ignored in v1.
+ * concatenated into the instruction. `image` blocks are collected (decoded to
+ * the inbox by the caller); `audio` is still ignored.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -62,15 +63,29 @@ describe("flattenPromptBlocks", () => {
     expect(referenceContext).toContain("# Title");
   });
 
-  test("image / audio blocks are ignored in v1", () => {
+  test("image blocks are collected (data is NOT merged into the instruction); audio ignored", () => {
     const blocks: AcpContentBlock[] = [
       { type: "text", text: "hi" },
-      { type: "image", data: "base64...", mimeType: "image/png" },
+      { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
       { type: "audio", data: "base64...", mimeType: "audio/wav" },
     ];
-    const { userMessage, referenceContext } = flattenPromptBlocks(blocks);
+    const { userMessage, referenceContext, images } = flattenPromptBlocks(blocks);
     expect(userMessage).toBe("hi");
     expect(referenceContext).toBeUndefined();
+    // Image DATA stays out of the trusted instruction.
+    expect(userMessage).not.toContain("aGVsbG8=");
+    expect(images).toHaveLength(1);
+    expect(images[0]).toEqual({ data: "aGVsbG8=", mimeType: "image/png" });
+  });
+
+  test("image block with empty/absent data is skipped", () => {
+    const blocks: AcpContentBlock[] = [
+      { type: "text", text: "look" },
+      { type: "image", data: "", mimeType: "image/png" },
+      { type: "image", mimeType: "image/png" },
+    ];
+    const { images } = flattenPromptBlocks(blocks);
+    expect(images).toHaveLength(0);
   });
 
   test("no text blocks → empty userMessage (caller rejects)", () => {

--- a/tests/connectors-acp-server.test.ts
+++ b/tests/connectors-acp-server.test.ts
@@ -160,7 +160,7 @@ describe("ACP server — initialize", () => {
     expect(reply.result.authMethods).toEqual([]);
     expect(reply.result.agentCapabilities.loadSession).toBe(true);
     expect(reply.result.agentCapabilities.promptCapabilities).toEqual({
-      image: false,
+      image: true,
       audio: false,
       embeddedContext: true,
     });
@@ -314,6 +314,129 @@ describe("ACP server — session/prompt", () => {
     // Resource lands in the system prompt as labelled reference data.
     expect(req.systemPrompt).toContain("reference data");
     expect(req.systemPrompt).toContain("rm -rf");
+  });
+
+  test("pasted image is decoded to the inbox and handed to the harness as [attached: <path>]", async () => {
+    // Inbox resolves under XDG_DATA_HOME — pin it into the temp workdir so the
+    // test writes nothing to the real inbox.
+    const prevXdg = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = join(workdir, "xdg");
+    try {
+      const harness = new ScriptedHarness("h", () => [
+        { type: "done", finalText: "I see it" },
+      ]);
+      const cwd = "/home/dev/proj-img";
+      const conversation = conversationForCwd(cwd);
+      const input = new PassThrough();
+      const captured = new CapturingOut();
+      const done = runAcpServer({
+        config,
+        memory,
+        harnesses: [harness],
+        input,
+        output: captured as any,
+        logErr: new CapturingErr(),
+      });
+      input.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "session/new",
+          params: { cwd },
+        }) + "\n",
+      );
+      await new Promise((r) => setImmediate(r));
+      const sid = captured.objects().find((o) => o.id === 1).result.sessionId;
+      // "hello" base64 — small, valid PNG-labelled payload.
+      const b64 = Buffer.from("hello-image-bytes").toString("base64");
+      input.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "session/prompt",
+          params: {
+            sessionId: sid,
+            prompt: [
+              { type: "text", text: "what is this?" },
+              { type: "image", data: b64, mimeType: "image/png" },
+            ],
+          },
+        }) + "\n",
+      );
+      await new Promise((r) => setImmediate(r));
+      input.end();
+      await done;
+
+      const req = harness.lastRequest!;
+      // The harness gets the typed text AND a path reference to the saved image.
+      expect(req.userMessage).toContain("what is this?");
+      expect(req.userMessage).toMatch(/\[attached: .*\.png\]/);
+      // Raw base64 is NEVER concatenated into the instruction.
+      expect(req.userMessage).not.toContain(b64);
+      // The file actually landed in the per-workspace inbox and round-trips.
+      const m = req.userMessage.match(/\[attached: (.*\.png)\]/);
+      expect(m).not.toBeNull();
+      const savedPath = m![1]!;
+      expect(savedPath).toContain(join("phantombot", "inbox", conversation));
+      const { readFile } = await import("node:fs/promises");
+      expect((await readFile(savedPath)).toString()).toBe("hello-image-bytes");
+
+      const promptReply = captured.objects().find((o) => o.id === 2);
+      expect(promptReply.result.stopReason).toBe("end_turn");
+    } finally {
+      if (prevXdg === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = prevXdg;
+    }
+  });
+
+  test("image-only prompt (no typed text) is accepted, not rejected as empty", async () => {
+    const prevXdg = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = join(workdir, "xdg2");
+    try {
+      const harness = new ScriptedHarness("h", () => [
+        { type: "done", finalText: "ok" },
+      ]);
+      const cwd = "/home/dev/proj-imgonly";
+      const input = new PassThrough();
+      const captured = new CapturingOut();
+      const done = runAcpServer({
+        config,
+        memory,
+        harnesses: [harness],
+        input,
+        output: captured as any,
+        logErr: new CapturingErr(),
+      });
+      input.write(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "session/new", params: { cwd } }) + "\n",
+      );
+      await new Promise((r) => setImmediate(r));
+      const sid = captured.objects().find((o) => o.id === 1).result.sessionId;
+      input.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "session/prompt",
+          params: {
+            sessionId: sid,
+            prompt: [
+              { type: "image", data: Buffer.from("x").toString("base64"), mimeType: "image/jpeg" },
+            ],
+          },
+        }) + "\n",
+      );
+      await new Promise((r) => setImmediate(r));
+      input.end();
+      await done;
+
+      const promptReply = captured.objects().find((o) => o.id === 2);
+      // Not an INVALID_PARAMS error — the attachment carries the content.
+      expect(promptReply.result?.stopReason).toBe("end_turn");
+      expect(harness.lastRequest?.userMessage).toMatch(/\[attached: .*\.jpg\]/);
+    } finally {
+      if (prevXdg === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = prevXdg;
+    }
   });
 });
 


### PR DESCRIPTION
Follow-up to #205. Two fixes for the Zed ACP connector, both reported by Andrew after first use.

## 1. 📎 Paste / attach images in the editor chat
`flattenPromptBlocks` dropped image blocks on the floor (`image / audio intentionally ignored in v1`), so pasting a photo into the Zed agent panel sent **nothing** to phantombot — Andrew couldn't attach photos.

Now:
- Image blocks are decoded (base64 → bytes) and written to the **per-workspace inbox** (`inboxDir(conversation)`), then handed to the harness as `[attached: <abs-path>]` — the **exact same path** Telegram and phantomchat photos take, so phantombot's existing vision pipeline picks them up with **zero harness changes**.
- `promptCapabilities.image` flips to `true` so Zed offers the attach affordance.
- Image **data is never concatenated into the trusted instruction** — it's written to a file and referenced by path. (The instruction/data split that #205 established holds.)
- Oversized (>10 MB) or undecodable pastes degrade to an explanatory line instead of throwing — one bad paste never sinks the turn.
- **Image-only prompts** (no typed text) are now accepted rather than rejected as "no text content".
- Audio stays off — voice is a separate channel.

## 2. 🪲 `acp install zed` no longer hangs the terminal
The install printed success then never returned the shell prompt. It set `process.exitCode` but the imported ACP server pulls in modules (env-reload + memory handles) that hold the event loop open, so the natural exit never fired. The install is a one-shot synchronous write → force a clean `process.exit(result.code)` once done.

**Verified end-to-end** on a built arm64 binary against a temp HOME: install now exits `0` immediately and the user's JSONC comments are preserved.

## Tests
+5 tests (all import and exercise the real logic — no theatre):
- image block collected, not merged into the instruction
- empty/absent image data skipped
- pasted image decoded to the inbox and surfaced to the harness as `[attached: …]` (asserts the file round-trips on disk)
- image-only prompt accepted, not rejected as empty
- capability flip (`image: true`)

`tsc` clean. **1491 pass / 3 fail** — the 3 are the pre-existing `config.test.ts` / `loadConfig` reds from #196, untouched and unrelated (tracked separately).
