### PR TITLE
fix(phantomchat): stamp voice-note duration so bubbles show real length

### DIFF
--- a/src/channels/phantomchat/oggOpusDuration.ts
+++ b/src/channels/phantomchat/oggOpusDuration.ts
@@ -1,0 +1,49 @@
+/**
+ * Compute the playback duration (in seconds) of an Ogg/Opus stream.
+ *
+ * Opus granule positions run on a fixed 48 kHz clock (RFC 7845 §4),
+ * independent of the originally-encoded sample rate. The total decoded sample
+ * count is the granule position of the LAST Ogg page; subtracting the pre-skip
+ * declared in the OpusHead identification header gives the audible sample
+ * count. Duration = audibleSamples / 48000.
+ *
+ * This is a tiny container walk — no decode — so it's cheap to run on every
+ * voice reply. Returns 0 for anything that isn't a parseable Ogg/Opus stream;
+ * callers treat 0 as "unknown duration" and simply omit the field.
+ */
+export function oggOpusDurationSeconds(buf: Buffer): number {
+  const OGGS = 0x4f676753; // "OggS" capture pattern, big-endian
+  const GRANULE_NONE = 0xffffffffffffffffn; // -1 → no packet completed on page
+
+  // Pre-skip: little-endian u16 at OpusHead + 10
+  // (magic[8] + version[1] + channelCount[1] = offset 10).
+  let preSkip = 0;
+  const headIdx = buf.indexOf("OpusHead", 0, "latin1");
+  if (headIdx >= 0 && headIdx + 12 <= buf.length) {
+    preSkip = buf.readUInt16LE(headIdx + 10);
+  }
+
+  // Walk Ogg pages to find the last valid granule position.
+  let lastGranule = -1;
+  for (let i = 0; i + 27 <= buf.length; ) {
+    if (buf.readUInt32BE(i) === OGGS) {
+      const granule = buf.readBigUInt64LE(i + 6);
+      const segCount = buf[i + 26] ?? 0;
+      const headerEnd = i + 27 + segCount;
+      if (headerEnd > buf.length) break;
+      let payload = 0;
+      for (let s = 0; s < segCount; s++) payload += buf[i + 27 + s] ?? 0;
+      if (granule !== GRANULE_NONE) lastGranule = Number(granule);
+      i = headerEnd + payload;
+    } else {
+      i++;
+    }
+  }
+
+  if (lastGranule < 0) return 0;
+  const samples = Math.max(0, lastGranule - preSkip);
+  if (samples === 0) return 0;
+  // Voice-note duration is conventionally whole seconds; never round a
+  // non-empty clip down to 0.
+  return Math.max(1, Math.round(samples / 48000));
+}

--- a/src/channels/phantomchat/transport.ts
+++ b/src/channels/phantomchat/transport.ts
@@ -27,6 +27,7 @@ import {
 } from "../../lib/nostrCrypto.ts";
 import { encryptFileBytes } from "./fileEncrypt.ts";
 import { uploadToBlossom } from "./blossomUpload.ts";
+import { oggOpusDurationSeconds } from "./oggOpusDuration.ts";
 
 /**
  * The five default public relays the PhantomChat PWA uses. phantombot must be
@@ -438,6 +439,10 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     // File metadata travels INSIDE the envelope's `content` (a JSON string), so
     // the recipient JSON.parses the envelope, then JSON.parses content → meta.
     // `size` is the PLAINTEXT byte count (matches the PWA's blob.size).
+    // Playback duration (seconds) so the recipient's bubble shows the real
+    // length instead of 0:00. 0 ⇒ unparseable; omit and let the player fall
+    // back rather than stamp a bogus length.
+    const durationS = oggOpusDurationSeconds(audio);
     const fileMeta = JSON.stringify({
       url,
       sha256: enc.sha256Hex,
@@ -447,6 +452,7 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
       iv: enc.ivHex,
       // Authoritative media class so the receiver never re-guesses voice vs file.
       mediaType: "voice",
+      ...(durationS > 0 ? { duration: durationS } : {}),
     });
     const envelope = JSON.stringify({
       id: `pc-${Date.now()}-${crypto.randomUUID().slice(0, 6)}`,

--- a/tests/channels-phantomchat-oggOpusDuration.test.ts
+++ b/tests/channels-phantomchat-oggOpusDuration.test.ts
@@ -1,0 +1,71 @@
+/*
+ * oggOpusDurationSeconds: walks an Ogg/Opus container and derives playback
+ * length from the last page's 48 kHz granule position minus the OpusHead
+ * pre-skip. These tests build minimal-but-valid Ogg pages so the parser's math
+ * is pinned without shipping a binary fixture.
+ */
+import { describe, expect, test } from "bun:test";
+import { oggOpusDurationSeconds } from "../src/channels/phantomchat/oggOpusDuration.ts";
+
+/** Build one Ogg page. Each segment payload must be < 255 bytes (no lacing). */
+function oggPage(granule: bigint, headerType: number, segments: Buffer[]): Buffer {
+  const header = Buffer.alloc(27);
+  header.write("OggS", 0, "latin1");
+  header[4] = 0; // stream structure version
+  header[5] = headerType; // 0x02 BOS, 0x04 EOS
+  header.writeBigUInt64LE(granule, 6);
+  // serial (14), page seq (18), CRC (22) left zero — parser ignores them.
+  header[26] = segments.length;
+  const segTable = Buffer.from(segments.map((s) => s.length));
+  return Buffer.concat([header, segTable, ...segments]);
+}
+
+/** OpusHead identification packet with the given pre-skip (LE u16 at +10). */
+function opusHead(preSkip: number): Buffer {
+  const head = Buffer.alloc(19);
+  head.write("OpusHead", 0, "latin1");
+  head[8] = 1; // version
+  head[9] = 1; // channel count
+  head.writeUInt16LE(preSkip, 10);
+  head.writeUInt32LE(48000, 12); // input sample rate
+  head.writeUInt16LE(0, 16); // output gain
+  head[18] = 0; // channel mapping family
+  return head;
+}
+
+describe("oggOpusDurationSeconds", () => {
+  test("derives duration from last granule minus pre-skip", () => {
+    const preSkip = 312;
+    const head = oggPage(0n, 0x02, [opusHead(preSkip)]);
+    // 3 audible seconds => 3*48000 samples + preSkip in the granule.
+    const last = oggPage(BigInt(3 * 48000 + preSkip), 0x04, [Buffer.alloc(10, 1)]);
+    expect(oggOpusDurationSeconds(Buffer.concat([head, last]))).toBe(3);
+  });
+
+  test("rounds to nearest whole second", () => {
+    const preSkip = 0;
+    const head = oggPage(0n, 0x02, [opusHead(preSkip)]);
+    // 2.7s -> rounds to 3
+    const last = oggPage(BigInt(Math.round(2.7 * 48000)), 0x04, [Buffer.alloc(5, 9)]);
+    expect(oggOpusDurationSeconds(Buffer.concat([head, last]))).toBe(3);
+  });
+
+  test("never rounds a non-empty clip down to zero", () => {
+    const head = oggPage(0n, 0x02, [opusHead(0)]);
+    // 0.2s -> Math.round would give 0; clamped to 1.
+    const last = oggPage(BigInt(Math.round(0.2 * 48000)), 0x04, [Buffer.alloc(3, 7)]);
+    expect(oggOpusDurationSeconds(Buffer.concat([head, last]))).toBe(1);
+  });
+
+  test("ignores -1 granule pages (no completed packet)", () => {
+    const head = oggPage(0n, 0x02, [opusHead(0)]);
+    const real = oggPage(BigInt(48000), 0x00, [Buffer.alloc(8, 2)]);
+    const noPacket = oggPage(0xffffffffffffffffn, 0x00, [Buffer.alloc(4, 3)]);
+    expect(oggOpusDurationSeconds(Buffer.concat([head, real, noPacket]))).toBe(1);
+  });
+
+  test("returns 0 for non-Ogg input", () => {
+    expect(oggOpusDurationSeconds(Buffer.from("not an ogg stream at all"))).toBe(0);
+    expect(oggOpusDurationSeconds(Buffer.alloc(0))).toBe(0);
+  });
+});


### PR DESCRIPTION
Follow-up to #210 (two-way voice notes). Outbound voice notes rendered as **0:00** in the recipient's bubble even though they played fine — the voice file-metadata envelope carried no `duration`, and the PWA bubble defaults to 0 when it's absent.

## Fix
Compute the Ogg/Opus playback length at send time from the container's 48 kHz granule position (minus the OpusHead pre-skip, per RFC 7845) and include it as `duration` in the voice metadata envelope. It's a cheap container walk — no decode.

- `oggOpusDuration.ts` — `oggOpusDurationSeconds()`; returns 0 for non-Ogg input (callers omit the field).
- `transport.sendVoice()` — stamps `duration` when > 0.

## Tests
`oggOpusDuration.test.ts` builds minimal Ogg/Opus pages to pin the granule math (whole-second rounding, the never-round-to-zero clamp, -1 granule skip, non-Ogg → 0). Typecheck clean, phantomchat suite green.