### PR TITLE
feat(memory): OKF field-weighted BM25 + link-graph expansion for the no-Gemini path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ phantombot/
 │   │   ├── turn.ts           # one-turn coordinator (persona → memory → screen → harness → persist)
 │   │   ├── fallback.ts       # harness chain (primary → fallback)
 │   │   ├── screen.ts         # makeScreener: threat-screen wiring for UNTRUSTED turns (see "Security perimeter")
-│   │   ├── retrieval.ts      # makeRetriever: semantic recall of prior turns/memory for the prompt
+│   │   ├── retrieval.ts      # makeRetriever: hybrid (Gemini) or OKF BM25F + link-graph recall of prior turns/memory for the prompt
 │   │   ├── recovery.ts       # generateRecoveryReply: graceful user-facing message on harness failure
 │   │   └── turnIndexer.ts    # makeTurnIndexer: embeds persisted turns for later retrieval
 │   ├── channels/             # channel-agnostic core + per-channel adapters (see "Channel layer")
@@ -131,7 +131,9 @@ phantombot/
 │       ├── githubReleases.ts updateNotify.ts    # latest-release discovery + post-update notify
 │       ├── audio.ts          # TTS/STT dispatch (ElevenLabs/OpenAI/Azure Edge)
 │       ├── voice.ts telegramApi.ts personaScaffold.ts personaTemplate.ts personaArchive.ts personaDefault.ts
-│       ├── memoryIndex.ts heartbeat.ts nightly.ts embedJob.ts geminiEmbed.ts
+│       ├── memoryIndex.ts   # FTS5 store: OKF field-weighted BM25F + link-graph expansion (no-Gemini path), hybrid RRF when embeddings present
+│       ├── okf.ts           # Open Knowledge Format parser: frontmatter/body/headings/links (powers BM25F columns + concept graph)
+│       ├── heartbeat.ts nightly.ts embedJob.ts geminiEmbed.ts
 │       └── runLock.ts        # single-instance lock (prevents two `phantombot run` on one box)
 ├── agents/
 │   └── phantom/              # placeholder persona used by tests

--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ for you to stitch together. What comes back is coherent and accountable,
 because one Phantom — with its own memory and judgment — saw it through.
 
 **It compounds.** Every Phantom keeps a private, local memory of your
-decisions, lessons, people, and standing preferences, embedded and searchable
-by *meaning* (Gemini embeddings + hybrid vector/keyword retrieval), not just
-exact keywords. It doesn't reset between sessions; it accumulates. So the
+decisions, lessons, people, and standing preferences, authored in the
+**[Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/)**
+(OKF — Google Cloud's open standard for agent knowledge) and searchable by
+*meaning* with Gemini embeddings + hybrid vector/keyword retrieval. No Gemini
+key? Memory still gets superpowers: OKF **field-weighted BM25** plus
+**concept-graph expansion** — far sharper than plain keyword search. It doesn't
+reset between sessions; it accumulates. So the
 longer a Phantom works with you, the more it understands your code and your
 world — and complex projects and long-lived codebases need *less* prompting
 and *less* re-explaining over time, exactly where most assistants fall off.
@@ -782,9 +786,9 @@ request: that simply never runs.)
 
 > **Recommended for production environments.** Threat screening itself needs no
 > extra configuration — it runs on your primary harness, which is always
-> present. A Gemini key ([`phantombot embedding`](#semantic-search)) only
+> present. A Gemini key ([`phantombot embedding`](#memory-search-okf-superpowers-by-default-gemini-semantic-on-top)) only
 > sharpens the judge's **briefing recall** (decisions/people/norms): without it,
-> recall falls back to keyword-only, which is a quality degrade, not a security
+> recall falls back to OKF field-weighted BM25 (lexical), which is a quality degrade, not a security
 > hole — screening still runs. Screening is **not** a wall —
 > a sufficiently clever injection can still fool an LLM judge, just as it can
 > fool a human — but it filters the obvious majority and puts a human beat in
@@ -847,11 +851,31 @@ phantombot memory list kb
 phantombot memory index --rebuild
 ```
 
-### Semantic Search
+### Memory search: OKF superpowers by default, Gemini semantic on top
 
-Keyword search works by default. Semantic search is optional and recommended.
-It uses Gemini embeddings so memory retrieval can match meaning, not just exact
-words.
+Phantombot stores memory in the **[Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/)**
+(OKF) — Google Cloud's open, vendor-neutral standard for the knowledge AI
+agents consume: atomic markdown files with YAML frontmatter, linked into a
+concept graph. Because the knowledge is *structured*, the default no-key search
+path is much stronger than plain keyword matching:
+
+- **Field-weighted BM25 (BM25F)** — frontmatter `title`, `tags`, and `aliases`
+  are indexed as their own weighted columns, so a hit in a title or tag
+  outranks the same word buried in prose.
+- **Tag / alias controlled vocabulary** — author-time synonyms collapse the
+  vocabulary-mismatch gap (e.g. "credential cycling" finds a note titled
+  "Secret Rotation").
+- **Concept-graph expansion** — after the lexical match, Phantombot walks the
+  OKF link graph one hop (outbound *and* inbound) and folds in connected
+  concepts a bare-keyword query would miss. A keyword-only stand-in for the
+  "semantic spread" embeddings give you — with **zero API keys**.
+
+This is the default. Every phantom gets it for free, no setup.
+
+**Add Gemini embeddings** (optional, recommended for production) to layer true
+**semantic** retrieval on top — matching by *meaning*, not just words. With a
+key, search becomes **hybrid**: OKF field-weighted BM25 *and* vector similarity,
+fused with reciprocal-rank fusion.
 
 Enable it:
 
@@ -872,7 +896,8 @@ model = "gemini-embedding-001"
 dims = 1536
 ```
 
-Without embeddings, search degrades cleanly to FTS-only.
+Without embeddings, search degrades cleanly to OKF field-weighted BM25 with
+link-graph expansion — never to plain keyword.
 
 ### Nightly and Doctor
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 
 1. **Hosts persona files.** Reads `BOOT.md` / `SOUL.md` / `IDENTITY.md`, optional `MEMORY.md`, optional `tools.md` / `AGENTS.md` from `$XDG_DATA_HOME/phantombot/personas/<name>/`.
 2. **Receives one user message** via `phantombot ask "msg"` or via the REPL line loop in `phantombot chat`.
-3. **Builds a turn context** for the configured agent: persona + recent memory + the new user message. (Vector retrieval slot is reserved but unused in v1.)
+3. **Builds a turn context** for the configured agent: persona + recent memory + retrieved knowledge + the new user message. Retrieval runs over an [Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/) store: **OKF field-weighted BM25 with link-graph expansion** by default, upgrading to **hybrid BM25 + Gemini-embedding vector search** (reciprocal-rank fusion) when an embeddings provider is configured.
 4. **Hands the turn to a harness.** Spawns `claude --print --output-format stream-json` (or `pi --print --mode json`) as a subprocess. Persona goes via `--system-prompt`. The user-side payload (history + new message) goes via stdin (claude) or argv (pi).
 5. **Streams the harness's stdout** back to the user. Text chunks land on stdout as they arrive; the trailing newline marks end-of-reply.
 6. **Falls back** to the next harness in the chain on recoverable error (rate limit, transient network, oversize payload pre-skip).
@@ -18,7 +18,7 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 
 - Translate `tools[]` arrays into anything. Each harness brings its own tools.
 - Enforce permission gates on tool calls. The harness handles that — Claude is run with `--permission-mode bypassPermissions`.
-- Implement vector retrieval, embeddings, RAG. The slot in the system prompt is empty in v1; if needed later, prefer SQLite FTS5 before reaching for sqlite-vec or embeddings.
+- *(Updated since v1.)* Retrieval is now implemented: SQLite FTS5 provides OKF field-weighted BM25 + link-graph expansion as the always-on baseline, with optional Gemini embeddings adding a hybrid vector leg. There is no RAG framework dependency — it's plain FTS5 + a local vector table.
 - Run a web UI, dashboard, status page, or admin panel.
 - Listen on chat channels (Telegram / Signal / Google Chat). The original skeleton was built for that; the current shape is CLI only. Channels can be added later without rearchitecting.
 - Hold API keys. OAuth-on-host: claude / pi are configured separately on the operator's machine and read their own credentials at spawn time.

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -638,8 +638,8 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   out.write(
     semanticSearch
       ? `  embeddings: semantic (vector) search ON — provider '${embProvider}'\n`
-      : "  embeddings: semantic (vector) search off — keyword (BM25) search " +
-        "active. Optional: enable with `phantombot embedding`\n",
+      : "  embeddings: semantic (vector) search off — OKF field-weighted BM25 " +
+        "+ link-graph expansion active. Optional: add Gemini with `phantombot embedding`\n",
   );
   if (needed) {
     out.write(`  repair: ${reason}\n`);

--- a/src/cli/embedding.ts
+++ b/src/cli/embedding.ts
@@ -5,7 +5,10 @@
  * /embedContent once, writes the result to [embeddings] in config.toml.
  *
  * No-key (provider=none) is a real choice: phantombot's memory search
- * still works, just on FTS5/BM25 only — no semantic similarity.
+ * still works on OKF field-weighted BM25 with link-graph expansion — the
+ * Open Knowledge Format superpowers (frontmatter field weighting, tag/alias
+ * controlled vocabulary, concept-graph walk). No semantic similarity, but a
+ * markedly stronger lexical recall than plain keyword search.
  */
 
 import { defineCommand } from "citty";
@@ -95,7 +98,10 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
       "Existing config",
     );
   } else if (!embedded && existing.provider === "none") {
-    p.note(`provider:  none (FTS5/BM25 search only)`, "Existing config");
+    p.note(
+      `provider:  none (OKF field-weighted BM25 + link-graph expansion)`,
+      "Existing config",
+    );
   }
 
   // The Gemini key powers semantic memory search AND the threat judge's
@@ -126,7 +132,8 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
       },
       {
         value: "none",
-        label: "None — keyword/BM25 search only",
+        label: "None — OKF field-weighted BM25 + link-graph expansion",
+        hint: "no API key · Open Knowledge Format superpowers, lexical only",
       },
       { value: "cancel", label: "Cancel" },
     ],
@@ -141,9 +148,10 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
     await applyEmbeddingConfig(config.configPath, { provider: "none" });
     p.note(
       `provider set to "none"\n` +
-        `search will use FTS5/BM25 only\n` +
+        `search uses OKF field-weighted BM25 + link-graph expansion\n` +
+        `(frontmatter weighting, tag/alias vocabulary, concept-graph walk)\n` +
         `threat screening stays ACTIVE (runs on your primary harness); judge ` +
-        `briefing recall is keyword-only — semantic recall recommended for production`,
+        `briefing recall is lexical-only — Gemini semantic recall recommended for production`,
       "Saved",
     );
     if (!embedded) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -210,8 +210,9 @@ export default defineCommand({
 
     // 4. Optional: semantic memory search.
     // Gated behind its own confirm (default OFF) so it never blocks a quick
-    // install — memory search works out of the box on keyword (FTS5/BM25)
-    // matching. This step exists purely to *expose* the option during setup;
+    // install — memory search works out of the box on OKF field-weighted
+    // BM25 with link-graph expansion. This step exists purely to *expose* the
+    // semantic option during setup;
     // skipping it is a fully-supported, fully-working configuration.
     // Like the install step below, it's a separate skippable confirmation
     // rather than part of runInitFlow. We call runEmbedding in `embedded`
@@ -222,12 +223,13 @@ export default defineCommand({
     // failure must never abort the wizard before install.
     p.log.step("Semantic Memory Search (optional)");
     p.note(
-      "Phantombot's memory search works out of the box using keyword matching.\n" +
-      "Adding an embeddings provider also enables SEMANTIC search — finding\n" +
-      "memories by meaning, not just exact words (e.g. \"how do I pay tax\"\n" +
-      "matches a note titled \"VAT filing steps\"). It's optional and free for\n" +
-      "typical use on Gemini's free tier. You can always enable it later with\n" +
-      "`phantombot embedding`.",
+      "Phantombot's memory search works out of the box on OKF field-weighted\n" +
+      "BM25 with link-graph expansion — the Open Knowledge Format superpowers\n" +
+      "(frontmatter field weighting, tag/alias vocabulary, concept-graph walk).\n" +
+      "Adding a Gemini embeddings provider layers SEMANTIC search on top — finding\n" +
+      "memories by meaning, not just words (e.g. \"how do I pay tax\" matches a note\n" +
+      "titled \"VAT filing steps\"). It's optional and free for typical use on\n" +
+      "Gemini's free tier. You can always enable it later with `phantombot embedding`.",
       "What this improves"
     );
     const wantEmbeddings = await p.confirm({

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -122,7 +122,7 @@ export async function runMemorySearch(
           scope: input.scope,
           limit: input.limit,
         })
-      : ge?.enabled !== false
+      : ge?.enabled
         ? ix.searchExpanded(input.query, {
             scope: input.scope,
             limit: input.limit,

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -114,15 +114,25 @@ export async function runMemorySearch(
       else err.write(`(query embed failed: ${r.error}; falling back to FTS-only)\n`);
     }
 
+    // No-embeddings path gets OKF link-graph expansion when enabled, matching
+    // turn-time auto-retrieval; the hybrid (Gemini) path is unchanged.
+    const ge = config.retrieval?.graphExpansion;
     const hits = queryVec
       ? ix.hybridSearch(input.query, queryVec, {
           scope: input.scope,
           limit: input.limit,
         })
-      : ix.search(input.query, {
-          scope: input.scope,
-          limit: input.limit,
-        });
+      : ge?.enabled !== false
+        ? ix.searchExpanded(input.query, {
+            scope: input.scope,
+            limit: input.limit,
+            hops: ge?.hops,
+            maxAdd: ge?.maxAdd,
+          })
+        : ix.search(input.query, {
+            scope: input.scope,
+            limit: input.limit,
+          });
     out.write(JSON.stringify({ persona, query: input.query, results: hits }, null, 2));
     out.write("\n");
   } finally {
@@ -481,7 +491,7 @@ export async function indexAfterCapture(
 // ---------------------------------------------------------------------------
 
 const searchCmd = defineCommand({
-  meta: { name: "search", description: "Hybrid (FTS5 today; +vec in phase 25) search across memory/ and kb/." },
+  meta: { name: "search", description: "Search memory/ and kb/: hybrid BM25+vector when Gemini embeddings are set, else OKF field-weighted BM25 with link-graph expansion." },
   args: {
     query: {
       type: "positional",

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -336,15 +336,16 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     );
   }
   // Gentle, one-time heads-up that semantic search is off. Embeddings are
-  // optional — memory still works on keyword (BM25) search — so this is an
-  // informational line, not a warning, and never blocks startup.
+  // optional — memory still works on OKF field-weighted BM25 with link-graph
+  // expansion — so this is an informational line, not a warning, and never
+  // blocks startup.
   const semanticSearch =
     config.embeddings?.provider === "gemini" &&
     !!config.embeddings?.gemini?.apiKey;
   if (!semanticSearch) {
     out.write(
-      "  memory: semantic (vector) search OFF — keyword search active. " +
-        "Optional: run `phantombot embedding` to enable.\n",
+      "  memory: semantic (vector) search OFF — OKF field-weighted BM25 + " +
+        "link-graph expansion active. Optional: run `phantombot embedding` to add Gemini.\n",
     );
     // Threat screening itself does NOT depend on this key — the judge runs
     // on your PRIMARY harness (whichever of claude/pi/gemini/codex), which is

--- a/src/config.ts
+++ b/src/config.ts
@@ -156,7 +156,31 @@ export interface RetrievalSettings {
   minScore: number;
   /** Derived index over raw conversation turns, searched alongside memory/kb. */
   turnIndexing: TurnIndexingSettings;
+  /**
+   * OKF link-graph expansion for the no-embeddings (BM25-only) path. When a
+   * persona has no Gemini key, fielded BM25 hits are augmented with concepts
+   * reachable via markdown links from those hits — the keyword-only stand-in
+   * for semantic spread. Ignored when embeddings are configured (the hybrid
+   * vector path is used instead, so Gemini users are unaffected).
+   */
+  graphExpansion: GraphExpansionSettings;
 }
+
+/** OKF link-graph expansion knobs (BM25-only retrieval path). */
+export interface GraphExpansionSettings {
+  /** Master switch for graph expansion on the FTS-only path. */
+  enabled: boolean;
+  /** Hops to walk out from each lexical hit. */
+  hops: number;
+  /** Max neighbour concepts to fold in per retrieval. */
+  maxAdd: number;
+}
+
+export const DEFAULT_GRAPH_EXPANSION: GraphExpansionSettings = {
+  enabled: true,
+  hops: 1,
+  maxAdd: 3,
+};
 
 export const DEFAULT_RETRIEVAL: RetrievalSettings = {
   enabled: true,
@@ -164,6 +188,7 @@ export const DEFAULT_RETRIEVAL: RetrievalSettings = {
   maxTokens: 1500,
   minScore: 0,
   turnIndexing: DEFAULT_TURN_INDEXING,
+  graphExpansion: DEFAULT_GRAPH_EXPANSION,
 };
 
 export interface TelegramStreamingSettings {
@@ -520,6 +545,34 @@ function buildRetrievalConfig(
     maxTokens: Math.max(0, maxTokens),
     minScore,
     turnIndexing: buildTurnIndexingConfig(tomlTurnIndexing),
+    graphExpansion: buildGraphExpansionConfig(
+      (tomlRetrieval.graph_expansion ?? {}) as Record<string, unknown>,
+    ),
+  };
+}
+
+function buildGraphExpansionConfig(
+  toml: Record<string, unknown>,
+): GraphExpansionSettings {
+  const enabled =
+    asBool(process.env.PHANTOMBOT_RETRIEVAL_GRAPH_EXPANSION_ENABLED) ??
+    asBool(toml.enabled) ??
+    DEFAULT_GRAPH_EXPANSION.enabled;
+  const hops =
+    asInt(process.env.PHANTOMBOT_RETRIEVAL_GRAPH_HOPS) ??
+    asInt(toml.hops) ??
+    DEFAULT_GRAPH_EXPANSION.hops;
+  const maxAdd =
+    asInt(process.env.PHANTOMBOT_RETRIEVAL_GRAPH_MAX_ADD) ??
+    asInt(toml.max_add) ??
+    DEFAULT_GRAPH_EXPANSION.maxAdd;
+  return {
+    enabled,
+    // 1..3 hops keeps expansion local; beyond that the graph fans out into
+    // noise. maxAdd is floored at 0 (disables) and capped to keep token cost
+    // bounded.
+    hops: Math.max(1, Math.min(3, hops)),
+    maxAdd: Math.max(0, Math.min(20, maxAdd)),
   };
 }
 

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -24,9 +24,24 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { mkdir } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+import { posix } from "node:path";
 import type { Turn } from "../memory/store.ts";
+import { parseOkf } from "./okf.ts";
 
 export type Scope = "memory" | "kb" | "turns";
+
+/**
+ * BM25F field weights for the `notes` table. A term hit in a concept's title,
+ * tags, or aliases is worth far more than the same term buried in the body —
+ * this is the lexical-precision half of the OKF superpowers, and it makes the
+ * frontmatter the index actually leans on. Positionally these map to the
+ * `notes` columns: [path, scope, title, tags, aliases, headings, body]. The
+ * two UNINDEXED columns get weight 0 (ignored by bm25 anyway).
+ */
+export const NOTE_FIELD_WEIGHTS = [0, 0, 8.0, 6.0, 6.0, 3.0, 1.0] as const;
+
+/** Column index of `body` in `notes` (for snippet()). */
+const NOTES_BODY_COL = 6;
 
 export interface IndexedFile {
   path: string; // relative to personaDir
@@ -44,6 +59,12 @@ export interface SearchHit {
   vecScore?: number;
   /** Reciprocal-rank-fusion score combining FTS + vec ranks. */
   rrfScore?: number;
+  /**
+   * True when this hit was not itself a lexical match but was pulled in by
+   * graph-walk expansion from a hit that was (OKF link-graph recall). Lets
+   * callers label or down-weight expanded neighbours.
+   */
+  expanded?: boolean;
   snippet: string;
 }
 
@@ -97,11 +118,34 @@ export function rrfMerge(
   return scores;
 }
 
+/**
+ * Bump when the on-disk schema of derived-from-disk tables changes (notes /
+ * files / note_links). On open, a mismatch drops and rebuilds JUST those
+ * tables — they're fully reconstructable by walking memory/ + kb/, so this is
+ * a safe, automatic, no-migration self-heal. The turn_docs / *_embeddings
+ * tables are NOT versioned here: they carry Gemini vectors and turn-index
+ * state that aren't cheaply rebuildable, so they're left untouched.
+ *
+ * v1 → v2: `notes` went from a single `content` column to OKF field columns
+ * (title / tags / aliases / headings / body) for BM25F, and `note_links` was
+ * added for graph-walk expansion.
+ */
+export const NOTES_SCHEMA_VERSION = 2;
+
 const SCHEMA = `
+CREATE TABLE IF NOT EXISTS meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS notes USING fts5(
   path UNINDEXED,
   scope UNINDEXED,
-  content,
+  title,
+  tags,
+  aliases,
+  headings,
+  body,
   tokenize = 'porter unicode61'
 );
 
@@ -110,9 +154,20 @@ CREATE TABLE IF NOT EXISTS files (
   scope       TEXT NOT NULL,
   mtime_ms    INTEGER NOT NULL,
   size        INTEGER NOT NULL,
+  title       TEXT NOT NULL DEFAULT '',
+  aliases     TEXT NOT NULL DEFAULT '',
   indexed_at  TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_files_scope ON files(scope);
+
+CREATE TABLE IF NOT EXISTS note_links (
+  src_path     TEXT NOT NULL,
+  target_raw   TEXT NOT NULL,
+  kind         TEXT NOT NULL,
+  target_path  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_note_links_src ON note_links(src_path);
+CREATE INDEX IF NOT EXISTS idx_note_links_target ON note_links(target_path);
 
 CREATE TABLE IF NOT EXISTS note_embeddings (
   path         TEXT NOT NULL,
@@ -159,6 +214,49 @@ export class MemoryIndex {
     // statement, or schema setup itself can throw SQLITE_BUSY when another
     // process touches the index DB concurrently.
     db.exec(SCHEMA);
+    this.selfHealNotesSchema();
+  }
+
+  /**
+   * If the persisted notes-schema version is older than NOTES_SCHEMA_VERSION
+   * (or absent, i.e. a pre-versioning v1 index), drop the derived-from-disk
+   * tables and let the next refreshStale() rebuild them from memory/ + kb/.
+   * Turn and embedding tables are untouched. Cheap and idempotent.
+   */
+  private selfHealNotesSchema(): void {
+    const row = this.db
+      .query("SELECT value FROM meta WHERE key = 'notes_schema_version'")
+      .get() as { value?: string } | null;
+    const have = row?.value ? Number(row.value) : 0;
+    // A fresh DB has the current `notes` columns already (just created), but
+    // no meta row and no rows yet — stamp it and move on.
+    const isEmpty =
+      (this.db.query("SELECT COUNT(*) AS c FROM files").get() as { c: number })
+        .c === 0;
+    if (have === NOTES_SCHEMA_VERSION) return;
+    if (have === 0 && isEmpty) {
+      this.stampNotesSchemaVersion();
+      return;
+    }
+    // Stale derived tables: drop and recreate so the new column layout sticks
+    // (CREATE ... IF NOT EXISTS won't alter an existing table's columns). All
+    // three are fully rebuilt from disk by the next refreshStale().
+    this.db.exec(
+      "DROP TABLE IF EXISTS notes;" +
+        "DROP TABLE IF EXISTS files;" +
+        "DROP TABLE IF EXISTS note_links;",
+    );
+    this.db.exec(SCHEMA);
+    this.stampNotesSchemaVersion();
+  }
+
+  private stampNotesSchemaVersion(): void {
+    this.db
+      .prepare(
+        "INSERT INTO meta (key, value) VALUES ('notes_schema_version', ?) " +
+          "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+      )
+      .run(String(NOTES_SCHEMA_VERSION));
   }
 
   static async open(indexPath: string): Promise<MemoryIndex> {
@@ -222,18 +320,54 @@ export class MemoryIndex {
       const prev = recorded.get(f.path);
       if (!forceAll && prev && prev.mtimeMs === f.mtimeMs) continue;
       const content = await readFile(join(personaDir, f.path), "utf8");
+      const doc = parseOkf(content);
       this.deletePath(f.path);
       this.db
         .prepare(
-          "INSERT INTO notes (path, scope, content) VALUES (?, ?, ?)",
+          "INSERT INTO notes (path, scope, title, tags, aliases, headings, body) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
-        .run(f.path, f.scope, content);
+        .run(
+          f.path,
+          f.scope,
+          doc.title,
+          doc.tags.join(" "),
+          doc.aliases.join(" "),
+          doc.headings.join(" \n "),
+          // Body keeps title/desc folded in so a query that matches them still
+          // returns a usable snippet, and so BM25 term-frequency stays sane on
+          // notes that put everything in frontmatter.
+          [doc.title, doc.description, doc.body].filter(Boolean).join("\n"),
+        );
       this.db
         .prepare(
-          "INSERT INTO files (path, scope, mtime_ms, size, indexed_at) " +
-            "VALUES (?, ?, ?, ?, ?)",
+          "INSERT INTO files (path, scope, mtime_ms, size, title, aliases, indexed_at) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
-        .run(f.path, f.scope, f.mtimeMs, f.size, new Date().toISOString());
+        .run(
+          f.path,
+          f.scope,
+          f.mtimeMs,
+          f.size,
+          doc.title,
+          doc.aliases.join(" ").toLowerCase(),
+          new Date().toISOString(),
+        );
+      for (const link of doc.links) {
+        this.db
+          .prepare(
+            "INSERT INTO note_links (src_path, target_raw, kind, target_path) " +
+              "VALUES (?, ?, ?, ?)",
+          )
+          .run(
+            f.path,
+            link.target,
+            link.kind,
+            link.kind === "md"
+              ? resolveMdLink(f.path, link.target)
+              : null,
+          );
+      }
       indexed++;
     }
     return { indexed, removed };
@@ -446,13 +580,17 @@ export class MemoryIndex {
 
     const ftsQuery = sanitizeFtsQuery(query);
 
+    // BM25F: weight title/tags/aliases/headings above body. Weights are SQL
+    // literals (bm25() doesn't bind them), sourced from NOTE_FIELD_WEIGHTS.
+    const bm = `bm25(notes, ${NOTE_FIELD_WEIGHTS.join(", ")})`;
+    const snip = `snippet(notes, ${NOTES_BODY_COL}, '«', '»', ' … ', 12)`;
+
     const noteRows =
       scope === "all"
         ? (this.db
             .query(
-              "SELECT path, scope, bm25(notes) AS rank, " +
-                "snippet(notes, 2, '«', '»', ' … ', 12) AS snip " +
-                "FROM notes WHERE content MATCH ? " +
+              `SELECT path, scope, ${bm} AS rank, ${snip} AS snip ` +
+                "FROM notes WHERE notes MATCH ? " +
                 "ORDER BY rank LIMIT ?",
             )
             .all(ftsQuery, limit) as Array<{
@@ -463,9 +601,8 @@ export class MemoryIndex {
           }>)
         : (this.db
             .query(
-              "SELECT path, scope, bm25(notes) AS rank, " +
-                "snippet(notes, 2, '«', '»', ' … ', 12) AS snip " +
-                "FROM notes WHERE content MATCH ? AND scope = ? " +
+              `SELECT path, scope, ${bm} AS rank, ${snip} AS snip ` +
+                "FROM notes WHERE notes MATCH ? AND scope = ? " +
                 "ORDER BY rank LIMIT ?",
             )
             .all(ftsQuery, scope, limit) as Array<{
@@ -522,6 +659,165 @@ export class MemoryIndex {
     ]
       .sort((a, b) => (b.ftsScore ?? 0) - (a.ftsScore ?? 0))
       .slice(0, limit);
+  }
+
+  /**
+   * BM25F search PLUS OKF link-graph expansion — the no-embeddings superpower.
+   *
+   * Runs the normal fielded BM25 search, then walks the link graph one or more
+   * hops out from the lexical hits and folds in directly-connected neighbour
+   * concepts that didn't match on their own. This is the keyword-only stand-in
+   * for the "semantic spread" embeddings give you: instead of a learned vector
+   * space, it uses the author's own explicit links to surface related concepts
+   * a bare term query would miss.
+   *
+   * Expanded neighbours are appended after the lexical hits (never displacing a
+   * real match) and flagged `expanded: true`. Only memory/ + kb/ notes
+   * participate — conversation turns aren't part of the concept graph.
+   */
+  searchExpanded(
+    query: string,
+    opts: {
+      scope?: Scope | "all";
+      limit?: number;
+      conversation?: string;
+      /** Hops to walk out from each lexical hit. Default 1. */
+      hops?: number;
+      /** Max neighbours to fold in. Default 3. */
+      maxAdd?: number;
+    } = {},
+  ): SearchHit[] {
+    const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
+    const hits = this.search(query, {
+      scope: opts.scope,
+      limit,
+      conversation: opts.conversation,
+    });
+    const maxAdd = Math.max(0, opts.maxAdd ?? 3);
+    if (maxAdd === 0) return hits;
+
+    // Only note hits (memory/kb) seed graph expansion; turns aren't concepts.
+    const seeds = hits.filter((h) => h.scope !== "turns").map((h) => h.path);
+    if (seeds.length === 0) return hits;
+
+    const present = new Set(hits.map((h) => h.path));
+    const neighbours = this.graphNeighbours(
+      seeds,
+      Math.max(1, opts.hops ?? 1),
+      present,
+      maxAdd,
+    );
+
+    const extra: SearchHit[] = [];
+    for (const path of neighbours) {
+      const hit = this.hitForPath(path);
+      if (hit) extra.push({ ...hit, expanded: true });
+    }
+    return [...hits, ...extra];
+  }
+
+  /**
+   * Breadth-first walk over note_links from the seed paths. Follows both
+   * outbound links (seed → target) and inbound links (other → seed), and
+   * resolves wikilink/markdown targets to concrete indexed paths. Returns up
+   * to `maxAdd` neighbour paths not already in `exclude`, nearest first.
+   */
+  private graphNeighbours(
+    seeds: string[],
+    hops: number,
+    exclude: Set<string>,
+    maxAdd: number,
+  ): string[] {
+    const found: string[] = [];
+    const visited = new Set<string>(seeds);
+    let frontier = [...seeds];
+
+    for (let hop = 0; hop < hops && found.length < maxAdd; hop++) {
+      const next: string[] = [];
+      for (const src of frontier) {
+        for (const path of this.linkedPaths(src)) {
+          if (visited.has(path)) continue;
+          visited.add(path);
+          next.push(path);
+          if (!exclude.has(path)) {
+            found.push(path);
+            if (found.length >= maxAdd) return found;
+          }
+        }
+      }
+      frontier = next;
+    }
+    return found;
+  }
+
+  /** Concrete indexed paths linked to/from `src` (outbound + inbound). */
+  private linkedPaths(src: string): string[] {
+    const out = new Set<string>();
+
+    // Outbound: resolved markdown targets are direct; wikilinks resolve by
+    // basename / title / alias against the files table.
+    const outboundRows = this.db
+      .query(
+        "SELECT target_raw, kind, target_path FROM note_links WHERE src_path = ?",
+      )
+      .all(src) as Array<{
+      target_raw: string;
+      kind: string;
+      target_path: string | null;
+    }>;
+    for (const r of outboundRows) {
+      if (r.target_path && this.pathExists(r.target_path)) {
+        out.add(r.target_path);
+        continue;
+      }
+      const resolved = this.resolveWikiTarget(r.target_raw);
+      if (resolved) out.add(resolved);
+    }
+
+    // Inbound: notes that link to this one by resolved markdown path.
+    const inboundRows = this.db
+      .query("SELECT src_path FROM note_links WHERE target_path = ?")
+      .all(src) as Array<{ src_path: string }>;
+    for (const r of inboundRows) out.add(r.src_path);
+
+    return [...out];
+  }
+
+  private pathExists(path: string): boolean {
+    return (
+      this.db.prepare("SELECT 1 FROM files WHERE path = ? LIMIT 1").get(path) !=
+      null
+    );
+  }
+
+  /**
+   * Resolve a wikilink / unresolved link target to an indexed note path by
+   * matching, case-insensitively: file basename (with/without .md), title, or
+   * any alias. Returns the first match or undefined.
+   */
+  private resolveWikiTarget(target: string): string | undefined {
+    const t = target.trim().toLowerCase().replace(/\.md$/, "");
+    if (!t) return undefined;
+    const rows = this.db
+      .query("SELECT path, title, aliases FROM files")
+      .all() as Array<{ path: string; title: string; aliases: string }>;
+    for (const r of rows) {
+      const base = posix
+        .basename(r.path.replace(/\\/g, "/"))
+        .replace(/\.md$/i, "")
+        .toLowerCase();
+      if (base === t) return r.path;
+      if (r.title && r.title.toLowerCase() === t) return r.path;
+      if (r.aliases && r.aliases.split(/\s+/).includes(t)) return r.path;
+    }
+    return undefined;
+  }
+
+  /** Build a SearchHit for a known indexed path (no lexical scores). */
+  private hitForPath(path: string): SearchHit | undefined {
+    const scope = this.lookupScope(path);
+    if (!scope) return undefined;
+    return { path, scope, snippet: this.snippetForPath(path) };
   }
 
   /**
@@ -637,16 +933,18 @@ export class MemoryIndex {
   }
 
   private snippetForPath(path: string): string {
-    const table = path.startsWith("turns/") ? "turn_docs" : "notes";
-    const row = this.db
-      .prepare(`SELECT content FROM ${table} WHERE path = ? LIMIT 1`)
-      .get(path) as { content?: string } | null;
-    return (row?.content ?? "").replace(/\s+/g, " ").trim().slice(0, 240);
+    const isTurn = path.startsWith("turns/");
+    const sql = isTurn
+      ? "SELECT content AS text FROM turn_docs WHERE path = ? LIMIT 1"
+      : "SELECT body AS text FROM notes WHERE path = ? LIMIT 1";
+    const row = this.db.prepare(sql).get(path) as { text?: string } | null;
+    return (row?.text ?? "").replace(/\s+/g, " ").trim().slice(0, 240);
   }
 
   private deletePath(path: string): void {
     this.db.prepare("DELETE FROM notes WHERE path = ?").run(path);
     this.db.prepare("DELETE FROM files WHERE path = ?").run(path);
+    this.db.prepare("DELETE FROM note_links WHERE src_path = ?").run(path);
     this.db
       .prepare("DELETE FROM note_embeddings WHERE path = ?")
       .run(path);
@@ -663,6 +961,24 @@ function blobToFloat32(blob: Buffer | Uint8Array): Float32Array {
   // Both expose .buffer + .byteOffset + .byteLength so we can construct
   // a Float32Array view without copying.
   return new Float32Array(blob.buffer, blob.byteOffset, blob.byteLength / 4);
+}
+
+/**
+ * Resolve a relative markdown link target against the linking note's path to a
+ * personaDir-relative note path (e.g. src "kb/infra/dns.md" + "../ops/ns" →
+ * "kb/ops/ns.md"). Returns null for absolute URLs or links that escape the
+ * persona tree. Exported for testing.
+ */
+export function resolveMdLink(srcPath: string, target: string): string | null {
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(target) || target.startsWith("/")) {
+    return null;
+  }
+  const dir = posix.dirname(srcPath.replace(/\\/g, "/"));
+  let rel = posix.normalize(posix.join(dir, target.replace(/\\/g, "/")));
+  if (!/\.md$/i.test(rel)) rel += ".md";
+  rel = rel.replace(/^\.\//, "");
+  if (rel.startsWith("..")) return null;
+  return rel;
 }
 
 /** Walk personaDir/memory/ and personaDir/kb/ for .md files. Synchronous. */

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -130,7 +130,7 @@ export function rrfMerge(
  * (title / tags / aliases / headings / body) for BM25F, and `note_links` was
  * added for graph-walk expansion.
  */
-export const NOTES_SCHEMA_VERSION = 2;
+export const NOTES_SCHEMA_VERSION = 3;
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS meta (
@@ -350,7 +350,9 @@ export class MemoryIndex {
           f.mtimeMs,
           f.size,
           doc.title,
-          doc.aliases.join(" ").toLowerCase(),
+          // Newline-delimited (not space-joined) so multi-word aliases like
+          // "credential cycling" survive intact for wiki-target resolution.
+          doc.aliases.join("\n").toLowerCase(),
           new Date().toISOString(),
         );
       for (const link of doc.links) {
@@ -370,7 +372,66 @@ export class MemoryIndex {
       }
       indexed++;
     }
+    // Resolve wikilink targets to concrete paths now that every changed note
+    // is in the files table. Done as a post-pass (not inline) so forward
+    // references — a note that [[links]] to one indexed later — still resolve,
+    // and so both outbound and inbound lookups can rely on target_path. Only
+    // runs when something changed, since unchanged runs can't add new targets.
+    if (indexed > 0 || removed > 0) this.resolveWikiLinks();
     return { indexed, removed };
+  }
+
+  /**
+   * Fill in `target_path` for every wikilink by matching its raw target
+   * against indexed notes' basename, title, or aliases. (Markdown links are
+   * resolved by relative path inline at insert time.) Idempotent: re-resolves
+   * the whole wiki link set so links that pointed at a now-renamed/-deleted
+   * note get repaired or cleared. This is what lets a note pull in the notes
+   * that wikilink *to* it — inbound lookup keys on target_path, so unresolved
+   * wikilinks are invisible to it.
+   */
+  private resolveWikiLinks(): void {
+    const nameIndex = this.buildNameIndex();
+    const rows = this.db
+      .query(
+        "SELECT rowid, target_raw FROM note_links WHERE kind = 'wiki'",
+      )
+      .all() as Array<{ rowid: number; target_raw: string }>;
+    const upd = this.db.prepare(
+      "UPDATE note_links SET target_path = ? WHERE rowid = ?",
+    );
+    for (const r of rows) {
+      const key = r.target_raw.trim().toLowerCase().replace(/\.md$/, "");
+      upd.run(key ? (nameIndex.get(key) ?? null) : null, r.rowid);
+    }
+  }
+
+  /**
+   * Lowercased name → indexed path map for wiki-target resolution. Built once
+   * per resolve pass (not per link) to avoid an O(files) scan per wikilink.
+   * Precedence basename > title > alias; first writer wins for stable results.
+   */
+  private buildNameIndex(): Map<string, string> {
+    const map = new Map<string, string>();
+    const rows = this.db
+      .query("SELECT path, title, aliases FROM files")
+      .all() as Array<{ path: string; title: string; aliases: string }>;
+    const add = (key: string, path: string) => {
+      const k = key.trim().toLowerCase();
+      if (k && !map.has(k)) map.set(k, path);
+    };
+    for (const r of rows) {
+      add(
+        posix.basename(r.path.replace(/\\/g, "/")).replace(/\.md$/i, ""),
+        r.path,
+      );
+    }
+    for (const r of rows) if (r.title) add(r.title, r.path);
+    for (const r of rows) {
+      // files.aliases is newline-delimited so multi-word aliases stay intact.
+      for (const a of r.aliases.split("\n")) if (a) add(a, r.path);
+    }
+    return map;
   }
 
   // -------------------------------------------------------------
@@ -750,36 +811,32 @@ export class MemoryIndex {
     return found;
   }
 
-  /** Concrete indexed paths linked to/from `src` (outbound + inbound). */
+  /**
+   * Concrete indexed paths linked to/from `src` (outbound + inbound). Both
+   * markdown and wikilink targets are resolved to concrete paths at index time
+   * (see resolveWikiLinks), so both directions simply key on target_path — no
+   * per-query table scan, and inbound wikilinks resolve symmetrically.
+   */
   private linkedPaths(src: string): string[] {
     const out = new Set<string>();
 
-    // Outbound: resolved markdown targets are direct; wikilinks resolve by
-    // basename / title / alias against the files table.
+    // Outbound: this note's links whose target resolved to an indexed note.
     const outboundRows = this.db
       .query(
-        "SELECT target_raw, kind, target_path FROM note_links WHERE src_path = ?",
+        "SELECT target_path FROM note_links WHERE src_path = ? AND target_path IS NOT NULL",
       )
-      .all(src) as Array<{
-      target_raw: string;
-      kind: string;
-      target_path: string | null;
-    }>;
+      .all(src) as Array<{ target_path: string }>;
     for (const r of outboundRows) {
-      if (r.target_path && this.pathExists(r.target_path)) {
-        out.add(r.target_path);
-        continue;
-      }
-      const resolved = this.resolveWikiTarget(r.target_raw);
-      if (resolved) out.add(resolved);
+      if (this.pathExists(r.target_path)) out.add(r.target_path);
     }
 
-    // Inbound: notes that link to this one by resolved markdown path.
+    // Inbound: notes whose (markdown OR wiki) link resolved to this one.
     const inboundRows = this.db
       .query("SELECT src_path FROM note_links WHERE target_path = ?")
       .all(src) as Array<{ src_path: string }>;
     for (const r of inboundRows) out.add(r.src_path);
 
+    out.delete(src);
     return [...out];
   }
 
@@ -788,29 +845,6 @@ export class MemoryIndex {
       this.db.prepare("SELECT 1 FROM files WHERE path = ? LIMIT 1").get(path) !=
       null
     );
-  }
-
-  /**
-   * Resolve a wikilink / unresolved link target to an indexed note path by
-   * matching, case-insensitively: file basename (with/without .md), title, or
-   * any alias. Returns the first match or undefined.
-   */
-  private resolveWikiTarget(target: string): string | undefined {
-    const t = target.trim().toLowerCase().replace(/\.md$/, "");
-    if (!t) return undefined;
-    const rows = this.db
-      .query("SELECT path, title, aliases FROM files")
-      .all() as Array<{ path: string; title: string; aliases: string }>;
-    for (const r of rows) {
-      const base = posix
-        .basename(r.path.replace(/\\/g, "/"))
-        .replace(/\.md$/i, "")
-        .toLowerCase();
-      if (base === t) return r.path;
-      if (r.title && r.title.toLowerCase() === t) return r.path;
-      if (r.aliases && r.aliases.split(/\s+/).includes(t)) return r.path;
-    }
-    return undefined;
   }
 
   /** Build a SearchHit for a known indexed path (no lexical scores). */

--- a/src/lib/okf.ts
+++ b/src/lib/okf.ts
@@ -1,0 +1,239 @@
+/**
+ * Minimal Open Knowledge Format (OKF) aware parser for memory/ and kb/ notes.
+ *
+ * OKF (Google Cloud's open spec, github.com/GoogleCloudPlatform/knowledge-catalog)
+ * describes a knowledge "concept" as a markdown file with YAML frontmatter
+ * (`type`, `title`, `description`, `tags`, …) and a body, where concepts link
+ * to each other with plain markdown links to form a graph.
+ *
+ * Phantombot's kb/ second brain is already this shape (Obsidian-style atomic
+ * notes with frontmatter + links). This parser extracts the structured parts
+ * so the FTS5 index can:
+ *   - weight frontmatter fields above body text (BM25F),
+ *   - index tags + aliases as controlled vocabulary (synonym fix), and
+ *   - follow links between concepts for graph-walk recall expansion.
+ *
+ * It is deliberately dependency-free and forgiving: a note with no frontmatter,
+ * malformed YAML, or no links still parses into a sane OkfDoc (everything in
+ * `body`, empty field lists). This is a search-index helper, not a validator —
+ * it must never throw on real-world content.
+ */
+
+export interface OkfDoc {
+  /** `title:` from frontmatter, else the first markdown H1, else "". */
+  title: string;
+  /** `type:` from frontmatter (OKF's only required field), else "". */
+  type: string;
+  /** `description:`/`summary:` from frontmatter, else "". */
+  description: string;
+  /** `tags:` — normalised lowercase, deduped. */
+  tags: string[];
+  /** `aliases:`/`alias:` — alternate names this concept goes by. */
+  aliases: string[];
+  /** All ATX/setext heading texts in the body (for mid-weight matching). */
+  headings: string[];
+  /** Body text with frontmatter stripped. */
+  body: string;
+  /** Outbound links to other concepts (markdown + wikilink targets). */
+  links: OkfLink[];
+}
+
+export interface OkfLink {
+  /** Raw link target as written, e.g. "infra/dns.md" or "DNS Runbook". */
+  target: string;
+  /** "md" for [text](path), "wiki" for [[Wikilink]]. */
+  kind: "md" | "wiki";
+}
+
+const FRONTMATTER_RE = /^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/;
+
+/**
+ * Parse a note's raw content into an OkfDoc. Never throws.
+ */
+export function parseOkf(raw: string): OkfDoc {
+  const { frontmatter, body } = splitFrontmatter(raw);
+  const fm = parseFrontmatter(frontmatter);
+
+  const headings = extractHeadings(body);
+  const title =
+    str(fm.title) ||
+    str(fm.name) ||
+    headings[0] ||
+    "";
+
+  return {
+    title,
+    type: str(fm.type),
+    description: str(fm.description) || str(fm.summary),
+    tags: list(fm.tags ?? fm.tag).map(normTag).filter(Boolean),
+    aliases: dedupe(list(fm.aliases ?? fm.alias).map((s) => s.trim()).filter(Boolean)),
+    headings,
+    body,
+    links: extractLinks(body),
+  };
+}
+
+/** Split leading YAML frontmatter (if any) from the markdown body. */
+export function splitFrontmatter(raw: string): {
+  frontmatter: string;
+  body: string;
+} {
+  const m = raw.match(FRONTMATTER_RE);
+  if (!m) return { frontmatter: "", body: stripBom(raw) };
+  return { frontmatter: m[1] ?? "", body: raw.slice(m[0].length) };
+}
+
+/**
+ * Tiny YAML-subset parser: flat `key: value` pairs plus block/flow lists.
+ * Handles the shapes OKF/Obsidian frontmatter actually uses:
+ *
+ *   title: My Concept
+ *   tags: [infra, dns, networking]
+ *   aliases:
+ *     - name resolution
+ *     - DNS
+ *
+ * Nested maps and multi-line scalars are ignored (kept out of the index
+ * rather than mis-parsed). Returns a plain record; values are string or
+ * string[]. Never throws.
+ */
+export function parseFrontmatter(src: string): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  if (!src.trim()) return out;
+
+  const lines = src.split(/\r?\n/);
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+    i++;
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+
+    const m = line.match(/^([A-Za-z0-9_-]+)[ \t]*:[ \t]*(.*)$/);
+    if (!m) continue;
+    const key = (m[1] ?? "").toLowerCase();
+    const rest = (m[2] ?? "").trim();
+
+    if (rest === "") {
+      // Possible block list on following indented "- item" lines.
+      const items: string[] = [];
+      while (i < lines.length) {
+        const next = lines[i] ?? "";
+        const lm = next.match(/^[ \t]+-[ \t]+(.*)$/);
+        if (!lm) break;
+        items.push(unquote((lm[1] ?? "").trim()));
+        i++;
+      }
+      out[key] = items;
+    } else if (rest.startsWith("[") && rest.endsWith("]")) {
+      // Flow list: [a, b, c]
+      out[key] = rest
+        .slice(1, -1)
+        .split(",")
+        .map((s) => unquote(s.trim()))
+        .filter((s) => s.length > 0);
+    } else {
+      out[key] = unquote(rest);
+    }
+  }
+  return out;
+}
+
+/** ATX (`# h`) and setext (underlined) heading texts, in document order. */
+function extractHeadings(body: string): string[] {
+  const out: string[] = [];
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const atx = line.match(/^#{1,6}[ \t]+(.+?)[ \t]*#*\s*$/);
+    if (atx) {
+      out.push((atx[1] ?? "").trim());
+      continue;
+    }
+    const next = lines[i + 1] ?? "";
+    if (line.trim() && /^(=+|-+)\s*$/.test(next) && !line.startsWith("-")) {
+      out.push(line.trim());
+    }
+  }
+  return out;
+}
+
+/**
+ * Outbound links: markdown `[text](target)` and `[[wikilink]]`. External
+ * URLs (http/https/mailto) and in-page anchors (#…) are skipped — only
+ * concept-to-concept links matter for graph expansion.
+ */
+export function extractLinks(body: string): OkfLink[] {
+  const out: OkfLink[] = [];
+  const seen = new Set<string>();
+
+  // [[Wikilink]] or [[path|alias]] — take the part before '|'.
+  for (const m of body.matchAll(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/g)) {
+    const target = (m[1] ?? "").trim();
+    if (!target) continue;
+    const key = `wiki:${target.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ target, kind: "wiki" });
+  }
+
+  // [text](target)
+  for (const m of body.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)) {
+    let target = (m[1] ?? "").trim();
+    // Strip optional "title" and #anchor.
+    target = target.replace(/\s+["'].*$/, "").split("#")[0]!.trim();
+    if (!target) continue;
+    if (/^(https?:|mailto:|tel:|ftp:|#)/i.test(target)) continue;
+    const key = `md:${target.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ target, kind: "md" });
+  }
+  return out;
+}
+
+// --- small helpers -------------------------------------------------------
+
+function stripBom(s: string): string {
+  return s.charCodeAt(0) === 0xfeff ? s.slice(1) : s;
+}
+
+function str(v: string | string[] | undefined): string {
+  if (Array.isArray(v)) return v.join(" ");
+  return (v ?? "").trim();
+}
+
+function list(v: string | string[] | undefined): string[] {
+  if (v === undefined) return [];
+  if (Array.isArray(v)) return v;
+  // Comma- or space-separated inline value, e.g. "infra, dns".
+  return v
+    .split(/[,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function normTag(t: string): string {
+  return t.trim().replace(/^#/, "").toLowerCase();
+}
+
+function dedupe(xs: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    const k = x.toLowerCase();
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(x);
+  }
+  return out;
+}
+
+function unquote(s: string): string {
+  if (
+    (s.startsWith('"') && s.endsWith('"') && s.length >= 2) ||
+    (s.startsWith("'") && s.endsWith("'") && s.length >= 2)
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}

--- a/src/orchestrator/retrieval.ts
+++ b/src/orchestrator/retrieval.ts
@@ -100,17 +100,29 @@ export async function retrieveContext(
         });
     }
 
+    // Gemini path: hybrid (BM25 + vector via RRF), unchanged. No-embeddings
+    // path: fielded BM25 plus OKF link-graph expansion (the superpower) when
+    // enabled — so keyword-only personas get semantic-ish spread for free.
+    const ge = opts.settings.graphExpansion;
     const hits = queryVec
       ? ix.hybridSearch(query, queryVec, {
           scope: "all",
           limit: opts.settings.limit,
           conversation: opts.conversation,
         })
-      : ix.search(query, {
-          scope: "all",
-          limit: opts.settings.limit,
-          conversation: opts.conversation,
-        });
+      : ge?.enabled
+        ? ix.searchExpanded(query, {
+            scope: "all",
+            limit: opts.settings.limit,
+            conversation: opts.conversation,
+            hops: ge.hops,
+            maxAdd: ge.maxAdd,
+          })
+        : ix.search(query, {
+            scope: "all",
+            limit: opts.settings.limit,
+            conversation: opts.conversation,
+          });
 
     return formatRetrieved(hits, opts.settings);
   } catch (e) {
@@ -169,7 +181,8 @@ export function formatRetrieved(
   let out = header;
   let included = 0;
   for (const h of usable) {
-    const block = `\n\n## ${h.path}\n${cleanSnippet(h.snippet)}`;
+    const label = h.expanded ? ` ${h.path} (linked concept)` : ` ${h.path}`;
+    const block = `\n\n##${label}\n${cleanSnippet(h.snippet)}`;
     // Always include at least one hit (so a single long snippet isn't
     // silently dropped); after that, respect the budget.
     if (included > 0 && out.length + block.length > budgetChars) break;

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -639,7 +639,8 @@ describe("runDoctor embeddings status line", () => {
     });
     expect(code).toBe(0);
     expect(out.text).toContain(
-      "embeddings: semantic (vector) search off — keyword (BM25) search active",
+      "embeddings: semantic (vector) search off — OKF field-weighted BM25 " +
+        "+ link-graph expansion active",
     );
     expect(out.text).toContain("phantombot embedding");
     // Crucially, NOT a WARN — the marker must never appear on this line.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -10,6 +10,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  DEFAULT_GRAPH_EXPANSION,
   DEFAULT_RETRIEVAL,
   DEFAULT_TELEGRAM_STREAMING,
   DEFAULT_TURN_INDEXING,
@@ -555,6 +556,7 @@ min_score = 0.25
       maxTokens: 3000,
       minScore: 0.25,
       turnIndexing: DEFAULT_TURN_INDEXING,
+      graphExpansion: DEFAULT_GRAPH_EXPANSION,
     });
   });
 
@@ -575,6 +577,7 @@ limit = 5
       maxTokens: 2200,
       minScore: 0.4,
       turnIndexing: DEFAULT_TURN_INDEXING,
+      graphExpansion: DEFAULT_GRAPH_EXPANSION,
     });
   });
 

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -8,10 +8,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   MemoryIndex,
+  NOTES_SCHEMA_VERSION,
+  resolveMdLink,
   sanitizeFtsQuery,
   turnPath,
   walkMarkdown,
 } from "../src/lib/memoryIndex.ts";
+import { Database } from "bun:sqlite";
 import type { Turn } from "../src/memory/store.ts";
 
 let workdir: string;
@@ -310,5 +313,159 @@ describe("MemoryIndex.rebuild", () => {
     await note("kb/concepts/B.md", "second");
     const r = await ix.rebuild(personaDir);
     expect(r.indexed).toBe(2);
+  });
+});
+
+describe("resolveMdLink", () => {
+  test("resolves relative targets against the linking note", () => {
+    expect(resolveMdLink("kb/infra/dns.md", "../ops/ns.md")).toBe(
+      "kb/ops/ns.md",
+    );
+    expect(resolveMdLink("kb/infra/dns.md", "vault")).toBe("kb/infra/vault.md");
+    expect(resolveMdLink("kb/a.md", "./b.md")).toBe("kb/b.md");
+  });
+
+  test("rejects external URLs and tree escapes", () => {
+    expect(resolveMdLink("kb/a.md", "https://x.com")).toBeNull();
+    expect(resolveMdLink("kb/a.md", "/etc/passwd")).toBeNull();
+    expect(resolveMdLink("kb/a.md", "../../etc/passwd")).toBeNull();
+  });
+});
+
+describe("BM25F field weighting", () => {
+  test("a title/tag match outranks a body-only match", async () => {
+    // Note A mentions "kubernetes" only deep in the body.
+    await note(
+      "kb/concepts/a.md",
+      "---\ntitle: Grocery list\n---\n# Grocery list\n" +
+        "milk eggs bread. an aside about kubernetes maybe.\n",
+    );
+    // Note B has it as the title + a tag — the authoritative concept.
+    await note(
+      "kb/concepts/b.md",
+      "---\ntitle: Kubernetes\ntags: [kubernetes, infra]\n---\n" +
+        "# Kubernetes\nour cluster notes.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const hits = ix.search("kubernetes", { scope: "kb", limit: 5 });
+    expect(hits[0]?.path).toBe("kb/concepts/b.md");
+  });
+
+  test("a query that matches only an alias still finds the note", async () => {
+    await note(
+      "kb/concepts/creds.md",
+      "---\ntitle: Secret Rotation\naliases: [credential cycling]\n---\n" +
+        "# Secret Rotation\nrun the playbook.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const hits = ix.search("credential cycling", { scope: "kb" });
+    expect(hits.map((h) => h.path)).toContain("kb/concepts/creds.md");
+  });
+});
+
+describe("MemoryIndex.searchExpanded (OKF link-graph)", () => {
+  test("pulls in a linked neighbour that did not match lexically", async () => {
+    // Seed matches "postgres"; neighbour is about backups and links nowhere
+    // near the query term, but is reachable via a markdown link.
+    await note(
+      "kb/infra/postgres.md",
+      "---\ntitle: Postgres\n---\n# Postgres\n" +
+        "Primary datastore. See [backups](backups.md).\n",
+    );
+    await note(
+      "kb/infra/backups.md",
+      "---\ntitle: Backups\n---\n# Backups\n" +
+        "Nightly snapshots to cold storage.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const plain = ix.search("postgres", { scope: "kb" }).map((h) => h.path);
+    expect(plain).toContain("kb/infra/postgres.md");
+    expect(plain).not.toContain("kb/infra/backups.md");
+
+    const expanded = ix.searchExpanded("postgres", { scope: "kb", maxAdd: 3 });
+    const byPath = new Map(expanded.map((h) => [h.path, h]));
+    expect(byPath.has("kb/infra/backups.md")).toBe(true);
+    expect(byPath.get("kb/infra/backups.md")?.expanded).toBe(true);
+    // The real lexical hit is never displaced and not flagged expanded.
+    expect(byPath.get("kb/infra/postgres.md")?.expanded).toBeUndefined();
+  });
+
+  test("inbound links expand too (neighbour links TO the hit)", async () => {
+    await note(
+      "kb/infra/dns.md",
+      "---\ntitle: DNS\n---\n# DNS\nname resolution notes.\n",
+    );
+    await note(
+      "kb/infra/cutover.md",
+      "---\ntitle: Cutover\n---\n# Cutover\nplan that references [dns](dns.md).\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const expanded = ix
+      .searchExpanded("resolution", { scope: "kb", maxAdd: 3 })
+      .map((h) => h.path);
+    expect(expanded).toContain("kb/infra/dns.md");
+    expect(expanded).toContain("kb/infra/cutover.md");
+  });
+
+  test("maxAdd 0 disables expansion", async () => {
+    await note("kb/infra/a.md", "# A\nalpha links to [b](b.md)\n");
+    await note("kb/infra/b.md", "# B\nbravo\n");
+    await ix.refreshStale(personaDir);
+    const hits = ix.searchExpanded("alpha", { scope: "kb", maxAdd: 0 });
+    expect(hits.every((h) => !h.expanded)).toBe(true);
+  });
+});
+
+describe("notes-schema self-heal", () => {
+  test("a legacy v1 single-column index is rebuilt on open", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "phantombot-mi-heal-"));
+    const idxPath = join(dir, "index.sqlite");
+    const pdir = join(dir, "persona");
+    await mkdir(join(pdir, "kb"), { recursive: true });
+    await writeFile(
+      join(pdir, "kb", "x.md"),
+      "---\ntitle: Widget\n---\n# Widget\nthe widget concept.\n",
+    );
+
+    // Hand-build a pre-OKF (v1) index: old single-column `notes`, a stale
+    // `files` row, and no meta version.
+    const raw = new Database(idxPath, { create: true });
+    raw.exec("PRAGMA journal_mode = WAL");
+    raw.exec(
+      "CREATE VIRTUAL TABLE notes USING fts5(path UNINDEXED, scope UNINDEXED, content, tokenize = 'porter unicode61');",
+    );
+    raw.exec(
+      "CREATE TABLE files (path TEXT PRIMARY KEY, scope TEXT, mtime_ms INTEGER, size INTEGER, indexed_at TEXT);",
+    );
+    raw
+      .prepare(
+        "INSERT INTO files (path, scope, mtime_ms, size, indexed_at) VALUES (?,?,?,?,?)",
+      )
+      .run("kb/x.md", "kb", 1, 1, new Date().toISOString());
+    raw.close();
+
+    // Opening through MemoryIndex must detect the stale schema, drop+rebuild,
+    // and then index the note with the new fielded columns.
+    const healed = await MemoryIndex.open(idxPath);
+    try {
+      await healed.refreshStale(pdir);
+      const hits = healed.search("widget", { scope: "kb" });
+      expect(hits.map((h) => h.path)).toContain("kb/x.md");
+      const ver = (
+        healed as unknown as {
+          db: { query: (s: string) => { get: () => { value: string } | null } };
+        }
+      ).db
+        .query("SELECT value FROM meta WHERE key = 'notes_schema_version'")
+        .get();
+      expect(Number(ver?.value)).toBe(NOTES_SCHEMA_VERSION);
+    } finally {
+      healed.close();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -418,6 +418,76 @@ describe("MemoryIndex.searchExpanded (OKF link-graph)", () => {
     const hits = ix.searchExpanded("alpha", { scope: "kb", maxAdd: 0 });
     expect(hits.every((h) => !h.expanded)).toBe(true);
   });
+
+  test("inbound wikilinks expand (a note that [[wikilinks]] TO the hit)", async () => {
+    // The target note matches lexically; the note that wikilinks to it does
+    // NOT. Before the fix, wiki targets were never resolved to target_path so
+    // inbound lookup (which keys on target_path) could never find them.
+    await note(
+      "kb/infra/store.md",
+      "---\ntitle: Credential Store\n---\n# Credential Store\nwhere secrets live.\n",
+    );
+    await note(
+      "kb/infra/rotate.md",
+      "---\ntitle: Rotate\n---\n# Rotate\nsee [[Credential Store]] for the vault.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const plain = ix.search("secrets", { scope: "kb" }).map((h) => h.path);
+    expect(plain).toContain("kb/infra/store.md");
+    expect(plain).not.toContain("kb/infra/rotate.md");
+
+    const expanded = ix
+      .searchExpanded("secrets", { scope: "kb", maxAdd: 3 })
+      .map((h) => h.path);
+    expect(expanded).toContain("kb/infra/rotate.md");
+  });
+
+  test("wikilinks resolve multi-word aliases", async () => {
+    // `[[credential cycling]]` must resolve to the note that declares
+    // `aliases: [credential cycling]`. The old space-joined alias storage +
+    // whitespace split could never match a multi-word alias.
+    await note(
+      "kb/infra/rotation.md",
+      "---\ntitle: Secret Rotation\naliases: [credential cycling]\n---\n" +
+        "# Secret Rotation\nrun the playbook.\n",
+    );
+    await note(
+      "kb/infra/onboard.md",
+      "---\ntitle: Onboarding\n---\n# Onboarding\n" +
+        "new hires must read [[credential cycling]] first. xyzzy.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const plain = ix.search("xyzzy", { scope: "kb" }).map((h) => h.path);
+    expect(plain).toContain("kb/infra/onboard.md");
+    expect(plain).not.toContain("kb/infra/rotation.md");
+
+    const expanded = ix
+      .searchExpanded("xyzzy", { scope: "kb", maxAdd: 3 })
+      .map((h) => h.path);
+    expect(expanded).toContain("kb/infra/rotation.md");
+  });
+
+  test("forward-referenced wikilink resolves after its target is indexed", async () => {
+    // The linking note is indexed before its target exists; a later refresh
+    // adds the target. The post-pass must repair the dangling wiki link.
+    await note(
+      "kb/infra/plan.md",
+      "---\ntitle: Plan\n---\n# Plan\nfollow [[Runbook]]. zzplan.\n",
+    );
+    await ix.refreshStale(personaDir);
+    await note(
+      "kb/infra/runbook.md",
+      "---\ntitle: Runbook\n---\n# Runbook\nthe steps.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const expanded = ix
+      .searchExpanded("zzplan", { scope: "kb", maxAdd: 3 })
+      .map((h) => h.path);
+    expect(expanded).toContain("kb/infra/runbook.md");
+  });
 });
 
 describe("notes-schema self-heal", () => {

--- a/tests/lib-okf.test.ts
+++ b/tests/lib-okf.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the OKF-aware note parser (src/lib/okf.ts).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  extractLinks,
+  parseFrontmatter,
+  parseOkf,
+  splitFrontmatter,
+} from "../src/lib/okf.ts";
+
+describe("splitFrontmatter", () => {
+  test("splits leading YAML block from body", () => {
+    const { frontmatter, body } = splitFrontmatter(
+      "---\ntitle: X\n---\nhello body\n",
+    );
+    expect(frontmatter).toBe("title: X");
+    expect(body).toBe("hello body\n");
+  });
+
+  test("no frontmatter → empty fm, full body", () => {
+    const { frontmatter, body } = splitFrontmatter("# Heading\ntext");
+    expect(frontmatter).toBe("");
+    expect(body).toBe("# Heading\ntext");
+  });
+
+  test("strips a UTF-8 BOM when no frontmatter", () => {
+    const { body } = splitFrontmatter("﻿# Heading");
+    expect(body).toBe("# Heading");
+  });
+});
+
+describe("parseFrontmatter", () => {
+  test("scalars, flow lists, and block lists", () => {
+    const fm = parseFrontmatter(
+      [
+        "title: DNS Runbook",
+        "type: runbook",
+        "tags: [infra, dns]",
+        "aliases:",
+        "  - name resolution",
+        '  - "DNS"',
+      ].join("\n"),
+    );
+    expect(fm.title).toBe("DNS Runbook");
+    expect(fm.type).toBe("runbook");
+    expect(fm.tags).toEqual(["infra", "dns"]);
+    expect(fm.aliases).toEqual(["name resolution", "DNS"]);
+  });
+
+  test("ignores comments and blank lines, never throws on junk", () => {
+    const fm = parseFrontmatter("# a comment\n\n: bad line\nkey: value\n");
+    expect(fm.key).toBe("value");
+  });
+});
+
+describe("extractLinks", () => {
+  test("captures markdown and wiki links, skips external URLs", () => {
+    const body = [
+      "See [the runbook](infra/dns.md) and [[DNS Cutover]].",
+      "External [docs](https://example.com) ignored.",
+      "Anchor [top](#intro) ignored.",
+    ].join("\n");
+    const links = extractLinks(body);
+    expect(links).toContainEqual({ target: "infra/dns.md", kind: "md" });
+    expect(links).toContainEqual({ target: "DNS Cutover", kind: "wiki" });
+    expect(links.some((l) => l.target.includes("example.com"))).toBe(false);
+    expect(links.some((l) => l.target.startsWith("#"))).toBe(false);
+  });
+
+  test("wikilink with display alias keeps the target", () => {
+    expect(extractLinks("[[concepts/foo|Foo the thing]]")).toEqual([
+      { target: "concepts/foo", kind: "wiki" },
+    ]);
+  });
+});
+
+describe("parseOkf", () => {
+  test("full concept note", () => {
+    const doc = parseOkf(
+      [
+        "---",
+        "title: Secret Rotation",
+        "type: runbook",
+        "description: How we cycle credentials.",
+        "tags: [#Creds, secrets]",
+        "aliases: [credential rotation]",
+        "---",
+        "# Secret Rotation",
+        "Body text linking to [vault](infra/vault.md).",
+        "## Steps",
+        "do the thing",
+      ].join("\n"),
+    );
+    expect(doc.title).toBe("Secret Rotation");
+    expect(doc.type).toBe("runbook");
+    expect(doc.description).toBe("How we cycle credentials.");
+    // tags normalised: lowercased, leading # stripped.
+    expect(doc.tags).toEqual(["creds", "secrets"]);
+    expect(doc.aliases).toEqual(["credential rotation"]);
+    expect(doc.headings).toEqual(["Secret Rotation", "Steps"]);
+    expect(doc.links).toEqual([{ target: "infra/vault.md", kind: "md" }]);
+  });
+
+  test("plain note with no frontmatter falls back to first H1 for title", () => {
+    const doc = parseOkf("# Just A Note\nsome content");
+    expect(doc.title).toBe("Just A Note");
+    expect(doc.tags).toEqual([]);
+    expect(doc.body).toContain("some content");
+  });
+
+  test("empty input never throws", () => {
+    const doc = parseOkf("");
+    expect(doc.title).toBe("");
+    expect(doc.links).toEqual([]);
+  });
+});

--- a/tests/lib-okf.test.ts
+++ b/tests/lib-okf.test.ts
@@ -65,8 +65,9 @@ describe("extractLinks", () => {
     const links = extractLinks(body);
     expect(links).toContainEqual({ target: "infra/dns.md", kind: "md" });
     expect(links).toContainEqual({ target: "DNS Cutover", kind: "wiki" });
-    expect(links.some((l) => l.target.includes("example.com"))).toBe(false);
-    expect(links.some((l) => l.target.startsWith("#"))).toBe(false);
+    const targets = links.map((l) => l.target);
+    expect(targets).not.toContain("https://example.com");
+    expect(targets).not.toContain("#intro");
   });
 
   test("wikilink with display alias keeps the target", () => {

--- a/www/index.html
+++ b/www/index.html
@@ -213,7 +213,7 @@
                 </div>
                 <div class="card">
                     <h3>Persistent Memory</h3>
-                    <p>Local SQLite turn store with hybrid search. Your agents remember every decision, lesson, and preference across sessions.</p>
+                    <p>Local SQLite store in the <a href="https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/">Open Knowledge Format</a>, with hybrid <strong>Gemini-embedding</strong> + BM25 search. Your agents remember every decision, lesson, and preference across sessions.</p>
                 </div>
                 <div class="card">
                     <h3>Survivor Mode</h3>
@@ -223,6 +223,11 @@
         </section>
 
         <section class="features-detailed">
+            <div class="feature">
+                <h3>Open Knowledge Format memory</h3>
+                <p>Phantombot stores memory in the <a href="https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing/">Open Knowledge Format</a> &mdash; Google Cloud's open, vendor-neutral standard for the knowledge AI agents consume: atomic markdown notes with structured frontmatter, linked into a concept graph. No lock-in, no proprietary blob &mdash; your Phantom's mind is portable, readable, and yours.</p>
+                <p>Because the knowledge is <em>structured</em>, search is sharp out of the box: <strong>field-weighted BM25</strong> (a hit in a title or tag outranks one buried in prose), tag&nbsp;&amp; alias controlled vocabulary, and <strong>concept-graph expansion</strong> that walks the links to pull in related notes a bare keyword query would miss &mdash; all with zero API keys. Add a <strong>Gemini embeddings</strong> key and it upgrades to true <strong>hybrid semantic search</strong>: meaning-aware vector recall fused with lexical BM25 via reciprocal-rank fusion, so &ldquo;how do I pay tax&rdquo; finds your note titled &ldquo;VAT filing steps.&rdquo;</p>
+            </div>
             <div class="feature">
                 <h3>Personas</h3>
                 <p>Switch identities with a single command. Memory is partitioned, so each persona keeps its own private history forever. Create, import, and switch seamlessly.</p>


### PR DESCRIPTION
## What & why

Personas **without a Gemini API key** fall back to FTS5/BM25-only memory retrieval. Today that's a plain single-column BM25 over note bodies. This PR upgrades that default path with three [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) (OKF) native superpowers — **without touching the Gemini hybrid (BM25+vector) path**.

OKF isn't a retrieval engine; it's a storage shape (markdown + YAML frontmatter + concept links). Our `kb/` second brain is already that shape, so each OKF feature maps directly onto a BM25 upgrade:

| OKF feature | BM25 upgrade |
|---|---|
| Frontmatter fields | **BM25F** — weight title/tags/aliases above body |
| Tags + aliases | **Controlled vocabulary** — fixes vocabulary-mismatch at author time |
| Concept links | **Graph-walk expansion** — keyword-only stand-in for semantic spread |

## Changes

- **BM25F field weighting.** `notes` FTS5 table goes from a single `content` column to fielded columns (`title`, `tags`, `aliases`, `headings`, `body`), ranked with per-column weights (`NOTE_FIELD_WEIGHTS`). A term in a title/tag now outranks the same term in paragraph nine.
- **Controlled vocabulary.** Tags and frontmatter `aliases` are indexed and searchable, so a query phrased unlike the prose still matches.
- **Link-graph expansion** (`MemoryIndex.searchExpanded`). After the lexical search, walk markdown links — **outbound and inbound** — one hop out and fold in connected concepts a bare term query would miss. Flagged `expanded: true` and appended after real hits (never displaces a lexical match). Gated to the no-embeddings path.
- **Self-healing schema.** The index is fully derived from disk, so a new `notes_schema_version` in a `meta` table triggers a one-time drop+rebuild of the `notes`/`files`/`note_links` tables on open. **Turn and embedding tables are untouched** — Gemini vectors and the turn index survive.
- **New `src/lib/okf.ts`** — dependency-free, never-throws parser for frontmatter, headings, and links.
- **Config:** `retrieval.graph_expansion` (`enabled`/`hops`/`max_add`) via TOML, plus `PHANTOMBOT_RETRIEVAL_GRAPH_EXPANSION_ENABLED` / `_GRAPH_HOPS` / `_GRAPH_MAX_ADD`. Defaults on, 1 hop, 3 neighbours.

## Gemini users are unaffected

- The vector/hybrid path (`hybridSearch`) still runs exactly as before; graph expansion is **only** applied on the no-embeddings branch in `retrieval.ts` and `cli/memory.ts`.
- The one shared change is that the FTS leg is now fielded BM25F instead of flat BM25. That feeds the RRF merge on the hybrid path too — a strictly-better lexical ranking, not a behavior switch. Embedding/vector tables and the turn index are not migrated.

## Testing

- `tests/lib-okf.test.ts` — parser (frontmatter scalars/flow/block lists, headings, md + wiki links, BOM, junk-tolerance).
- `tests/lib-memoryIndex.test.ts` — BM25F (title/tag beats body), alias-only match, graph expansion (outbound + inbound), `maxAdd=0` off-switch, `resolveMdLink`, and legacy-v1-index self-heal.
- Full suite: **1706 pass / 0 fail**, `tsc --noEmit` clean.

## Follow-ups (not in this PR)

- Whole-bundle injection for small bounded domains (perfect recall, zero retrieval).
- OKF bundle export/import for cross-phantom knowledge sharing.