### PR TITLE
feat(phantomchat): only the addressed bot replies in multi-bot groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Node
+node_modules
 node_modules/
 dist/
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -398,9 +398,28 @@ for the app itself and the wire-protocol details.
 ### Multiple bots in one group
 
 When several persona bots share a PhantomChat group, each one would otherwise
-answer **every** message — three bots, three replies to one question. To get the
-Telegram behaviour (only the bot you addressed responds), tell each persona who
-its **sibling bots** are by adding a `group_bots` list to its `phantomchat.json`:
+answer **every** message — three bots, three replies to one question. PhantomChat
+gives you the Telegram behaviour (only the bot you addressed responds)
+**automatically, with no configuration**:
+
+- A bot replies only when its **persona name** appears in the message ("hey
+  **Lena**, …"), or when it's the bot currently holding the thread (so a no-name
+  follow-up still reaches it). Address a different bot by name and the previous
+  one falls quiet.
+- A bot **never reacts to another bot's** messages — in a group *or* a 1:1 DM —
+  so one bot's reply can't trigger another and start a back-and-forth loop. Only
+  humans drive the conversation.
+
+This works out of the box because every Phantom publishes a NIP-24 **`bot: true`**
+flag and a display name in its Nostr profile (kind-0). Each bot reads the
+profiles of the group's members, so it learns who the *other* bots are — and
+their names — straight from the protocol. Nothing to wire up; just add the bots
+to a group.
+
+**Optional override.** If you want deterministic behaviour from the very first
+message (before profiles resolve), or to force-mark a specific account as a
+sibling bot, you can still seed the roster per-persona with a `group_bots` list
+in `phantomchat.json`. It's merged with what's auto-detected:
 
 ```json
 {
@@ -413,22 +432,7 @@ its **sibling bots** are by adding a `group_bots` list to its `phantomchat.json`
 }
 ```
 
-Configure this for **every** bot in the group, each listing the *others* (a bot
-never lists itself — it knows its own name and npub). With this in place:
-
-- A bot replies only when its **persona name** appears in the message ("hey
-  **Lena**, …"), or when it's the bot currently holding the thread (so a no-name
-  follow-up still reaches it). When you address a different bot by name, the
-  previous one falls quiet — that's why every bot needs the full name roster.
-- A bot **never reacts to another bot's** messages, so one bot's reply can't
-  trigger another and start a back-and-forth loop. Only humans drive the
-  conversation.
-
-`group_bots` is per-persona and travels inside the portable persona folder. With
-no `group_bots` configured a lone bot behaves exactly as before — it answers
-every group message — so this is opt-in and changes nothing for single-bot
-groups. (The `name`/`npub` pairing mirrors Telegram's `group_persona_names`,
-plus the npub the encrypted Nostr layer needs to recognise a sibling.)
+Most setups won't need it — the auto-detection covers them.
 
 ## Editors: VS Code, Zed & JetBrains
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,41 @@ Relays come from a shared canonical list and can be edited by re-running the
 command. See the [PhantomChat repo](https://github.com/phantomyard/phantomchat)
 for the app itself and the wire-protocol details.
 
+### Multiple bots in one group
+
+When several persona bots share a PhantomChat group, each one would otherwise
+answer **every** message — three bots, three replies to one question. To get the
+Telegram behaviour (only the bot you addressed responds), tell each persona who
+its **sibling bots** are by adding a `group_bots` list to its `phantomchat.json`:
+
+```json
+{
+  "nsec": "nsec1…",
+  "allowed_npubs": ["npub1…"],
+  "group_bots": [
+    { "name": "kai",  "npub": "npub1kai…" },
+    { "name": "robbie", "npub": "npub1robbie…" }
+  ]
+}
+```
+
+Configure this for **every** bot in the group, each listing the *others* (a bot
+never lists itself — it knows its own name and npub). With this in place:
+
+- A bot replies only when its **persona name** appears in the message ("hey
+  **Lena**, …"), or when it's the bot currently holding the thread (so a no-name
+  follow-up still reaches it). When you address a different bot by name, the
+  previous one falls quiet — that's why every bot needs the full name roster.
+- A bot **never reacts to another bot's** messages, so one bot's reply can't
+  trigger another and start a back-and-forth loop. Only humans drive the
+  conversation.
+
+`group_bots` is per-persona and travels inside the portable persona folder. With
+no `group_bots` configured a lone bot behaves exactly as before — it answers
+every group message — so this is opt-in and changes nothing for single-bot
+groups. (The `name`/`npub` pairing mirrors Telegram's `group_persona_names`,
+plus the npub the encrypted Nostr layer needs to recognise a sibling.)
+
 ## Editors: VS Code, Zed & JetBrains
 
 Your Phantom runs **inside your editor** as a first-class agent over the

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../../phantombot/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../phantombot/node_modules

--- a/src/channels/phantomchat/personaStore.ts
+++ b/src/channels/phantomchat/personaStore.ts
@@ -24,12 +24,19 @@
  *                                       //   allowlist is empty, the FIRST npub to
  *                                       //   DM is trusted, appended here, and the
  *                                       //   bot then locks to it (tofu cleared)
- *     "greeted": ["npub1…", …]          // optional — npubs the bot has already
+ *     "greeted": ["npub1…", …],         // optional — npubs the bot has already
  *                                       //   sent its proactive "Hello" to. On
  *                                       //   every start the bot greets any
  *                                       //   allowed npub NOT in this list, then
  *                                       //   records it here so restarts don't
  *                                       //   re-spam onboarded contacts.
+ *     "group_bots": [                   // optional — the OTHER bots that share
+ *       {"name": "kai",  "npub": "…"},  //   groups with this persona. Drives the
+ *       {"name": "lena", "npub": "…"}   //   group name-addressing roster (so a
+ *     ]                                 //   bot only replies when addressed by
+ *                                       //   name / when it holds the thread) AND
+ *                                       //   the "never reply to another bot"
+ *                                       //   cascade kill. List every sibling.
  *   }
  *
  * Allowlist semantics:
@@ -55,12 +62,32 @@ import {
 import { log } from "../../lib/logger.ts";
 import {
   decodeAllowedNpubs,
+  decodeNpubToHex,
   identityFromNsec,
   type NostrIdentity,
 } from "../../lib/nostrIdentity.ts";
 
 /** Filename of the per-persona phantomchat config inside an agent dir. */
 export const PHANTOMCHAT_FILE = "phantomchat.json";
+
+/**
+ * One SIBLING bot that shares groups with this persona. Both fields matter:
+ *   - `name`  feeds the shared name-addressing roster, so every bot in a group
+ *             knows when the human has handed the thread to a DIFFERENT bot and
+ *             can fall quiet (see decideGroupReply). The roster MUST list every
+ *             bot's name verbatim and identically across all of them.
+ *   - `npub`  is decoded to `hex` and added to the "don't react to me" set:
+ *             a bot NEVER replies to another bot's message (cascade kill —
+ *             option (a)). Only the human drives addressing.
+ */
+export interface PhantomchatGroupBot {
+  /** The sibling bot's persona name (its addressing token in groups). */
+  name: string;
+  /** The sibling bot's npub (or 64-char hex) as written in the file. */
+  npub: string;
+  /** Decoded lowercase 64-char hex pubkey — the ignore-set comparison form. */
+  hex: string;
+}
 
 /** Resolved phantomchat config for one persona. */
 export interface PhantomchatPersonaConfig {
@@ -85,6 +112,13 @@ export interface PhantomchatPersonaConfig {
    * since last time, never the ones already onboarded.
    */
   greeted: string[];
+  /**
+   * Sibling bots that share groups with this persona (name + npub + decoded
+   * hex). Drives the group name-addressing roster AND the "ignore other bots"
+   * cascade kill. Empty when the file omits `group_bots` — a lone bot in a
+   * group still works (it answers when its own name is used).
+   */
+  groupBots: PhantomchatGroupBot[];
   /** Absolute path to the phantomchat.json this came from. */
   path: string;
 }
@@ -101,11 +135,42 @@ interface PhantomchatFileShape {
   allowed_npubs?: unknown;
   tofu?: unknown;
   greeted?: unknown;
+  group_bots?: unknown;
 }
 
 function asStringArray(v: unknown): string[] {
   if (!Array.isArray(v)) return [];
   return v.filter((x): x is string => typeof x === "string" && x.length > 0);
+}
+
+/**
+ * Parse the raw `group_bots` array into resolved {name, npub, hex} entries.
+ * Each entry must have a non-empty string `name` and an `npub` that decodes to
+ * a valid pubkey; anything malformed is skipped (a typo in one sibling must not
+ * disable the whole gate). Deduped by hex so a doubled entry can't, e.g., make
+ * a bot appear twice in the name roster.
+ */
+function parseGroupBots(v: unknown): PhantomchatGroupBot[] {
+  if (!Array.isArray(v)) return [];
+  const out: PhantomchatGroupBot[] = [];
+  const seenHex = new Set<string>();
+  for (const raw of v) {
+    if (!raw || typeof raw !== "object") continue;
+    const name = (raw as { name?: unknown }).name;
+    const npub = (raw as { npub?: unknown }).npub;
+    if (typeof name !== "string" || name.length === 0) continue;
+    if (typeof npub !== "string" || npub.length === 0) continue;
+    let hex: string;
+    try {
+      hex = decodeNpubToHex(npub).toLowerCase();
+    } catch {
+      continue; // not a valid npub/hex — skip this sibling
+    }
+    if (seenHex.has(hex)) continue;
+    seenHex.add(hex);
+    out.push({ name, npub, hex });
+  }
+  return out;
 }
 
 /**
@@ -151,6 +216,7 @@ export function loadPhantomchatPersonaConfig(
     allowedHex: decodeAllowedNpubs(allowedNpubs),
     tofu: parsed.tofu === true,
     greeted: asStringArray(parsed.greeted),
+    groupBots: parseGroupBots(parsed.group_bots),
     path,
   };
 }
@@ -168,6 +234,7 @@ export async function savePhantomchatPersonaConfig(
     allowedNpubs: string[];
     tofu?: boolean;
     greeted?: string[];
+    groupBots?: PhantomchatGroupBot[];
   },
 ): Promise<string> {
   const path = phantomchatConfigPath(agentDir);
@@ -181,6 +248,11 @@ export async function savePhantomchatPersonaConfig(
   if (data.tofu) body.tofu = true;
   // Only persist greeted when non-empty — keep fresh files clean.
   if (data.greeted && data.greeted.length > 0) body.greeted = data.greeted;
+  // Persist group_bots verbatim ({name, npub}) — the hex is derived on load, so
+  // it never goes to disk. Only written when non-empty to keep fresh files clean.
+  if (data.groupBots && data.groupBots.length > 0) {
+    body.group_bots = data.groupBots.map((b) => ({ name: b.name, npub: b.npub }));
+  }
   const tmp = `${path}.tmp`;
   try {
     await writeFile(tmp, JSON.stringify(body, null, 2) + "\n", {
@@ -218,6 +290,7 @@ export async function cacheRelaysForPersona(
     allowedNpubs: existing.allowedNpubs,
     tofu: existing.tofu,
     greeted: existing.greeted,
+    groupBots: existing.groupBots,
   });
   return true;
 }
@@ -244,6 +317,7 @@ export async function recordTrustedNpub(
     allowedNpubs,
     tofu: false,
     greeted: existing.greeted,
+    groupBots: existing.groupBots,
   });
   return allowedNpubs;
 }
@@ -273,6 +347,7 @@ export async function recordGreeted(
     allowedNpubs: existing.allowedNpubs,
     tofu: existing.tofu,
     greeted,
+    groupBots: existing.groupBots,
   });
   return greeted;
 }

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -41,6 +41,7 @@ import {
   VOICE_REPLY_INSTRUCTION,
   voiceUnavailableMessage,
 } from "../core/prompts.ts";
+import { getPublicKey } from "nostr-tools/pure";
 import type { Channel, ChannelMessage } from "../core/types.ts";
 import {
   decideGroupReply,
@@ -54,7 +55,7 @@ import {
   StreamSegmenter,
 } from "../streamSegmenter.ts";
 import type { ServiceControl } from "../../lib/systemd.ts";
-import type { PhantomchatTransport } from "./transport.ts";
+import type { NostrProfileMeta, PhantomchatTransport } from "./transport.ts";
 import { sttSupport, synthesize, transcribe, ttsSupported } from "../../lib/audio.ts";
 import {
   clearReplyModeOverride,
@@ -135,21 +136,33 @@ export interface RunPhantomchatServerInput {
    */
   allowedHex: string[];
   /**
-   * Shared group-addressing roster: the persona names of EVERY bot that shares
-   * groups with this one (this persona's own name is merged in automatically).
-   * In a group the bot only SPEAKS when its own name is addressed, or when it
-   * already holds the thread (sticky last-addressed). Every bot must be given
-   * the same roster so the hand-off between bots is consistent. Empty/absent →
-   * the bot still answers when its own name is used (lone-bot default).
+   * OPTIONAL config seed for the group-addressing roster: persona names of other
+   * bots that share groups with this one. Normally the roster is derived
+   * automatically from group members' kind-0 profiles (any member whose NIP-24
+   * `bot` flag is set contributes its display name), so this is only needed as a
+   * deterministic override / cold-start seed. Merged with the auto-derived names;
+   * this persona's own name is always included.
    */
   groupPersonaNames?: string[];
   /**
-   * Hex pubkeys of the OTHER bots in the group. A message whose cryptographic
-   * sender is in this set is IGNORED in group context (no reply, no state
-   * change) — bots only ever react to humans, which kills bot-to-bot reply
-   * cascades (option (a)). Has no effect on 1:1 DMs.
+   * OPTIONAL config seed for the "ignore other bots" set: hex pubkeys of known
+   * sibling bots. Normally a sender is recognised as a bot from its kind-0
+   * `bot` flag (see `fetchProfiles`); this just force-marks specific pubkeys as
+   * bots even before their profile resolves. A message from a bot is NEVER
+   * replied to — in a group OR a 1:1 DM — which kills bot-to-bot cascades
+   * (option (a)). Merged with the auto-detected bot set.
    */
   siblingBotHex?: string[];
+  /**
+   * Resolve kind-0 profiles for a set of lowercased hex pubkeys → metadata. The
+   * server uses it to (a) recognise sibling bots via the NIP-24 `bot` flag so it
+   * never replies to another bot, and (b) auto-derive the group name-addressing
+   * roster from members' display names. Lazily called and cached. Production
+   * binds it to `transport.fetchProfiles`; tests inject a stub. Absent → bot
+   * detection falls back to the static `siblingBotHex` / `groupPersonaNames`
+   * config alone (the pre-auto-resolve behaviour).
+   */
+  fetchProfiles?: (authors: string[]) => Promise<Map<string, NostrProfileMeta>>;
   /**
    * Trust-on-first-use. Only consulted when `allowedHex` is empty:
    *   - tofu true  → the FIRST sender is trusted, persisted via `persistTrust`,
@@ -208,36 +221,116 @@ export async function runPhantomchatServer(
   // TOFU is armed only when we start with an empty allowlist and tofu is on.
   let tofuArmed = allowedSet.size === 0 && input.tofu === true;
 
-  // ===================== GROUP ADDRESSING GATE =====================
+  // ===================== GROUP ADDRESSING + BOT DETECTION =====================
   // Mirrors the Telegram engine (core/engine.ts): in a group, every bot
   // receives every human message, but a bot must only SPEAK when addressed by
-  // name or when it currently holds the thread. The decision is computed purely
-  // from the shared human-message stream (decideGroupReply), so every bot
-  // converges with no coordination. State is per-group, in-memory.
+  // name or when it currently holds the thread; and a bot NEVER replies to
+  // another bot (in a group OR a DM), which kills bot-to-bot cascades. The
+  // decision is computed purely from the shared human-message stream
+  // (decideGroupReply), so every bot converges with no coordination. State is
+  // per-group, in-memory.
   const groupChats = new Map<string, GroupChatState>();
   const selfName = input.persona;
-  // The shared roster, with our own name always present so a lone bot answers to
-  // its name with zero config. Dedup case-insensitively, preserve order.
-  const groupPersonaNames = (() => {
-    const merged = [...(input.groupPersonaNames ?? [])];
-    if (!merged.some((n) => n.toLowerCase() === selfName.toLowerCase())) {
-      merged.push(selfName);
-    }
-    return merged;
-  })();
-  // Option (a): never react to another bot. Hex set for O(1) membership.
-  const siblingBotHexSet = new Set(
+  // Our own hex pubkey — excluded from the roster and always treated as a bot
+  // (so the bot never replies to its own self-wrapped group echo).
+  const ourHex = getPublicKey(input.secretKey).toLowerCase();
+  // OPTIONAL config seeds (pre-auto-resolve overrides). The roster always
+  // contains our own name; sibling names/hexes are MERGED with what we resolve
+  // from members' kind-0 profiles at decision time.
+  const configRosterNames = input.groupPersonaNames ?? [];
+  const configSiblingHex = new Set(
     (input.siblingBotHex ?? []).map((h) => h.toLowerCase()),
   );
-  // The addressing gate ONLY engages when this persona knows it shares groups
-  // with OTHER bots (group_bots configured). A lone or unconfigured bot keeps
-  // the original behaviour — it answers every group message — so this change is
-  // a no-op for single-bot groups and can't make an existing deployment go mute.
-  // Name-disambiguation only matters when there's actually more than one bot.
-  const groupAddressingActive =
-    groupPersonaNames.length > 1 || siblingBotHexSet.size > 0;
+
+  // ----- kind-0 profile cache (bot detection + name resolution) -----
+  // Lazily populated via input.fetchProfiles; bounded refresh so an absent
+  // profile (a human with no kind-0) isn't re-fetched on every message.
+  const PROFILE_TTL_MS = 5 * 60 * 1000;
+  const profileCache = new Map<string, NostrProfileMeta>();
+  const profileFetchedAt = new Map<string, number>();
+  const profileInFlight = new Map<string, Promise<void>>();
+
+  /** Resolve (and cache) the kind-0 profiles for `hexes`, skipping ourselves and
+   *  any pubkey fetched within PROFILE_TTL_MS. Concurrent fetches of the same
+   *  author are de-duped. Best-effort — a failed/absent fetch leaves the cache
+   *  empty for that author (treated as human/unknown by `isBot`). */
+  const ensureProfiles = async (hexes: string[]): Promise<void> => {
+    if (!input.fetchProfiles) return;
+    const now = Date.now();
+    const due = [...new Set(hexes.map((h) => h.toLowerCase()))].filter(
+      (h) => h.length > 0 && h !== ourHex &&
+        now - (profileFetchedAt.get(h) ?? 0) >= PROFILE_TTL_MS,
+    );
+    if (due.length === 0) return;
+    const toFetch = due.filter((h) => !profileInFlight.has(h));
+    if (toFetch.length > 0) {
+      const p = (async () => {
+        try {
+          const got = await input.fetchProfiles!(toFetch);
+          const t = Date.now();
+          for (const h of toFetch) {
+            profileFetchedAt.set(h, t);
+            const meta = got.get(h);
+            if (meta) profileCache.set(h, meta);
+          }
+        } catch (e) {
+          log.warn("phantomchat: profile fetch failed (non-fatal)", {
+            error: (e as Error).message,
+          });
+        }
+      })();
+      for (const h of toFetch) profileInFlight.set(h, p);
+      void p.finally(() => {
+        for (const h of toFetch) {
+          if (profileInFlight.get(h) === p) profileInFlight.delete(h);
+        }
+      });
+    }
+    await Promise.all(
+      due.map((h) => profileInFlight.get(h)).filter((x): x is Promise<void> => !!x),
+    );
+  };
+
+  /** Is `hex` a bot? True for ourselves, any configured sibling, or any pubkey
+   *  whose resolved kind-0 carries the NIP-24 `bot` flag. */
+  const isBot = (hex: string): boolean => {
+    const h = hex.toLowerCase();
+    if (h === ourHex || configSiblingHex.has(h)) return true;
+    return profileCache.get(h)?.bot === true;
+  };
+
+  /** Build the group name-addressing roster for a message: our own name + any
+   *  configured sibling names + the display names of every OTHER member resolved
+   *  as a bot. Deduped case-insensitively, order preserved. */
+  const buildRoster = (memberHexes: string[]): string[] => {
+    const names = [selfName, ...configRosterNames];
+    for (const hex of memberHexes) {
+      const h = hex.toLowerCase();
+      if (h === ourHex) continue;
+      const meta = profileCache.get(h);
+      if (meta?.bot === true) {
+        const n = meta.name || meta.display_name;
+        if (n) names.push(n);
+      }
+    }
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const n of names) {
+      const k = n.toLowerCase();
+      if (n.length === 0 || seen.has(k)) continue;
+      seen.add(k);
+      out.push(n);
+    }
+    return out;
+  };
 
   // ===================== CACHE WARMING =====================
+  // Warm the profile cache for known peers so a DM partner's bot-status is known
+  // before their first message (avoids a cold-start fetch gating the first
+  // reply). Fire-and-forget; group members are resolved lazily on first message.
+  if (input.fetchProfiles && allowedSet.size > 0) {
+    void ensureProfiles([...allowedSet]).catch(() => {});
+  }
   // Pre-derive symmetric keys for all allowed peers so inbound v2 DMs
   // (which use ephemeral envelope signing) can be decrypted immediately.
   // Fire-and-forget: keys derived after the first unwrap will be picked up
@@ -315,76 +408,99 @@ export async function runPhantomchatServer(
 
     if (!authorize(msg)) return;
 
+    // ===================== PROFILE RESOLUTION + BOT GATE =====================
+    // Resolve the kind-0 profiles this decision needs: always the sender (for the
+    // global bot-gate just below) and, for a group, every member (to auto-derive
+    // the name roster). Lazy + cached, so a warm cache makes this a no-op. The
+    // await only populates the cache — the per-group state mutation further down
+    // stays a single synchronous (atomic) read-modify-write.
+    const memberHexes = msg.groupId ? msg.groupMemberHexes ?? [] : [];
+    await ensureProfiles([senderHex, ...memberHexes]);
+
+    // GLOBAL cascade kill (option (a)): a bot NEVER replies to another bot — in a
+    // group OR a 1:1 DM. A sender is a bot if its kind-0 carries the NIP-24 `bot`
+    // flag (or it's a configured sibling / ourselves). Only humans drive
+    // conversation, so a bot's own reply can't trigger another. Drop silently —
+    // no receipt, no state change — exactly like a non-allowed sender.
+    if (isBot(senderHex)) {
+      log.info("phantomchat: ignoring message from a bot", {
+        persona: input.persona,
+        ...(msg.groupId ? { group: msg.groupId } : {}),
+        sender: senderHex.slice(0, 12) + "…",
+      });
+      return;
+    }
+
     // ===================== GROUP ADDRESSING GATE =====================
-    // Only for group messages. Decide — from the shared human message stream —
+    // Only for group messages, and only when this bot shares the group with at
+    // least one OTHER bot. Decide — from the shared human message stream —
     // whether THIS bot should reply, mirroring core/engine.ts. Runs BEFORE the
     // (paid) voice/media pipeline so a message aimed at another bot costs no STT.
-    // The whole block is await-free, so its read-modify-write of the per-group
-    // state is atomic against other peers' interleaved turns (JS single thread).
+    // The read-modify-write of the per-group state below is await-free, so it's
+    // atomic against other peers' interleaved turns (JS single thread).
     let groupContext: string | undefined;
-    if (msg.groupId && groupAddressingActive) {
-      // Option (a): a sibling bot's message NEVER triggers a reply and never
-      // touches addressing state. Only humans drive the conversation, so a bot's
-      // own reply (which may name another bot) can't start a cascade.
-      if (siblingBotHexSet.has(senderHex.toLowerCase())) {
-        log.info("phantomchat: ignoring sibling bot in group", {
-          persona: input.persona,
-          group: msg.groupId,
-          sender: senderHex.slice(0, 12) + "…",
-        });
-        return;
-      }
-
-      const state =
-        groupChats.get(msg.conversationId) ?? { lastAddressed: [], buffer: [] };
-      // Route on the message text. A bare media message (e.g. a group voice
-      // note) has empty text, so it continues the current thread rather than
-      // re-addressing — same as Telegram routing on text/caption only.
-      const matchText = msg.text ?? "";
-      const matched = matchPersonaNames(matchText, groupPersonaNames);
-      const decision = decideGroupReply({
-        self: selfName,
-        matched,
-        lastAddressed: state.lastAddressed,
-      });
-      state.lastAddressed = decision.nextLastAddressed;
-
-      // What to keep in the rolling buffer for context catch-up. Text keeps its
-      // words; a media message keeps a short label so the thread reads coherently.
-      const bufText =
-        matchText.trim().length > 0
-          ? matchText.trim()
-          : msg.media
-            ? `[${msg.media.kind}]`
-            : "";
-      // No usernames on Nostr — label the buffer entry by the short sender hex.
-      const fromLabel = senderHex.slice(0, 8) + "…";
-
-      if (!decision.reply) {
-        if (bufText.length > 0) {
-          state.buffer.push({ from: fromLabel, text: bufText, delivered: false });
-        }
-        while (state.buffer.length > GROUP_BUFFER_MAX) state.buffer.shift();
-        groupChats.set(msg.conversationId, state);
-        log.info("phantomchat: group message not for this bot — staying quiet", {
-          persona: input.persona,
-          group: msg.groupId,
+    if (msg.groupId) {
+      // Auto-derived roster: our own name + configured siblings + the display
+      // names of every member resolved as a bot. The gate engages ONLY when
+      // another bot is actually present — a lone bot in a group answers
+      // everything (Telegram single-bot behaviour), so this can't make an
+      // existing single-bot deployment go mute.
+      const roster = buildRoster(memberHexes);
+      const otherBotPresent =
+        roster.length > 1 ||
+        memberHexes.some((h) => h.toLowerCase() !== ourHex && isBot(h));
+      if (otherBotPresent) {
+        const state =
+          groupChats.get(msg.conversationId) ?? { lastAddressed: [], buffer: [] };
+        // Route on the message text. A bare media message (e.g. a group voice
+        // note) has empty text, so it continues the current thread rather than
+        // re-addressing — same as Telegram routing on text/caption only.
+        const matchText = msg.text ?? "";
+        const matched = matchPersonaNames(matchText, roster);
+        const decision = decideGroupReply({
+          self: selfName,
           matched,
           lastAddressed: state.lastAddressed,
         });
-        return;
-      }
+        state.lastAddressed = decision.nextLastAddressed;
 
-      // We're replying: hand the harness the messages we observed but stayed
-      // quiet through as a context preamble, then mark the buffer delivered.
-      const undelivered = state.buffer.filter((e) => !e.delivered);
-      groupContext = formatGroupContext(undelivered) || undefined;
-      for (const e of state.buffer) e.delivered = true;
-      if (bufText.length > 0) {
-        state.buffer.push({ from: fromLabel, text: bufText, delivered: true });
+        // What to keep in the rolling buffer for context catch-up. Text keeps its
+        // words; a media message keeps a short label so the thread stays coherent.
+        const bufText =
+          matchText.trim().length > 0
+            ? matchText.trim()
+            : msg.media
+              ? `[${msg.media.kind}]`
+              : "";
+        // No usernames on Nostr — label the buffer entry by the short sender hex.
+        const fromLabel = senderHex.slice(0, 8) + "…";
+
+        if (!decision.reply) {
+          if (bufText.length > 0) {
+            state.buffer.push({ from: fromLabel, text: bufText, delivered: false });
+          }
+          while (state.buffer.length > GROUP_BUFFER_MAX) state.buffer.shift();
+          groupChats.set(msg.conversationId, state);
+          log.info("phantomchat: group message not for this bot — staying quiet", {
+            persona: input.persona,
+            group: msg.groupId,
+            matched,
+            lastAddressed: state.lastAddressed,
+          });
+          return;
+        }
+
+        // We're replying: hand the harness the messages we observed but stayed
+        // quiet through as a context preamble, then mark the buffer delivered.
+        const undelivered = state.buffer.filter((e) => !e.delivered);
+        groupContext = formatGroupContext(undelivered) || undefined;
+        for (const e of state.buffer) e.delivered = true;
+        if (bufText.length > 0) {
+          state.buffer.push({ from: fromLabel, text: bufText, delivered: true });
+        }
+        while (state.buffer.length > GROUP_BUFFER_MAX) state.buffer.shift();
+        groupChats.set(msg.conversationId, state);
       }
-      while (state.buffer.length > GROUP_BUFFER_MAX) state.buffer.shift();
-      groupChats.set(msg.conversationId, state);
     }
 
     // ===================== DELIVERY RECEIPT =====================

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -43,6 +43,13 @@ import {
 } from "../core/prompts.ts";
 import type { Channel, ChannelMessage } from "../core/types.ts";
 import {
+  decideGroupReply,
+  formatGroupContext,
+  GROUP_BUFFER_MAX,
+  type GroupChatState,
+  matchPersonaNames,
+} from "../core/routing.ts";
+import {
   splitIntoSegments,
   StreamSegmenter,
 } from "../streamSegmenter.ts";
@@ -128,6 +135,22 @@ export interface RunPhantomchatServerInput {
    */
   allowedHex: string[];
   /**
+   * Shared group-addressing roster: the persona names of EVERY bot that shares
+   * groups with this one (this persona's own name is merged in automatically).
+   * In a group the bot only SPEAKS when its own name is addressed, or when it
+   * already holds the thread (sticky last-addressed). Every bot must be given
+   * the same roster so the hand-off between bots is consistent. Empty/absent →
+   * the bot still answers when its own name is used (lone-bot default).
+   */
+  groupPersonaNames?: string[];
+  /**
+   * Hex pubkeys of the OTHER bots in the group. A message whose cryptographic
+   * sender is in this set is IGNORED in group context (no reply, no state
+   * change) — bots only ever react to humans, which kills bot-to-bot reply
+   * cascades (option (a)). Has no effect on 1:1 DMs.
+   */
+  siblingBotHex?: string[];
+  /**
    * Trust-on-first-use. Only consulted when `allowedHex` is empty:
    *   - tofu true  → the FIRST sender is trusted, persisted via `persistTrust`,
    *     and the bot locks to it (every later stranger is dropped).
@@ -184,6 +207,35 @@ export async function runPhantomchatServer(
   const allowedSet = new Set(input.allowedHex.map((h) => h.toLowerCase()));
   // TOFU is armed only when we start with an empty allowlist and tofu is on.
   let tofuArmed = allowedSet.size === 0 && input.tofu === true;
+
+  // ===================== GROUP ADDRESSING GATE =====================
+  // Mirrors the Telegram engine (core/engine.ts): in a group, every bot
+  // receives every human message, but a bot must only SPEAK when addressed by
+  // name or when it currently holds the thread. The decision is computed purely
+  // from the shared human-message stream (decideGroupReply), so every bot
+  // converges with no coordination. State is per-group, in-memory.
+  const groupChats = new Map<string, GroupChatState>();
+  const selfName = input.persona;
+  // The shared roster, with our own name always present so a lone bot answers to
+  // its name with zero config. Dedup case-insensitively, preserve order.
+  const groupPersonaNames = (() => {
+    const merged = [...(input.groupPersonaNames ?? [])];
+    if (!merged.some((n) => n.toLowerCase() === selfName.toLowerCase())) {
+      merged.push(selfName);
+    }
+    return merged;
+  })();
+  // Option (a): never react to another bot. Hex set for O(1) membership.
+  const siblingBotHexSet = new Set(
+    (input.siblingBotHex ?? []).map((h) => h.toLowerCase()),
+  );
+  // The addressing gate ONLY engages when this persona knows it shares groups
+  // with OTHER bots (group_bots configured). A lone or unconfigured bot keeps
+  // the original behaviour — it answers every group message — so this change is
+  // a no-op for single-bot groups and can't make an existing deployment go mute.
+  // Name-disambiguation only matters when there's actually more than one bot.
+  const groupAddressingActive =
+    groupPersonaNames.length > 1 || siblingBotHexSet.size > 0;
 
   // ===================== CACHE WARMING =====================
   // Pre-derive symmetric keys for all allowed peers so inbound v2 DMs
@@ -262,6 +314,78 @@ export async function runPhantomchatServer(
     const senderHex = msg.senderId;
 
     if (!authorize(msg)) return;
+
+    // ===================== GROUP ADDRESSING GATE =====================
+    // Only for group messages. Decide — from the shared human message stream —
+    // whether THIS bot should reply, mirroring core/engine.ts. Runs BEFORE the
+    // (paid) voice/media pipeline so a message aimed at another bot costs no STT.
+    // The whole block is await-free, so its read-modify-write of the per-group
+    // state is atomic against other peers' interleaved turns (JS single thread).
+    let groupContext: string | undefined;
+    if (msg.groupId && groupAddressingActive) {
+      // Option (a): a sibling bot's message NEVER triggers a reply and never
+      // touches addressing state. Only humans drive the conversation, so a bot's
+      // own reply (which may name another bot) can't start a cascade.
+      if (siblingBotHexSet.has(senderHex.toLowerCase())) {
+        log.info("phantomchat: ignoring sibling bot in group", {
+          persona: input.persona,
+          group: msg.groupId,
+          sender: senderHex.slice(0, 12) + "…",
+        });
+        return;
+      }
+
+      const state =
+        groupChats.get(msg.conversationId) ?? { lastAddressed: [], buffer: [] };
+      // Route on the message text. A bare media message (e.g. a group voice
+      // note) has empty text, so it continues the current thread rather than
+      // re-addressing — same as Telegram routing on text/caption only.
+      const matchText = msg.text ?? "";
+      const matched = matchPersonaNames(matchText, groupPersonaNames);
+      const decision = decideGroupReply({
+        self: selfName,
+        matched,
+        lastAddressed: state.lastAddressed,
+      });
+      state.lastAddressed = decision.nextLastAddressed;
+
+      // What to keep in the rolling buffer for context catch-up. Text keeps its
+      // words; a media message keeps a short label so the thread reads coherently.
+      const bufText =
+        matchText.trim().length > 0
+          ? matchText.trim()
+          : msg.media
+            ? `[${msg.media.kind}]`
+            : "";
+      // No usernames on Nostr — label the buffer entry by the short sender hex.
+      const fromLabel = senderHex.slice(0, 8) + "…";
+
+      if (!decision.reply) {
+        if (bufText.length > 0) {
+          state.buffer.push({ from: fromLabel, text: bufText, delivered: false });
+        }
+        while (state.buffer.length > GROUP_BUFFER_MAX) state.buffer.shift();
+        groupChats.set(msg.conversationId, state);
+        log.info("phantomchat: group message not for this bot — staying quiet", {
+          persona: input.persona,
+          group: msg.groupId,
+          matched,
+          lastAddressed: state.lastAddressed,
+        });
+        return;
+      }
+
+      // We're replying: hand the harness the messages we observed but stayed
+      // quiet through as a context preamble, then mark the buffer delivered.
+      const undelivered = state.buffer.filter((e) => !e.delivered);
+      groupContext = formatGroupContext(undelivered) || undefined;
+      for (const e of state.buffer) e.delivered = true;
+      if (bufText.length > 0) {
+        state.buffer.push({ from: fromLabel, text: bufText, delivered: true });
+      }
+      while (state.buffer.length > GROUP_BUFFER_MAX) state.buffer.shift();
+      groupChats.set(msg.conversationId, state);
+    }
 
     // ===================== DELIVERY RECEIPT =====================
     // The sender just passed the auth gate, so acknowledging receipt to them is
@@ -391,6 +515,16 @@ export async function runPhantomchatServer(
           }
         }
       }
+    }
+
+    // Group catch-up context goes at the very TOP of the turn input so the
+    // harness reads the room (messages this bot saw but stayed quiet through)
+    // before the specific message it's answering. Mirrors core/engine.ts.
+    if (groupContext) {
+      userMessage =
+        userMessage.length > 0
+          ? `${groupContext}\n\n${userMessage}`
+          : groupContext;
     }
 
     // A sender that PASSES the allowlist is a trusted principal — exactly the

--- a/src/channels/phantomchat/transport.ts
+++ b/src/channels/phantomchat/transport.ts
@@ -91,6 +91,15 @@ export const GIFTWRAP_SINCE_WINDOW_SEC = 120;
 const FETCH_GIFTWRAPS_TIMEOUT_MS = 4000;
 
 /**
+ * Hard cap on the one-shot kind-0 profile pull (`fetchProfiles`). Kept short:
+ * resolving a sender/member profile gates a reply, so a slow or missing relay
+ * answer must fall through quickly to the default (treat as human) rather than
+ * stall the turn. The persistent relay backlog and re-fetch-on-miss make a
+ * missed profile self-healing on the next message anyway.
+ */
+const FETCH_PROFILES_TIMEOUT_MS = 3000;
+
+/**
  * The Nostr filter shape we subscribe with. Kept minimal: kind-1059 gift-wraps
  * tagged to our pubkey, from roughly now. We deliberately set `since` to a
  * SMALL window (or omit it) because a gift-wrap's `created_at` is randomized up
@@ -99,8 +108,25 @@ const FETCH_GIFTWRAPS_TIMEOUT_MS = 4000;
  */
 export interface NostrFilter {
   kinds: number[];
-  "#p": string[];
+  /** Recipient p-tag filter (gift-wrap subscriptions). Omitted for `authors`. */
+  "#p"?: string[];
+  /** Author filter — used by the kind-0 profile pull (`fetchProfiles`). */
+  authors?: string[];
   since?: number;
+}
+
+/**
+ * The slice of a NIP-01 kind-0 profile we read. Everything is optional — a
+ * remote profile may omit any field, and `bot` is the NIP-24 automation flag we
+ * use to recognise sibling bots (so a bot never replies to another bot).
+ */
+export interface NostrProfileMeta {
+  /** The handle/addressing token (`name`), e.g. "lena". */
+  name?: string;
+  /** A prettier label (`display_name`); falls back to `name` for addressing. */
+  display_name?: string;
+  /** NIP-24: the account is (partly) automated. PhantomChat bots publish this. */
+  bot?: boolean;
 }
 
 /**
@@ -177,6 +203,17 @@ export interface PhantomchatTransport extends ChannelTransport {
     ourPubHex: string,
     sinceSec: number,
   ): Promise<NTNostrEvent[]>;
+  /**
+   * ONE-SHOT profile pull: query the relays for the kind-0 metadata of every
+   * pubkey in `authors`, resolving with a hex→profile map once the relays signal
+   * EOSE (or a short hard timeout fires). kind-0 is replaceable, so per author we
+   * keep the event with the newest `created_at` across relays. Used to recognise
+   * which group members / DM senders are bots (NIP-24 `bot` flag) and to derive
+   * their addressing names — so a bot replies by name to humans but never to
+   * another bot. Best-effort: a missing/unreachable profile simply isn't in the
+   * returned map (caller treats absence as "human / unknown"). Never throws.
+   */
+  fetchProfiles(authors: string[]): Promise<Map<string, NostrProfileMeta>>;
   /** Publish an already-wrapped kind-1059 event to all relays. */
   publishWrap(event: NTNostrEvent): Promise<void>;
   /**
@@ -343,6 +380,59 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
       sub = this.pool.subscribeMany(this.relays, filter, {
         onevent: (event) => {
           events.push(event);
+        },
+        oneose: finish,
+      });
+    });
+  }
+
+  fetchProfiles(authors: string[]): Promise<Map<string, NostrProfileMeta>> {
+    const out = new Map<string, NostrProfileMeta>();
+    // De-dup + lowercase the author list; an empty list resolves immediately.
+    const wanted = [...new Set(authors.map((a) => a.toLowerCase()))].filter(
+      (a) => a.length > 0,
+    );
+    if (wanted.length === 0) return Promise.resolve(out);
+    // Newest kind-0 wins per author (replaceable event, multiple relays).
+    const seenAt = new Map<string, number>();
+    const filter: NostrFilter = { kinds: [0], authors: wanted };
+    return new Promise<Map<string, NostrProfileMeta>>((resolve) => {
+      let settled = false;
+      let sub: { close(): void } | undefined;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try {
+          sub?.close();
+        } catch {
+          // already torn down — nothing to do.
+        }
+        resolve(out);
+      };
+      const timer = setTimeout(finish, FETCH_PROFILES_TIMEOUT_MS);
+      sub = this.pool.subscribeMany(this.relays, filter, {
+        onevent: (event) => {
+          const author = (event.pubkey ?? "").toLowerCase();
+          if (!author) return;
+          const at = event.created_at ?? 0;
+          if ((seenAt.get(author) ?? -1) >= at) return; // older — keep newest
+          let meta: NostrProfileMeta;
+          try {
+            const parsed = JSON.parse(event.content) as Record<string, unknown>;
+            meta = {
+              name: typeof parsed.name === "string" ? parsed.name : undefined,
+              display_name:
+                typeof parsed.display_name === "string"
+                  ? parsed.display_name
+                  : undefined,
+              bot: parsed.bot === true,
+            };
+          } catch {
+            return; // unparseable content — ignore this event
+          }
+          seenAt.set(author, at);
+          out.set(author, meta);
         },
         oneose: finish,
       });

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -498,7 +498,18 @@ export async function runRun(input: RunInput = {}): Promise<number> {
       }
 
       for (const spec of phantomchatPersonas) {
-        const { identity, allowedHex, tofu } = spec.config;
+        const { identity, allowedHex, tofu, groupBots } = spec.config;
+
+        // Group addressing (multi-bot groups). From the configured sibling bots
+        // derive: the shared NAME roster (every bot's name + our own, so a bot
+        // only replies when addressed by name / when it holds the thread) and
+        // the sibling-bot HEX set (so a bot never reacts to another bot —
+        // cascade kill, option (a)).
+        const groupPersonaNames = [
+          spec.persona,
+          ...groupBots.map((b) => b.name),
+        ];
+        const siblingBotHex = groupBots.map((b) => b.hex);
 
         // Effective relays: canonical (if fetched) else the persona's cached
         // relays. When canonical differs from the cache, write it back so a
@@ -531,6 +542,11 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         out.write(
           `  [phantomchat:${spec.persona}] npub ${identity.npub}, ${relays.length} relay(s), allowed npubs: ${allowedLabel}\n`,
         );
+        if (groupBots.length > 0) {
+          out.write(
+            `  [phantomchat:${spec.persona}] group roster: ${groupPersonaNames.join(", ")} (${groupBots.length} sibling bot(s) ignored in groups)\n`,
+          );
+        }
         // enablePing: nostr-tools sends a keepalive (ws ping, or a dummy REQ for
         // WebSocket impls without .ping()) every ~30s so an idle relay socket is
         // never closed for inactivity. This is the root fix for "the persona
@@ -621,6 +637,8 @@ export async function runRun(input: RunInput = {}): Promise<number> {
             channel,
             secretKey: identity.secretKey,
             allowedHex,
+            groupPersonaNames,
+            siblingBotHex,
             tofu,
             // TOFU commit: encode the proven sender hex → npub and persist it to
             // this persona's phantomchat.json (clearing tofu). Best-effort.

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -639,6 +639,12 @@ export async function runRun(input: RunInput = {}): Promise<number> {
             allowedHex,
             groupPersonaNames,
             siblingBotHex,
+            // Auto bot-detection + name resolution: the server fetches members'
+            // kind-0 profiles to recognise sibling bots (NIP-24 `bot` flag) and
+            // derive their addressing names, so multi-bot groups work with no
+            // group_bots config (the static lists above are now just optional
+            // seeds/overrides).
+            fetchProfiles: (authors: string[]) => transport.fetchProfiles(authors),
             tofu,
             // TOFU commit: encode the proven sender hex → npub and persist it to
             // this persona's phantomchat.json (clearing tofu). Best-effort.

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -149,6 +149,9 @@ async function runOnce(opts: {
   streaming?: TelegramStreamingSettings;
   // How long to let listen() enqueue + the handler drain before aborting.
   waitMs?: number;
+  // Stub kind-0 resolver (lowercased hex → {name, bot}). Lets a DM test exercise
+  // the GLOBAL "never reply to a bot" rule via the sender's profile bot flag.
+  profiles?: Record<string, { name?: string; bot?: boolean }>;
 }): Promise<FakePool> {
   const botHex = getPublicKey(opts.botSk);
   const pool = new FakePool();
@@ -190,6 +193,16 @@ async function runOnce(opts: {
     allowedHex: opts.allowedHex,
     tofu: opts.tofu,
     persistTrust: opts.persistTrust,
+    fetchProfiles: opts.profiles
+      ? async (authors: string[]) => {
+          const out = new Map<string, { name?: string; bot?: boolean }>();
+          for (const a of authors) {
+            const meta = opts.profiles![a.toLowerCase()];
+            if (meta) out.set(a.toLowerCase(), meta);
+          }
+          return out;
+        }
+      : undefined,
     oneShot: true,
     signal: ac.signal,
   });
@@ -1316,8 +1329,12 @@ describe("phantomchat group addressing gate (multi-bot)", () => {
     botSk: Uint8Array;
     persona: string;
     allowedHex: string[];
-    groupPersonaNames: string[];
-    siblingBotHex: string[];
+    groupPersonaNames?: string[];
+    siblingBotHex?: string[];
+    /** Stub kind-0 resolver: lowercased hex → {name, bot}. Models what the bot
+     *  would fetch from relays, so auto bot-detection / name resolution can be
+     *  tested with no config seeds. */
+    profiles?: Record<string, { name?: string; bot?: boolean }>;
     harness: Harness;
   }): {
     pool: FakePool;
@@ -1353,6 +1370,16 @@ describe("phantomchat group addressing gate (multi-bot)", () => {
       allowedHex: opts.allowedHex,
       groupPersonaNames: opts.groupPersonaNames,
       siblingBotHex: opts.siblingBotHex,
+      fetchProfiles: opts.profiles
+        ? async (authors: string[]) => {
+            const out = new Map<string, { name?: string; bot?: boolean }>();
+            for (const a of authors) {
+              const meta = opts.profiles![a.toLowerCase()];
+              if (meta) out.set(a.toLowerCase(), meta);
+            }
+            return out;
+          }
+        : undefined,
       oneShot: false,
       signal: ac.signal,
     });
@@ -1548,6 +1575,143 @@ describe("phantomchat group addressing gate (multi-bot)", () => {
     });
     // A message that does NOT name the bot still gets a reply (old behaviour).
     srv.feedGroup(c.andrewSk, [c.lenaHex], "what's the weather?", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(1);
+    expect(replyWraps(srv.pool).length).toBeGreaterThan(0);
+  });
+
+  // ===== auto bot-detection / name resolution from kind-0 (no config) =====
+  // These tests pass NO group_bots config — the bot must discover that Kai is a
+  // sibling bot (and his name) purely from his kind-0 profile (bot:true), so a
+  // zero-config multi-bot group behaves correctly.
+
+  test("auto: human addresses a sibling resolved from kind-0 → this bot stays quiet", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      // No groupPersonaNames / siblingBotHex — Kai is discovered via his profile.
+      profiles: {
+        [c.kaiHex.toLowerCase()]: { name: "kai", bot: true },
+        [c.andrewHex.toLowerCase()]: { name: "andrew" }, // human: no bot flag
+      },
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "hey kai, status?", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    // "kai" was in the auto-derived roster, so Lena recognised the hand-off.
+    expect(harness.invocations).toBe(0);
+    expect(replyWraps(srv.pool).length).toBe(0);
+  });
+
+  test("auto: human addresses THIS bot in a zero-config multi-bot group → it replies", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "on it" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      profiles: {
+        [c.kaiHex.toLowerCase()]: { name: "kai", bot: true },
+        [c.andrewHex.toLowerCase()]: { name: "andrew" },
+      },
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "lena, what's up?", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(1);
+    expect(replyWraps(srv.pool).length).toBe(3);
+  });
+
+  test("auto: a sibling bot's message is ignored via its kind-0 bot flag (cascade kill, no config)", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      profiles: {
+        [c.kaiHex.toLowerCase()]: { name: "kai", bot: true },
+      },
+      harness,
+    });
+    // Kai (a bot, by profile) names Lena. The global bot-gate must drop it.
+    srv.feedGroup(c.kaiSk, [c.lenaHex, c.andrewHex], "good point, lena!", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(0);
+    expect(replyWraps(srv.pool).length).toBe(0);
+  });
+
+  test("auto: a bot is ignored even in a 1:1 DM (global rule)", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    // Kai (a bot) DMs Lena directly. allowlisted, so auth passes — but the
+    // global bot-gate must still drop him with no reply.
+    const pool = await runOnce({
+      senderSk: c.kaiSk,
+      botSk: c.lenaSk,
+      allowedHex: [c.andrewHex, c.kaiHex],
+      harness,
+      text: "hey lena, ping",
+      profiles: { [c.kaiHex.toLowerCase()]: { name: "kai", bot: true } },
+    });
+
+    expect(harness.invocations).toBe(0);
+    expect(pool.published.filter((e) => e.kind === 1059).length).toBe(0);
+  });
+
+  test("auto: a human DM is still answered (bot-gate doesn't over-block)", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "hi Andrew" },
+    ]);
+    const pool = await runOnce({
+      senderSk: c.andrewSk,
+      botSk: c.lenaSk,
+      allowedHex: [c.andrewHex],
+      harness,
+      text: "hey lena",
+      profiles: { [c.andrewHex.toLowerCase()]: { name: "andrew" } }, // no bot flag
+    });
+
+    expect(harness.invocations).toBe(1);
+    expect(pool.published.filter((e) => e.kind === 1059).length).toBeGreaterThan(0);
+  });
+
+  test("auto: cold cache (no profile resolves) → lone bot answers, no false mute", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "sure" },
+    ]);
+    // Profiles map is empty: nothing resolves, so no OTHER bot is detected. The
+    // group must behave like a lone-bot group (answer everything) rather than
+    // go mute on an unaddressed message.
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      profiles: {}, // resolver present but returns nothing
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "what's the weather?", "HQ");
     await groupSleep(150);
     await srv.stop();
 

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -1293,3 +1293,265 @@ describe("phantomchat slash commands", () => {
     expect(await dmBubbles(srv.pool, senderSk)).toContain("restarting…");
   });
 });
+
+/**
+ * Group name-addressing gate (issue: multi-bot groups). When several bots share
+ * a group, only the bot addressed BY NAME (or the one currently holding the
+ * thread) replies — instead of all of them piling on. The gate reuses the
+ * channel-agnostic decideGroupReply/matchPersonaNames (core/routing.ts), the
+ * same logic Telegram uses, driven from the shared human message stream.
+ *
+ * Option (a): a bot NEVER reacts to another bot's message (cascade kill) — only
+ * humans drive addressing. The gate engages ONLY when sibling bots are
+ * configured (group_bots); a lone/unconfigured bot still answers everything, so
+ * this is a no-op for single-bot groups (proven by the HQ tests above).
+ */
+describe("phantomchat group addressing gate (multi-bot)", () => {
+  /**
+   * A long-lived group server for one bot persona, aware of its sibling bots.
+   * feedGroup() wraps a group message from `senderSk` to `otherMemberHexes` and
+   * feeds the bot the wrap it can unwrap — exactly how a relay would deliver it.
+   */
+  function makeGroupServer(opts: {
+    botSk: Uint8Array;
+    persona: string;
+    allowedHex: string[];
+    groupPersonaNames: string[];
+    siblingBotHex: string[];
+    harness: Harness;
+  }): {
+    pool: FakePool;
+    feedGroup: (
+      senderSk: Uint8Array,
+      otherMemberHexes: string[],
+      text: string,
+      groupId: string,
+    ) => void;
+    stop: () => Promise<void>;
+  } {
+    const botHex = getPublicKey(opts.botSk);
+    const pool = new FakePool();
+    const transport = new SimplePoolPhantomchatTransport(
+      opts.botSk,
+      ["wss://test.relay"],
+      pool,
+    );
+    const channel = createPhantomchatChannel({
+      secretKey: opts.botSk,
+      publicKeyHex: botHex,
+      transport,
+    });
+    const ac = new AbortController();
+    const done = runPhantomchatServer({
+      config: baseConfig(),
+      memory,
+      harnesses: [opts.harness],
+      agentDir,
+      persona: opts.persona,
+      channel,
+      secretKey: opts.botSk,
+      allowedHex: opts.allowedHex,
+      groupPersonaNames: opts.groupPersonaNames,
+      siblingBotHex: opts.siblingBotHex,
+      oneShot: false,
+      signal: ac.signal,
+    });
+    let n = 0;
+    const feedGroup = (
+      senderSk: Uint8Array,
+      otherMemberHexes: string[],
+      text: string,
+      groupId: string,
+    ) => {
+      const payload = JSON.stringify({
+        content: text,
+        type: "text",
+        id: `g-${++n}`,
+        timestamp: Date.now(),
+      });
+      const { wraps } = wrapGroupMessage(
+        senderSk,
+        otherMemberHexes,
+        payload,
+        groupId,
+      );
+      let forBot: NTNostrEvent | undefined;
+      for (const w of wraps) {
+        try {
+          unwrapNip17Message(w as NTNostrEvent, opts.botSk);
+          forBot = w as NTNostrEvent;
+          break;
+        } catch {
+          /* not ours */
+        }
+      }
+      if (forBot) pool.feed(forBot);
+    };
+    const stop = async () => {
+      ac.abort();
+      await done;
+    };
+    return { pool, feedGroup, stop };
+  }
+
+  const groupSleep = (ms: number): Promise<void> =>
+    new Promise((r) => setTimeout(r, ms));
+
+  // Cast for these tests: Andrew (human) + Lena (this bot) + Kai (sibling bot).
+  function cast() {
+    const andrewSk = generateSecretKey();
+    const lenaSk = generateSecretKey();
+    const kaiSk = generateSecretKey();
+    return {
+      andrewSk,
+      lenaSk,
+      kaiSk,
+      andrewHex: getPublicKey(andrewSk),
+      lenaHex: getPublicKey(lenaSk),
+      kaiHex: getPublicKey(kaiSk),
+    };
+  }
+
+  const replyWraps = (pool: FakePool) =>
+    pool.published.filter((e) => e.kind === 1059);
+
+  test("addressed by name → this bot replies", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "on it, Andrew" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "hey lena, status?", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(1);
+    // Group broadcast: Andrew + Kai + Lena's self-wrap = 3 wraps (no DM receipt).
+    expect(replyWraps(srv.pool).length).toBe(3);
+  });
+
+  test("another bot addressed by name → this bot stays quiet", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "hey kai, status?", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(0);
+    expect(replyWraps(srv.pool).length).toBe(0);
+  });
+
+  test("option (a): a sibling bot's message is ignored even if it names this bot", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "should not run" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      // Kai is allowlisted (so the auth gate would admit him) — the bot-ignore
+      // must drop him at the group gate regardless.
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    // Kai (a bot) sends a message that explicitly names Lena. Without option (a)
+    // this would trigger Lena and start a bot-to-bot cascade.
+    srv.feedGroup(c.kaiSk, [c.lenaHex, c.andrewHex], "good point, lena!", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(0);
+    expect(replyWraps(srv.pool).length).toBe(0);
+  });
+
+  test("sticky: a no-name follow-up still reaches the bot that holds the thread", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "first" },
+      { type: "done", finalText: "second" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "lena, do X", "HQ");
+    await groupSleep(150);
+    // No name — but Lena holds the thread, so she answers the follow-up.
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "thanks, and also Y?", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(2);
+    expect(replyWraps(srv.pool).length).toBe(6); // two 3-wrap broadcasts
+  });
+
+  test("hand-off: once Andrew addresses the sibling, this bot falls quiet", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "first" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "lena, do X", "HQ");
+    await groupSleep(150);
+    // Andrew hands the thread to Kai. Lena must go quiet (only her own first
+    // reply ran) — she needs "kai" in her roster to detect the hand-off.
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "kai, your turn", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(1);
+    expect(replyWraps(srv.pool).length).toBe(3); // only the first reply
+  });
+
+  test("no sibling bots configured → lone bot still answers every group message", async () => {
+    const c = cast();
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "sure" },
+    ]);
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex],
+      groupPersonaNames: [], // no roster → gate inactive (backward compat)
+      siblingBotHex: [],
+      harness,
+    });
+    // A message that does NOT name the bot still gets a reply (old behaviour).
+    srv.feedGroup(c.andrewSk, [c.lenaHex], "what's the weather?", "HQ");
+    await groupSleep(150);
+    await srv.stop();
+
+    expect(harness.invocations).toBe(1);
+    expect(replyWraps(srv.pool).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/channels-phantomchat-transport.test.ts
+++ b/tests/channels-phantomchat-transport.test.ts
@@ -533,3 +533,110 @@ describe("phantomchat transport subscription wire shape", () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe("phantomchat transport fetchProfiles (kind-0)", () => {
+  test("queries kind-0 by authors and resolves a parsed hex→profile map on EOSE", async () => {
+    let captured: NostrFilter | undefined;
+    const botPk = "a".repeat(64);
+    const humanPk = "b".repeat(64);
+    const fakePool: RelayPool = {
+      subscribeMany(_relays, filter, params) {
+        captured = filter;
+        // Deliver one bot profile + one human profile, then signal EOSE.
+        params.onevent({
+          kind: 0,
+          pubkey: botPk,
+          created_at: 100,
+          content: JSON.stringify({ name: "kai", display_name: "Kai", bot: true }),
+        } as NTNostrEvent);
+        params.onevent({
+          kind: 0,
+          pubkey: humanPk,
+          created_at: 100,
+          content: JSON.stringify({ name: "andrew" }),
+        } as NTNostrEvent);
+        params.oneose?.();
+        return { close() {} };
+      },
+      publish() {
+        return [];
+      },
+      close() {},
+    };
+
+    const transport = new SimplePoolPhantomchatTransport(
+      generateSecretKey(),
+      ["wss://relay.example"],
+      fakePool,
+    );
+
+    const map = await transport.fetchProfiles([botPk.toUpperCase(), humanPk]);
+
+    // Filter shape: kind-0 by authors (lowercased), no #p tag.
+    expect(captured?.kinds).toEqual([0]);
+    expect(captured?.authors).toEqual([botPk, humanPk]);
+    expect(captured?.["#p"]).toBeUndefined();
+    // Parsed + keyed by lowercased hex; bot flag preserved.
+    expect(map.get(botPk)).toEqual({ name: "kai", display_name: "Kai", bot: true });
+    expect(map.get(humanPk)).toEqual({ name: "andrew", display_name: undefined, bot: false });
+  });
+
+  test("keeps the newest kind-0 per author (replaceable event)", async () => {
+    const pk = "c".repeat(64);
+    const fakePool: RelayPool = {
+      subscribeMany(_relays, _filter, params) {
+        // Older event arrives AFTER the newer one — newest created_at must win.
+        params.onevent({
+          kind: 0,
+          pubkey: pk,
+          created_at: 200,
+          content: JSON.stringify({ name: "new", bot: true }),
+        } as NTNostrEvent);
+        params.onevent({
+          kind: 0,
+          pubkey: pk,
+          created_at: 100,
+          content: JSON.stringify({ name: "old", bot: false }),
+        } as NTNostrEvent);
+        params.oneose?.();
+        return { close() {} };
+      },
+      publish() {
+        return [];
+      },
+      close() {},
+    };
+
+    const transport = new SimplePoolPhantomchatTransport(
+      generateSecretKey(),
+      ["wss://relay.example"],
+      fakePool,
+    );
+
+    const map = await transport.fetchProfiles([pk]);
+    expect(map.get(pk)?.name).toBe("new");
+    expect(map.get(pk)?.bot).toBe(true);
+  });
+
+  test("empty author list resolves to an empty map without subscribing", async () => {
+    let subscribed = false;
+    const fakePool: RelayPool = {
+      subscribeMany() {
+        subscribed = true;
+        return { close() {} };
+      },
+      publish() {
+        return [];
+      },
+      close() {},
+    };
+    const transport = new SimplePoolPhantomchatTransport(
+      generateSecretKey(),
+      ["wss://relay.example"],
+      fakePool,
+    );
+    const map = await transport.fetchProfiles([]);
+    expect(map.size).toBe(0);
+    expect(subscribed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

When several persona bots share a PhantomChat group, **every bot answers every message** — say something to one and all of them pile on (see the HQ screenshot in the issue). The phantomchat server ran a turn for any authorized sender with no notion of "who was addressed."

Telegram already solved this: each bot decides locally, from the shared human message stream, whether *it* was addressed (`matchPersonaNames` + `decideGroupReply` in `core/routing.ts`). That logic is deliberately channel-agnostic — the phantomchat server just never called it.

## Fix

Wire that same gate into `runPhantomchatServer`'s group path. A bot replies only when:
- its **persona name** appears in the message ("hey **Lena**, …"), or
- it currently **holds the thread** (so a no-name follow-up still reaches it).

When you address a different bot by name, the previous one falls quiet (hand-off) — which is why each bot needs the full name roster.

### Option (a): bots never react to each other

A bot **ignores any message whose cryptographic sender is another bot** — no reply, no state change. This kills bot-to-bot cascades dead: one bot's reply (which might mention another bot's name) can never trigger a chain. Only humans drive addressing. This was the explicit design choice over enabling bot-to-bot collaboration.

### Config: `group_bots`

Siblings are declared per-persona in `phantomchat.json`:

```json
"group_bots": [
  { "name": "kai",    "npub": "npub1kai…" },
  { "name": "robbie", "npub": "npub1robbie…" }
]
```

- `name` → feeds the shared addressing roster (name-disambiguation + hand-off).
- `npub` → decoded to hex, feeds the "ignore other bots" set.

Configure it for **every** bot in the group, each listing the others.

### No regression for single-bot groups

The gate **engages only when sibling bots are configured**. A lone/unconfigured bot keeps the original behaviour (answers every group message), so this is opt-in and can't make an existing deployment go mute. Backward compatibility is proven by the pre-existing HQ tests still passing unchanged.

## Changes

- `personaStore.ts` — parse + round-trip `group_bots` (name + npub + decoded hex) through every save helper.
- `server.ts` — group addressing gate + catch-up context preamble, run **before** the paid voice/media pipeline so an unaddressed message costs no STT.
- `run.ts` — derive the name roster + sibling-bot hex set from `group_bots`.
- README — document `group_bots`.

## Tests

6 new gate tests (in `channels-phantomchat-server.test.ts`):
- addressed by name → replies
- another bot named → stays quiet
- option (a): sibling bot's message ignored even when it names this bot
- sticky no-name follow-up → still reaches the thread-holder
- hand-off → bot falls quiet once Andrew addresses the sibling
- no siblings configured → lone bot still answers everything

**Guard-proved**: neutering the gate fails the 3 silence-asserting tests. Full suite: **1737 pass / 0 fail**, `tsc` clean.