### PR TITLE
refactor(typing): dedicated non-ephemeral kind for typing/voice + inbound kind guard

### DIFF
--- a/src/channels/phantomchat/channel.ts
+++ b/src/channels/phantomchat/channel.ts
@@ -36,6 +36,7 @@ import {
   unwrapNip17Message,
   unwrapV2,
   isV2Event,
+  NOSTR_KIND_TYPING_RUMOR,
   type NTNostrEvent,
 } from "../../lib/nostrCrypto.ts";
 import type { PhantomchatTransport } from "./transport.ts";
@@ -229,6 +230,18 @@ export function createPhantomchatChannel(
         // (4) Dedup by rumor id — the SAME logical message can arrive via more
         // than one wrap; the rumor id is stable across them.
         if (!remember(seenRumorIds, rumor.id)) return;
+
+        // (4a) Typing / voice tick — NEVER a message turn. The PWA gift-wraps
+        // typing on a dedicated inner kind (NOSTR_KIND_TYPING_RUMOR). Drop it
+        // structurally by kind: without this, a user's 'stop' tick fails
+        // JSON.parse, falls through to the plain-text path, and gets enqueued —
+        // i.e. the bot would reply to "stop". Discriminating by kind (not
+        // content) means a genuine user message that simply says "stop"
+        // (kind-14) still gets answered.
+        if (rumor.kind === NOSTR_KIND_TYPING_RUMOR) {
+          log.debug("phantomchat: dropping inbound typing tick");
+          return;
+        }
 
         // (5) Parse the JSON envelope. `type === "text"` is a chat message;
         // `presence-ping` / `presence-pong` are legacy types, silently dropped

--- a/src/lib/nostrCrypto.ts
+++ b/src/lib/nostrCrypto.ts
@@ -70,6 +70,22 @@ export interface SignedEvent extends UnsignedEvent {
 }
 
 /**
+ * Inner rumor kind for gift-wrapped typing / voice indicators. MUST stay in
+ * lockstep with the PWA's `NOSTR_KIND_TYPING_RUMOR`
+ * (phantomchat src/lib/phantomchat/nostr-crypto.ts).
+ *
+ * Typing ticks are gift-wrapped (NIP-59 / kind-1059) for privacy like DMs, but
+ * the INNER rumor must NOT reuse the message kind-14: sharing it made a tick
+ * indistinguishable from a chat message except by sniffing content ('stop' /
+ * 'recording' / ''), so a replayed tick could render as a "Stopped" bubble on
+ * the PWA and the bot's own inbound could enqueue 'stop' as a message turn.
+ * A dedicated kind makes the distinction STRUCTURAL — route/drop on rumor.kind,
+ * never on content. 1414 is a regular (non-ephemeral) kind, unassigned by any
+ * NIP, and only ever exists encrypted inside a kind-1059 wrap.
+ */
+export const NOSTR_KIND_TYPING_RUMOR = 1414;
+
+/**
  * In-memory conversation-key cache, keyed by sender secret-key OBJECT identity
  * (a WeakMap) → recipient hex → derived NIP-44 conversation key. Keying on the
  * Uint8Array object (not its hex) keeps the private key from being materialized
@@ -596,10 +612,11 @@ export function createRumor(
   content: string,
   senderSk: Uint8Array,
   tags?: string[][],
+  kind: number = 14,
 ): UnsignedEvent {
   const pubkey = getPublicKey(senderSk);
   const event = {
-    kind: 14,
+    kind,
     created_at: Math.floor(Date.now() / 1000),
     tags: tags || [],
     content,
@@ -684,7 +701,7 @@ export function wrapTypingGiftWrap(
   content: string,
   conversationId: string,
 ): NTNostrEvent {
-  const rumor = createRumor(content, senderSk, [["d", conversationId]]);
+  const rumor = createRumor(content, senderSk, [["d", conversationId]], NOSTR_KIND_TYPING_RUMOR);
   const seal = createSeal(rumor, senderSk, recipientPubHex);
 
   const ephemeralSk = generateSecretKey();
@@ -714,7 +731,7 @@ export function wrapGroupTypingGiftWrap(
   content: string,
   groupId: string,
 ): NTNostrEvent[] {
-  const rumor = createRumor(content, senderSk, [["d", groupId], ["group", groupId]]);
+  const rumor = createRumor(content, senderSk, [["d", groupId], ["group", groupId]], NOSTR_KIND_TYPING_RUMOR);
   const now = Math.floor(Date.now() / 1000);
 
   return memberPubkeys.map((recipientPk) => {

--- a/tests/channels-phantomchat-channel.test.ts
+++ b/tests/channels-phantomchat-channel.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../src/channels/phantomchat/transport.ts";
 import {
   wrapNip17Message,
+  wrapTypingGiftWrap,
   type NTNostrEvent,
 } from "../src/lib/nostrCrypto.ts";
 
@@ -252,6 +253,34 @@ describe("phantomchat channel — NIP-17 dual-read (plain text)", () => {
     await pump;
 
     expect(got.length).toBe(0);
+  });
+
+  test("a live typing tick (dedicated kind) is dropped, never enqueued as a turn", async () => {
+    // Regression: the PWA gift-wraps typing on NOSTR_KIND_TYPING_RUMOR. A 'stop'
+    // tick is non-empty content, so before the kind guard it failed JSON.parse,
+    // fell through to the plain-text path, and the bot REPLIED to "stop". The
+    // inbound guard drops it structurally by inner kind.
+    const { ourPub, pool, channel } = setup();
+    const ac = new AbortController();
+    const got: ChannelMessage[] = [];
+    const pump = (async () => {
+      for await (const msg of channel.listen!(ac.signal)) got.push(msg);
+    })();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const peerSk = generateSecretKey();
+    // Both lifecycle markers a user emits while typing at the bot.
+    const startTick = wrapTypingGiftWrap(peerSk, ourPub, "", ourPub);
+    const stopTick = wrapTypingGiftWrap(peerSk, ourPub, "stop", ourPub);
+    pool.feed(startTick as unknown as NTNostrEvent);
+    pool.feed(stopTick as unknown as NTNostrEvent);
+
+    await new Promise((r) => setTimeout(r, 30));
+    ac.abort();
+    await pump;
+
+    expect(got.length).toBe(0); // no turn from either tick
+    expect(pool.published.length).toBe(0); // and certainly no reply published
   });
 });
 

--- a/tests/channels-phantomchat-transport.test.ts
+++ b/tests/channels-phantomchat-transport.test.ts
@@ -109,8 +109,8 @@ describe("phantomchat transport subscription wire shape", () => {
     expect(published.length).toBe(1);
     const ev = published[0]!;
     // NIP-17 gift-wrap: the relay only sees kind-1059 + ephemeral pubkey.
-    // The inner kind-14 rumor (with typing content + ['d', conversationId])
-    // is encrypted inside.
+    // The inner typing rumor (NOSTR_KIND_TYPING_RUMOR, with the lifecycle
+    // content + ['d', conversationId]) is encrypted inside.
     expect(ev.kind).toBe(1059);
     expect(ev.tags).toEqual(expect.arrayContaining([["p", recipient]]));
     // Real signature — finalizeEvent produces id + sig.

--- a/tests/lib-nostrCrypto.test.ts
+++ b/tests/lib-nostrCrypto.test.ts
@@ -18,16 +18,38 @@ import {
 
 import {
   GiftWrapVerificationError,
+  NOSTR_KIND_TYPING_RUMOR,
   createGiftWrap,
   createRumor,
   getConversationKey,
   nip44Encrypt,
   unwrapNip17Message,
   wrapNip17Message,
+  wrapTypingGiftWrap,
   type NTNostrEvent,
   type SignedEvent,
   type UnsignedEvent,
 } from "../src/lib/nostrCrypto.ts";
+
+describe("wrapTypingGiftWrap — dedicated inner kind", () => {
+  test("inner rumor carries NOSTR_KIND_TYPING_RUMOR (not the message kind 14)", () => {
+    const senderSk = generateSecretKey();
+    const recipientSk = generateSecretKey();
+    const recipientHex = getPublicKey(recipientSk);
+
+    const wrap = wrapTypingGiftWrap(senderSk, recipientHex, "stop", recipientHex);
+    // Outer wrap is the standard gift-wrap kind; relays see only this.
+    expect(wrap.kind).toBe(1059);
+
+    const rumor = unwrapNip17Message(wrap, recipientSk);
+    // Inner kind is the dedicated typing kind — this is what keeps a tick from
+    // ever being mistaken for a kind-14 message on the receive side.
+    expect(rumor.kind).toBe(NOSTR_KIND_TYPING_RUMOR);
+    expect(rumor.kind).not.toBe(14);
+    expect(rumor.content).toBe("stop");
+    expect(rumor.tags.some((t) => t[0] === "d")).toBe(true);
+  });
+});
 
 describe("wrapNip17Message / unwrapNip17Message round-trip", () => {
   test("recipient recovers the exact plaintext envelope; sender is rumor.pubkey", () => {


### PR DESCRIPTION
Pairs with **phantomchat #57**. Both repos must agree on the typing wire and
deploy together.

## Why

Typing/voice ticks were gift-wrapped on the **kind-14 message rumor**, told
apart from real DMs only by content. That leaked **both ways**:
- the PWA rendered a `'stop'` tick as a "Stopped" bubble;
- the bot's inbound had **no kind guard at all** — a user's `'stop'` tick
  fails `JSON.parse`, falls through to the plain-text path, and the bot
  **replies to "stop"**.

## What changed

- `NOSTR_KIND_TYPING_RUMOR = 1414` (regular/non-ephemeral, `!= 14/15`, matches
  the PWA constant). `createRumor` gains an optional `kind` (default 14 — message
  path unchanged); `wrapTypingGiftWrap` / `wrapGroupTypingGiftWrap` stamp it.
- **`channel.listen` inbound guard:** drop rumors whose kind is
  `NOSTR_KIND_TYPING_RUMOR` before envelope parsing — structurally, so the bot
  never enqueues a tick as a turn. Discriminating by kind (not content) means a
  genuine user message that literally says "stop" (kind-14) **is still answered**.

## Verification

- `wrapTypingGiftWrap` stamps the dedicated inner kind (not 14).
- A live typing tick (start + stop) is dropped — no turn, no reply published.
- typecheck ✓ · full suite **1754/1754** ✓.