### PR TITLE
fix(telegram): re-poll on non-JSON getUpdates body instead of crashing

### DIFF
--- a/src/channels/telegram/transport.ts
+++ b/src/channels/telegram/transport.ts
@@ -132,11 +132,26 @@ export class HttpTelegramTransport implements TelegramTransport {
       log.warn("telegram: getUpdates non-OK", { status: res.status });
       return { updates: [], nextOffset: offset };
     }
-    const body = (await res.json()) as {
+    let body: {
       ok?: boolean;
       result?: TelegramRawUpdate[];
       description?: string;
     };
+    try {
+      body = (await res.json()) as typeof body;
+    } catch (e) {
+      // A 200 with a non-JSON body (captive portal, proxy error page, an
+      // empty/truncated response) makes res.json() throw. Swallow it like
+      // the fetch failure above — log and re-poll — instead of letting it
+      // escape. The engine drives getUpdates inside a try/FINALLY (no
+      // catch), so an uncaught throw here unwinds the poll loop, rejects
+      // the run's Promise.all, and tears down EVERY sibling listener over
+      // one transient bad body.
+      log.warn("telegram: getUpdates body not JSON", {
+        error: (e as Error).message,
+      });
+      return { updates: [], nextOffset: offset };
+    }
     if (!body.ok) {
       log.warn("telegram: getUpdates not ok", { description: body.description });
       return { updates: [], nextOffset: offset };

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -3717,3 +3717,38 @@ describe("HttpTelegramTransport AbortSignal", () => {
     }
   });
 });
+
+describe("HttpTelegramTransport getUpdates non-JSON body", () => {
+  // A 200 whose body is not JSON (captive portal, proxy error page, an
+  // empty/truncated response) makes res.json() throw. getUpdates must
+  // swallow it and re-poll the SAME offset, not let the throw escape: the
+  // engine drives getUpdates in a try/finally (no catch), so an uncaught
+  // error there unwinds the poll loop and tears down every sibling listener.
+  async function expectEmptyReprobe(bodyResponse: Response): Promise<void> {
+    const originalFetch = globalThis.fetch;
+    try {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = (async () =>
+        bodyResponse) as unknown as typeof fetch;
+      const t = new HttpTelegramTransport("anything");
+      const r = await t.getUpdates(7, 30);
+      expect(r.updates).toEqual([]);
+      // Offset is preserved so the loop re-polls the same batch.
+      expect(r.nextOffset).toBe(7);
+    } finally {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    }
+  }
+
+  test("HTML body on a 200 returns empty without throwing", async () => {
+    await expectEmptyReprobe(
+      new Response("<html><body>captive portal</body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+  });
+
+  test("empty body on a 200 returns empty without throwing", async () => {
+    await expectEmptyReprobe(new Response("", { status: 200 }));
+  });
+});


### PR DESCRIPTION
## Summary

A single transient non-JSON HTTP response from one Telegram bot could tear down the **entire** `phantombot run` process — every sibling listener included.

This guards the `getUpdates` JSON parse so a bad body re-polls cleanly instead of propagating.

## The problem

In `HttpTelegramTransport.getUpdates`, the response body was parsed unguarded:

```ts
const body = (await res.json()) as { ok?: boolean; result?: ...; description?: string };
```
res.json() throws when the body is a 200 that isn't JSON — a captive portal, a proxy/middlebox error page, or an empty/truncated response. The fetch call above it is wrapped in try/catch, but this parse was not, so the throw escaped getUpdates.

That throw is not contained downstream:

- the engine drives getUpdates inside a try { … } finally { … } (no catch), so the error unwinds the poll loop;
- it then rejects await Promise.all(tasks) in run.ts, whose handler all sibling listeners and re-raises.

Net effect: one bot receiving one malformed 200 takes the whole process down (non-zero exit). Under systemd that becomes a full restart cycle transient network condition.

The fix

Wrap the parse and handle failure exactly like the existing fetch-failure and non-OK branches — log a warning and return an empty batch with the preserved, so the loop simply re-polls the same updates on the next pass:

```ts
try {
  body = (await res.json()) as typeof body;
} catch (e) {
  log.warn("telegram: getUpdates body not JSON", { error: (e as Error).message });
  return { updates: [], nextOffset: offset };
}
```

No behavioral change on the happy path; this only converts a previo parse error into the same self-healing re-poll used for every other transport hiccup.