### PR TITLE
fix(acp): self-heal default persona instead of exit 2

### DIFF
--- a/src/connectors/acp/server.ts
+++ b/src/connectors/acp/server.ts
@@ -23,6 +23,7 @@ import { join } from "node:path";
 import type { Readable, Writable } from "node:stream";
 
 import { type Config, loadConfig, personaDir } from "../../config.ts";
+import { healDefaultPersonaIfBroken } from "../../lib/personaDefault.ts";
 import { buildHarnessChain } from "../../harnesses/buildChain.ts";
 import { resolveHarnessBinsForConfig } from "../../lib/harnessAvailability.ts";
 import type { Harness } from "../../harnesses/types.ts";
@@ -91,11 +92,31 @@ export async function runAcpServer(
   const logErr: WriteSink = options.logErr ?? process.stderr;
 
   let config = options.config ?? (await loadConfig());
-  const persona = options.persona ?? config.defaultPersona;
-  const agentDir = personaDir(config, persona);
+  // Resolve the persona. An explicit `--persona NAME` is honored verbatim and
+  // hard-errors if missing (the user named a specific one). When no persona is
+  // given we fall back to `config.defaultPersona`, and if that dir doesn't exist
+  // we self-heal to any persona on disk — mirroring `phantombot run` — so a fresh
+  // box (whose built-in default `phantom` dir was never created) still starts the
+  // editor over ACP instead of dying with exit 2. Only hard-error if there are
+  // genuinely zero personas to fall back to.
+  let persona = options.persona ?? config.defaultPersona;
+  let agentDir = personaDir(config, persona);
   if (!existsSync(agentDir)) {
-    logErr.write(`phantombot acp: persona '${persona}' not found at ${agentDir}\n`);
-    return 2;
+    if (options.persona !== undefined) {
+      logErr.write(`phantombot acp: persona '${persona}' not found at ${agentDir}\n`);
+      return 2;
+    }
+    const healed = await healDefaultPersonaIfBroken(config, logErr);
+    if (!healed) {
+      logErr.write(
+        `phantombot acp: default persona '${persona}' not found at ${agentDir} ` +
+          "and no other personas exist.\nCreate one with `phantombot persona`.\n",
+      );
+      return 2;
+    }
+    persona = healed;
+    config.defaultPersona = healed;
+    agentDir = personaDir(config, persona);
   }
 
   let harnesses = options.harnesses;

--- a/tests/connectors-acp-server.test.ts
+++ b/tests/connectors-acp-server.test.ts
@@ -585,3 +585,93 @@ describe("ACP server — bad input", () => {
     expect(reply.error.code).toBe(-32700);
   });
 });
+
+describe("ACP server — persona resolution & self-heal", () => {
+  let pdir: string;
+  let savedStateEnv: string | undefined;
+  let healConfig: Config;
+
+  beforeEach(async () => {
+    pdir = await mkdtemp(join(tmpdir(), "phantombot-acp-persona-"));
+    savedStateEnv = process.env.PHANTOMBOT_STATE;
+    process.env.PHANTOMBOT_STATE = join(pdir, "state.json");
+    healConfig = {
+      defaultPersona: "phantom", // built-in default whose dir is NOT created
+      harnessIdleTimeoutMs: 5000,
+      harnessHardTimeoutMs: 5000,
+      personasDir: join(pdir, "personas"),
+      memoryDbPath: join(pdir, "memory.sqlite"),
+      configPath: join(pdir, "config.toml"),
+      harnesses: {
+        chain: ["claude"],
+        claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+        pi: { bin: "pi", maxPayloadBytes: 1 },
+        gemini: { bin: "gemini", model: "" },
+      },
+      channels: {},
+      embeddings: { provider: "none" },
+      voice: { provider: "none" },
+    };
+  });
+
+  afterEach(async () => {
+    if (savedStateEnv === undefined) delete process.env.PHANTOMBOT_STATE;
+    else process.env.PHANTOMBOT_STATE = savedStateEnv;
+    await rm(pdir, { recursive: true, force: true });
+  });
+
+  // Run the server to completion with an immediately-closed input stream.
+  // Returns the exit code and captured stderr. Injects a harness so harness
+  // resolution is skipped — we're exercising the persona gate only.
+  async function runToClose(persona?: string): Promise<{ code: number; err: string }> {
+    const input = new PassThrough();
+    const errSink = new CapturingErr();
+    const done = runAcpServer({
+      config: healConfig,
+      memory,
+      harnesses: [new ScriptedHarness("h", () => [])],
+      input,
+      output: new CapturingOut() as any,
+      logErr: errSink,
+      ...(persona !== undefined ? { persona } : {}),
+    });
+    input.end();
+    const code = await done;
+    return { code, err: errSink.buf };
+  }
+
+  test("no --persona: heals to an existing persona when default dir is missing", async () => {
+    // 'phantom' (the default) has no dir; only 'robbie' exists on disk.
+    const robbie = join(pdir, "personas", "robbie");
+    await mkdir(robbie, { recursive: true });
+    await writeFile(join(robbie, "BOOT.md"), "# Robbie\n", "utf8");
+
+    const { code, err } = await runToClose();
+
+    expect(code).toBe(0); // started cleanly, no exit-2 config error
+    expect(err).toContain("healed default_persona");
+    expect(err).toContain("robbie");
+  });
+
+  test("no --persona + zero personas on disk: hard-errors with exit 2", async () => {
+    await mkdir(join(pdir, "personas"), { recursive: true }); // empty dir
+
+    const { code, err } = await runToClose();
+
+    expect(code).toBe(2);
+    expect(err).toContain("no other personas exist");
+  });
+
+  test("explicit --persona that doesn't exist still hard-errors with exit 2", async () => {
+    // A real persona exists, but the user explicitly asked for a missing one —
+    // we honor their choice and error rather than silently substituting.
+    const robbie = join(pdir, "personas", "robbie");
+    await mkdir(robbie, { recursive: true });
+    await writeFile(join(robbie, "BOOT.md"), "# Robbie\n", "utf8");
+
+    const { code, err } = await runToClose("ghost");
+
+    expect(code).toBe(2);
+    expect(err).toContain("persona 'ghost' not found");
+  });
+});


### PR DESCRIPTION
## What

When `phantombot acp` starts **without** an explicit `--persona`, it now falls back to `config.defaultPersona` and — if that persona dir is missing — **self-heals to any persona on disk**, mirroring the existing `phantombot run` behavior (`healDefaultPersonaIfBroken`). Previously it died with **exit code 2**.

## Why

A fresh box has no `default_persona` set, so phantombot falls back to the hardcoded built-in name `phantom` — whose persona dir was never created. The VS Code chat participant (and Zed) spawn `phantombot acp` with no `--persona`, so **every first-time editor user hit exit 2** and got a blank failure. Reported by Andrew hitting it in VS Code.

## Behavior

- **No `--persona`, default dir missing, ≥1 persona on disk** → heal to an existing persona, start cleanly. ✅
- **No `--persona`, zero personas on disk** → hard-error exit 2 with a `phantombot persona` hint (unchanged — nothing to fall back to).
- **Explicit `--persona NAME` missing** → still hard-errors exit 2 (honors the user's explicit choice; no silent substitution).

## Verification

- 3 new tests in `connectors-acp-server.test.ts` covering all three branches.
- Full suite **1590 pass / 0 fail**, root typecheck clean.
- **arm64 handshake smoke** against the real compiled binary: default `phantom` → healed `robbie`, `initialize` returns, exit 0, `state.json` persisted.

ACP-only, no MCP. Scoped to the persona-resolution gate in `runAcpServer`.