### PR TITLE
fix(acp): session/load must return a struct, not null — fixes agent failing to launch in Zed

### DIFF
--- a/src/connectors/acp/server.ts
+++ b/src/connectors/acp/server.ts
@@ -194,7 +194,12 @@ export async function runAcpServer(
             };
       send(update);
     }
-    send(jsonRpcResult(id, null));
+    // ACP requires session/load to return a LoadSessionResponse struct, NOT
+    // null. Zed's Rust client deserializes the result into the struct and
+    // fails hard on null ("invalid type: null, expected struct
+    // LoadSessionResponse"), which kills the agent on startup and whenever an
+    // old thread is reopened. `modes: null` is the valid empty form.
+    send(jsonRpcResult(id, { modes: null }));
   }
 
   async function handleSessionPrompt(id: JsonRpcId, params: unknown): Promise<void> {

--- a/tests/connectors-acp-server.test.ts
+++ b/tests/connectors-acp-server.test.ts
@@ -547,6 +547,11 @@ describe("ACP server — session/load", () => {
     const reply = out.objects().find((o) => o.id === 1);
     expect(reply).toBeDefined();
     expect("result" in reply).toBe(true);
+    // The result MUST be a LoadSessionResponse struct, never null — Zed's Rust
+    // client fails deserialization on null ("expected struct
+    // LoadSessionResponse"), killing the agent on startup / reopening a thread.
+    expect(reply.result).not.toBeNull();
+    expect(typeof reply.result).toBe("object");
   });
 });
 


### PR DESCRIPTION
## The bug

Every Zed startup — and every time an old phantombot thread is reopened — the agent fails to launch with:

```
Parse error: { "error": "invalid type: null, expected struct LoadSessionResponse", "json": null, "phase": "deserialization" }
```

## Root cause

Zed persists per-workspace ACP threads, so on startup (and on reopening any saved thread) it calls `session/load` to rehydrate. Our handler replayed history correctly but ended with `send(jsonRpcResult(id, null))` — returning a JSON-RPC result of **`null`**. ACP requires `session/load` to return a `LoadSessionResponse` **struct**; Zed's Rust client fails deserialization on `null` and kills the agent before it ever appears.

Ironically this only bites *after* phantombot has been used once in a workspace (that's what creates the thread Zed tries to reload) — which is why it worked initially then broke on the next launch.

## Fix

Return `{ modes: null }` (the valid empty `LoadSessionResponse`) instead of `null`. One line.

Fixes both reported symptoms: agent failing to launch on Zed startup, and the same error when clicking into an old chat thread.

## Test

The existing `session/load` test passed *despite* the bug because it only asserted `"result" in reply` — which is true even when `result` is `null`. Strengthened it to assert the result is a **non-null object**, so this can't silently regress.

## Verification

- `tsc` clean
- ACP server suite: 10 pass
- Full suite: **1491 pass / 3 fail** — the 3 are the pre-existing `loadConfig` reds from #196, untouched. Zero new failures.