### PR TITLE
fix(update,typing): route /update confirmation back to PhantomChat + harden opening typing indicator

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -260,10 +260,13 @@ async function handleUpdate(
   const r = await runUpdateFlow({
     config: ctx.config,
     currentVersion: VERSION,
-    // The update-notify subsystem keys recipients by numeric Telegram chat
-    // id (it persists the id into the post-restart marker). Convert the
-    // channel-neutral string conversation id back at this boundary.
+    // Telegram-only numeric id, kept for the Telegram post-restart path. For a
+    // PhantomChat conversation `ctx.chatId` is a hex pubkey → NaN here, which is
+    // exactly why `conversation` below is the authoritative router: it carries
+    // the channel-neutral key ("telegram:42" / "phantomchat:<hex>") so the
+    // confirmation lands back where `/update` was typed, not on Telegram.
     chatId: Number(ctx.chatId),
+    conversation: ctx.conversation,
     persona: ctx.persona,
   });
   return { reply: r.reply, afterSend: r.restart };

--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -99,6 +99,66 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Delay (ms) before the opening typing/recording indicator is re-emitted once.
+ * Small enough to feel instant, long enough for a just-(re)connecting relay
+ * socket to come up so the second tick lands. See `emitOpeningIndicator`.
+ */
+export const OPENING_INDICATOR_REEMIT_MS = 600;
+
+/**
+ * Robust opening indicator — the fix for the flaky typing/recording dots.
+ *
+ * The first indicator tick of a turn races transport connection state. On
+ * Telegram that's a cheap idempotent HTTP `sendChatAction`, but on PhantomChat
+ * the indicator is a fire-and-forget EPHEMERAL Nostr event (kind-20001): relays
+ * do not store it, so if the relay socket isn't OPEN at the instant we publish,
+ * the tick is silently dropped. On a FAST turn — the reply lands before the 2s
+ * throttle would fire a second refresh — that single dropped tick means the
+ * user sees NO indicator at all. That's the intermittent "typing dots don't
+ * show" Andrew keeps hitting.
+ *
+ * Fix: emit the opening tick immediately AND schedule exactly ONE more a short
+ * moment later (`OPENING_INDICATOR_REEMIT_MS`), by which point the pool has had
+ * time to (re)connect — so a single cold-socket drop can no longer swallow the
+ * whole indicator. Returns a cancel handle the turn invokes on completion so
+ * the delayed pulse never fires into an already-finished turn. Idempotent and
+ * harmless on Telegram (a second chat-action is free).
+ *
+ * The timer fns are injectable so the regression test drives the schedule
+ * deterministically instead of waiting on a wall-clock delay.
+ */
+export function emitOpeningIndicator(
+  sendStatus: () => void,
+  opts?: {
+    extraPulseDelayMs?: number;
+    // Handle typed as `unknown` so the seam is agnostic to the runtime's timer
+    // handle shape (bun's `Timer` vs Node's `Timeout`); the real globals and a
+    // test's counter-based stub both satisfy it.
+    setTimeoutFn?: (fn: () => void, ms: number) => unknown;
+    clearTimeoutFn?: (handle: unknown) => void;
+  },
+): () => void {
+  const delay = opts?.extraPulseDelayMs ?? OPENING_INDICATOR_REEMIT_MS;
+  const setT: (fn: () => void, ms: number) => unknown =
+    opts?.setTimeoutFn ?? setTimeout;
+  const clearT: (handle: unknown) => void =
+    opts?.clearTimeoutFn ?? (clearTimeout as (handle: unknown) => void);
+
+  // Pulse 1 — immediate, so the dots appear the instant the turn starts.
+  sendStatus();
+
+  // Pulse 2 — once, after the relay has had a beat to connect.
+  const handle = setT(() => sendStatus(), delay);
+
+  let cancelled = false;
+  return () => {
+    if (cancelled) return;
+    cancelled = true;
+    clearT(handle);
+  };
+}
+
 export interface RunTelegramServerInput {
   config: Config;
   memory: MemoryStore;
@@ -863,9 +923,15 @@ async function processChatMessage(
     }
   };
 
-  // Initial nudge so the user sees "typing…" the moment we start
-  // working, before the first chunk lands.
-  refreshIndicator();
+  // Initial nudge so the user sees "typing…" the moment we start working,
+  // before the first chunk lands. Emitted as a robust double-pulse (immediate
+  // + one short re-emit) so a cold-relay drop of the first ephemeral tick on
+  // PhantomChat can't leave a fast turn with no indicator at all. Each pulse
+  // updates the throttle clock so the per-chunk refresh stays correctly spaced.
+  const cancelOpeningIndicator = emitOpeningIndicator(() => {
+    lastSendStatusAt = Date.now();
+    void sendStatus();
+  });
 
   // Register the AbortController so /stop can find us.
   const controller = new AbortController();
@@ -1111,6 +1177,9 @@ async function processChatMessage(
     log.error("telegram: turn threw", { error: errored });
   } finally {
     stopToolRefresh();
+    // Cancel the delayed opening-indicator pulse if it hasn't fired yet, so it
+    // never emits a tick into an already-finished turn.
+    cancelOpeningIndicator();
     // Only deregister if we're still the active turn for this chat.
     // (Defensive: a /reset or /stop could have replaced us.)
     if (activeTurns.get(msg.conversationId) === turnHandle) {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -53,7 +53,10 @@ import {
   defaultLockPath,
   isLockHandle,
 } from "../lib/runLock.ts";
-import { notifyPostRestartIfPending } from "../lib/updateNotify.ts";
+import {
+  notifyPhantomchatPostRestart,
+  notifyPostRestartIfPending,
+} from "../lib/updateNotify.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { VERSION } from "../version.ts";
 import { runDoctor } from "./doctor.ts";
@@ -551,6 +554,33 @@ export async function runRun(input: RunInput = {}): Promise<number> {
           publicKeyHex: identity.publicKeyHex,
           transport,
         });
+        // Post-restart confirmation for a `/update` that was issued FROM
+        // PhantomChat. The Telegram notify above deliberately deferred any
+        // phantomchat-origin marker; this routes "✅ Updated to vX" back to the
+        // exact DM it was typed in, over this persona's own relays. Best-effort
+        // + detached so a relay hiccup never delays the listener coming up.
+        void notifyPhantomchatPostRestart({
+          persona: spec.persona,
+          transport,
+          currentVersion: VERSION,
+        })
+          .then((r) => {
+            if (
+              r.status === "success_notified" ||
+              r.status === "failure_notified"
+            ) {
+              log.info("run: phantomchat post-restart notify", {
+                status: r.status,
+                persona: spec.persona,
+                targetTag: r.marker?.targetTag,
+              });
+            }
+          })
+          .catch((e) =>
+            log.warn(`phantomchat[${spec.persona}]: post-restart notify threw`, {
+              error: (e as Error).message,
+            }),
+          );
         // Register/refresh this persona's public profile (NIP-01 kind 0) so the
         // PWA shows a real name ("Lena", not the npub) and badges it as a bot
         // (NIP-24 bot:true). kind 0 is replaceable, so this just supersedes the

--- a/src/lib/updateNotify.ts
+++ b/src/lib/updateNotify.ts
@@ -80,6 +80,16 @@ export interface PendingUpdate {
    */
   chatId?: number;
   /**
+   * Channel-neutral conversation key of the chat that issued `/update`,
+   * e.g. "telegram:42" or "phantomchat:<64-hex>". This is the AUTHORITATIVE
+   * routing field — `chatId` above only works for Telegram (a numeric id),
+   * so a PhantomChat-origin `/update` (whose conversation id is a hex pubkey)
+   * used to coerce to NaN→null and wrongly fall back to a Telegram broadcast.
+   * The post-restart notify reads the prefix here to pick the right channel.
+   * Optional so markers written by older binaries still parse.
+   */
+  conversation?: string;
+  /**
    * Persona whose Telegram bot handled `/update`. Used after restart to
    * send the confirmation through the same bot in hybrid default+persona
    * configs. Optional so markers written by older versions still work.
@@ -128,7 +138,9 @@ export async function readPendingUpdate(
       typeof parsed?.targetTag !== "string" ||
       typeof parsed?.previousVersion !== "string" ||
       typeof parsed?.writtenAt !== "string" ||
-      (parsed.persona !== undefined && typeof parsed.persona !== "string")
+      (parsed.persona !== undefined && typeof parsed.persona !== "string") ||
+      (parsed.conversation !== undefined &&
+        typeof parsed.conversation !== "string")
     ) {
       log.warn("updateNotify: pending-update marker missing required fields", {
         path,
@@ -249,6 +261,12 @@ export interface RunUpdateFlowInput {
    * post-restart notify lands in the same DM the request came from.
    */
   chatId: number;
+  /**
+   * Channel-neutral conversation key that issued `/update`
+   * (e.g. "telegram:42" or "phantomchat:<hex>"). Authoritative router for
+   * the post-restart notify; `chatId` alone can't address a PhantomChat DM.
+   */
+  conversation?: string;
   /** Persona whose Telegram listener handled `/update`. */
   persona?: string;
   fetchImpl?: typeof fetch;
@@ -333,6 +351,7 @@ export async function runUpdateFlow(
       targetVersion: release.version,
       targetTag: release.tag,
       chatId: input.chatId,
+      conversation: input.conversation,
       persona: input.persona,
       previousVersion: input.currentVersion,
       writtenAt: new Date().toISOString(),
@@ -557,13 +576,56 @@ export interface NotifyPostRestartInput {
 }
 
 export interface NotifyPostRestartResult {
-  /** "no_marker" | "success_notified" | "failure_notified" | "no_telegram" */
+  /** "no_marker" | "success_notified" | "failure_notified" | "no_telegram"
+   *  | "deferred_other_channel" */
   status:
     | "no_marker"
     | "success_notified"
     | "failure_notified"
-    | "no_telegram";
+    | "no_telegram"
+    /**
+     * The marker was raised by a non-Telegram channel (e.g. PhantomChat).
+     * The Telegram notify deliberately leaves the marker UNTOUCHED — neither
+     * sending nor clearing — so the owning channel's own post-restart notify
+     * (see `notifyPhantomchatPostRestart`) can deliver the confirmation to the
+     * right conversation. Returning instead of broadcasting to Telegram is the
+     * fix for "`/update` from PhantomChat replied on Telegram".
+     */
+    | "deferred_other_channel";
   marker?: PendingUpdate;
+}
+
+/**
+ * Which channel a pending-update marker should be confirmed back on. Derived
+ * from the channel-neutral `conversation` key (e.g. "phantomchat:<hex>").
+ * Legacy markers without `conversation` (or with a "telegram:" prefix, or a
+ * numeric chatId) are Telegram — that's the only channel older binaries and
+ * the heartbeat path ever wrote.
+ */
+export function pendingUpdateChannel(
+  marker: Pick<PendingUpdate, "conversation">,
+): "telegram" | "phantomchat" | "other" {
+  const conv = marker.conversation;
+  if (!conv) return "telegram";
+  if (conv.startsWith("phantomchat:")) return "phantomchat";
+  if (conv.startsWith("telegram:")) return "telegram";
+  return "other";
+}
+
+/**
+ * The success/failure line shown after a restart. Shared by every channel's
+ * post-restart notify so PhantomChat and Telegram render identically.
+ */
+export function renderPostRestartMessage(
+  marker: PendingUpdate,
+  currentVersion: string,
+): { success: boolean; message: string } {
+  const success = marker.targetVersion === currentVersion;
+  const message = success
+    ? `✅ Updated to ${marker.targetTag} (was v${marker.previousVersion}). Back online.`
+    : `⚠️ Update to ${marker.targetTag} didn't take — still on v${currentVersion}. ` +
+      `Check phantombot logs and try /update again.`;
+  return { success, message };
 }
 
 /**
@@ -585,6 +647,14 @@ export async function notifyPostRestartIfPending(
 ): Promise<NotifyPostRestartResult> {
   const marker = await readPendingUpdate(input.pendingPath);
   if (!marker) return { status: "no_marker" };
+
+  // Non-Telegram origin (e.g. PhantomChat): leave the marker in place so the
+  // owning channel's post-restart notify routes the confirmation back to the
+  // conversation that asked. Do NOT clear and do NOT broadcast to Telegram —
+  // that broadcast was the "/update from PhantomChat answered on Telegram" bug.
+  if (pendingUpdateChannel(marker) === "phantomchat") {
+    return { status: "deferred_other_channel", marker };
+  }
 
   // Pick the account that drives this notify. New markers include the
   // persona that handled `/update`, so hybrid default+persona configs can
@@ -613,11 +683,10 @@ export async function notifyPostRestartIfPending(
     input.createTransport?.(adminAccount) ??
     new HttpTelegramTransport(adminAccount.token);
 
-  const success = marker.targetVersion === input.currentVersion;
-  const message = success
-    ? `✅ Updated to ${marker.targetTag} (was v${marker.previousVersion}). Back online.`
-    : `⚠️ Update to ${marker.targetTag} didn't take — still on v${input.currentVersion}. ` +
-      `Check phantombot logs and try /update again.`;
+  const { success, message } = renderPostRestartMessage(
+    marker,
+    input.currentVersion,
+  );
 
   // Recipient rule: explicit chatId from the marker wins; fall back to
   // broadcasting to allowed_user_ids when the marker came from a non-
@@ -642,6 +711,95 @@ export async function notifyPostRestartIfPending(
 
   await clearPendingUpdate(input.pendingPath);
 
+  return {
+    status: success ? "success_notified" : "failure_notified",
+    marker,
+  };
+}
+
+/* -------------------------------------------------------------------------- *
+ * Compose: post-restart confirmation on startup — PhantomChat origin
+ * -------------------------------------------------------------------------- */
+
+/** Minimal transport seam: just enough to DM a hex pubkey. The real
+ *  SimplePoolPhantomchatTransport satisfies this; tests pass a fake. */
+export interface PhantomchatNotifyTransport {
+  sendMessage(conversationId: string, text: string): Promise<void>;
+}
+
+export interface NotifyPhantomchatPostRestartInput {
+  /** This persona's name; must match the marker's `persona` to claim it. */
+  persona: string;
+  /** Transport bound to this persona's identity + relays. */
+  transport: PhantomchatNotifyTransport;
+  currentVersion: string;
+  pendingPath?: string;
+}
+
+export interface NotifyPhantomchatPostRestartResult {
+  /**
+   *  "no_marker"        — nothing pending
+   *  "not_phantomchat"  — marker exists but isn't a PhantomChat origin
+   *  "not_this_persona" — PhantomChat marker, but a different persona owns it
+   *  "success_notified" / "failure_notified" — sent + cleared
+   */
+  status:
+    | "no_marker"
+    | "not_phantomchat"
+    | "not_this_persona"
+    | "success_notified"
+    | "failure_notified";
+  marker?: PendingUpdate;
+}
+
+/**
+ * PhantomChat counterpart to `notifyPostRestartIfPending`. Run once per
+ * PhantomChat persona at startup (after its relay transport is built). It
+ * claims a pending-update marker ONLY when the marker came from PhantomChat
+ * AND names this persona, then DMs the success/failure line straight back to
+ * the originating pubkey over Nostr — the conversation `/update` was typed in —
+ * and clears the marker so no other listener re-sends it.
+ *
+ * Multi-persona safety: a marker whose `persona` is someone else's is left
+ * untouched ("not_this_persona") so the persona that actually handled `/update`
+ * is the one that confirms it. Telegram-origin markers are ignored here and
+ * handled by `notifyPostRestartIfPending`.
+ */
+export async function notifyPhantomchatPostRestart(
+  input: NotifyPhantomchatPostRestartInput,
+): Promise<NotifyPhantomchatPostRestartResult> {
+  const marker = await readPendingUpdate(input.pendingPath);
+  if (!marker) return { status: "no_marker" };
+  if (pendingUpdateChannel(marker) !== "phantomchat") {
+    return { status: "not_phantomchat", marker };
+  }
+  // A PhantomChat marker should always name the persona that handled it, so a
+  // multi-persona box only lets the right listener claim it. If persona is
+  // unset (shouldn't happen for new markers) we don't guess — leave it.
+  if (!marker.persona || marker.persona !== input.persona) {
+    return { status: "not_this_persona", marker };
+  }
+
+  // conversation is "phantomchat:<hex>"; the recipient is the bare hex pubkey.
+  const recipientHex = (marker.conversation ?? "").slice("phantomchat:".length);
+  const { success, message } = renderPostRestartMessage(
+    marker,
+    input.currentVersion,
+  );
+
+  try {
+    await input.transport.sendMessage(recipientHex, message);
+  } catch (e) {
+    log.warn("updateNotify: phantomchat post-restart notify send failed", {
+      persona: input.persona,
+      error: (e as Error).message,
+    });
+    // Send failed — leave the marker in place so a later restart can retry.
+    // There's exactly one recipient here, so retry can't double-spam a group.
+    return { status: success ? "success_notified" : "failure_notified", marker };
+  }
+
+  await clearPendingUpdate(input.pendingPath);
   return {
     status: success ? "success_notified" : "failure_notified",
     marker,

--- a/tests/channels-core-engine-indicator.test.ts
+++ b/tests/channels-core-engine-indicator.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for the robust opening typing/recording indicator
+ * (`emitOpeningIndicator` in src/channels/core/engine.ts).
+ *
+ * Why this exists: the typing dots kept intermittently NOT showing. Root cause
+ * is that on PhantomChat the indicator is a fire-and-forget ephemeral Nostr
+ * event — if the relay socket isn't connected at the instant of the FIRST tick,
+ * the tick is silently dropped, and a fast turn (reply before the 2s throttle
+ * fires a second refresh) then shows no indicator at all. The fix emits the
+ * opening tick immediately AND once more a short moment later, so a single
+ * cold-socket drop can't swallow the whole indicator.
+ *
+ * These tests lock in that double-pulse contract with INJECTED timers so they
+ * are deterministic (no wall-clock waits): exactly one immediate emit, exactly
+ * one scheduled re-emit, and a cancel handle that prevents the re-emit firing
+ * into a turn that already finished.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  emitOpeningIndicator,
+  OPENING_INDICATOR_REEMIT_MS,
+} from "../src/channels/core/engine.ts";
+
+/** A tiny deterministic timer harness: captures scheduled callbacks instead of
+ *  running them on the wall clock, so the test decides when "later" happens. */
+function fakeTimers() {
+  const scheduled: Array<{ id: number; fn: () => void; ms: number }> = [];
+  let nextId = 1;
+  const cleared: number[] = [];
+  return {
+    scheduled,
+    cleared,
+    setTimeoutFn: (fn: () => void, ms: number): unknown => {
+      const id = nextId++;
+      scheduled.push({ id, fn, ms });
+      return id;
+    },
+    clearTimeoutFn: (handle: unknown): void => {
+      cleared.push(handle as number);
+    },
+    /** Run every still-pending (not cleared) scheduled callback. */
+    flush(): void {
+      for (const s of scheduled) {
+        if (!cleared.includes(s.id)) s.fn();
+      }
+    },
+  };
+}
+
+describe("emitOpeningIndicator — robust opening typing indicator", () => {
+  test("emits the opening tick immediately (pulse 1)", () => {
+    let calls = 0;
+    const timers = fakeTimers();
+    emitOpeningIndicator(() => calls++, {
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    // Pulse 1 is synchronous — the dots appear the instant the turn starts.
+    expect(calls).toBe(1);
+  });
+
+  test("schedules exactly one re-emit, at the configured short delay", () => {
+    let calls = 0;
+    const timers = fakeTimers();
+    emitOpeningIndicator(() => calls++, {
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    // One and only one delayed pulse is scheduled (not a runaway interval).
+    expect(timers.scheduled.length).toBe(1);
+    expect(timers.scheduled[0]!.ms).toBe(OPENING_INDICATOR_REEMIT_MS);
+  });
+
+  test("the scheduled re-emit fires a SECOND tick (covers a dropped first tick)", () => {
+    let calls = 0;
+    const timers = fakeTimers();
+    emitOpeningIndicator(() => calls++, {
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    expect(calls).toBe(1); // pulse 1
+    timers.flush(); // relay had a beat to connect → pulse 2 lands
+    expect(calls).toBe(2);
+  });
+
+  test("honours a custom re-emit delay", () => {
+    const timers = fakeTimers();
+    emitOpeningIndicator(() => {}, {
+      extraPulseDelayMs: 250,
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    expect(timers.scheduled[0]!.ms).toBe(250);
+  });
+
+  test("cancel() prevents the re-emit firing into an already-finished turn", () => {
+    let calls = 0;
+    const timers = fakeTimers();
+    const cancel = emitOpeningIndicator(() => calls++, {
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    expect(calls).toBe(1); // pulse 1 already happened
+    cancel(); // turn ended before the re-emit window
+    expect(timers.cleared).toEqual([timers.scheduled[0]!.id]);
+    timers.flush(); // even if the timer somehow ran, it was cleared
+    expect(calls).toBe(1); // NO second tick into a dead turn
+  });
+
+  test("cancel() is idempotent — calling it twice clears only once", () => {
+    const timers = fakeTimers();
+    const cancel = emitOpeningIndicator(() => {}, {
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    cancel();
+    cancel();
+    expect(timers.cleared.length).toBe(1);
+  });
+});

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -23,7 +23,9 @@ import type { ServiceControl } from "../src/lib/systemd.ts";
 import {
   checkAndNotifyOnce,
   clearPendingUpdate,
+  notifyPhantomchatPostRestart,
   notifyPostRestartIfPending,
+  pendingUpdateChannel,
   readLastNotified,
   readPendingUpdate,
   runUpdateFlow,
@@ -935,5 +937,243 @@ describe("notifyPostRestartIfPending", () => {
     });
     expect(r.status).toBe("success_notified");
     expect(transport.sent.map((s) => s.chatId)).toEqual(["777"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PhantomChat /update routing (regression)
+//
+// The bug: `/update` typed in the PhantomChat PWA replied "✅ Updated to vX"
+// on Telegram instead of back in PhantomChat. Root cause — the marker only
+// carried a numeric Telegram chatId; a PhantomChat conversation id is a hex
+// pubkey, so `Number(hex)` → NaN → serialized null → the Telegram notify fell
+// through to broadcasting to the allowlist. These tests lock in the fix:
+//   1. the marker carries the channel-neutral `conversation` key;
+//   2. the Telegram notify DEFERS (doesn't send, doesn't clear) a PhantomChat
+//      marker so it can't leak onto Telegram;
+//   3. the PhantomChat notifier sends the confirmation back to the originating
+//      pubkey over its own transport and clears the marker.
+// ---------------------------------------------------------------------------
+
+const PC_HEX =
+  "abc123def456abc123def456abc123def456abc123def456abc123def4560000";
+
+/** Minimal fake of the PhantomChat transport seam — records DM sends. */
+class FakePhantomchatTransport {
+  sent: Array<{ to: string; text: string }> = [];
+  shouldThrow = false;
+  async sendMessage(conversationId: string, text: string): Promise<void> {
+    if (this.shouldThrow) throw new Error("relay down");
+    this.sent.push({ to: conversationId, text });
+  }
+}
+
+describe("pendingUpdateChannel", () => {
+  test("legacy marker without conversation → telegram", () => {
+    expect(pendingUpdateChannel({})).toBe("telegram");
+  });
+  test("telegram: prefix → telegram", () => {
+    expect(pendingUpdateChannel({ conversation: "telegram:42" })).toBe(
+      "telegram",
+    );
+  });
+  test("phantomchat: prefix → phantomchat", () => {
+    expect(
+      pendingUpdateChannel({ conversation: `phantomchat:${PC_HEX}` }),
+    ).toBe("phantomchat");
+  });
+});
+
+describe("runUpdateFlow persists the conversation key into the marker", () => {
+  test("PhantomChat-origin /update writes conversation + persona, NaN chatId", async () => {
+    const r = await runUpdateFlow({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      // commands.ts does Number(ctx.chatId); for a hex pubkey that's NaN —
+      // exactly the case that used to silently fall back to Telegram.
+      chatId: Number(PC_HEX),
+      conversation: `phantomchat:${PC_HEX}`,
+      persona: "lena",
+      fetchImpl: fakeReleaseFetch(),
+      serviceControl: fakeSvc().svc,
+      runUpdateImpl: fakeRunUpdate(0),
+      pendingPath,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(r.restart).toBeDefined();
+    const marker = await readPendingUpdate(pendingPath);
+    expect(marker?.conversation).toBe(`phantomchat:${PC_HEX}`);
+    expect(marker?.persona).toBe("lena");
+  });
+});
+
+describe("notifyPostRestartIfPending defers PhantomChat markers", () => {
+  test("a PhantomChat marker is NOT sent to Telegram and is NOT cleared", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        conversation: `phantomchat:${PC_HEX}`,
+        persona: "lena",
+        previousVersion: "1.0.42",
+        writtenAt: "2026-06-28T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakeTransport();
+    const r = await notifyPostRestartIfPending({
+      config: baseConfig(), // Telegram IS configured — the bug's trigger
+      currentVersion: "1.0.99",
+      transport,
+      pendingPath,
+    });
+    // The regression: must NOT broadcast on Telegram…
+    expect(r.status).toBe("deferred_other_channel");
+    expect(transport.sent.length).toBe(0);
+    // …and must leave the marker for the PhantomChat path to claim.
+    expect(await readPendingUpdate(pendingPath)).not.toBeUndefined();
+  });
+});
+
+describe("notifyPhantomchatPostRestart", () => {
+  test("matching persona + success → DMs the originating pubkey, clears marker", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        conversation: `phantomchat:${PC_HEX}`,
+        persona: "lena",
+        previousVersion: "1.0.42",
+        writtenAt: "2026-06-28T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakePhantomchatTransport();
+    const r = await notifyPhantomchatPostRestart({
+      persona: "lena",
+      transport,
+      currentVersion: "1.0.99",
+      pendingPath,
+    });
+    expect(r.status).toBe("success_notified");
+    expect(transport.sent.length).toBe(1);
+    // Sent to the bare hex pubkey (no "phantomchat:" prefix).
+    expect(transport.sent[0]!.to).toBe(PC_HEX);
+    expect(transport.sent[0]!.text).toContain("✅");
+    expect(transport.sent[0]!.text).toContain("v1.0.99");
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+  });
+
+  test("version mismatch → failure DM, marker cleared", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        conversation: `phantomchat:${PC_HEX}`,
+        persona: "lena",
+        previousVersion: "1.0.42",
+        writtenAt: "2026-06-28T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakePhantomchatTransport();
+    const r = await notifyPhantomchatPostRestart({
+      persona: "lena",
+      transport,
+      currentVersion: "1.0.42", // didn't take
+      pendingPath,
+    });
+    expect(r.status).toBe("failure_notified");
+    expect(transport.sent[0]!.text).toContain("⚠️");
+    expect(await readPendingUpdate(pendingPath)).toBeUndefined();
+  });
+
+  test("different persona → leaves marker untouched (the right listener claims it)", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        conversation: `phantomchat:${PC_HEX}`,
+        persona: "lena",
+        previousVersion: "1.0.42",
+        writtenAt: "2026-06-28T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakePhantomchatTransport();
+    const r = await notifyPhantomchatPostRestart({
+      persona: "kai", // a different persona's listener
+      transport,
+      currentVersion: "1.0.99",
+      pendingPath,
+    });
+    expect(r.status).toBe("not_this_persona");
+    expect(transport.sent.length).toBe(0);
+    // Marker stays so Lena's listener can still confirm it.
+    expect(await readPendingUpdate(pendingPath)).not.toBeUndefined();
+  });
+
+  test("a Telegram-origin marker is ignored here (not_phantomchat), left for the Telegram path", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        conversation: "telegram:42",
+        chatId: 42,
+        previousVersion: "1.0.42",
+        writtenAt: "2026-06-28T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakePhantomchatTransport();
+    const r = await notifyPhantomchatPostRestart({
+      persona: "lena",
+      transport,
+      currentVersion: "1.0.99",
+      pendingPath,
+    });
+    expect(r.status).toBe("not_phantomchat");
+    expect(transport.sent.length).toBe(0);
+    expect(await readPendingUpdate(pendingPath)).not.toBeUndefined();
+  });
+
+  test("send failure → marker preserved for a later retry", async () => {
+    await writePendingUpdate(
+      {
+        targetVersion: "1.0.99",
+        targetTag: "v1.0.99",
+        conversation: `phantomchat:${PC_HEX}`,
+        persona: "lena",
+        previousVersion: "1.0.42",
+        writtenAt: "2026-06-28T00:00:00Z",
+      },
+      pendingPath,
+    );
+    const transport = new FakePhantomchatTransport();
+    transport.shouldThrow = true;
+    const r = await notifyPhantomchatPostRestart({
+      persona: "lena",
+      transport,
+      currentVersion: "1.0.99",
+      pendingPath,
+    });
+    // Still reports the would-be outcome, but keeps the marker (one recipient,
+    // so a retry can't double-spam).
+    expect(r.status).toBe("success_notified");
+    expect(await readPendingUpdate(pendingPath)).not.toBeUndefined();
+  });
+
+  test("no marker → no-op", async () => {
+    const transport = new FakePhantomchatTransport();
+    const r = await notifyPhantomchatPostRestart({
+      persona: "lena",
+      transport,
+      currentVersion: "1.0.99",
+      pendingPath,
+    });
+    expect(r.status).toBe("no_marker");
+    expect(transport.sent.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Two reliability fixes (both phantombot-side)

### 1. `/update` from PhantomChat replied on Telegram, not PhantomChat 🐛
**Root cause:** the pending-update marker only carried a numeric Telegram `chatId`. A PhantomChat conversation id is a 64-char hex pubkey, so `Number(hex)` → `NaN` → serialized `null` → on restart the post-restart notify fell through to **broadcasting "✅ Updated to vX" to the Telegram allowlist**. (This is the channel-abstraction nit Kai flagged on #168.)

**Fix:** the marker now carries the channel-neutral `conversation` key (`telegram:42` / `phantomchat:<hex>`), which is the authoritative router.
- `notifyPostRestartIfPending` (Telegram) now **defers** a PhantomChat marker — it neither sends nor clears it — so it can never leak onto Telegram.
- New `notifyPhantomchatPostRestart`, run once per persona after its relay transport is up, DMs the confirmation **back to the originating pubkey** over Nostr and clears the marker.
- Multi-persona safe: only the persona that actually handled `/update` claims its marker.

### 2. Flaky typing / "recording voice" indicator 🐛
The #33 receive-side `ensureUser` fix was necessary but not sufficient — this is the **send side**. The opening indicator tick races relay connection state: on PhantomChat the tick is a *fire-and-forget ephemeral Nostr event* (kind-20001), so if the relay socket isn't OPEN at `t=0` it's **silently dropped**. On a fast turn (reply lands before the 2s throttle fires a second refresh) that single dropped tick means **no dots at all** — exactly the intermittent failure.

**Fix:** `emitOpeningIndicator` emits the opening tick immediately **and once more after a short delay** (`OPENING_INDICATOR_REEMIT_MS = 600`), by which point the pool has had a beat to (re)connect — so a single cold-socket drop can no longer swallow the whole indicator. Cancelled on turn completion so it never fires into a finished turn. Idempotent/harmless on Telegram.

## Regression tests
- **`tests/channels-core-engine-indicator.test.ts`** (new): the double-pulse contract with **injected timers** (deterministic, no wall-clock waits) — immediate emit, exactly one scheduled re-emit at the configured delay, the re-emit fires a second tick, `cancel()` prevents it, cancel is idempotent.
- **`tests/lib-updateNotify.test.ts`**: `conversation` persisted into the marker (incl. the NaN-chatId PhantomChat case); Telegram notify **defers** a PhantomChat marker (no Telegram leak, marker preserved); PhantomChat notifier sends to the right pubkey + clears; wrong-persona and Telegram-origin markers left untouched; send-failure preserves the marker for retry; channel-classification helper.

## Validation
- Full suite: **1651 pass / 0 fail** (+17 vs baseline).
- `bun tsc --noEmit`: clean.
- `bun build --compile` (arm64): OK.

## Note on validating the typing fix
Fix #2 is the most probable cause of the remaining flakiness (cold-relay drop of the single opening tick), but it can't be 100% reproduced without your device. The regression test locks in the double-pulse behaviour; the real-world confirmation is you on a fresh build. Since phantombot ships as a binary (not Pages), that means a rebuild/redeploy after merge — happy to do that and have you sanity-check before we call it.