### PR TITLE
feat(acp): first-party VS Code extension with embedded ACP client

### DIFF
--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.vsix

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,9 @@
+# Source + tooling — only ship the bundled extension + manifest + readme.
+src/**
+tests/**
+tsconfig.json
+.vscodeignore
+**/*.ts
+**/*.map
+node_modules/**
+.gitignore

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,82 @@
+# phantombot for VS Code
+
+First-party VS Code extension that brings **phantombot** — Andrew's
+personality-first chat agent — into VS Code's native Chat panel as
+`@phantombot`.
+
+## How it works
+
+The extension is a thin bridge. It does **not** build its own chat UI: it
+registers a [Chat Participant](https://code.visualstudio.com/api/extension-guides/chat)
+(`@phantombot`) so you get VS Code's native scrollback, history and theming for
+free.
+
+Under the hood it spawns `phantombot acp` as a subprocess and speaks
+**newline-delimited JSON-RPC 2.0 over stdio** — the
+[Agent Client Protocol](https://agentclientprotocol.com) (ACP). The extension is
+the *client*; phantombot is the *agent*. The lifecycle is:
+
+```
+initialize → session/new (or session/load) → session/prompt …
+```
+
+phantombot streams `session/update` notifications (assistant text chunks +
+tool-call indicators) back while a prompt is in flight; the extension maps those
+straight into the chat response stream.
+
+**Persona, memory, tools and the trusted-turn perimeter all live server-side in
+phantombot.** The extension never sees them — it only forwards your typed turn
+and renders the streamed reply. This is the same trust model the Zed connector
+uses: the local OS user who launched the editor is the principal.
+
+## Requirements
+
+- VS Code `^1.93.0` (Chat Participant API).
+- A `phantombot` binary on the machine. The extension finds it via:
+  1. the `phantombot.binaryPath` setting (absolute path), then
+  2. your `PATH`, then
+  3. common install locations (`~/.local/bin`, `/usr/local/bin`, `/usr/bin`,
+     Homebrew on macOS; `%LOCALAPPDATA%` / `%USERPROFILE%` on Windows).
+
+  If none resolve, the panel shows a clear error telling you to set
+  `phantombot.binaryPath` — it never hangs silently.
+
+## Settings
+
+| Setting | Description |
+|---------|-------------|
+| `phantombot.binaryPath` | Absolute path to the `phantombot` binary. Empty = auto-discover. |
+| `phantombot.persona` | Persona to bind the session to (passed as `--persona`). Empty = phantombot's default. |
+
+## Usage
+
+Open the Chat panel, type `@phantombot`, and ask. Cancelling a turn in the panel
+sends `session/cancel` to the agent. Reopening the same workspace lands back in
+the same phantombot conversation (memory is keyed on the workspace folder
+server-side).
+
+## Building
+
+```bash
+bun install
+bun run build      # bundles src/extension.ts → dist/extension.js via esbuild
+bun run typecheck
+bun test ./tests
+```
+
+The ACP client, binary resolver and prompt bridge are pure modules with no
+`vscode` dependency, so they run under `bun test` alongside the rest of the
+phantombot suite.
+
+## Platform support
+
+Binary/path resolution handles linux, darwin and win32 via `process.platform`
+switches. linux + darwin are exercised in CI and by hand; the win32 branch is
+**implemented but untested** (no Windows host available yet).
+
+## Roadmap
+
+- **PR2** will bundle this extension as a `.vsix` into the phantombot binary and
+  auto-install it via `reconcileEditorConnectors()` — a VS Code `EditorSpec`
+  slots in beside the existing Zed one. This package is structured to make that
+  a drop-in.

--- a/editors/vscode/bun.lock
+++ b/editors/vscode/bun.lock
@@ -1,0 +1,76 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "phantombot-vscode",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.93.0",
+        "esbuild": "^0.24.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.24.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.24.2", "", { "os": "android", "cpu": "arm" }, "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.24.2", "", { "os": "android", "cpu": "arm64" }, "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.24.2", "", { "os": "android", "cpu": "x64" }, "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.24.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.24.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.24.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.24.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.24.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.24.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.24.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.24.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.24.2", "", { "os": "linux", "cpu": "none" }, "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.24.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.24.2", "", { "os": "linux", "cpu": "x64" }, "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.24.2", "", { "os": "none", "cpu": "arm64" }, "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.24.2", "", { "os": "none", "cpu": "x64" }, "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.24.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.24.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.24.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.24.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.24.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg=="],
+
+    "@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
+    "@types/vscode": ["@types/vscode@1.125.0", "", {}, "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA=="],
+
+    "esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "phantombot-vscode",
+  "displayName": "phantombot",
+  "description": "Chat with phantombot — your personality-first agent — in VS Code's native Chat panel via an embedded ACP client.",
+  "version": "0.1.0",
+  "publisher": "phantomyard",
+  "private": true,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantomyard/phantombot.git",
+    "directory": "editors/vscode"
+  },
+  "engines": {
+    "vscode": "^1.93.0"
+  },
+  "categories": [
+    "AI",
+    "Chat"
+  ],
+  "activationEvents": [
+    "onChatParticipant:phantombot.chat"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "chatParticipants": [
+      {
+        "id": "phantombot.chat",
+        "name": "phantombot",
+        "fullName": "phantombot",
+        "description": "Ask phantombot — persona, memory and tools live server-side.",
+        "isSticky": true
+      }
+    ],
+    "configuration": {
+      "title": "phantombot",
+      "properties": {
+        "phantombot.binaryPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Absolute path to the `phantombot` binary. Leave empty to auto-discover via PATH and common install locations."
+        },
+        "phantombot.persona": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Persona to bind the ACP session to (passed as `--persona`). Leave empty to use phantombot's configured default persona."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "bun run build",
+    "build": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node18",
+    "watch": "bun run build -- --watch --sourcemap",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test ./tests"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.93.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/editors/vscode/src/acpClient.ts
+++ b/editors/vscode/src/acpClient.ts
@@ -1,0 +1,390 @@
+/**
+ * Embedded ACP client — spawns `phantombot acp` and speaks newline-delimited
+ * JSON-RPC 2.0 over its stdio.
+ *
+ * The extension is the CLIENT; phantombot is the AGENT. We hand-roll the wire
+ * protocol over stdio (no MCP libraries, no third-party ACP client) reusing the
+ * exact shapes the server already implements (see ./protocol.ts, which mirrors
+ * the server's src/connectors/acp/protocol.ts). Lifecycle:
+ *
+ *     initialize → session/new (or session/load) → session/prompt …
+ *
+ * `session/prompt` is long-running: the agent streams `session/update`
+ * notifications (agent_message_chunk / tool_call) while the request is in
+ * flight, then resolves the request with `{ stopReason }`. We surface those
+ * updates through a per-prompt callback and resolve the prompt promise on the
+ * matching response.
+ *
+ * STDOUT IS THE PROTOCOL CHANNEL on the server side — so the agent's stderr is
+ * the ONLY place diagnostics appear. We forward stderr to an injected sink for
+ * surfacing into the panel / output channel.
+ *
+ * The transport is fully injectable (`AcpTransport`) so the handshake/streaming
+ * logic is unit-tested over an in-memory duplex with zero real subprocess and
+ * zero `vscode` dependency — mirroring how the server's own tests drive
+ * runAcpServer over a PassThrough.
+ */
+
+import { spawn } from "node:child_process";
+
+import {
+  ACP_PROTOCOL_VERSION,
+  allocId,
+  isJsonRpcError,
+  jsonRpcNotification,
+  jsonRpcRequest,
+  textPrompt,
+  type AcpContentBlock,
+  type AcpInitializeResult,
+  type AcpLoadSessionResult,
+  type AcpNewSessionResult,
+  type AcpPromptResult,
+  type AcpSessionUpdate,
+  type AcpStopReason,
+  type JsonRpcId,
+  type JsonRpcResponse,
+  type SessionUpdateParams,
+} from "./protocol.ts";
+
+/** A bidirectional newline-delimited byte transport to the agent. */
+export interface AcpTransport {
+  /** Write one already-serialized line (no trailing newline) to the agent. */
+  write(line: string): void;
+  /** Register a handler for each complete line received from the agent. */
+  onLine(handler: (line: string) => void): void;
+  /** Register a handler for stderr text from the agent (diagnostics only). */
+  onStderr(handler: (text: string) => void): void;
+  /** Register the close handler (process exit / pipe end). */
+  onClose(handler: (info: { code: number | null }) => void): void;
+  /** Tear the transport (and underlying process) down. */
+  close(): void;
+}
+
+/** What the caller gets streamed during a prompt turn. */
+export interface PromptHandlers {
+  /** A delta of assistant text. */
+  onText?(text: string): void;
+  /** A presentational tool-call indicator ("working on X"). */
+  onToolCall?(title: string, status: string): void;
+  /** Raw update escape hatch (rarely needed). */
+  onUpdate?(update: AcpSessionUpdate): void;
+}
+
+export interface AcpClientOptions {
+  /** Pre-built transport (tests). Default: spawn `binaryPath acp [--persona]`. */
+  transport?: AcpTransport;
+  /** Absolute path / command for the phantombot binary. */
+  binaryPath?: string;
+  /** Persona override → `phantombot acp --persona NAME`. */
+  persona?: string;
+  /** Working dir the subprocess is spawned in (session cwd is passed separately). */
+  cwd?: string;
+  /** Per-call request timeout (ms). Prompts are exempt (they're long-running). */
+  requestTimeoutMs?: number;
+  /** Diagnostics sink for agent stderr + transport notes. */
+  onDiagnostic?(text: string): void;
+}
+
+interface Pending {
+  resolve(value: unknown): void;
+  reject(reason: Error): void;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Spawn `phantombot acp` (or wrap an injected transport) and expose the ACP
+ * client lifecycle. One client instance owns one subprocess.
+ */
+export class AcpClient {
+  private readonly transport: AcpTransport;
+  private readonly pending = new Map<JsonRpcId, Pending>();
+  private readonly requestTimeoutMs: number;
+  private readonly onDiagnostic: (text: string) => void;
+  /** sessionId → live prompt handlers, set for the duration of a prompt. */
+  private readonly promptStreams = new Map<string, PromptHandlers>();
+  private closed = false;
+  private closeError: Error | undefined;
+
+  constructor(options: AcpClientOptions = {}) {
+    this.requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.onDiagnostic = options.onDiagnostic ?? (() => {});
+    this.transport = options.transport ?? spawnAcpTransport(options);
+
+    this.transport.onLine((line) => this.handleLine(line));
+    this.transport.onStderr((text) => this.onDiagnostic(text));
+    this.transport.onClose((info) => this.handleClose(info));
+  }
+
+  // ── public lifecycle ─────────────────────────────────────────────────
+
+  /** `initialize` — negotiate protocol version + capabilities. */
+  async initialize(): Promise<AcpInitializeResult> {
+    const result = (await this.request("initialize", {
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      clientCapabilities: {},
+    })) as AcpInitializeResult;
+    return result;
+  }
+
+  /** `session/new` — open a fresh session bound to a workspace cwd. */
+  async newSession(cwd: string): Promise<string> {
+    const result = (await this.request("session/new", {
+      cwd,
+      // phantombot owns its own tools; we register no MCP servers.
+      mcpServers: [],
+    })) as AcpNewSessionResult;
+    return result.sessionId;
+  }
+
+  /**
+   * `session/load` — reattach to an existing session id for a cwd. The agent
+   * replays history as `session/update` chunks before resolving; route those
+   * through `handlers`. Returns the (struct, never-null) load result.
+   */
+  async loadSession(
+    sessionId: string,
+    cwd: string,
+    handlers?: PromptHandlers,
+  ): Promise<AcpLoadSessionResult> {
+    if (handlers) this.promptStreams.set(sessionId, handlers);
+    try {
+      const result = (await this.request("session/load", {
+        sessionId,
+        cwd,
+      })) as AcpLoadSessionResult;
+      return result;
+    } finally {
+      if (handlers) this.promptStreams.delete(sessionId);
+    }
+  }
+
+  /**
+   * `session/prompt` — send the user's turn and stream the response. Resolves
+   * with the stop reason when the agent finishes the turn. This request is
+   * long-running and is NOT subject to `requestTimeoutMs`.
+   */
+  async prompt(
+    sessionId: string,
+    prompt: string | AcpContentBlock[],
+    handlers: PromptHandlers = {},
+  ): Promise<AcpStopReason> {
+    const blocks = typeof prompt === "string" ? textPrompt(prompt) : prompt;
+    this.promptStreams.set(sessionId, handlers);
+    try {
+      const result = (await this.request(
+        "session/prompt",
+        { sessionId, prompt: blocks },
+        { longRunning: true },
+      )) as AcpPromptResult;
+      return result.stopReason;
+    } finally {
+      this.promptStreams.delete(sessionId);
+    }
+  }
+
+  /** `session/cancel` — fire-and-forget notification to abort the live turn. */
+  cancel(sessionId: string): void {
+    if (this.closed) return;
+    this.sendRaw(jsonRpcNotification("session/cancel", { sessionId }));
+  }
+
+  /** Tear down the subprocess and reject any in-flight requests. */
+  dispose(): void {
+    if (this.closed) return;
+    this.transport.close();
+    this.handleClose({ code: null });
+  }
+
+  // ── request plumbing ─────────────────────────────────────────────────
+
+  private request(
+    method: string,
+    params: unknown,
+    opts: { longRunning?: boolean } = {},
+  ): Promise<unknown> {
+    if (this.closed) {
+      return Promise.reject(
+        this.closeError ?? new Error(`acp client is closed (method ${method})`),
+      );
+    }
+    const id = allocId();
+    return new Promise<unknown>((resolve, reject) => {
+      const pending: Pending = { resolve, reject };
+      if (!opts.longRunning && this.requestTimeoutMs > 0) {
+        pending.timer = setTimeout(() => {
+          this.pending.delete(id);
+          reject(
+            new Error(
+              `phantombot acp: '${method}' timed out after ${this.requestTimeoutMs}ms`,
+            ),
+          );
+        }, this.requestTimeoutMs);
+        // Don't keep the event loop alive on a stuck timer in node hosts.
+        (pending.timer as { unref?: () => void }).unref?.();
+      }
+      this.pending.set(id, pending);
+      this.sendRaw(jsonRpcRequest(id, method, params));
+    });
+  }
+
+  private sendRaw(message: unknown): void {
+    this.transport.write(JSON.stringify(message));
+  }
+
+  // ── inbound line handling ────────────────────────────────────────────
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let msg: unknown;
+    try {
+      msg = JSON.parse(trimmed);
+    } catch {
+      this.onDiagnostic(`acp client: dropping non-JSON line: ${trimmed.slice(0, 200)}`);
+      return;
+    }
+    if (!msg || typeof msg !== "object") return;
+
+    const obj = msg as Record<string, unknown>;
+
+    // A response carries an id and either result or error.
+    if ("id" in obj && ("result" in obj || "error" in obj)) {
+      this.handleResponse(obj as unknown as JsonRpcResponse);
+      return;
+    }
+
+    // Otherwise it's a notification (or a request from the agent, which the
+    // server side never sends in v1). Route session/update; ignore the rest.
+    if (obj.method === "session/update") {
+      this.handleSessionUpdate(obj.params as SessionUpdateParams | undefined);
+      return;
+    }
+    // Unknown notification — diagnostic only, never throws.
+    if (typeof obj.method === "string") {
+      this.onDiagnostic(`acp client: ignoring notification ${obj.method}`);
+    }
+  }
+
+  private handleResponse(res: JsonRpcResponse): void {
+    const id = res.id;
+    if (id === null || id === undefined) return;
+    const pending = this.pending.get(id);
+    if (!pending) return;
+    this.pending.delete(id);
+    if (pending.timer) clearTimeout(pending.timer);
+    if (isJsonRpcError(res)) {
+      pending.reject(
+        new Error(`phantombot acp error ${res.error.code}: ${res.error.message}`),
+      );
+    } else {
+      pending.resolve(res.result);
+    }
+  }
+
+  private handleSessionUpdate(params: SessionUpdateParams | undefined): void {
+    if (!params || typeof params !== "object") return;
+    const handlers = this.promptStreams.get(params.sessionId);
+    if (!handlers) return;
+    const update = params.update;
+    if (!update || typeof update !== "object") return;
+
+    handlers.onUpdate?.(update);
+    switch (update.sessionUpdate) {
+      case "agent_message_chunk":
+      case "user_message_chunk":
+        if (update.content?.type === "text") {
+          handlers.onText?.(update.content.text);
+        }
+        return;
+      case "tool_call":
+        handlers.onToolCall?.(update.title, update.status);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private handleClose(info: { code: number | null }): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeError = new Error(
+      info.code === null || info.code === 0
+        ? "phantombot acp: subprocess closed"
+        : `phantombot acp: subprocess exited with code ${info.code}`,
+    );
+    for (const [, pending] of this.pending) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(this.closeError);
+    }
+    this.pending.clear();
+    this.promptStreams.clear();
+  }
+}
+
+/**
+ * Default transport: spawn `phantombot acp [--persona NAME]` and wire its
+ * stdio into the line-delimited contract. Buffers partial stdout lines.
+ */
+export function spawnAcpTransport(options: AcpClientOptions): AcpTransport {
+  const bin = options.binaryPath;
+  if (!bin) {
+    throw new Error(
+      "spawnAcpTransport: binaryPath is required (resolve the phantombot binary first)",
+    );
+  }
+  const args = ["acp"];
+  if (options.persona) args.push("--persona", options.persona);
+
+  const child = spawn(bin, args, {
+    cwd: options.cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+    // Inherit env so phantombot finds its config/secrets exactly as on a TTY.
+    env: process.env,
+  });
+
+  let stdoutBuf = "";
+  let lineHandler: (line: string) => void = () => {};
+  let stderrHandler: (text: string) => void = () => {};
+  let closeHandler: (info: { code: number | null }) => void = () => {};
+
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdoutBuf += chunk;
+    let idx: number;
+    while ((idx = stdoutBuf.indexOf("\n")) >= 0) {
+      const line = stdoutBuf.slice(0, idx);
+      stdoutBuf = stdoutBuf.slice(idx + 1);
+      lineHandler(line);
+    }
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => stderrHandler(chunk));
+  child.on("close", (code) => closeHandler({ code }));
+  child.on("error", (err) => stderrHandler(`spawn error: ${err.message}`));
+
+  return {
+    write(line: string) {
+      child.stdin?.write(line + "\n");
+    },
+    onLine(handler) {
+      lineHandler = handler;
+    },
+    onStderr(handler) {
+      stderrHandler = handler;
+    },
+    onClose(handler) {
+      closeHandler = handler;
+    },
+    close() {
+      try {
+        child.stdin?.end();
+      } catch {
+        /* ignore */
+      }
+      child.kill();
+    },
+  };
+}

--- a/editors/vscode/src/binaryResolver.ts
+++ b/editors/vscode/src/binaryResolver.ts
@@ -1,0 +1,168 @@
+/**
+ * phantombot binary discovery for the VS Code extension.
+ *
+ * Resolution order (first hit wins):
+ *   1. Explicit override — the `phantombot.binaryPath` setting.
+ *   2. PATH — a `phantombot` (or `phantombot.exe` on win32) entry on $PATH.
+ *   3. Common install locations — the user-prefix + system paths phantombot's
+ *      own install.sh writes to, per platform.
+ *
+ * On total failure we return `undefined` and the caller surfaces a clear,
+ * actionable error into the chat panel — never a silent hang.
+ *
+ * This module is pure (it only touches the filesystem + env via injected
+ * seams), so it runs under `bun test` with zero `vscode` dependency. The
+ * platform switch is driven by an injected `platform`/`env`/`exists` so a
+ * single test can exercise linux, darwin AND the win32 branch — the win32
+ * branch is therefore implemented but, on this box, only unit-tested (no real
+ * Windows host available).
+ */
+
+import { posix, win32 } from "node:path";
+import { existsSync } from "node:fs";
+
+export type Platform = "linux" | "darwin" | "win32" | string;
+
+export interface ResolveDeps {
+  /** process.platform. */
+  platform: Platform;
+  /** process.env (we read PATH, HOME, USERPROFILE, LOCALAPPDATA). */
+  env: Record<string, string | undefined>;
+  /** Existence probe — injectable for tests. Default node:fs existsSync. */
+  exists?: (p: string) => boolean;
+  /** Explicit `phantombot.binaryPath` setting, if the user set one. */
+  configuredPath?: string;
+}
+
+export interface ResolveResult {
+  /** Absolute path (or PATH-relative command) to spawn. */
+  path: string;
+  /** How it was found — surfaced in diagnostics. */
+  source: "setting" | "path" | "install-location";
+}
+
+/** The bare executable name for the platform. */
+export function binaryName(platform: Platform): string {
+  return platform === "win32" ? "phantombot.exe" : "phantombot";
+}
+
+/**
+ * Join path segments using the TARGET platform's rules — not the host's. This
+ * matters because the resolver may run on linux/darwin while reasoning about a
+ * win32 layout (and vice-versa in tests): `node:path`'s default `join` uses the
+ * HOST separator, which would mangle a Windows path on a POSIX box.
+ */
+function joinFor(platform: Platform, ...segments: string[]): string {
+  return platform === "win32"
+    ? win32.join(...segments)
+    : posix.join(...segments);
+}
+
+/** The PATH entry separator for the platform. */
+function pathSeparator(platform: Platform): string {
+  return platform === "win32" ? ";" : ":";
+}
+
+/**
+ * Candidate well-known install locations, in priority order, per platform.
+ * These mirror where phantombot's install.sh + `phantombot update` place the
+ * binary. Kept conservative — we only probe paths we actually write to.
+ */
+export function installLocationCandidates(
+  platform: Platform,
+  env: Record<string, string | undefined>,
+): string[] {
+  const name = binaryName(platform);
+  if (platform === "win32") {
+    // Implemented, UNTESTED on a real Windows host (no Windows box here).
+    const candidates: string[] = [];
+    const localAppData = env.LOCALAPPDATA;
+    if (localAppData) {
+      candidates.push(joinFor(platform, localAppData, "phantombot", "bin", name));
+      candidates.push(joinFor(platform, localAppData, "Programs", "phantombot", name));
+    }
+    const userProfile = env.USERPROFILE;
+    if (userProfile) {
+      candidates.push(joinFor(platform, userProfile, ".local", "bin", name));
+      candidates.push(joinFor(platform, userProfile, "bin", name));
+    }
+    candidates.push(joinFor(platform, "C:\\", "Program Files", "phantombot", name));
+    return candidates;
+  }
+
+  // linux + darwin share the POSIX layout.
+  const home = env.HOME;
+  const candidates: string[] = [];
+  if (home) {
+    candidates.push(joinFor(platform, home, ".local", "bin", name));
+    candidates.push(joinFor(platform, home, "bin", name));
+  }
+  candidates.push(joinFor(platform, "/usr", "local", "bin", name));
+  candidates.push(joinFor(platform, "/usr", "bin", name));
+  if (platform === "darwin") {
+    // Homebrew on Apple Silicon.
+    candidates.push(joinFor(platform, "/opt", "homebrew", "bin", name));
+  }
+  return candidates;
+}
+
+/** Probe every directory on $PATH for the binary. Returns the first hit. */
+export function findOnPath(
+  platform: Platform,
+  env: Record<string, string | undefined>,
+  exists: (p: string) => boolean,
+): string | undefined {
+  const rawPath = env.PATH ?? env.Path ?? "";
+  if (!rawPath) return undefined;
+  const name = binaryName(platform);
+  const sep = pathSeparator(platform);
+  for (const dir of rawPath.split(sep)) {
+    if (!dir) continue;
+    const candidate = joinFor(platform, dir, name);
+    if (exists(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the phantombot binary. Returns `undefined` if nothing is found, so
+ * the caller can render a precise error rather than spawning a bad path.
+ */
+export function resolvePhantombotBinary(
+  deps: ResolveDeps,
+): ResolveResult | undefined {
+  const exists = deps.exists ?? existsSync;
+
+  // 1. Explicit setting wins — but only if it actually exists, so a stale
+  //    setting falls through to discovery rather than dead-ending.
+  const configured = deps.configuredPath?.trim();
+  if (configured && exists(configured)) {
+    return { path: configured, source: "setting" };
+  }
+
+  // 2. PATH.
+  const onPath = findOnPath(deps.platform, deps.env, exists);
+  if (onPath) return { path: onPath, source: "path" };
+
+  // 3. Common install locations.
+  for (const candidate of installLocationCandidates(deps.platform, deps.env)) {
+    if (exists(candidate)) {
+      return { path: candidate, source: "install-location" };
+    }
+  }
+
+  return undefined;
+}
+
+/** Human-readable guidance shown in the panel when resolution fails. */
+export function notFoundMessage(platform: Platform): string {
+  const setting =
+    "Set the `phantombot.binaryPath` setting to its absolute path, " +
+    "or add it to your PATH.";
+  const name = binaryName(platform);
+  return (
+    `Could not find the \`${name}\` binary. ${setting}\n\n` +
+    "Install it from https://github.com/phantomyard/phantombot, then reload " +
+    "the window."
+  );
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,178 @@
+/**
+ * phantombot VS Code extension — `activate()` registers the `@phantombot` chat
+ * participant in VS Code's native Chat panel and bridges every turn to an
+ * embedded ACP client (a spawned `phantombot acp` subprocess).
+ *
+ * This is the ONLY module that imports `vscode`. Everything it leans on
+ * (binary resolution, the ACP client, the prompt bridge) is pure and unit
+ * tested under `bun test` with no `vscode` dependency. extension.ts is the thin
+ * glue: resolve the binary, lazily spawn one ACP client per workspace, open a
+ * session keyed on the workspace folder, and route chat requests through the
+ * bridge.
+ *
+ * PR2 will bundle this as a `.vsix` and auto-install it via
+ * reconcileEditorConnectors() (a VS Code EditorSpec slots beside ZED_EDITOR).
+ * Nothing here precludes that — the binary the editor spawns is exactly the one
+ * the connector will register.
+ */
+
+import * as vscode from "vscode";
+
+import { AcpClient } from "./acpClient.ts";
+import {
+  notFoundMessage,
+  resolvePhantombotBinary,
+  type ResolveResult,
+} from "./binaryResolver.ts";
+import { bridgePromptToStream } from "./participant.ts";
+
+const PARTICIPANT_ID = "phantombot.chat";
+
+/**
+ * One ACP client + session per workspace folder. The session id is opaque to
+ * us; phantombot keys its memory on the cwd (see session.ts), so reopening the
+ * same workspace lands in the same conversation server-side.
+ */
+interface WorkspaceConn {
+  client: AcpClient;
+  sessionId: string;
+  cwd: string;
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  const output = vscode.window.createOutputChannel("phantombot");
+  context.subscriptions.push(output);
+
+  // workspace cwd → live connection, spawned lazily on first prompt.
+  const conns = new Map<string, WorkspaceConn>();
+
+  const disposeAll = () => {
+    for (const [, conn] of conns) conn.client.dispose();
+    conns.clear();
+  };
+  context.subscriptions.push({ dispose: disposeAll });
+
+  const handler: vscode.ChatRequestHandler = async (
+    request,
+    _ctx,
+    stream,
+    token,
+  ) => {
+    const cwd = currentWorkspaceCwd();
+
+    let conn: WorkspaceConn;
+    try {
+      conn = await ensureConnection(cwd, output, conns, context);
+    } catch (e) {
+      const msg = (e as Error).message;
+      stream.markdown(`**phantombot could not start.**\n\n${msg}`);
+      output.appendLine(`[activate] connection failed: ${msg}`);
+      return { errorDetails: { message: msg } };
+    }
+
+    try {
+      const { stopReason } = await bridgePromptToStream({
+        client: conn.client,
+        sessionId: conn.sessionId,
+        request: { prompt: request.prompt },
+        stream: {
+          markdown: (v) => stream.markdown(v),
+          progress: (v) => stream.progress(v),
+        },
+        token: {
+          isCancellationRequested: token.isCancellationRequested,
+          onCancellationRequested: (l) => token.onCancellationRequested(l),
+        },
+      });
+      if (stopReason === "refusal") {
+        stream.markdown("\n\n_(phantombot declined this turn.)_");
+      }
+      return {};
+    } catch (e) {
+      // The subprocess died mid-turn, or the agent errored. Surface it — never
+      // a silent hang. Drop the dead connection so the next turn respawns.
+      const msg = (e as Error).message;
+      conn.client.dispose();
+      conns.delete(conn.cwd);
+      stream.markdown(`\n\n**phantombot error:** ${msg}`);
+      output.appendLine(`[prompt] ${msg}`);
+      return { errorDetails: { message: msg } };
+    }
+  };
+
+  const participant = vscode.chat.createChatParticipant(PARTICIPANT_ID, handler);
+  // Icon ships with the extension; falls back to the default robot if absent.
+  participant.iconPath = new vscode.ThemeIcon("hubot");
+  context.subscriptions.push(participant);
+
+  output.appendLine("phantombot chat participant registered (@phantombot).");
+}
+
+export function deactivate(): void {
+  // Subscriptions (incl. the disposeAll hook) are torn down by VS Code.
+}
+
+/** Resolve the workspace cwd, falling back to the home dir when none is open. */
+function currentWorkspaceCwd(): string {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (folder) return folder.uri.fsPath;
+  return process.cwd();
+}
+
+/**
+ * Lazily spawn + handshake an ACP client for a workspace, caching it. On any
+ * failure (binary not found, handshake error) this throws with an actionable
+ * message — the caller renders it into the panel.
+ */
+async function ensureConnection(
+  cwd: string,
+  output: vscode.OutputChannel,
+  conns: Map<string, WorkspaceConn>,
+  _context: vscode.ExtensionContext,
+): Promise<WorkspaceConn> {
+  const existing = conns.get(cwd);
+  if (existing) return existing;
+
+  const resolved = resolveBinaryOrThrow(output);
+  output.appendLine(
+    `[activate] using phantombot at ${resolved.path} (via ${resolved.source})`,
+  );
+
+  const persona = vscode.workspace
+    .getConfiguration("phantombot")
+    .get<string>("persona");
+
+  const client = new AcpClient({
+    binaryPath: resolved.path,
+    persona: persona && persona.trim() ? persona.trim() : undefined,
+    cwd,
+    onDiagnostic: (text) => output.append(text.endsWith("\n") ? text : text + "\n"),
+  });
+
+  await client.initialize();
+  const sessionId = await client.newSession(cwd);
+
+  const conn: WorkspaceConn = { client, sessionId, cwd };
+  conns.set(cwd, conn);
+  return conn;
+}
+
+/** Resolve the binary from settings/PATH/install-locations or throw. */
+function resolveBinaryOrThrow(output: vscode.OutputChannel): ResolveResult {
+  const configuredPath = vscode.workspace
+    .getConfiguration("phantombot")
+    .get<string>("binaryPath");
+
+  const resolved = resolvePhantombotBinary({
+    platform: process.platform,
+    env: process.env,
+    configuredPath: configuredPath || undefined,
+  });
+
+  if (!resolved) {
+    const msg = notFoundMessage(process.platform);
+    output.appendLine(`[activate] ${msg}`);
+    throw new Error(msg);
+  }
+  return resolved;
+}

--- a/editors/vscode/src/participant.ts
+++ b/editors/vscode/src/participant.ts
@@ -1,0 +1,93 @@
+/**
+ * Chat-participant bridge: VS Code chat request → ACP prompt → response stream.
+ *
+ * The UI surface is VS Code's native Chat panel via the Chat Participant API
+ * (`vscode.chat.createChatParticipant`, exposed as `@phantombot`). We do NOT
+ * build a webview — VS Code gives us scrollback, history and theming for free.
+ * This module is the thin bridge: it takes one chat request, drives a
+ * `session/prompt` over the embedded ACP client, and maps the streamed
+ * `session/update` chunks back into the panel's response stream.
+ *
+ * To keep the bridge unit-testable WITHOUT a `vscode` dependency, the core
+ * mapping (`bridgePromptToStream`) is written against minimal structural
+ * interfaces (`ResponseStream`, `PromptRequest`) that VS Code's real
+ * `ChatResponseStream` / `ChatRequest` satisfy at the call site in
+ * extension.ts. The bridge therefore runs under `bun test` over a fake stream +
+ * a fake ACP client, exactly as the server tests drive runAcpServer over a
+ * PassThrough.
+ */
+
+import type { AcpClient } from "./acpClient.ts";
+import type { AcpStopReason } from "./protocol.ts";
+
+/** The slice of `vscode.ChatResponseStream` the bridge writes to. */
+export interface ResponseStream {
+  /** Append assistant markdown text to the panel. */
+  markdown(value: string): void;
+  /** Optional: render a progress note (a presentational tool indicator). */
+  progress?(value: string): void;
+}
+
+/** The slice of `vscode.ChatRequest` the bridge reads. */
+export interface PromptRequest {
+  /** The user's typed prompt (already stripped of the @participant mention). */
+  prompt: string;
+}
+
+/** The slice of `vscode.CancellationToken` the bridge observes. */
+export interface CancellationLike {
+  isCancellationRequested: boolean;
+  onCancellationRequested(listener: () => void): { dispose(): void };
+}
+
+export interface BridgeOptions {
+  client: AcpClient;
+  sessionId: string;
+  request: PromptRequest;
+  stream: ResponseStream;
+  token?: CancellationLike;
+}
+
+export interface BridgeResult {
+  stopReason: AcpStopReason;
+}
+
+/**
+ * Drive one chat turn through the ACP client and into the response stream.
+ *
+ * - Text chunks (`agent_message_chunk`) are appended as markdown — VS Code
+ *   renders incrementally, so this is the live streaming surface.
+ * - Tool-call chunks become progress notes when the stream supports them.
+ * - Cancellation from the panel fires `session/cancel`; the agent settles the
+ *   prompt with `stopReason: "cancelled"`, which we return.
+ *
+ * Errors from the client (e.g. the subprocess died) propagate to the caller so
+ * extension.ts can render a precise message into the panel — never a silent
+ * hang.
+ */
+export async function bridgePromptToStream(
+  opts: BridgeOptions,
+): Promise<BridgeResult> {
+  const { client, sessionId, request, stream, token } = opts;
+
+  let cancelSub: { dispose(): void } | undefined;
+  if (token) {
+    if (token.isCancellationRequested) {
+      client.cancel(sessionId);
+    } else {
+      cancelSub = token.onCancellationRequested(() => {
+        client.cancel(sessionId);
+      });
+    }
+  }
+
+  try {
+    const stopReason = await client.prompt(sessionId, request.prompt, {
+      onText: (text) => stream.markdown(text),
+      onToolCall: (title) => stream.progress?.(title),
+    });
+    return { stopReason };
+  } finally {
+    cancelSub?.dispose();
+  }
+}

--- a/editors/vscode/src/protocol.ts
+++ b/editors/vscode/src/protocol.ts
@@ -1,0 +1,216 @@
+/**
+ * ACP (Agent Client Protocol) JSON-RPC 2.0 wire types — CLIENT side.
+ *
+ * This is the editor-side mirror of `src/connectors/acp/protocol.ts` in the
+ * phantombot server. The shapes here are deliberately a 1:1 copy of the wire
+ * contract the server already implements — they are NOT invented. Grounding
+ * references (server source, as of PR #209):
+ *
+ *   - initialize result:
+ *       { protocolVersion, agentInfo:{name,version}, authMethods:[],
+ *         agentCapabilities:{ loadSession, promptCapabilities:{...} } }
+ *     (server.ts handleInitialize)
+ *   - session/new params { cwd?, mcpServers? } → result { sessionId }
+ *     (server.ts handleSessionNew)
+ *   - session/load params { sessionId, cwd? } → streams session/update,
+ *     then result { modes: null }   (server.ts handleSessionLoad)
+ *   - session/prompt params { sessionId, prompt: AcpContentBlock[] } →
+ *       streams agent_message_chunk + tool_call session/update notifications,
+ *       then result { stopReason }   (server.ts handleSessionPrompt)
+ *   - session/update notification { sessionId, update }
+ *       update.sessionUpdate ∈ { agent_message_chunk, user_message_chunk,
+ *                                tool_call }   (protocol.ts + server.ts)
+ *   - session/cancel notification { sessionId }   (server.ts handleSessionCancel)
+ *
+ * The extension is the CLIENT (it spawns `phantombot acp` and drives it);
+ * phantombot is the AGENT and owns persona/memory/tools/trust server-side.
+ * This module is pure data — no I/O — so the client and participant layers
+ * share one definition.
+ */
+
+// ── JSON-RPC 2.0 envelopes ─────────────────────────────────────────────
+
+/** A JSON-RPC id is a string or number (the server never uses null ids). */
+export type JsonRpcId = string | number;
+
+/** A request OR a notification (notifications have no `id`). */
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  /** Absent ⇒ this is a notification (no response expected). */
+  id?: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcSuccess {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result: unknown;
+}
+
+export interface JsonRpcErrorObject {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface JsonRpcError {
+  jsonrpc: "2.0";
+  id: JsonRpcId | null;
+  error: JsonRpcErrorObject;
+}
+
+export type JsonRpcResponse = JsonRpcSuccess | JsonRpcError;
+
+/** True for the success arm of a JSON-RPC response. */
+export function isJsonRpcError(r: JsonRpcResponse): r is JsonRpcError {
+  return (r as JsonRpcError).error !== undefined;
+}
+
+// ── ACP protocol constants ─────────────────────────────────────────────
+
+/** Protocol version phantombot speaks. ACP draft = 1. Must match the server. */
+export const ACP_PROTOCOL_VERSION = 1;
+
+// ── ACP content blocks (subset we send) ────────────────────────────────
+
+export interface AcpTextBlock {
+  type: "text";
+  text: string;
+}
+
+export interface AcpResourceContents {
+  uri: string;
+  text?: string;
+  mimeType?: string;
+}
+
+export interface AcpResourceBlock {
+  type: "resource";
+  resource: AcpResourceContents;
+}
+
+export interface AcpResourceLinkBlock {
+  type: "resource_link";
+  uri: string;
+  name?: string;
+  mimeType?: string;
+  text?: string;
+}
+
+export interface AcpImageBlock {
+  type: "image";
+  data?: string;
+  mimeType?: string;
+}
+
+export type AcpContentBlock =
+  | AcpTextBlock
+  | AcpResourceBlock
+  | AcpResourceLinkBlock
+  | AcpImageBlock;
+
+// ── initialize result ──────────────────────────────────────────────────
+
+export interface AcpPromptCapabilities {
+  image?: boolean;
+  audio?: boolean;
+  embeddedContext?: boolean;
+}
+
+export interface AcpAgentCapabilities {
+  loadSession?: boolean;
+  promptCapabilities?: AcpPromptCapabilities;
+}
+
+export interface AcpInitializeResult {
+  protocolVersion: number;
+  agentInfo?: { name?: string; version?: string };
+  authMethods?: unknown[];
+  agentCapabilities?: AcpAgentCapabilities;
+}
+
+// ── session/new + session/load results ─────────────────────────────────
+
+export interface AcpNewSessionResult {
+  sessionId: string;
+}
+
+/** session/load returns a LoadSessionResponse struct (NEVER null). */
+export interface AcpLoadSessionResult {
+  modes: unknown | null;
+}
+
+// ── session/update notification payloads (what we receive) ─────────────
+
+export interface AgentMessageChunkUpdate {
+  sessionUpdate: "agent_message_chunk";
+  content: AcpTextBlock;
+}
+
+export interface UserMessageChunkUpdate {
+  sessionUpdate: "user_message_chunk";
+  content: AcpTextBlock;
+}
+
+export interface ToolCallUpdate {
+  sessionUpdate: "tool_call";
+  toolCallId: string;
+  title: string;
+  status: "pending" | "in_progress" | "completed" | "failed";
+  kind?: string;
+}
+
+export type AcpSessionUpdate =
+  | AgentMessageChunkUpdate
+  | UserMessageChunkUpdate
+  | ToolCallUpdate;
+
+export interface SessionUpdateParams {
+  sessionId: string;
+  update: AcpSessionUpdate;
+}
+
+/** Why a `session/prompt` stopped. */
+export type AcpStopReason = "end_turn" | "cancelled" | "refusal" | "max_tokens";
+
+export interface AcpPromptResult {
+  stopReason: AcpStopReason;
+}
+
+// ── Builders (client → agent) ──────────────────────────────────────────
+
+let nextId = 1;
+/** Monotonic JSON-RPC request id. Reset only for tests via `resetIdCounter`. */
+export function allocId(): number {
+  return nextId++;
+}
+
+/** TEST-ONLY: make id allocation deterministic across cases. */
+export function resetIdCounter(start = 1): void {
+  nextId = start;
+}
+
+export function jsonRpcRequest(
+  id: JsonRpcId,
+  method: string,
+  params?: unknown,
+): JsonRpcRequest {
+  const req: JsonRpcRequest = { jsonrpc: "2.0", id, method };
+  if (params !== undefined) req.params = params;
+  return req;
+}
+
+export function jsonRpcNotification(
+  method: string,
+  params?: unknown,
+): JsonRpcRequest {
+  const req: JsonRpcRequest = { jsonrpc: "2.0", method };
+  if (params !== undefined) req.params = params;
+  return req;
+}
+
+/** Build the `prompt` content-block array for a plain text user turn. */
+export function textPrompt(text: string): AcpContentBlock[] {
+  return [{ type: "text", text }];
+}

--- a/editors/vscode/tests/acpClient.test.ts
+++ b/editors/vscode/tests/acpClient.test.ts
@@ -1,0 +1,310 @@
+/**
+ * ACP client handshake + streaming tests.
+ *
+ * These drive the REAL `AcpClient` over an in-memory `AcpTransport` (a fake
+ * duplex) — no real `phantombot acp` subprocess, no `vscode` dependency. The
+ * fake transport mirrors the wire contract the server implements: it receives
+ * the client's serialized JSON lines, and we feed back exactly the responses /
+ * `session/update` notifications the real server emits (grounded in
+ * src/connectors/acp/server.ts).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { AcpClient, type AcpTransport } from "../src/acpClient.ts";
+import { resetIdCounter } from "../src/protocol.ts";
+
+/**
+ * A fake transport that captures what the client writes and lets the test push
+ * lines / stderr / close back. Models the agent side of the pipe.
+ */
+class FakeTransport implements AcpTransport {
+  written: string[] = [];
+  private lineHandler: (line: string) => void = () => {};
+  private stderrHandler: (text: string) => void = () => {};
+  private closeHandler: (info: { code: number | null }) => void = () => {};
+  closed = false;
+
+  write(line: string): void {
+    this.written.push(line);
+  }
+  onLine(handler: (line: string) => void): void {
+    this.lineHandler = handler;
+  }
+  onStderr(handler: (text: string) => void): void {
+    this.stderrHandler = handler;
+  }
+  onClose(handler: (info: { code: number | null }) => void): void {
+    this.closeHandler = handler;
+  }
+  close(): void {
+    this.closed = true;
+  }
+
+  // ── test-side drivers ──
+  /** Parse the most recent written message. */
+  lastSent(): any {
+    return JSON.parse(this.written[this.written.length - 1]!);
+  }
+  sent(index: number): any {
+    return JSON.parse(this.written[index]!);
+  }
+  /** Push a server line to the client. */
+  push(obj: unknown): void {
+    this.lineHandler(JSON.stringify(obj));
+  }
+  pushRaw(line: string): void {
+    this.lineHandler(line);
+  }
+  pushStderr(text: string): void {
+    this.stderrHandler(text);
+  }
+  fireClose(code: number | null): void {
+    this.closeHandler({ code });
+  }
+}
+
+describe("AcpClient — initialize", () => {
+  test("sends an initialize request and resolves the negotiated result", async () => {
+    resetIdCounter();
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+
+    const p = client.initialize();
+    const sent = t.lastSent();
+    expect(sent.jsonrpc).toBe("2.0");
+    expect(sent.method).toBe("initialize");
+    expect(sent.params.protocolVersion).toBe(1);
+    expect(typeof sent.id).toBe("number");
+
+    // Reply with the exact shape the server's handleInitialize emits.
+    t.push({
+      jsonrpc: "2.0",
+      id: sent.id,
+      result: {
+        protocolVersion: 1,
+        agentInfo: { name: "Phantombot", version: "0.1.0-dev" },
+        authMethods: [],
+        agentCapabilities: {
+          loadSession: true,
+          promptCapabilities: { image: true, audio: false, embeddedContext: true },
+        },
+      },
+    });
+
+    const result = await p;
+    expect(result.protocolVersion).toBe(1);
+    expect(result.agentInfo?.name).toBe("Phantombot");
+    expect(result.agentCapabilities?.loadSession).toBe(true);
+  });
+});
+
+describe("AcpClient — session/new", () => {
+  test("requests a session and returns the minted sessionId", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+
+    const p = client.newSession("/home/dev/proj");
+    const sent = t.lastSent();
+    expect(sent.method).toBe("session/new");
+    expect(sent.params.cwd).toBe("/home/dev/proj");
+    expect(sent.params.mcpServers).toEqual([]);
+
+    t.push({ jsonrpc: "2.0", id: sent.id, result: { sessionId: "acp_abc123" } });
+    expect(await p).toBe("acp_abc123");
+  });
+});
+
+describe("AcpClient — session/prompt streaming", () => {
+  test("streams ordered agent_message_chunks then resolves the stop reason", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+
+    const chunks: string[] = [];
+    const tools: string[] = [];
+    const p = client.prompt("acp_s", "say hi", {
+      onText: (txt) => chunks.push(txt),
+      onToolCall: (title) => tools.push(title),
+    });
+
+    const sent = t.lastSent();
+    expect(sent.method).toBe("session/prompt");
+    expect(sent.params.sessionId).toBe("acp_s");
+    expect(sent.params.prompt).toEqual([{ type: "text", text: "say hi" }]);
+
+    // Agent streams updates exactly as server.ts does.
+    t.push({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acp_s",
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Hello " } },
+      },
+    });
+    t.push({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acp_s",
+        update: { sessionUpdate: "tool_call", toolCallId: "tool_1", title: "thinking", status: "in_progress" },
+      },
+    });
+    t.push({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acp_s",
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "world" } },
+      },
+    });
+    // Then the prompt request resolves.
+    t.push({ jsonrpc: "2.0", id: sent.id, result: { stopReason: "end_turn" } });
+
+    const stopReason = await p;
+    expect(stopReason).toBe("end_turn");
+    expect(chunks).toEqual(["Hello ", "world"]);
+    expect(tools).toEqual(["thinking"]);
+  });
+
+  test("ignores updates for a different sessionId", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+    const chunks: string[] = [];
+    const p = client.prompt("acp_mine", "go", { onText: (txt) => chunks.push(txt) });
+    const sent = t.lastSent();
+
+    // An update for a foreign session must NOT leak into this prompt.
+    t.push({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acp_other",
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "leak" } },
+      },
+    });
+    t.push({ jsonrpc: "2.0", id: sent.id, result: { stopReason: "end_turn" } });
+
+    await p;
+    expect(chunks).toEqual([]);
+  });
+
+  test("cancel sends a session/cancel notification and the prompt settles cancelled", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+    const p = client.prompt("acp_c", "long task");
+    const promptSent = t.lastSent();
+
+    client.cancel("acp_c");
+    const cancelMsg = t.lastSent();
+    expect(cancelMsg.method).toBe("session/cancel");
+    expect(cancelMsg.id).toBeUndefined(); // notification — no id
+    expect(cancelMsg.params.sessionId).toBe("acp_c");
+
+    // Server settles the prompt as cancelled (server.ts: abort → stopReason).
+    t.push({ jsonrpc: "2.0", id: promptSent.id, result: { stopReason: "cancelled" } });
+    expect(await p).toBe("cancelled");
+  });
+});
+
+describe("AcpClient — session/load replay", () => {
+  test("routes replayed user+assistant chunks to the load handlers", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+    const texts: string[] = [];
+    const p = client.loadSession("acp_loaded", "/home/dev/p", {
+      onText: (txt) => texts.push(txt),
+    });
+    const sent = t.lastSent();
+    expect(sent.method).toBe("session/load");
+    expect(sent.params.sessionId).toBe("acp_loaded");
+
+    // Server replays history as user_message_chunk + agent_message_chunk.
+    t.push({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acp_loaded",
+        update: { sessionUpdate: "user_message_chunk", content: { type: "text", text: "earlier Q" } },
+      },
+    });
+    t.push({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acp_loaded",
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "earlier A" } },
+      },
+    });
+    // LoadSessionResponse struct — NEVER null (the #207 lesson).
+    t.push({ jsonrpc: "2.0", id: sent.id, result: { modes: null } });
+
+    const result = await p;
+    expect(result).not.toBeNull();
+    expect(texts).toEqual(["earlier Q", "earlier A"]);
+  });
+});
+
+describe("AcpClient — error + lifecycle handling", () => {
+  test("a JSON-RPC error response rejects the request", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+    const p = client.prompt("acp_bad", "x");
+    const sent = t.lastSent();
+    t.push({
+      jsonrpc: "2.0",
+      id: sent.id,
+      error: { code: -32602, message: "unknown sessionId 'acp_bad'" },
+    });
+    await expect(p).rejects.toThrow(/-32602.*unknown sessionId/);
+  });
+
+  test("subprocess close rejects all in-flight requests", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+    const p = client.prompt("acp_s", "hi");
+    t.fireClose(1);
+    await expect(p).rejects.toThrow(/exited with code 1/);
+  });
+
+  test("requests after close reject immediately rather than hanging", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+    t.fireClose(0);
+    await expect(client.newSession("/x")).rejects.toThrow(/closed/);
+  });
+
+  test("a non-JSON line is dropped via the diagnostic sink, not thrown", async () => {
+    const diags: string[] = [];
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t, onDiagnostic: (d) => diags.push(d) });
+    const p = client.initialize();
+    const sent = t.lastSent();
+    t.pushRaw("this is not json");
+    t.push({ jsonrpc: "2.0", id: sent.id, result: { protocolVersion: 1 } });
+    await p;
+    expect(diags.some((d) => d.includes("non-JSON"))).toBe(true);
+  });
+
+  test("stderr from the agent is forwarded to the diagnostic sink", async () => {
+    const diags: string[] = [];
+    const t = new FakeTransport();
+    new AcpClient({ transport: t, onDiagnostic: (d) => diags.push(d) });
+    t.pushStderr("[acp] some warning");
+    expect(diags).toContain("[acp] some warning");
+  });
+
+  test("a short request timeout fires when no response arrives", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t, requestTimeoutMs: 10 });
+    await expect(client.initialize()).rejects.toThrow(/timed out/);
+  });
+
+  test("dispose tears down the transport and rejects pending work", async () => {
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+    const p = client.prompt("acp_s", "hi");
+    client.dispose();
+    expect(t.closed).toBe(true);
+    await expect(p).rejects.toThrow();
+  });
+});

--- a/editors/vscode/tests/binaryResolver.test.ts
+++ b/editors/vscode/tests/binaryResolver.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Binary-resolution tests — drive the pure resolver with injected
+ * platform/env/exists so a single suite exercises linux, darwin AND the win32
+ * branch (which is implemented but has no real Windows host to run on).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  binaryName,
+  findOnPath,
+  installLocationCandidates,
+  notFoundMessage,
+  resolvePhantombotBinary,
+} from "../src/binaryResolver.ts";
+
+describe("binaryName", () => {
+  test("appends .exe on win32 only", () => {
+    expect(binaryName("linux")).toBe("phantombot");
+    expect(binaryName("darwin")).toBe("phantombot");
+    expect(binaryName("win32")).toBe("phantombot.exe");
+  });
+});
+
+describe("resolvePhantombotBinary — precedence", () => {
+  test("an existing configured path wins over everything", () => {
+    const r = resolvePhantombotBinary({
+      platform: "linux",
+      env: { PATH: "/usr/bin", HOME: "/home/dev" },
+      configuredPath: "/opt/custom/phantombot",
+      exists: (p) => p === "/opt/custom/phantombot" || p === "/usr/bin/phantombot",
+    });
+    expect(r).toEqual({ path: "/opt/custom/phantombot", source: "setting" });
+  });
+
+  test("a stale (non-existent) configured path falls through to PATH", () => {
+    const r = resolvePhantombotBinary({
+      platform: "linux",
+      env: { PATH: "/usr/bin", HOME: "/home/dev" },
+      configuredPath: "/gone/phantombot",
+      exists: (p) => p === "/usr/bin/phantombot",
+    });
+    expect(r).toEqual({ path: "/usr/bin/phantombot", source: "path" });
+  });
+
+  test("PATH is searched in order before install locations", () => {
+    const r = resolvePhantombotBinary({
+      platform: "linux",
+      env: { PATH: "/a:/b:/c", HOME: "/home/dev" },
+      exists: (p) => p === "/b/phantombot" || p === "/home/dev/.local/bin/phantombot",
+    });
+    // /b on PATH beats the install-location candidate.
+    expect(r).toEqual({ path: "/b/phantombot", source: "path" });
+  });
+
+  test("falls back to a common install location when not on PATH", () => {
+    const r = resolvePhantombotBinary({
+      platform: "linux",
+      env: { PATH: "/nowhere", HOME: "/home/dev" },
+      exists: (p) => p === "/home/dev/.local/bin/phantombot",
+    });
+    expect(r).toEqual({
+      path: "/home/dev/.local/bin/phantombot",
+      source: "install-location",
+    });
+  });
+
+  test("returns undefined when nothing resolves", () => {
+    const r = resolvePhantombotBinary({
+      platform: "linux",
+      env: { PATH: "/nowhere", HOME: "/home/dev" },
+      exists: () => false,
+    });
+    expect(r).toBeUndefined();
+  });
+});
+
+describe("resolvePhantombotBinary — darwin", () => {
+  test("probes the Homebrew Apple-Silicon path", () => {
+    const candidates = installLocationCandidates("darwin", { HOME: "/Users/dev" });
+    expect(candidates).toContain("/opt/homebrew/bin/phantombot");
+    const r = resolvePhantombotBinary({
+      platform: "darwin",
+      env: { PATH: "/nowhere", HOME: "/Users/dev" },
+      exists: (p) => p === "/opt/homebrew/bin/phantombot",
+    });
+    expect(r?.source).toBe("install-location");
+  });
+});
+
+describe("resolvePhantombotBinary — win32 (implemented, untested on real host)", () => {
+  test("uses ; as the PATH separator and phantombot.exe", () => {
+    const found = findOnPath(
+      "win32",
+      { PATH: "C:\\bin;C:\\tools" },
+      (p) => p === "C:\\tools\\phantombot.exe",
+    );
+    expect(found).toBe("C:\\tools\\phantombot.exe");
+  });
+
+  test("install-location candidates use LOCALAPPDATA + USERPROFILE", () => {
+    const candidates = installLocationCandidates("win32", {
+      LOCALAPPDATA: "C:\\Users\\dev\\AppData\\Local",
+      USERPROFILE: "C:\\Users\\dev",
+    });
+    expect(
+      candidates.some((c) => c.includes("AppData\\Local") && c.endsWith("phantombot.exe")),
+    ).toBe(true);
+    expect(candidates.some((c) => c.endsWith("phantombot.exe"))).toBe(true);
+  });
+
+  test("resolves a win32 install location end-to-end", () => {
+    const r = resolvePhantombotBinary({
+      platform: "win32",
+      env: {
+        PATH: "C:\\nowhere",
+        LOCALAPPDATA: "C:\\Users\\dev\\AppData\\Local",
+        USERPROFILE: "C:\\Users\\dev",
+      },
+      exists: (p) => p.endsWith("phantombot.exe") && p.includes("AppData\\Local"),
+    });
+    expect(r?.source).toBe("install-location");
+    expect(r?.path.endsWith("phantombot.exe")).toBe(true);
+  });
+});
+
+describe("notFoundMessage", () => {
+  test("names the platform binary and points at the setting", () => {
+    expect(notFoundMessage("linux")).toContain("phantombot");
+    expect(notFoundMessage("linux")).toContain("phantombot.binaryPath");
+    expect(notFoundMessage("win32")).toContain("phantombot.exe");
+  });
+});

--- a/editors/vscode/tests/participant.test.ts
+++ b/editors/vscode/tests/participant.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Participant-bridge tests.
+ *
+ * `bridgePromptToStream` is written against minimal structural interfaces so it
+ * runs with no `vscode` dependency. We drive it with a fake ACP client (the
+ * shape extension.ts uses) and a fake response stream, asserting that streamed
+ * chunks land in the panel, tool calls become progress notes, and cancellation
+ * fires session/cancel.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  bridgePromptToStream,
+  type CancellationLike,
+  type ResponseStream,
+} from "../src/participant.ts";
+import type { AcpClient } from "../src/acpClient.ts";
+import type { AcpStopReason } from "../src/protocol.ts";
+
+/** A fake stream recording markdown + progress writes. */
+class FakeStream implements ResponseStream {
+  md: string[] = [];
+  prog: string[] = [];
+  markdown(value: string): void {
+    this.md.push(value);
+  }
+  progress(value: string): void {
+    this.prog.push(value);
+  }
+}
+
+/** A controllable cancellation token. */
+class FakeToken implements CancellationLike {
+  isCancellationRequested = false;
+  private listeners: (() => void)[] = [];
+  onCancellationRequested(listener: () => void): { dispose(): void } {
+    this.listeners.push(listener);
+    return { dispose: () => {} };
+  }
+  fire(): void {
+    this.isCancellationRequested = true;
+    for (const l of this.listeners) l();
+  }
+}
+
+/**
+ * A fake ACP client that, on prompt(), drives the supplied handlers with a
+ * scripted set of chunks, then resolves a stop reason. Records cancels.
+ */
+function makeFakeClient(opts: {
+  text?: string[];
+  tools?: { title: string; status: string }[];
+  stopReason?: AcpStopReason;
+  /** If set, prompt() waits for cancel() before resolving (cancellation test). */
+  blockUntilCancel?: boolean;
+}): AcpClient & { cancels: string[] } {
+  const cancels: string[] = [];
+  let cancelled = false;
+  let releaseOnCancel: (() => void) | undefined;
+  const fake = {
+    cancels,
+    cancel(sessionId: string) {
+      cancels.push(sessionId);
+      cancelled = true;
+      releaseOnCancel?.();
+    },
+    async prompt(
+      _sessionId: string,
+      _prompt: string,
+      handlers: {
+        onText?(t: string): void;
+        onToolCall?(title: string, status: string): void;
+      },
+    ): Promise<AcpStopReason> {
+      for (const t of opts.text ?? []) handlers.onText?.(t);
+      for (const tc of opts.tools ?? []) handlers.onToolCall?.(tc.title, tc.status);
+      if (opts.blockUntilCancel) {
+        // The server settles a prompt as cancelled once the cancel notification
+        // arrives — model that here regardless of cancel/prompt ordering.
+        if (!cancelled) {
+          await new Promise<void>((resolve) => {
+            releaseOnCancel = resolve;
+          });
+        }
+        return "cancelled";
+      }
+      return opts.stopReason ?? "end_turn";
+    },
+  };
+  return fake as unknown as AcpClient & { cancels: string[] };
+}
+
+describe("bridgePromptToStream", () => {
+  test("streams text chunks into the panel as markdown and returns the stop reason", async () => {
+    const client = makeFakeClient({ text: ["Hello ", "world"], stopReason: "end_turn" });
+    const stream = new FakeStream();
+    const result = await bridgePromptToStream({
+      client,
+      sessionId: "acp_s",
+      request: { prompt: "hi" },
+      stream,
+    });
+    expect(stream.md).toEqual(["Hello ", "world"]);
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  test("maps tool_call updates to progress notes", async () => {
+    const client = makeFakeClient({
+      text: ["done"],
+      tools: [{ title: "searching", status: "in_progress" }],
+    });
+    const stream = new FakeStream();
+    await bridgePromptToStream({
+      client,
+      sessionId: "acp_s",
+      request: { prompt: "find x" },
+      stream,
+    });
+    expect(stream.prog).toEqual(["searching"]);
+    expect(stream.md).toEqual(["done"]);
+  });
+
+  test("a pre-cancelled token fires session/cancel up front", async () => {
+    const client = makeFakeClient({ blockUntilCancel: true });
+    const token = new FakeToken();
+    token.isCancellationRequested = true;
+    const stream = new FakeStream();
+    const result = await bridgePromptToStream({
+      client,
+      sessionId: "acp_pc",
+      request: { prompt: "go" },
+      stream,
+      token,
+    });
+    expect(client.cancels).toContain("acp_pc");
+    expect(result.stopReason).toBe("cancelled");
+  });
+
+  test("cancelling mid-turn fires session/cancel and settles cancelled", async () => {
+    const client = makeFakeClient({ text: ["working"], blockUntilCancel: true });
+    const token = new FakeToken();
+    const stream = new FakeStream();
+    const promise = bridgePromptToStream({
+      client,
+      sessionId: "acp_mid",
+      request: { prompt: "long" },
+      stream,
+      token,
+    });
+    // Let the prompt emit its first chunk, then cancel.
+    await new Promise((r) => setImmediate(r));
+    token.fire();
+    const result = await promise;
+    expect(client.cancels).toEqual(["acp_mid"]);
+    expect(result.stopReason).toBe("cancelled");
+    expect(stream.md).toEqual(["working"]);
+  });
+
+  test("client errors propagate so the caller can render them", async () => {
+    const failing = {
+      cancel() {},
+      async prompt(): Promise<AcpStopReason> {
+        throw new Error("subprocess died");
+      },
+    } as unknown as AcpClient;
+    await expect(
+      bridgePromptToStream({
+        client: failing,
+        sessionId: "acp_e",
+        request: { prompt: "x" },
+        stream: new FakeStream(),
+      }),
+    ).rejects.toThrow(/subprocess died/);
+  });
+});

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node", "vscode"]
+  },
+  "//": "Tests are run + type-checked by `bun test` (they use the bun:test runner and @types/bun). `tsc` here checks the shippable extension source against the vscode + node types.",
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## What

First-party VS Code extension (`editors/vscode/`) that registers phantombot as a native **chat participant** (`@phantombot`) and speaks **ACP directly** to the phantombot binary — **no third-party extension dependency**.

This is PR1 of the VS Code work. It's the extension package itself; **PR2** will wire `.vsix` bundling + auto-install into `reconcileEditorConnectors()` (the same flow as Zed in #209).

## Why first-party

VS Code has no native ACP support, and leaning on a stranger's extension (e.g. `formulahendry.acp-client`) means depending on its schema/maintenance. A first-party extension keeps phantombot in control of registration, UX, and the update path — and works the same on Linux/Mac/Windows.

Phantombot runs as a subprocess over ACP, so persona, memory, tools, and the trusted-turn perimeter all stay server-side — Copilot/VS Code can't reach across the stdio pipe and strip any of it.

## Layout

- **`src/acpClient.ts`** — spawns `phantombot acp`, JSON-RPC 2.0 over stdio (`initialize` → `session/new`|`session/load` → `session/prompt`), streams `session/update`. Transport injected for testability.
- **`src/participant.ts`** — bridges a VS Code chat request → ACP prompt, maps streamed `session/update` chunks back into the native chat panel (free scrollback/history/theming). Pure bridge fn for tests.
- **`src/binaryResolver.ts`** — `phantombot.binaryPath` setting → `PATH` → common install locations; win32-ready.
- **`src/extension.ts`** — vscode-bound activation + session lifecycle.

## Discipline / lessons respected

- **ACP only, no MCP** — avoids the wrong-protocol mistake that got #202/#203 reverted.
- `session/load` returns the `LoadSessionResponse` struct, not `null` (per #207).

## Verification

- Root typecheck clean; extension typecheck clean.
- Full suite **1537 pass / 0 fail** (+29 new extension tests).
- esbuild bundle builds (16.9kb, `vscode` externalized).
- ACP handshake **smoke-tested against the real arm64 binary**: `initialize` (protocolVersion 1, agentInfo "Phantombot", loadSession true) → `session/new` (`acp_<hex>`) → `session/load` (`{modes:null}` struct).
