### PR TITLE
fix(acp): auto-register in detected editors + fix macOS Zed settings path

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -46,6 +46,11 @@ import {
   routingExtensionStatus,
 } from "../lib/piExtensionProvision.ts";
 import { currentPlatform } from "../lib/platform.ts";
+import {
+  editorConnectorBroken,
+  reconcileEditorConnectors,
+  type EditorConnectorResult,
+} from "../connectors/acp/autoInstall.ts";
 import { saveHarnessBins } from "../state.ts";
 import {
   BunSystemctlRunner,
@@ -194,6 +199,16 @@ export interface DoctorReport {
     dir: string;
     repaired?: boolean;
   };
+  /**
+   * ACP editor registrations (Zed today; VS Code when PR2 lands). One entry per
+   * supported editor: `not-detected` (editor not installed), `current` (already
+   * registered with this binary), `registered`/`updated` (reconciled this run),
+   * `stale` (needs work but --no-repair so nothing written), `error` (e.g.
+   * unparseable settings — the data-loss guard refused to touch it). Gated to
+   * the real `phantombot` binary so dev/test never writes the dev box's editor
+   * settings.
+   */
+  editorConnectors?: EditorConnectorResult[];
   repair_needed: boolean;
   repair_reason?: string;
   repair_triggered: boolean;
@@ -247,6 +262,16 @@ export interface RunDoctorInput {
   checkPiExtension?:
     | false
     | (() => Promise<DoctorReport["piExtension"] | undefined>);
+  /**
+   * Test seam for the ACP editor-connector reconcile. Pass `false` to skip.
+   * Pass a function (it receives whether repair is enabled) to substitute a
+   * fake report, bypassing the binary gate and any real settings writes. In
+   * production this is undefined and doctor reconciles the real editor settings
+   * (writing when repair is on, reporting only when --no-repair).
+   */
+  checkEditorConnectors?:
+    | false
+    | ((repair: boolean) => DoctorReport["editorConnectors"]);
 }
 
 function decideRepair(
@@ -456,6 +481,24 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     };
   }
 
+  // ACP editor connectors. With repair on (the default), doctor actively
+  // (re)registers phantombot into any detected editor — the same self-heal as
+  // the pi extension / systemd checks, and a second entry point besides
+  // startup so Andrew never runs `acp install` by hand. With --no-repair it
+  // only reports drift. Gated to the real `phantombot` binary so dev/test never
+  // writes the dev box's editor settings.
+  let editorConnectors: DoctorReport["editorConnectors"];
+  if (input.checkEditorConnectors === false) {
+    // explicitly skipped by a test
+  } else if (input.checkEditorConnectors) {
+    editorConnectors = input.checkEditorConnectors(repair);
+  } else if (basename(process.execPath) === "phantombot") {
+    editorConnectors = reconcileEditorConnectors({
+      binaryPath: process.execPath,
+      repair,
+    });
+  }
+
   const report: DoctorReport = {
     persona,
     nightly: {
@@ -493,6 +536,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     ...(timersReport ? { timers: timersReport } : {}),
     ...(harnessReport ? { harnesses: harnessReport } : {}),
     ...(piExtensionReport ? { piExtension: piExtensionReport } : {}),
+    ...(editorConnectors ? { editorConnectors } : {}),
     repair_needed: needed,
     repair_reason: reason,
     repair_triggered: repairTriggered,
@@ -523,6 +567,14 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     !!piExtensionReport &&
     piExtensionReport.drifted &&
     !piExtensionReport.repaired;
+  // A detected editor that's still un-registered (or whose settings couldn't be
+  // parsed) after this run is a health failure — same diagnostic-only exit code
+  // as the checks above (it never gates the daemon; run.ts only logs it).
+  // `stale` only appears under --no-repair; `error` means the data-loss guard
+  // refused to touch a malformed settings file. `registered`/`updated` are
+  // successful heals, not failures.
+  const editorConnectorsBroken =
+    !!editorConnectors && editorConnectors.some(editorConnectorBroken);
   const exitCode =
     needed && !repairTriggered
       ? 1
@@ -534,7 +586,9 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
             ? 1
             : piExtensionBroken
               ? 1
-              : 0;
+              : editorConnectorsBroken
+                ? 1
+                : 0;
 
   if (input.json) {
     out.write(JSON.stringify(report, null, 2) + "\n");
@@ -709,6 +763,39 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
         out.write(
           `managed capability-routing extension present and current at ${r.dir}\n`,
         );
+      }
+    }
+  }
+
+  if (editorConnectors && editorConnectors.length > 0) {
+    for (const e of editorConnectors) {
+      const ok = !editorConnectorBroken(e);
+      out.write(`  editor (${e.editor}): ${tick(ok)} — `);
+      switch (e.action) {
+        case "not-detected":
+          out.write("not installed on this machine; nothing to register\n");
+          break;
+        case "current":
+          out.write(`registered and current in ${e.settingsPath}\n`);
+          break;
+        case "registered":
+          out.write(`registered phantombot in ${e.settingsPath}\n`);
+          break;
+        case "updated":
+          out.write(
+            `updated phantombot registration (binary path changed) in ${e.settingsPath}\n`,
+          );
+          break;
+        case "stale":
+          out.write(
+            `registration missing or out of date in ${e.settingsPath} — run \`phantombot doctor\` (without --no-repair) or restart to fix\n`,
+          );
+          break;
+        case "error":
+          out.write(
+            `could not register in ${e.settingsPath}${e.error ? ` — ${e.error}` : ""}\n`,
+          );
+          break;
       }
     }
   }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -58,6 +58,7 @@ import { openMemoryStore } from "../memory/store.ts";
 import { VERSION } from "../version.ts";
 import { runDoctor } from "./doctor.ts";
 import { ensureRoutingExtension } from "../lib/piExtensionProvision.ts";
+import { reconcileEditorConnectors } from "../connectors/acp/autoInstall.ts";
 
 export interface RunInput {
   config?: Config;
@@ -399,6 +400,42 @@ export async function runRun(input: RunInput = {}): Promise<number> {
           error: (e as Error).message,
         }),
     );
+  }
+
+  // Auto-register phantombot into any detected editor (Zed today; VS Code when
+  // PR2 lands) so Andrew never has to run `acp install` by hand. Idempotent:
+  // only writes when the registration is missing or points at a different
+  // binary path (e.g. just updated), so it doesn't churn on every startup.
+  // Fully error-isolated — `reconcileEditorConnectors` never throws and this is
+  // best-effort, so a broken editor settings file can NEVER block startup or a
+  // self-update. `doctor` re-reconciles on demand. Gated to the real
+  // `phantombot` binary (same gate as the pi extension) so `bun run`/dev never
+  // writes to the dev box's real ~/.config/zed.
+  if (basename(process.execPath) === "phantombot") {
+    try {
+      for (const r of reconcileEditorConnectors({
+        binaryPath: process.execPath,
+      })) {
+        if (r.action === "registered" || r.action === "updated") {
+          log.info("run: registered phantombot as ACP agent", {
+            editor: r.editor,
+            action: r.action,
+            settings: r.settingsPath,
+          });
+        } else if (r.action === "error") {
+          log.warn("run: editor connector registration failed", {
+            editor: r.editor,
+            error: r.error,
+          });
+        }
+      }
+    } catch (e) {
+      // Defensive: reconcile is internally guarded, but startup must survive
+      // anything here regardless.
+      log.warn("run: editor connector reconcile threw", {
+        error: (e as Error).message,
+      });
+    }
   }
 
   const ac = new AbortController();

--- a/src/connectors/acp/autoInstall.ts
+++ b/src/connectors/acp/autoInstall.ts
@@ -1,0 +1,195 @@
+/**
+ * Auto-registration of phantombot as an ACP agent in detected editors.
+ *
+ * Andrew shouldn't have to run `phantombot acp install zed` (or `… vscode`)
+ * by hand. This module detects which supported editors are present on the
+ * machine and registers phantombot into each one's settings — idempotently,
+ * and with hard error isolation so it can NEVER break phantombot's startup.
+ *
+ * Two callers wire this in (see run.ts and doctor.ts):
+ *   - startup     — fire-and-forget right after the listener is up, so a
+ *                   freshly-installed/updated binary registers itself
+ *                   immediately (no 30-min wait, no manual command).
+ *   - doctor      — repairs/registers on demand AND, with --no-repair, just
+ *                   reports drift so the wiring is diagnosable.
+ *
+ * Idempotency is the whole game: we only WRITE when phantombot is missing
+ * from the editor's settings, or registered under a different binary path
+ * (e.g. the binary moved or the user installed a newer one). When the
+ * registration already points at this exact binary we touch nothing — so
+ * running every startup doesn't churn backups or rewrite the user's file.
+ *
+ * Detection is "the editor's config dir exists". That keeps us from creating
+ * config dirs for editors the user doesn't have installed: if `~/.config/zed`
+ * isn't there, Zed isn't there, and we skip it.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { parse } from "jsonc-parser";
+
+import type { WriteSink } from "../../lib/io.ts";
+import { defaultZedSettingsPath, installZed } from "./installZed.ts";
+
+/** A sink that drops everything — keeps reconcile silent on stdout/stderr. */
+const SILENT: WriteSink = { write: () => true };
+
+export type EditorConnectorAction =
+  /** Editor not installed on this machine — nothing to do. */
+  | "not-detected"
+  /** Already registered with this exact binary path — no write. */
+  | "current"
+  /** Was absent; we wrote the registration. */
+  | "registered"
+  /** Was registered under a different binary path; we rewrote it. */
+  | "updated"
+  /** Needs (re)registration but repair was off — reported, not written. */
+  | "stale"
+  /** A failure (e.g. unparseable settings ⇒ data-loss guard aborted). */
+  | "error";
+
+export interface EditorConnectorResult {
+  editor: string;
+  action: EditorConnectorAction;
+  settingsPath: string;
+  error?: string;
+}
+
+/**
+ * One supported editor. Kept tiny + data-driven so VS Code (PR2) slots in by
+ * adding a second entry — the reconcile loop below is editor-agnostic.
+ */
+export interface EditorSpec {
+  id: string;
+  /** Resolve this editor's settings.json path. */
+  settingsPath(): string;
+  /**
+   * Directory whose existence signals the editor is present. Defaults to the
+   * settings file's parent dir (e.g. ~/.config/zed).
+   */
+  detectionDir(settingsPath: string): string;
+  /** Read the phantombot command currently registered, if any. */
+  currentCommand(settingsPath: string): string | undefined;
+  /** Perform the idempotent registration write. Returns a 0/1 code. */
+  install(binaryPath: string, out?: WriteSink, err?: WriteSink): { code: number };
+}
+
+/** Best-effort read of `agent_servers.Phantombot.command` from JSONC settings. */
+function readZedCommand(settingsPath: string): string | undefined {
+  try {
+    const raw = readFileSync(settingsPath, "utf8");
+    // Tolerant parse (comments + trailing commas). On a malformed file this
+    // returns a best-effort value or undefined; either way installZed re-parses
+    // with error collection and aborts safely, so we never risk data loss here.
+    const parsed = parse(raw) as
+      | { agent_servers?: { Phantombot?: { command?: unknown } } }
+      | undefined;
+    const cmd = parsed?.agent_servers?.Phantombot?.command;
+    return typeof cmd === "string" ? cmd : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export const ZED_EDITOR: EditorSpec = {
+  id: "zed",
+  settingsPath: defaultZedSettingsPath,
+  detectionDir: (settingsPath) => dirname(settingsPath),
+  currentCommand: readZedCommand,
+  install: (binaryPath, out, err) => installZed({ binaryPath, out, err }),
+};
+
+/** Editors phantombot knows how to register itself into. */
+export const KNOWN_EDITORS: EditorSpec[] = [ZED_EDITOR];
+
+export interface ReconcileOptions {
+  /** Absolute path to the phantombot binary the editor should spawn. */
+  binaryPath: string;
+  /** Write when registration is missing/stale. False = report only. Default true. */
+  repair?: boolean;
+  /** Override the editor list (tests). Default: KNOWN_EDITORS. */
+  editors?: EditorSpec[];
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+/**
+ * Detect supported editors and bring each one's phantombot registration in
+ * line with `binaryPath`. Per-editor try/catch means one editor's failure
+ * never affects the others, and the function as a whole never throws — safe to
+ * call fire-and-forget from startup.
+ */
+export function reconcileEditorConnectors(
+  opts: ReconcileOptions,
+): EditorConnectorResult[] {
+  const repair = opts.repair ?? true;
+  const editors = opts.editors ?? KNOWN_EDITORS;
+  const results: EditorConnectorResult[] = [];
+
+  for (const editor of editors) {
+    let settingsPath = "";
+    try {
+      settingsPath = editor.settingsPath();
+
+      // Detection: only touch editors actually present on this machine.
+      if (!existsSync(editor.detectionDir(settingsPath))) {
+        results.push({ editor: editor.id, action: "not-detected", settingsPath });
+        continue;
+      }
+
+      const current = editor.currentCommand(settingsPath);
+      if (current === opts.binaryPath) {
+        results.push({ editor: editor.id, action: "current", settingsPath });
+        continue;
+      }
+
+      const wasRegistered = current !== undefined;
+
+      if (!repair) {
+        // Report-only mode (doctor --no-repair): surface the drift, write nothing.
+        results.push({ editor: editor.id, action: "stale", settingsPath });
+        continue;
+      }
+
+      // Silence installZed's own stdout/stderr chatter by default: reconcile is
+      // a background/diagnostic path (startup logs via the result; `doctor
+      // --json` must emit ONLY JSON on stdout). The manual `acp install zed`
+      // command still prints, because it calls installZed directly, not here.
+      const r = editor.install(
+        opts.binaryPath,
+        opts.out ?? SILENT,
+        opts.err ?? SILENT,
+      );
+      if (r.code !== 0) {
+        // installZed aborts (code 1) on an unparseable settings file rather
+        // than risk clobbering it — that's a real WARN, not a silent failure.
+        results.push({
+          editor: editor.id,
+          action: "error",
+          settingsPath,
+          error: "settings file not parseable as JSONC — left untouched",
+        });
+        continue;
+      }
+      results.push({
+        editor: editor.id,
+        action: wasRegistered ? "updated" : "registered",
+        settingsPath,
+      });
+    } catch (e) {
+      results.push({
+        editor: editor.id,
+        action: "error",
+        settingsPath,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  return results;
+}
+
+/** True if a result represents a state an operator should be warned about. */
+export function editorConnectorBroken(r: EditorConnectorResult): boolean {
+  return r.action === "error" || r.action === "stale";
+}

--- a/src/connectors/acp/installZed.ts
+++ b/src/connectors/acp/installZed.ts
@@ -29,7 +29,7 @@ import {
   renameSync,
   writeFileSync,
 } from "node:fs";
-import { homedir, platform } from "node:os";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { applyEdits, modify, parse, type ParseError } from "jsonc-parser";
 
@@ -63,20 +63,16 @@ export function phantombotAgentServerBlock(binaryPath: string): {
 }
 
 /**
- * Resolve the default Zed settings.json path for the current platform.
- *   - macOS: ~/Library/Application Support/Zed/settings.json
- *   - Linux (+ others): $XDG_CONFIG_HOME/zed/settings.json (≈ ~/.config/zed)
+ * Resolve the default Zed settings.json path.
+ *
+ * Zed reads its user settings from `~/.config/zed/settings.json` on EVERY
+ * platform — including macOS (that's the file `⌘,` opens). The earlier
+ * `~/Library/Application Support/Zed/settings.json` branch was wrong: the
+ * registration landed in a file Zed never reads, so the agent silently never
+ * appeared in Zed's External Agents list on Macs. We honour XDG_CONFIG_HOME
+ * when set, falling back to ~/.config otherwise.
  */
 export function defaultZedSettingsPath(): string {
-  if (platform() === "darwin") {
-    return join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "Zed",
-      "settings.json",
-    );
-  }
   const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
   return join(xdg, "zed", "settings.json");
 }

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -873,3 +873,99 @@ describe("runDoctor pi extension health check", () => {
     expect(out.text).toContain("pi extension: WARN");
   });
 });
+
+describe("runDoctor — editor connectors", () => {
+  beforeEach(async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+  });
+
+  const isolate = {
+    checkSystemd: false as const,
+    checkTimers: false as const,
+    checkHarnesses: false as const,
+    checkPiExtension: false as const,
+  };
+
+  test("editor not installed → ok and exit 0", async () => {
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      ...isolate,
+      checkEditorConnectors: () => [
+        { editor: "zed", action: "not-detected", settingsPath: "/x/zed" },
+      ],
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("editor (zed): ok");
+    expect(out.text).toContain("not installed");
+  });
+
+  test("already current → ok and exit 0", async () => {
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      ...isolate,
+      checkEditorConnectors: () => [
+        { editor: "zed", action: "current", settingsPath: "/x/zed" },
+      ],
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("editor (zed): ok");
+  });
+
+  test("registered this run → ok and exit 0", async () => {
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      ...isolate,
+      checkEditorConnectors: () => [
+        { editor: "zed", action: "registered", settingsPath: "/x/zed" },
+      ],
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("registered phantombot");
+  });
+
+  test("stale under --no-repair → WARN and exit 1", async () => {
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      repair: false,
+      ...isolate,
+      checkEditorConnectors: (repair) => {
+        // doctor must pass repair through so report-only mode reports drift.
+        expect(repair).toBe(false);
+        return [{ editor: "zed", action: "stale", settingsPath: "/x/zed" }];
+      },
+    });
+    expect(code).toBe(1);
+    expect(out.text).toContain("editor (zed): WARN");
+  });
+
+  test("unparseable settings (error) → WARN and exit 1", async () => {
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      ...isolate,
+      checkEditorConnectors: () => [
+        {
+          editor: "zed",
+          action: "error",
+          settingsPath: "/x/zed",
+          error: "settings file not parseable as JSONC — left untouched",
+        },
+      ],
+    });
+    expect(code).toBe(1);
+    expect(out.text).toContain("editor (zed): WARN");
+    expect(out.text).toContain("not parseable");
+  });
+});

--- a/tests/connectors-acp-autoInstall.test.ts
+++ b/tests/connectors-acp-autoInstall.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Editor connector auto-registration tests.
+ *
+ * Exercises the REAL `reconcileEditorConnectors` against a fake editor backed
+ * by a temp settings file, proving the behaviours startup + doctor depend on:
+ *   - detection gate: skip editors whose config dir is absent (don't create it)
+ *   - register when missing, idempotent "current" (no write) when already set
+ *   - update when the registered binary path differs
+ *   - report-only "stale" under repair:false (no write)
+ *   - "error" surfaced when the installer aborts (unparseable settings)
+ *   - per-editor isolation: one editor throwing doesn't sink the others
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { parse } from "jsonc-parser";
+
+import {
+  reconcileEditorConnectors,
+  type EditorSpec,
+} from "../src/connectors/acp/autoInstall.ts";
+import { installZed } from "../src/connectors/acp/installZed.ts";
+
+let workdir: string;
+let settingsPath: string;
+const BIN = "/home/dev/.local/bin/phantombot";
+
+/** A Zed-shaped editor pointed at a temp settings file (real installZed). */
+function fakeZed(path: string): EditorSpec {
+  return {
+    id: "zed",
+    settingsPath: () => path,
+    detectionDir: (p) => dirname(p),
+    currentCommand: (p) => {
+      try {
+        const parsed = parse(readFileSync(p, "utf8")) as any;
+        const cmd = parsed?.agent_servers?.Phantombot?.command;
+        return typeof cmd === "string" ? cmd : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    install: (binaryPath, out, err) =>
+      installZed({ settingsPath: path, binaryPath, out, err }),
+  };
+}
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-autoinstall-"));
+  // The editor's config dir exists (editor "installed") but settings.json may not.
+  settingsPath = join(workdir, "zed", "settings.json");
+  mkdirSync(dirname(settingsPath), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("reconcileEditorConnectors", () => {
+  test("editor not installed (config dir absent) → not-detected, nothing created", () => {
+    const missing = join(workdir, "no-such-editor", "settings.json");
+    const results = reconcileEditorConnectors({
+      binaryPath: BIN,
+      editors: [fakeZed(missing)],
+    });
+    expect(results[0]!.action).toBe("not-detected");
+    expect(existsSync(dirname(missing))).toBe(false); // did NOT create the dir
+  });
+
+  test("registers when missing, then idempotent (no write, no backup churn)", () => {
+    // First run: no settings.json yet → registered.
+    const first = reconcileEditorConnectors({
+      binaryPath: BIN,
+      editors: [fakeZed(settingsPath)],
+    });
+    expect(first[0]!.action).toBe("registered");
+    const parsed = parse(readFileSync(settingsPath, "utf8")) as any;
+    expect(parsed.agent_servers.Phantombot.command).toBe(BIN);
+
+    // Capture file bytes, run again → current, file untouched, no backup made.
+    const before = readFileSync(settingsPath, "utf8");
+    const second = reconcileEditorConnectors({
+      binaryPath: BIN,
+      editors: [fakeZed(settingsPath)],
+    });
+    expect(second[0]!.action).toBe("current");
+    expect(readFileSync(settingsPath, "utf8")).toBe(before);
+    expect(existsSync(`${settingsPath}.phantombot-bak`)).toBe(false);
+  });
+
+  test("updates when the registered binary path differs", () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        agent_servers: { Phantombot: { command: "/old/path", args: ["acp"], env: {} } },
+      }),
+      "utf8",
+    );
+    const results = reconcileEditorConnectors({
+      binaryPath: BIN,
+      editors: [fakeZed(settingsPath)],
+    });
+    expect(results[0]!.action).toBe("updated");
+    const parsed = parse(readFileSync(settingsPath, "utf8")) as any;
+    expect(parsed.agent_servers.Phantombot.command).toBe(BIN);
+  });
+
+  test("repair:false reports stale and writes nothing", () => {
+    const results = reconcileEditorConnectors({
+      binaryPath: BIN,
+      repair: false,
+      editors: [fakeZed(settingsPath)],
+    });
+    expect(results[0]!.action).toBe("stale");
+    expect(existsSync(settingsPath)).toBe(false); // report-only, no write
+  });
+
+  test("unparseable settings → error, file untouched", () => {
+    const broken = `{ "theme": "One Dark`; // unterminated string
+    writeFileSync(settingsPath, broken, "utf8");
+    const results = reconcileEditorConnectors({
+      binaryPath: BIN,
+      editors: [fakeZed(settingsPath)],
+    });
+    expect(results[0]!.action).toBe("error");
+    expect(readFileSync(settingsPath, "utf8")).toBe(broken); // data-loss guard held
+  });
+
+  test("per-editor isolation: one throwing editor doesn't sink the others", () => {
+    const exploding: EditorSpec = {
+      id: "boom",
+      settingsPath: () => {
+        throw new Error("kaboom");
+      },
+      detectionDir: (p) => p,
+      currentCommand: () => undefined,
+      install: () => ({ code: 0 }),
+    };
+    const results = reconcileEditorConnectors({
+      binaryPath: BIN,
+      editors: [exploding, fakeZed(settingsPath)],
+    });
+    expect(results[0]!.action).toBe("error");
+    expect(results[0]!.error).toContain("kaboom");
+    // The healthy editor after it still got registered.
+    expect(results[1]!.action).toBe("registered");
+  });
+});

--- a/tests/connectors-acp-installZed.test.ts
+++ b/tests/connectors-acp-installZed.test.ts
@@ -15,7 +15,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parse } from "jsonc-parser";
 
-import { installZed } from "../src/connectors/acp/installZed.ts";
+import {
+  defaultZedSettingsPath,
+  installZed,
+} from "../src/connectors/acp/installZed.ts";
 
 class Sink {
   buf = "";
@@ -36,6 +39,30 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(workdir, { recursive: true, force: true });
+});
+
+describe("defaultZedSettingsPath", () => {
+  const saved = process.env.XDG_CONFIG_HOME;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = saved;
+  });
+
+  test("resolves under ~/.config/zed on every platform (incl. macOS)", () => {
+    delete process.env.XDG_CONFIG_HOME;
+    const p = defaultZedSettingsPath();
+    // The macOS bug was returning Library/Application Support — Zed never reads
+    // that. It must be the .config/zed path everywhere.
+    expect(p.endsWith(join(".config", "zed", "settings.json"))).toBe(true);
+    expect(p).not.toContain("Application Support");
+  });
+
+  test("honours XDG_CONFIG_HOME", () => {
+    process.env.XDG_CONFIG_HOME = "/tmp/xdg-test";
+    expect(defaultZedSettingsPath()).toBe(
+      join("/tmp/xdg-test", "zed", "settings.json"),
+    );
+  });
 });
 
 describe("installZed — JSONC preservation", () => {


### PR DESCRIPTION
## What & why

Two fixes so Andrew never runs `acp install` by hand, and so it works on macOS.

### 🐛 macOS Zed path bug
`defaultZedSettingsPath()` returned `~/Library/Application Support/Zed/settings.json` on macOS — but Zed reads `~/.config/zed/settings.json` on **every** platform (that's the file `⌘,` opens). The registration was landing in a file Zed ignores, so phantombot never appeared under External Agents on Macs. Now resolves `~/.config/zed` everywhere (honouring `XDG_CONFIG_HOME`).

### ✨ Auto-install on detection (startup + doctor, **not** heartbeat)
New shared `reconcileEditorConnectors()` (`connectors/acp/autoInstall.ts`):
- **Detects** editors by config-dir presence (no dir ⇒ editor not installed ⇒ skip; never creates a config dir for an absent editor).
- **Idempotent** — only writes when the registration is missing or points at a different binary path (e.g. just updated). Re-running every startup does **not** churn backups or rewrite the user's file.
- **Per-editor `try/catch`**; the function never throws.

Wired into two entry points (per Andrew's steer — explicitly **not** the 30-min heartbeat, so no wait after startup):
- **startup** (`run.ts`): fire-and-forget, gated to the real `phantombot` binary, fully error-isolated — a broken editor settings file can never block startup or a self-update.
- **doctor**: registers when repairing (default), report-only (`stale`) under `--no-repair`, surfaces `error` when the data-loss guard refuses a malformed settings file. New `editorConnectors[]` report section + human summary line + exit-code wiring (diagnostic only — never gates the daemon).

Editor list is data-driven (Zed today) so **VS Code slots straight in for PR2**. `reconcile` silences `installZed`'s stdout so `doctor --json` stays pure JSON.

## Verification
- `tsc` clean; full suite **1508 pass / 0 fail**. **+13 tests**: autoInstall (detect / register / idempotent-no-write / update / stale / error / per-editor isolation), doctor `editorConnectors` via test seam, macOS path regression.
- arm64 binary smoke-tested end-to-end against throwaway HOMEs:
  - `acp install zed` writes to `~/.config/zed/settings.json` ✅
  - doctor: **registered → current** (idempotent, 0 backups) **→ not-detected** ✅
  - human line: `editor (zed): ok — registered and current in …` ✅

## Notes
- Idempotency means startup re-registration is cheap and safe to run forever.
- Exit-code contribution is the same diagnostic-only signal as the systemd/harness/pi-extension checks; `run.ts` only logs a non-zero code, so the "phantombot must never exit 1" service invariant is intact.
