### PR TITLE
fix(run): force-exit watchdog so a hung relay socket can't stall shutdown 90s

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -63,6 +63,29 @@ import { runDoctor } from "./doctor.ts";
 import { ensureRoutingExtension } from "../lib/piExtensionProvision.ts";
 import { reconcileEditorConnectors } from "../connectors/acp/autoInstall.ts";
 
+/**
+ * After SIGINT/SIGTERM we abort and let the event loop drain naturally. If a
+ * lingering handle (e.g. a relay ws.close() stuck on a half-open socket) keeps
+ * the loop alive past this window, force a clean exit rather than ride to
+ * systemd's 90s SIGKILL. .unref()'d, so clean shutdowns never wait on it.
+ */
+export const SHUTDOWN_GRACE_MS = 5000;
+
+/**
+ * Arm a one-shot watchdog that runs `onForce` if graceful teardown hasn't
+ * drained the event loop within `graceMs`. .unref()'d so a clean shutdown
+ * (the common case) exits on its own without ever waiting on this timer —
+ * it only bites when a lingering handle would otherwise wedge the process.
+ */
+export function armShutdownWatchdog(
+  graceMs: number,
+  onForce: () => void,
+): ReturnType<typeof setTimeout> {
+  const t = setTimeout(onForce, graceMs);
+  t.unref();
+  return t;
+}
+
 export interface RunInput {
   config?: Config;
   out?: WriteSink;
@@ -443,7 +466,26 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   }
 
   const ac = new AbortController();
-  const onSig = () => ac.abort();
+  let forcedExit = false;
+  const onSig = () => {
+    ac.abort();
+    // Graceful teardown drains the event loop naturally (run() sets
+    // process.exitCode and returns — there is no process.exit()). But a relay
+    // ws.close() on a half-open socket can leave the FD alive, keeping the loop
+    // open until systemd's 90s SIGKILL. Arm a force-exit watchdog so a wedged
+    // shutdown is bounded to the grace window instead. .unref() so a clean
+    // shutdown (the common case) never waits on this timer — it exits on its
+    // own in a few seconds. Memory is durable (SQLite/WAL) and the lock is a
+    // stale-checked pidfile, so an abrupt exit(0) here is safe.
+    if (forcedExit) return;
+    forcedExit = true;
+    armShutdownWatchdog(SHUTDOWN_GRACE_MS, () => {
+      log.warn("run: graceful shutdown exceeded grace window — forcing exit", {
+        graceMs: SHUTDOWN_GRACE_MS,
+      });
+      process.exit(0);
+    });
+  };
   process.on("SIGINT", onSig);
   process.on("SIGTERM", onSig);
 

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -114,6 +114,11 @@ RestartSec=5
 # Declaring 143 a success exit status keeps self-restart journals quiet
 # and stops a spurious Restart= cycle on top of the real one.
 SuccessExitStatus=143
+# Backstop to the in-process force-exit watchdog (see src/cli/run.ts): if the
+# watchdog itself can't fire, cap systemd's stop wait at 15s instead of the
+# 90s default so a hung relay socket can't stall a restart for a minute and a
+# half. The code-level watchdog (~5s) is the primary fix; this is the floor.
+TimeoutStopSec=15s
 Environment="PATH=${PHANTOMBOT_SERVICE_PATH}"
 ${ENVIRONMENT_FILE_LINES}
 StandardOutput=journal

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -8,7 +8,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { planListeners, runRun } from "../src/cli/run.ts";
+import {
+  armShutdownWatchdog,
+  planListeners,
+  runRun,
+  SHUTDOWN_GRACE_MS,
+} from "../src/cli/run.ts";
 import { savePhantomchatPersonaConfig } from "../src/channels/phantomchat/personaStore.ts";
 import { generateIdentity } from "../src/lib/nostrIdentity.ts";
 import type { Config } from "../src/config.ts";
@@ -518,5 +523,36 @@ describe("runRun — phantomchat-only (no Telegram)", () => {
     expect(code).toBe(2);
     expect(err.text).toContain("phantombot harness"); // got past the persona-missing fatal
     expect(err.text).not.toContain("no other personas exist");
+  });
+});
+
+describe("shutdown force-exit watchdog", () => {
+  // On SIGTERM we abort and let the loop drain naturally — but a relay
+  // ws.close() stuck on a half-open socket can keep the loop alive until
+  // systemd's 90s SIGKILL. The watchdog bounds that to the grace window.
+  test("grace window is bounded well under systemd's 90s SIGKILL", () => {
+    expect(SHUTDOWN_GRACE_MS).toBeGreaterThan(0);
+    expect(SHUTDOWN_GRACE_MS).toBeLessThan(90_000);
+  });
+
+  // The critical safety property: the watchdog must NOT keep the event loop
+  // alive. If it were ref'd, every clean shutdown would stall for the full
+  // grace window. hasRef() === false proves .unref() was applied.
+  test("watchdog timer is unref'd so it never delays a clean shutdown", () => {
+    const t = armShutdownWatchdog(60_000, () => {});
+    expect((t as unknown as { hasRef(): boolean }).hasRef()).toBe(false);
+    clearTimeout(t);
+  });
+
+  // And it actually fires onForce once the window elapses — this is what
+  // replaces the 90s SIGKILL with a prompt clean exit.
+  test("watchdog fires onForce after the grace window elapses", async () => {
+    let fired = 0;
+    armShutdownWatchdog(20, () => {
+      fired += 1;
+    });
+    expect(fired).toBe(0);
+    await new Promise((r) => setTimeout(r, 60));
+    expect(fired).toBe(1);
   });
 });

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -137,6 +137,18 @@ describe("generateSystemdUnit", () => {
     expect(u).toContain("SuccessExitStatus=143");
   });
 
+  test("caps TimeoutStopSec so a hung relay socket can't stall a restart 90s", () => {
+    // Backstop to the in-process force-exit watchdog (src/cli/run.ts). If the
+    // watchdog can't fire, systemd's default 90s stop-timeout would still
+    // stall every restart for 90s on a half-open relay socket. Capping the
+    // stop wait at 15s bounds the worst case below the default.
+    const u = generateSystemdUnit({
+      binPath: "/home/kai/.local/bin/phantombot",
+      args: ["run"],
+    });
+    expect(u).toContain("TimeoutStopSec=15s");
+  });
+
   test("service PATH includes stable user harness shim locations", () => {
     const u = generateSystemdUnit({
       binPath: "/home/kai/.local/bin/phantombot",


### PR DESCRIPTION
## Problem

Restarts have been taking ~90s since around Jun 28. The journal shows **total log silence between SIGTERM and SIGKILL** — the abort fires but the process physically can't exit.

**Root cause:** \`phantombot run\` shuts down by letting the event loop drain naturally — it sets \`process.exitCode\` and *returns*. There is **no \`process.exit()\`**. That's fine only if every handle releases cleanly. On SIGTERM the relay teardown calls \`pool.close()\` → \`ws.close()\` per relay. \`ws.close()\` returns instantly but the underlying socket waits for the relay's close-handshake reply; on a **half-open/unresponsive relay that never completes**, so the FD keeps Bun's loop alive until systemd's default **90s \`TimeoutStopSec\`** SIGKILLs it.

**Not a #233 regression** — diffing shutdown timings in the journal shows the slow shutdowns began Jun 28 (before #233 merged), correlating with increased \`relay(s) dropped — re-arming\` churn. This is a pre-existing fragility (no force-exit guard) that a flapping relay started exposing. Confirmed with a throwaway Bun repro: \`pool.close()\` returned at 388ms but the process stayed alive several seconds on the relay sockets alone (watchdog \`.unref()\`'d, so only the relay FDs held the loop).

## Fix

Arm an \`.unref()\`'d force-exit watchdog in the signal handler:

- **Clean shutdowns** finish in their natural few seconds — \`.unref()\` means the timer never adds delay.
- **Wedged shutdowns** are bounded to a 5s grace window → clean \`exit(0)\` instead of a 90s SIGKILL (also clears the \`result 'timeout'\` noise and \`Restart=on-failure\` risk).
- **Handle-agnostic** — covers this *and* any future lingering-handle gremlin.
- **Safe**: memory is SQLite/WAL (durable); the lock is a stale-checked pidfile, so an abrupt \`exit(0)\` is fine.

Suggested companion (ops, not in this PR): set \`TimeoutStopSec=15s\` in the unit as a backstop. The code guard is the real fix.

## Tests

Extracted \`armShutdownWatchdog()\` for unit testing (a real \`process.exit(0)\` can't be driven through \`runRun\` safely). New tests assert:
- the timer is **\`.unref()\`'d** (the safety property — guard-proved: fails if \`.unref()\` is removed),
- it **fires onForce** after the window elapses,
- the grace window is well under systemd's 90s.

Full suite **1749 pass / 0 fail**, \`tsc\` clean.