### PR TITLE
feat(harnesses): enrich ACP tool-call titles with arguments (#218)

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -49,6 +49,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { buildToolNote } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -357,6 +358,7 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
 
   let text = "";
   let toolName: string | undefined;
+  let toolInput: unknown;
   let sawOtherNonText = false;
   for (const part of content) {
     if (typeof part === "object" && part !== null) {
@@ -365,13 +367,14 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
         text += p.text;
       } else if (p.type === "tool_use") {
         toolName = typeof p.name === "string" ? p.name : toolName ?? "tool";
+        toolInput = p.input;
       } else if (typeof p.type === "string") {
         sawOtherNonText = true;
       }
     }
   }
   if (text) return { type: "text", text };
-  if (toolName) return { type: "progress", note: `tool: ${toolName}` };
+  if (toolName) return { type: "progress", note: buildToolNote(toolName, toolInput) };
   if (sawOtherNonText) return { type: "heartbeat" };
   return undefined;
 }

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -14,6 +14,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { buildToolNote } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -151,7 +152,8 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
     if (typeof item !== "object" || item === null) return undefined;
     const it = item as Record<string, unknown>;
     if (typeof it.type === "string" && it.type.includes("tool")) {
-      return { type: "progress", note: "tool" };
+      const name = typeof it.name === "string" ? it.name : undefined;
+      return { type: "progress", note: buildToolNote(name, it) };
     }
     // Non-tool starts are still useful liveness signals while the model is
     // preparing output, but they should not flush user-visible narration.
@@ -165,7 +167,8 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
       return { type: "text", text: it.text };
     }
     if (typeof it.type === "string" && it.type.includes("tool")) {
-      return { type: "progress", note: "tool" };
+      const name = typeof it.name === "string" ? it.name : undefined;
+      return { type: "progress", note: buildToolNote(name, it) };
     }
     return { type: "heartbeat" };
   }

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -38,6 +38,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import { buildToolNote } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -266,7 +267,8 @@ export function parseGeminiEvent(parsed: unknown): HarnessChunk | undefined {
   if (type === "tool_use") {
     const name =
       typeof obj.tool_name === "string" ? obj.tool_name : "(unknown tool)";
-    return { type: "progress", note: `tool: ${name}` };
+    const args = obj.args ?? obj.parameters ?? obj.tool_input ?? obj.input;
+    return { type: "progress", note: buildToolNote(name, args) };
   }
 
   if (type === "tool_result") {

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -35,6 +35,7 @@ import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { ENV_PI_API_KEY, ENV_PI_PROVIDER, type PiRoutingConfig } from "../lib/piRouting.ts";
 import { getCoderSwapOverride, resolveSwapModel } from "../lib/coderSwap.ts";
+import { buildToolNote } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -319,7 +320,8 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
         : typeof obj.tool_name === "string"
           ? obj.tool_name
           : undefined;
-    return { type: "progress", note: toolName ? `tool: ${toolName}` : "tool" };
+    const args = obj.args ?? obj.input;
+    return { type: "progress", note: buildToolNote(toolName, args) };
   }
 
   // tool_execution_update is fired while a tool is mid-run, carrying its

--- a/src/harnesses/toolNote.ts
+++ b/src/harnesses/toolNote.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared tool-call note formatter (issue #218).
+ *
+ * Every harness adapter (claude, codex, gemini, pi) emits a `progress` chunk
+ * when the model invokes a tool. That note becomes the `title` of the ACP
+ * `tool_call` update Zed renders in its agent panel. Historically each adapter
+ * built a bare `"tool: <name>"` string inline (codex didn't even capture the
+ * name), so the panel showed undifferentiated labels — you couldn't tell
+ * `Bash: git status` from `Bash: rm -rf /`.
+ *
+ * This module centralises the formatting so the per-tool rules live in ONE
+ * place and every harness benefits. Adapters are responsible only for the
+ * (per-harness, differently-shaped) extraction of the tool name + raw input;
+ * they hand both here and get back a single-line, length-capped title.
+ *
+ * Design notes:
+ *   - Backward compatible: when no useful detail can be extracted we return the
+ *     exact legacy `"tool: <name>"` (or bare `"tool"`) string, so existing
+ *     /status wording and tests are unchanged. The richer `"<Name>: <detail>"`
+ *     shape is purely additive — it only appears when args are present.
+ *   - Extraction keys on well-known INPUT FIELD NAMES (command, file_path,
+ *     query…) rather than per-harness tool names, so one rule set works across
+ *     all adapters even though their event shapes differ.
+ *   - Minimal redaction by design (Andrew's call on #218): we truncate and
+ *     collapse whitespace; we do NOT attempt secret masking. Keep this in mind
+ *     before surfacing inputs to any noisier sink than the Zed panel.
+ *   - Never throws. Bad/partial input degrades to the legacy label.
+ */
+
+/** Max length of a rendered tool-call title, including the name prefix. */
+export const MAX_TOOL_NOTE_LEN = 80;
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Collapse all runs of whitespace (incl. newlines) to single spaces + trim. */
+function collapse(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Pull the first usable string from `input` across a list of candidate keys.
+ * Handles plain strings and string arrays (codex shell `command` is an array
+ * of argv tokens). Returns undefined if nothing usable is present.
+ */
+function firstField(
+  input: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const v = input[key];
+    if (typeof v === "string") {
+      const c = collapse(v);
+      if (c) return c;
+    } else if (Array.isArray(v)) {
+      const joined = collapse(
+        v.filter((x): x is string => typeof x === "string").join(" "),
+      );
+      if (joined) return joined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract a human-meaningful detail string from a tool's raw input, keyed on
+ * common field names so it works regardless of which harness produced it.
+ */
+function extractToolDetail(input: unknown): string | undefined {
+  if (!isRecord(input)) return undefined;
+
+  // Shell/command tools (Bash, shell, run_shell_command, bash…)
+  const command = firstField(input, ["command", "cmd"]);
+  if (command) return command;
+
+  // File tools (Read/Edit/Write, read_file/write_file/replace…)
+  const path = firstField(input, [
+    "file_path",
+    "filePath",
+    "path",
+    "absolute_path",
+  ]);
+  if (path) return path;
+
+  // Search tools (Grep/Glob, search…)
+  const pattern = firstField(input, ["pattern", "query"]);
+  if (pattern) return pattern;
+
+  // Sub-agent / task delegation (Agent/Task): subagent + a prompt snippet.
+  const subagent = firstField(input, ["subagent_type", "description"]);
+  const prompt = firstField(input, ["prompt"]);
+  if (subagent && prompt) return `${subagent} — ${prompt}`;
+  if (subagent) return subagent;
+  if (prompt) return prompt;
+
+  // Web tools
+  const url = firstField(input, ["url"]);
+  if (url) return url;
+
+  return undefined;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  if (max <= 1) return "…";
+  return `${s.slice(0, max - 1)}…`;
+}
+
+/**
+ * Build the progress note (ACP tool_call title) for a tool invocation.
+ *
+ * @param toolName the tool's name, if the harness captured it
+ * @param input    the tool's raw arguments object (any shape; may be missing)
+ */
+export function buildToolNote(
+  toolName: string | undefined,
+  input?: unknown,
+): string {
+  const name = typeof toolName === "string" ? collapse(toolName) : "";
+
+  if (name) {
+    const detail = extractToolDetail(input);
+    if (detail) return truncate(`${name}: ${detail}`, MAX_TOOL_NOTE_LEN);
+    // No detail → preserve the exact legacy label for back-compat.
+    return `tool: ${name}`;
+  }
+
+  // No name at all (some codex/pi events) → legacy bare fallback.
+  return "tool";
+}

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -151,6 +151,18 @@ describe("parseStreamJson", () => {
     expect(c).toEqual({ type: "progress", note: "tool: Bash" });
   });
 
+  test("progress note surfaces the tool input when present (#218)", () => {
+    const c = parseStreamJson({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", name: "Bash", input: { command: "git status" } },
+        ],
+      },
+    });
+    expect(c).toEqual({ type: "progress", note: "Bash: git status" });
+  });
+
   test("heartbeat for thinking blocks (no flush — mirrors pi.ts)", () => {
     const c = parseStreamJson({
       type: "assistant",

--- a/tests/harnesses-codex.test.ts
+++ b/tests/harnesses-codex.test.ts
@@ -66,11 +66,18 @@ describe("parseCodexEvent", () => {
     expect(parseCodexEvent({ type: "turn.started" })).toEqual({ type: "heartbeat" });
   });
 
-  test("item.started tool -> progress", () => {
+  test("item.started tool -> progress (now captures the tool name; #218)", () => {
     expect(parseCodexEvent({
       type: "item.started",
       item: { type: "tool_call", name: "shell" },
-    })).toEqual({ type: "progress", note: "tool" });
+    })).toEqual({ type: "progress", note: "tool: shell" });
+  });
+
+  test("item.started tool with a command surfaces it in the title (#218)", () => {
+    expect(parseCodexEvent({
+      type: "item.started",
+      item: { type: "tool_call", name: "shell", command: ["git", "status"] },
+    })).toEqual({ type: "progress", note: "shell: git status" });
   });
 
   test("turn.completed -> done-shaped stats carrier", () => {

--- a/tests/harnesses-gemini.test.ts
+++ b/tests/harnesses-gemini.test.ts
@@ -119,6 +119,17 @@ describe("parseGeminiEvent", () => {
     ).toEqual({ type: "progress", note: "tool: run_shell_command" });
   });
 
+  test("tool_use → progress note surfaces parameters when present (#218)", () => {
+    expect(
+      parseGeminiEvent({
+        type: "tool_use",
+        tool_name: "run_shell_command",
+        tool_id: "x",
+        parameters: { command: "ls -la" },
+      }),
+    ).toEqual({ type: "progress", note: "run_shell_command: ls -la" });
+  });
+
   test("tool_use without tool_name → progress with placeholder", () => {
     const c = parseGeminiEvent({ type: "tool_use" });
     expect(c?.type).toBe("progress");

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -102,6 +102,15 @@ describe("parsePiEvent", () => {
     expect(c).toEqual({ type: "progress", note: "tool: bash" });
   });
 
+  test("tool_execution_start surfaces args in the note when present (#218)", () => {
+    const c = parsePiEvent({
+      type: "tool_execution_start",
+      toolName: "bash",
+      args: { command: "npm test" },
+    });
+    expect(c).toEqual({ type: "progress", note: "bash: npm test" });
+  });
+
   test("emits progress for tool_execution_start (legacy 0.67.x tool_name field)", () => {
     const c = parsePiEvent({
       type: "tool_execution_start",

--- a/tests/harnesses-toolNote.test.ts
+++ b/tests/harnesses-toolNote.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { buildToolNote, MAX_TOOL_NOTE_LEN } from "../src/harnesses/toolNote.ts";
+
+describe("buildToolNote", () => {
+  test("shell command → '<Name>: <command>'", () => {
+    expect(buildToolNote("Bash", { command: "git status" })).toBe(
+      "Bash: git status",
+    );
+  });
+
+  test("file tools surface the path", () => {
+    expect(buildToolNote("Read", { file_path: "src/foo.ts" })).toBe(
+      "Read: src/foo.ts",
+    );
+    expect(buildToolNote("Write", { path: "/tmp/out.txt" })).toBe(
+      "Write: /tmp/out.txt",
+    );
+    expect(
+      buildToolNote("read_file", { absolute_path: "/etc/hosts" }),
+    ).toBe("read_file: /etc/hosts");
+  });
+
+  test("search tools surface the pattern/query", () => {
+    expect(buildToolNote("Grep", { pattern: "TODO" })).toBe("Grep: TODO");
+    expect(buildToolNote("search", { query: "vector index" })).toBe(
+      "search: vector index",
+    );
+  });
+
+  test("sub-agent delegation combines subagent + prompt", () => {
+    expect(
+      buildToolNote("Agent", {
+        subagent_type: "Explore",
+        prompt: "find the retrieval code",
+      }),
+    ).toBe("Agent: Explore — find the retrieval code");
+  });
+
+  test("sub-agent with only a description still shows it", () => {
+    expect(buildToolNote("Task", { description: "audit deps" })).toBe(
+      "Task: audit deps",
+    );
+  });
+
+  test("codex shell command-array is joined", () => {
+    // codex passes the whole item; command can be an argv array
+    expect(
+      buildToolNote("shell", {
+        type: "tool_call",
+        name: "shell",
+        command: ["git", "log", "--oneline"],
+      }),
+    ).toBe("shell: git log --oneline");
+  });
+
+  test("web tools surface the url", () => {
+    expect(
+      buildToolNote("WebFetch", { url: "https://example.com/x" }),
+    ).toBe("WebFetch: https://example.com/x");
+  });
+
+  test("multi-line / whitespace-heavy commands collapse to one line", () => {
+    expect(
+      buildToolNote("Bash", { command: "for f in *; do\n  echo $f\ndone" }),
+    ).toBe("Bash: for f in *; do echo $f done");
+  });
+
+  test("over-long titles are truncated with an ellipsis at the cap", () => {
+    const long = "x".repeat(200);
+    const note = buildToolNote("Bash", { command: long });
+    expect(note.length).toBe(MAX_TOOL_NOTE_LEN);
+    expect(note.startsWith("Bash: ")).toBe(true);
+    expect(note.endsWith("…")).toBe(true);
+  });
+
+  // --- backward-compatibility (legacy label preserved) ---
+
+  test("no usable detail → legacy 'tool: <name>'", () => {
+    expect(buildToolNote("Bash", {})).toBe("tool: Bash");
+    expect(buildToolNote("Read")).toBe("tool: Read");
+    expect(buildToolNote("run_shell_command", { foo: 1 })).toBe(
+      "tool: run_shell_command",
+    );
+  });
+
+  test("no name at all → legacy bare 'tool'", () => {
+    expect(buildToolNote(undefined)).toBe("tool");
+    expect(buildToolNote("")).toBe("tool");
+    expect(buildToolNote(undefined, { command: "git status" })).toBe("tool");
+  });
+
+  test("never throws on hostile input", () => {
+    expect(() => buildToolNote("X", null)).not.toThrow();
+    expect(() => buildToolNote("X", 42)).not.toThrow();
+    expect(() => buildToolNote("X", "a string")).not.toThrow();
+    expect(() => buildToolNote("X", [1, 2, 3])).not.toThrow();
+    // unusable input degrades to the legacy label
+    expect(buildToolNote("X", "a string")).toBe("tool: X");
+  });
+});


### PR DESCRIPTION
Closes #218 (Part 1).

## What & why
Inside Zed (ACP panel) every tool call rendered as a dead label — `tool: Bash`, `tool: Read`, or for codex literally just `tool`. You could watch the agent work but not see *what* it was doing. This enriches the `tool_call` title so the panel shows the actual operation: `Bash: git status`, `Read: src/foo.ts`, `Agent: Explore — find the retrieval code`.

It's our side, not Zed's — Zed faithfully renders whatever `title` string our ACP bridge sends. The fix is to build a richer note before it leaves the harness.

## How
There was **no shared helper** — each of the four harness adapters (claude, codex, gemini, pi) built the note inline, in a different event shape. This centralises the formatting:

- **New `src/harnesses/toolNote.ts`** — a pure, never-throws `buildToolNote(name, input)`. Detail extraction keys on well-known **input field names** (`command`/`cmd`, `file_path`/`path`/…, `pattern`/`query`, `subagent_type`+`prompt`, `url`) rather than per-harness tool names, so one rule set works across every adapter despite their differing shapes. Single-line (whitespace collapsed), capped at **80 chars** with an ellipsis.
- **Wired all four harnesses** to it. **Codex** now captures the tool name it previously dropped entirely — bare `tool` → `tool: shell`, or `shell: git status` when the command is present.

## Scope decisions (per #218, confirmed with Andrew)
- **Part 1 only.** Protocol-level `locations`/`kind`/`content` (clickable file paths, per-tool icons) change the `progress` callback signature and the ACP type — different blast radius, **deferred to a Part 2 follow-up**.
- **Minimal redaction.** Truncate + whitespace-collapse only; **no secret masking**. (Noted in the module doc so a future, noisier sink than the Zed panel gets a second look.)

## Backward compatibility
When no useful detail can be extracted, we emit the **exact legacy `tool: <name>`** (or bare `tool`) label — so `/status` wording and all existing harness tests are unchanged. The richer `<Name>: <detail>` shape is purely additive, appearing only when args are present.

## Tests
- New `tests/harnesses-toolNote.test.ts` — per-tool rules, array commands (codex argv), whitespace collapse, 80-char truncation, hostile-input safety, and the legacy-label fallbacks.
- Per-harness wiring tests (claude/codex/gemini/pi) proving the detail flows end-to-end.
- Full suite green, `tsc --noEmit` clean.