### PR TITLE
Fix anonymous Pi tool progress in ACP clients

### DIFF
--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -296,10 +296,10 @@ export function renderPayload(req: HarnessRequest): string {
  * time, that's pi actually thinking — the indicator vanishing means the
  * model has gone silent (and may be wedged on a tool call).
  *
- * toolcall_* (pi ≥0.79; formerly tool_use_*) event types inside
- * assistantMessageEvent → `progress` so the channel layer flushes narration
- * into a bubble before the tool runs. thinking_delta + other event types →
- * `heartbeat`.
+ * tool_execution_start carries the useful tool name/args and is the primary
+ * progress signal. Nameless toolcall_* (pi ≥0.79; formerly tool_use_*) events
+ * inside assistantMessageEvent are only liveness noise, so they become
+ * `heartbeat` unless they carry a real tool name or useful args.
  *
  * Exported for testing.
  */
@@ -349,16 +349,17 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
   }
 
   if (typeof ame.type === "string") {
-    // toolcall_* assistantMessageEvent: the model has decided to call
-    // a tool — emit `progress` so the channel layer flushes narration
-    // into a bubble before the tool runs. Previously these were mapped
-    // to heartbeats, which kept the typing indicator alive but never
-    // triggered a bubble flush (defeating the purpose of PR #74).
-    //
-    // pi 0.79.x renamed these events `tool_use_*` → `toolcall_*`. Match
-    // both prefixes so narration surfaces across pi versions.
+    // Pi also emits assistantMessageEvent toolcall_* / tool_use_* records while
+    // streaming the assistant message. In practice these can be nameless
+    // internal deltas; surfacing those as progress creates stacks of anonymous
+    // "tool" rows in ACP clients. Keep them as liveness heartbeats unless the
+    // event itself carries enough detail to title a real tool call. The
+    // top-level tool_execution_start remains the canonical useful signal.
     if (ame.type.startsWith("toolcall") || ame.type.startsWith("tool_use")) {
-      return { type: "progress", note: "tool" };
+      const note = buildAssistantToolNote(ame);
+      return note
+        ? { type: "progress", note }
+        : { type: "heartbeat" };
     }
     // thinking_delta + anything else → heartbeat.
     // We intentionally do NOT include the content in the chunk (would leak
@@ -398,4 +399,59 @@ export function piActivity(parsed: unknown, chunk: HarnessChunk): HarnessActivit
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function buildAssistantToolNote(ame: Record<string, unknown>): string | undefined {
+  const partial = isObject(ame.partial) ? ame.partial : undefined;
+  const toolName = firstString(
+    ame.toolName,
+    ame.tool_name,
+    ame.name,
+    partial?.toolName,
+    partial?.tool_name,
+    partial?.name,
+  );
+  const args =
+    ame.args ??
+    ame.input ??
+    partial?.args ??
+    partial?.input ??
+    partial?.parameters;
+
+  if (toolName) return buildToolNote(toolName, args);
+  const detail = extractUsefulArgDetail(args);
+  if (detail) return `tool: ${detail}`;
+  return undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function extractUsefulArgDetail(args: unknown): string | undefined {
+  if (!isObject(args)) return undefined;
+  for (const key of [
+    "command",
+    "cmd",
+    "file_path",
+    "filePath",
+    "path",
+    "query",
+    "pattern",
+    "prompt",
+  ]) {
+    const value = args[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (Array.isArray(value)) {
+      const joined = value
+        .filter((item): item is string => typeof item === "string")
+        .join(" ")
+        .trim();
+      if (joined) return joined;
+    }
+  }
+  return undefined;
 }

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -138,7 +138,7 @@ describe("parsePiEvent", () => {
     expect(c).toEqual({ type: "heartbeat" });
   });
 
-  test("emits progress for toolcall_* / tool_use_* assistantMessageEvent (not heartbeat)", () => {
+  test("emits heartbeat for anonymous toolcall_* / tool_use_* assistantMessageEvent noise", () => {
     for (const ameType of [
       // pi 0.79.x names
       "toolcall_start",
@@ -155,8 +155,35 @@ describe("parsePiEvent", () => {
           assistantMessageEvent: { type: ameType, contentIndex: 0 },
           message: {},
         }),
-      ).toEqual({ type: "progress", note: "tool" });
+      ).toEqual({ type: "heartbeat" });
     }
+  });
+
+  test("emits progress for named assistantMessageEvent tool calls", () => {
+    const c = parsePiEvent({
+      type: "message_update",
+      assistantMessageEvent: {
+        type: "toolcall_start",
+        contentIndex: 0,
+        toolName: "bash",
+        args: { command: "npm test" },
+      },
+      message: {},
+    });
+    expect(c).toEqual({ type: "progress", note: "bash: npm test" });
+  });
+
+  test("emits progress for assistantMessageEvent tool calls with useful args but no name", () => {
+    const c = parsePiEvent({
+      type: "message_update",
+      assistantMessageEvent: {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        partial: { input: { file_path: "/tmp/example.txt" } },
+      },
+      message: {},
+    });
+    expect(c).toEqual({ type: "progress", note: "tool: /tmp/example.txt" });
   });
 
   test("emits heartbeat for text_start / text_end / thinking_start / thinking_end markers", () => {


### PR DESCRIPTION
## Summary

This fixes the anonymous `tool` rows Pi can produce in ACP clients such as Zed. Pi emits both top-level `tool_execution_start` events, which carry the useful tool name and arguments, and lower-level assistant `toolcall_*` / `tool_use_*` stream events, which can be nameless internal deltas.

## Description

The Pi adapter now treats nameless assistant toolcall stream events as heartbeat-only liveness signals instead of ACP progress updates. If one of those assistant events does carry a real tool name or useful argument detail, it can still surface a meaningful progress title. The top-level `tool_execution_start` path remains the canonical source for visible tool progress, so useful titles like `bash: npm test` are preserved.

## Why

Zed renders phantombot progress chunks as tool call rows. Mapping Pi's anonymous internal toolcall deltas to progress created repeated bare `tool` rows, which made Pi look noisier and less polished than Claude despite the real tool execution event arriving separately with better metadata.

## Testing

- `~/.bun/bin/bun test tests/harnesses-pi.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bun run typecheck`
- `~/.bun/bin/bun test`
- `PATH="$HOME/.bun/bin:$PATH" bun run build`