### PR TITLE
feat(acp): register Phantombot as an ACP agent for JetBrains IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Interactive setup:
 | `phantombot voice` | Configure TTS/STT providers |
 | `phantombot embedding` | Configure semantic memory |
 | `phantombot acp install zed` | Register phantombot as an ACP agent in Zed |
+| `phantombot acp install jetbrains` | Register phantombot as an ACP agent in JetBrains IDEs (Rider, IntelliJ, …) |
 | `phantombot acp install vscode` | Install the first-party VS Code extension |
 
 Runtime:
@@ -394,23 +395,26 @@ Relays come from a shared canonical list and can be edited by re-running the
 command. See the [PhantomChat repo](https://github.com/phantomyard/phantomchat)
 for the app itself and the wire-protocol details.
 
-## Editors: VS Code & Zed
+## Editors: VS Code, Zed & JetBrains
 
 Your Phantom runs **inside your editor** as a first-class agent over the
-[Agent Client Protocol (ACP)](https://agentclientprotocol.com) — VS Code and
-Zed both supported. It's the *same* Phantom: one persona, one memory store, one
+[Agent Client Protocol (ACP)](https://agentclientprotocol.com) — VS Code, Zed
+and JetBrains IDEs (Rider, IntelliJ, …) all supported. It's the *same* Phantom:
+one persona, one memory store, one
 set of tools, served from your machine. Start a thread in the editor, pick it
 up later from PhantomChat or Telegram — there's only ever one soul behind all
 the surfaces.
 
 ```bash
 phantombot acp install zed       # merge the ACP registration into Zed's settings.json
+phantombot acp install jetbrains # merge the ACP registration into ~/.jetbrains/acp.json (Rider, IntelliJ, …)
 phantombot acp install vscode    # install the bundled first-party VS Code extension (.vsix)
 ```
 
-Both installers are idempotent and version-aware: Zed gets a JSONC-safe
-settings merge (your original is backed up), and VS Code installs the bundled
-extension through the `code` CLI, skipping cleanly if the editor isn't present.
+All installers are idempotent and version-aware: Zed and JetBrains get a
+JSONC-safe settings merge (your original is backed up), and VS Code installs the
+bundled extension through the `code` CLI, skipping cleanly if the editor isn't
+present.
 
 The connector sits **beside** the channel layer — it calls the turn engine
 directly with `trusted: true`. The principal is the local OS user who launched

--- a/src/cli/acp.ts
+++ b/src/cli/acp.ts
@@ -1,20 +1,20 @@
 /**
  * `phantombot acp` — register phantombot as a first-class ACP (Agent Client
- * Protocol) agent inside Zed.
+ * Protocol) agent inside an ACP-capable editor (Zed, JetBrains IDEs, …).
  *
- *   phantombot acp                 run the ACP stdio server (Zed spawns this)
+ *   phantombot acp                 run the ACP stdio server (the editor spawns this)
  *   phantombot acp --persona NAME  …bound to a specific persona
  *   phantombot acp install zed       write the Zed settings.json registration
  *   phantombot acp install jetbrains write the JetBrains ~/.jetbrains/acp.json registration
  *   phantombot acp install vscode    install the first-party VS Code extension (.vsix)
  *
  * The connector sits BESIDE the channel layer: it calls runTurn directly with
- * `trusted: true`. The principal is the local OS user who launched Zed — they
- * already have full filesystem access to everything phantombot owns, so the
+ * `trusted: true`. The principal is the local OS user who launched the editor —
+ * they already have full filesystem access to everything phantombot owns, so the
  * threat judge is skipped (see connectors/acp/turnBridge.ts).
  *
- * The bare `acp` command is the long-running stdio server: Zed launches it as
- * a subprocess and talks newline-delimited JSON-RPC 2.0 over stdin/stdout.
+ * The bare `acp` command is the long-running stdio server: the editor launches it
+ * as a subprocess and talks newline-delimited JSON-RPC 2.0 over stdin/stdout.
  * stdout is the protocol channel — NEVER write logs there.
  */
 

--- a/src/cli/acp.ts
+++ b/src/cli/acp.ts
@@ -4,8 +4,9 @@
  *
  *   phantombot acp                 run the ACP stdio server (Zed spawns this)
  *   phantombot acp --persona NAME  …bound to a specific persona
- *   phantombot acp install zed     write the Zed settings.json registration
- *   phantombot acp install vscode  install the first-party VS Code extension (.vsix)
+ *   phantombot acp install zed       write the Zed settings.json registration
+ *   phantombot acp install jetbrains write the JetBrains ~/.jetbrains/acp.json registration
+ *   phantombot acp install vscode    install the first-party VS Code extension (.vsix)
  *
  * The connector sits BESIDE the channel layer: it calls runTurn directly with
  * `trusted: true`. The principal is the local OS user who launched Zed — they
@@ -21,6 +22,7 @@ import { defineCommand } from "citty";
 
 import { runAcpServer } from "../connectors/acp/server.ts";
 import { installZed } from "../connectors/acp/installZed.ts";
+import { installJetbrains } from "../connectors/acp/installJetbrains.ts";
 import { installVscode } from "../connectors/acp/installVscode.ts";
 
 const installZedCmd = defineCommand({
@@ -35,6 +37,20 @@ const installZedCmd = defineCommand({
     // work, but importing the ACP server pulls in modules that hold the event
     // loop open (env-reload + memory handles), so a natural exit hangs after
     // printing success. Force a clean exit once the write is done.
+    process.exit(result.code);
+  },
+});
+
+const installJetbrainsCmd = defineCommand({
+  meta: {
+    name: "jetbrains",
+    description:
+      "Register phantombot as an ACP agent for JetBrains IDEs (Rider, IntelliJ, WebStorm, …) in ~/.jetbrains/acp.json (JSON-safe merge, backs up the original).",
+  },
+  async run() {
+    const result = installJetbrains({ binaryPath: process.execPath });
+    // Same event-loop caveat as installZed: importing the ACP server keeps the
+    // loop open, so force a clean exit once the write is done.
     process.exit(result.code);
   },
 });
@@ -62,10 +78,11 @@ const installCmd = defineCommand({
   meta: {
     name: "install",
     description:
-      "Install the ACP registration into a detected editor (zed: settings merge; vscode: first-party extension).",
+      "Install the ACP registration into a detected editor (zed/jetbrains: settings merge; vscode: first-party extension).",
   },
   subCommands: {
     zed: installZedCmd,
+    jetbrains: installJetbrainsCmd,
     vscode: installVscodeCmd,
   },
 });
@@ -74,7 +91,7 @@ export default defineCommand({
   meta: {
     name: "acp",
     description:
-      "Run phantombot as an ACP agent server over stdio (Zed spawns this). Use `acp install zed` (settings merge) or `acp install vscode` (first-party extension) to register it with an editor.",
+      "Run phantombot as an ACP agent server over stdio (Zed/JetBrains spawn this). Use `acp install zed` / `acp install jetbrains` (settings merge) or `acp install vscode` (first-party extension) to register it with an editor.",
   },
   args: {
     persona: {

--- a/src/connectors/acp/autoInstall.ts
+++ b/src/connectors/acp/autoInstall.ts
@@ -31,6 +31,10 @@ import { parse } from "jsonc-parser";
 import type { WriteSink } from "../../lib/io.ts";
 import { defaultZedSettingsPath, installZed } from "./installZed.ts";
 import {
+  defaultJetbrainsConfigPath,
+  installJetbrains,
+} from "./installJetbrains.ts";
+import {
   checkVscode,
   installVscode,
   type VscodeInstallResult,
@@ -101,13 +105,18 @@ export interface EditorSpec {
   install?(binaryPath: string, out?: WriteSink, err?: WriteSink): { code: number };
 }
 
-/** Best-effort read of `agent_servers.Phantombot.command` from JSONC settings. */
-function readZedCommand(settingsPath: string): string | undefined {
+/**
+ * Best-effort read of `agent_servers.Phantombot.command` from a JSONC ACP
+ * settings file. Both Zed (settings.json) and JetBrains (~/.jetbrains/acp.json)
+ * use this exact shape, so they share one reader.
+ */
+function readAgentServerCommand(settingsPath: string): string | undefined {
   try {
     const raw = readFileSync(settingsPath, "utf8");
     // Tolerant parse (comments + trailing commas). On a malformed file this
-    // returns a best-effort value or undefined; either way installZed re-parses
-    // with error collection and aborts safely, so we never risk data loss here.
+    // returns a best-effort value or undefined; either way the installer
+    // re-parses with error collection and aborts safely, so we never risk data
+    // loss here.
     const parsed = parse(raw) as
       | { agent_servers?: { Phantombot?: { command?: unknown } } }
       | undefined;
@@ -122,8 +131,22 @@ export const ZED_EDITOR: EditorSpec = {
   id: "zed",
   settingsPath: defaultZedSettingsPath,
   detectionDir: (settingsPath) => dirname(settingsPath),
-  currentCommand: readZedCommand,
+  currentCommand: readAgentServerCommand,
   install: (binaryPath, out, err) => installZed({ binaryPath, out, err }),
+};
+
+/**
+ * JetBrains AI Assistant (Rider, IntelliJ IDEA, WebStorm, PyCharm, …) speaks
+ * ACP natively from 2026.1, reading external agents from a single shared
+ * per-user file `~/.jetbrains/acp.json`. Registration is the same settings
+ * merge as Zed — no IDE plugin required — so it's a plain settings-model editor.
+ */
+export const JETBRAINS_EDITOR: EditorSpec = {
+  id: "jetbrains",
+  settingsPath: defaultJetbrainsConfigPath,
+  detectionDir: (configPath) => dirname(configPath),
+  currentCommand: readAgentServerCommand,
+  install: (binaryPath, out, err) => installJetbrains({ binaryPath, out, err }),
 };
 
 /**
@@ -177,7 +200,11 @@ export const VSCODE_EDITOR: EditorSpec = {
 };
 
 /** Editors phantombot knows how to register itself into. */
-export const KNOWN_EDITORS: EditorSpec[] = [ZED_EDITOR, VSCODE_EDITOR];
+export const KNOWN_EDITORS: EditorSpec[] = [
+  ZED_EDITOR,
+  JETBRAINS_EDITOR,
+  VSCODE_EDITOR,
+];
 
 export interface ReconcileOptions {
   /** Absolute path to the phantombot binary the editor should spawn. */

--- a/src/connectors/acp/installJetbrains.ts
+++ b/src/connectors/acp/installJetbrains.ts
@@ -1,0 +1,151 @@
+/**
+ * `phantombot acp install jetbrains` backend — JSON-safe JetBrains ACP writer.
+ *
+ * Registers phantombot as an ACP agent server in the JetBrains AI Assistant
+ * config (`~/.jetbrains/acp.json`, shared across every JetBrains IDE — Rider,
+ * IntelliJ IDEA, WebStorm, PyCharm, GoLand, …) by merging in:
+ *
+ *   { "agent_servers": { "Phantombot": {
+ *       "command": "<abs phantombot binary>", "args": ["acp"], "env": {…} } } }
+ *
+ * JetBrains 2026.1+ AI Assistant speaks ACP NATIVELY: there is no Kotlin/Gradle
+ * plugin to ship — registration is purely this config merge, exactly like Zed.
+ * The file is plain JSON, but JetBrains tolerates the JSONC superset and may
+ * carry sibling keys (e.g. `default_mcp_settings`), so we reuse the same
+ * jsonc-parser machinery as the Zed installer to PARSE tolerantly and EDIT
+ * surgically — preserving every other key, comment, and the file's formatting.
+ *
+ * DATA-LOSS-PROOF PROCEDURE (identical to installZed, non-negotiable):
+ *   1. Read existing file.
+ *   2. Parse with jsonc-parser (tolerant of comments + trailing commas).
+ *   3. If parse FAILS ⇒ ABORT. Write nothing. Return an error result with the
+ *      manual snippet to paste. NEVER "start fresh", NEVER overwrite.
+ *   4. On success, merge agent_servers.Phantombot via jsonc-parser's
+ *      modify/applyEdits so formatting + sibling keys survive.
+ *   5. Back up the original to acp.json.phantombot-bak, then write atomically
+ *      (temp file + rename).
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { applyEdits, modify, parse, type ParseError } from "jsonc-parser";
+
+import type { WriteSink } from "../../lib/io.ts";
+import { phantombotAgentServerBlock } from "./installZed.ts";
+
+export interface InstallJetbrainsOptions {
+  /** Override the config path (tests). Default: ~/.jetbrains/acp.json. */
+  configPath?: string;
+  /** Absolute path to the phantombot binary JetBrains should spawn. */
+  binaryPath: string;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export interface InstallJetbrainsResult {
+  /** 0 success, 1 abort (unparseable file — nothing written). */
+  code: number;
+  /** Resolved config path acted on. */
+  configPath: string;
+  /** Backup path, when a backup was made. */
+  backupPath?: string;
+}
+
+/**
+ * Resolve the default JetBrains ACP config path.
+ *
+ * JetBrains AI Assistant reads external ACP agents from a single per-user file,
+ * `~/.jetbrains/acp.json`, shared across every installed JetBrains IDE. It is
+ * NOT under `$XDG_CONFIG_HOME` — JetBrains hardcodes `~/.jetbrains/` — so we
+ * resolve it straight off the home dir.
+ */
+export function defaultJetbrainsConfigPath(): string {
+  return join(homedir(), ".jetbrains", "acp.json");
+}
+
+/** The snippet a user pastes manually if we abort. */
+export function manualSnippet(binaryPath: string): string {
+  const block = {
+    agent_servers: { Phantombot: phantombotAgentServerBlock(binaryPath) },
+  };
+  return JSON.stringify(block, null, 2);
+}
+
+export function installJetbrains(
+  options: InstallJetbrainsOptions,
+): InstallJetbrainsResult {
+  const out = options.out ?? process.stdout;
+  const err = options.err ?? process.stderr;
+  const configPath = options.configPath ?? defaultJetbrainsConfigPath();
+  const block = phantombotAgentServerBlock(options.binaryPath);
+
+  // ── Read existing content (missing file ⇒ start from an empty object) ──
+  let existing: string;
+  let fileExisted = true;
+  try {
+    existing = readFileSync(configPath, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+      existing = "{}";
+      fileExisted = false;
+    } else {
+      throw e;
+    }
+  }
+
+  // ── Parse tolerantly. ANY structural error ⇒ ABORT, write nothing. ──
+  if (fileExisted) {
+    const errors: ParseError[] = [];
+    parse(existing, errors, {
+      allowTrailingComma: true,
+      disallowComments: false,
+    });
+    if (errors.length > 0) {
+      err.write(
+        `phantombot acp install jetbrains: ${configPath} is not parseable as JSON — ` +
+          `refusing to touch it to avoid data loss. Nothing was written.\n` +
+          `Add this block manually:\n\n${manualSnippet(options.binaryPath)}\n`,
+      );
+      return { code: 1, configPath };
+    }
+  }
+
+  // ── Surgical edit — preserves comments + formatting of every other key ──
+  const formatting = {
+    formattingOptions: { tabSize: 2, insertSpaces: true, eol: "\n" },
+  };
+  const edits = modify(
+    existing,
+    ["agent_servers", "Phantombot"],
+    block,
+    formatting,
+  );
+  const updated = applyEdits(existing, edits);
+
+  // ── Atomic write: backup original, write temp, rename into place. ──
+  mkdirSync(dirname(configPath), { recursive: true });
+
+  let backupPath: string | undefined;
+  if (fileExisted) {
+    backupPath = `${configPath}.phantombot-bak`;
+    writeFileSync(backupPath, existing, "utf8");
+  }
+
+  const tmpPath = `${configPath}.phantombot-tmp`;
+  writeFileSync(tmpPath, updated, "utf8");
+  renameSync(tmpPath, configPath);
+
+  out.write(
+    `phantombot acp install jetbrains: registered "Phantombot" in ${configPath}` +
+      (backupPath ? ` (backup: ${backupPath})` : " (new file)") +
+      `\n`,
+  );
+
+  return { code: 0, configPath, backupPath };
+}

--- a/tests/connectors-acp-installJetbrains.test.ts
+++ b/tests/connectors-acp-installJetbrains.test.ts
@@ -1,0 +1,160 @@
+/**
+ * JetBrains installer data-loss-guard regression tests.
+ *
+ * Exercises the REAL `installJetbrains` against a temp config file:
+ *   - JSON with a sibling key + comment → all keys preserved + block added
+ *   - unparseable file → ABORT, file byte-for-byte unchanged, non-zero code
+ *   - no file → creates a valid one
+ *   - backup created when the file existed
+ *
+ * Mirrors connectors-acp-installZed.test.ts — JetBrains registration is the
+ * same `agent_servers.Phantombot` merge, just into ~/.jetbrains/acp.json.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse } from "jsonc-parser";
+
+import {
+  defaultJetbrainsConfigPath,
+  installJetbrains,
+} from "../src/connectors/acp/installJetbrains.ts";
+
+class Sink {
+  buf = "";
+  write(s: string): boolean {
+    this.buf += s;
+    return true;
+  }
+}
+
+let workdir: string;
+let configPath: string;
+const BIN = "/home/dev/.local/bin/phantombot";
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-jetbrains-"));
+  configPath = join(workdir, "acp.json");
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("defaultJetbrainsConfigPath", () => {
+  test("resolves to ~/.jetbrains/acp.json (not under XDG_CONFIG_HOME)", () => {
+    const p = defaultJetbrainsConfigPath();
+    expect(p).toBe(join(homedir(), ".jetbrains", "acp.json"));
+  });
+
+  test("ignores XDG_CONFIG_HOME (JetBrains hardcodes ~/.jetbrains)", () => {
+    const saved = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = "/tmp/xdg-test";
+    try {
+      expect(defaultJetbrainsConfigPath()).toBe(
+        join(homedir(), ".jetbrains", "acp.json"),
+      );
+    } finally {
+      if (saved === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = saved;
+    }
+  });
+});
+
+describe("installJetbrains — JSON preservation", () => {
+  test("preserves sibling keys + comment, adds the block", async () => {
+    // JetBrains carries `default_mcp_settings` alongside agent_servers; a
+    // comment proves we route through the JSONC-tolerant path too.
+    const original = `{
+  // existing JetBrains ACP config — keep me
+  "default_mcp_settings": {},
+  "agent_servers": {
+    "Gemini": { "command": "/usr/bin/gemini", "args": ["acp"] },
+  },
+}`;
+    writeFileSync(configPath, original, "utf8");
+
+    const out = new Sink();
+    const err = new Sink();
+    const result = installJetbrains({ configPath, binaryPath: BIN, out, err });
+
+    expect(result.code).toBe(0);
+    const updated = readFileSync(configPath, "utf8");
+
+    // Comment + pre-existing keys + the other agent survive.
+    expect(updated).toContain("// existing JetBrains ACP config — keep me");
+    const parsed = parse(updated) as any;
+    expect(parsed.default_mcp_settings).toEqual({});
+    expect(parsed.agent_servers.Gemini.command).toBe("/usr/bin/gemini");
+
+    // Our block is present + parses with the agent registration.
+    expect(parsed.agent_servers.Phantombot.command).toBe(BIN);
+    expect(parsed.agent_servers.Phantombot.args).toEqual(["acp"]);
+    // Same absolute PHANTOMBOT_CONFIG insurance as Zed; never PERSONAS_DIR.
+    expect(parsed.agent_servers.Phantombot.env.PHANTOMBOT_CONFIG).toMatch(
+      /\/phantombot\/config\.toml$/,
+    );
+    expect(
+      parsed.agent_servers.Phantombot.env.PHANTOMBOT_PERSONAS_DIR,
+    ).toBeUndefined();
+  });
+
+  test("backup of the original is created", async () => {
+    const original = `{ "default_mcp_settings": {} }`;
+    writeFileSync(configPath, original, "utf8");
+
+    const result = installJetbrains({
+      configPath,
+      binaryPath: BIN,
+      out: new Sink(),
+      err: new Sink(),
+    });
+
+    expect(result.backupPath).toBe(`${configPath}.phantombot-bak`);
+    expect(existsSync(result.backupPath!)).toBe(true);
+    expect(readFileSync(result.backupPath!, "utf8")).toBe(original);
+  });
+});
+
+describe("installJetbrains — data-loss guard", () => {
+  test("unparseable file → abort, file byte-for-byte unchanged, non-zero", async () => {
+    const broken = `{ "agent_servers": `;
+    writeFileSync(configPath, broken, "utf8");
+
+    const err = new Sink();
+    const result = installJetbrains({
+      configPath,
+      binaryPath: BIN,
+      out: new Sink(),
+      err,
+    });
+
+    expect(result.code).toBe(1);
+    expect(readFileSync(configPath, "utf8")).toBe(broken);
+    expect(existsSync(`${configPath}.phantombot-bak`)).toBe(false);
+    expect(err.buf).toContain("agent_servers");
+    expect(err.buf).toContain("Phantombot");
+  });
+});
+
+describe("installJetbrains — no existing file", () => {
+  test("creates a valid acp.json with the block, no backup", async () => {
+    expect(existsSync(configPath)).toBe(false);
+
+    const result = installJetbrains({
+      configPath,
+      binaryPath: BIN,
+      out: new Sink(),
+      err: new Sink(),
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.backupPath).toBeUndefined();
+    expect(existsSync(configPath)).toBe(true);
+    const parsed = parse(readFileSync(configPath, "utf8")) as any;
+    expect(parsed.agent_servers.Phantombot.command).toBe(BIN);
+  });
+});


### PR DESCRIPTION
## What

Registers Phantombot as an [ACP](https://www.jetbrains.com/help/ai-assistant/acp.html) agent for **JetBrains IDEs** (Rider, IntelliJ, PyCharm, etc.). Rider 2026.1's AI Assistant speaks ACP natively, so **no plugin is required** — Phantombot just registers itself in `~/.jetbrains/acp.json`, the same way it does for Zed.

## How

Mirrors the existing Zed installer:

- **`installJetbrains.ts`** — writes/merges `agent_servers.Phantombot` into `~/.jetbrains/acp.json`. Same data-loss guard as Zed (parse-or-abort, backup, atomic write), and reuses the shared agent-server block so the `PHANTOMBOT_CONFIG` pinning stays single-sourced.
- **`autoInstall.ts`** — adds `JETBRAINS_EDITOR` to `KNOWN_EDITORS`, which auto-wires `doctor` and startup registration. Generalizes the shared command-reader.
- **`acp.ts`** — new `phantombot acp install jetbrains` subcommand + updated help text.
- **Tests** — new suite mirroring the Zed tests.

## Test

- 40/40 ACP tests pass
- `tsc --noEmit` clean
- Real `acp install jetbrains` run wrote a correct `~/.jetbrains/acp.json`

## Notes

There's a known pre-existing limitation (shared with the Zed installer): when run from source under `bun`/`node` rather than a compiled binary, the emitted `command`/`args` drop the entrypoint script. That's a separate fix — not in scope here.