### PR TITLE
fix(harness): put the harness binary's own dir on the child PATH so nvm shebangs resolve under systemd

### DIFF
--- a/src/lib/processGroup.ts
+++ b/src/lib/processGroup.ts
@@ -36,8 +36,56 @@
  * cmd in `setsid` and accept the spawn-time race.
  */
 
+import { dirname } from "node:path";
 import type { Subprocess, SpawnOptions } from "bun";
 import { log } from "./logger.ts";
+
+/**
+ * Ensure an absolute executable's OWN directory is on the child's PATH.
+ *
+ * Why this exists (the systemd-vs-Zed harness bug, 2026-07-01): the harness
+ * CLIs (`pi`, and any nvm/fnm/volta-installed `claude`/`gemini`/`codex`) are
+ * Node scripts whose shebang is `#!/usr/bin/env node`. The kernel honors the
+ * shebang by re-invoking `env node`, which needs `node` ON PATH. An
+ * nvm-installed `pi` lives at `~/.nvm/versions/node/<v>/bin/pi` with `node`
+ * RIGHT NEXT TO IT in the same directory — but that directory is only on PATH
+ * inside an interactive/desktop session.
+ *
+ * phantombot's `harnessSearchPath()` is smart enough to FIND `pi` on the
+ * filesystem and spawn it by absolute path, so the spawn itself succeeds. But
+ * the child inherits phantombot's PATH, and under systemd that PATH is narrow
+ * (no nvm dir) — so the shebang's `env node` fails and the process dies with
+ * exit 127. Under Zed / VS Code the extension host inherits the desktop
+ * session's PATH (nvm already on it), so `node` is found and it Just Works —
+ * which is exactly why the same bot answers from the editor but not Telegram.
+ *
+ * The fix is transport-agnostic: prepend the executable's own directory to the
+ * child PATH so `env node` resolves the interpreter sitting beside the binary,
+ * no matter how narrow the parent PATH is. This makes systemd behave like the
+ * editor without tampering with the user's shell/systemd config.
+ *
+ * Only acts when `bin` is ABSOLUTE — a bare command name (`"pi"`) is being
+ * resolved via the existing PATH, and `dirname("pi")` is `"."`, which we must
+ * never inject. Returns a FRESH object (never mutates the caller's env, which
+ * may be the shared `process.env` reference) and is a no-op when the directory
+ * is already present.
+ *
+ * Exported for testing.
+ */
+export function withCommandDirOnPath(
+  bin: string,
+  env: Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  if (!bin.startsWith("/")) return env;
+  const binDir = dirname(bin);
+  const currentPath = env.PATH ?? "";
+  const entries = currentPath.split(":");
+  if (entries.includes(binDir)) return env;
+  return {
+    ...env,
+    PATH: currentPath ? `${binDir}:${currentPath}` : binDir,
+  };
+}
 
 /**
  * Spawn a subprocess as the leader of a fresh process group/session.
@@ -57,8 +105,17 @@ export function spawnInNewSession<
   if (cmd.length === 0) {
     throw new Error("spawnInNewSession: cmd cannot be empty");
   }
+  // Make the child's PATH self-sufficient for a `#!/usr/bin/env node` shebang:
+  // prepend the binary's own directory (where the matching `node` lives for an
+  // nvm/fnm/volta install) so the interpreter resolves under a narrow systemd
+  // PATH exactly as it does under a desktop/editor session. See
+  // withCommandDirOnPath for the full rationale (exit-127 bug, 2026-07-01).
+  const env = opts.env
+    ? withCommandDirOnPath(cmd[0]!, opts.env as Record<string, string | undefined>)
+    : opts.env;
   return Bun.spawn(cmd, {
     ...opts,
+    env,
     // Undocumented but stable Bun option (maps to POSIX_SPAWN_SETSID).
     // See module docstring for why this beats a `setsid` wrapper.
     detached: true,

--- a/tests/lib-processGroup.test.ts
+++ b/tests/lib-processGroup.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   killProcessGroup,
   spawnInNewSession,
+  withCommandDirOnPath,
 } from "../src/lib/processGroup.ts";
 
 function isAlive(pid: number): boolean {
@@ -190,6 +191,81 @@ describe("killProcessGroup — SIGTERM→SIGKILL escalation", () => {
     // sit out the full 5s grace.
     expect(elapsedMs).toBeLessThan(500);
     expect(isAlive(proc.pid!)).toBe(false);
+  });
+});
+
+describe("withCommandDirOnPath — shebang interpreter resolution", () => {
+  test("prepends an absolute binary's own dir to PATH", () => {
+    const out = withCommandDirOnPath("/opt/nvm/versions/node/v24/bin/pi", {
+      PATH: "/usr/bin:/bin",
+    });
+    expect(out.PATH).toBe("/opt/nvm/versions/node/v24/bin:/usr/bin:/bin");
+  });
+
+  test("is a no-op when the dir is already on PATH", () => {
+    const env = { PATH: "/opt/nvm/versions/node/v24/bin:/usr/bin" };
+    const out = withCommandDirOnPath("/opt/nvm/versions/node/v24/bin/pi", env);
+    // Same object reference back — nothing to change, no needless clone churn.
+    expect(out).toBe(env);
+    expect(out.PATH).toBe("/opt/nvm/versions/node/v24/bin:/usr/bin");
+  });
+
+  test("handles an empty/absent PATH by seeding it with the bin dir", () => {
+    expect(withCommandDirOnPath("/opt/tools/bin/pi", {}).PATH).toBe(
+      "/opt/tools/bin",
+    );
+    expect(withCommandDirOnPath("/opt/tools/bin/pi", { PATH: "" }).PATH).toBe(
+      "/opt/tools/bin",
+    );
+  });
+
+  test("leaves a bare (PATH-resolved) command name untouched", () => {
+    const env = { PATH: "/usr/bin:/bin" };
+    const out = withCommandDirOnPath("pi", env);
+    // A relative command is resolved via the existing PATH; dirname("pi")
+    // is ".", which must NEVER be injected.
+    expect(out).toBe(env);
+    expect(out.PATH).toBe("/usr/bin:/bin");
+  });
+
+  test("never mutates the caller's env object", () => {
+    const env = { PATH: "/usr/bin" };
+    const out = withCommandDirOnPath("/opt/bin/pi", env);
+    expect(out).not.toBe(env);
+    expect(env.PATH).toBe("/usr/bin"); // original untouched
+  });
+});
+
+describe("spawnInNewSession — shebang interpreter on a narrow PATH", () => {
+  test("a #!/usr/bin/env node script beside its interpreter runs with a stripped PATH", async () => {
+    // Reproduce the systemd exit-127 bug in miniature: put a Node-shebang
+    // script in the SAME dir as a `node` symlink, then spawn it with a PATH
+    // that does NOT contain that dir. Without the fix, `env node` fails
+    // (exit 127); with it, the binary's own dir is prepended and node
+    // resolves.
+    const dir = `/tmp/pg-shebang-${process.pid}-${Date.now()}`;
+    await Bun.$`mkdir -p ${dir}`.quiet();
+    // Symlink a real node interpreter next to the script (mirrors nvm layout).
+    await Bun.$`ln -sf ${process.execPath} ${dir}/node`.quiet();
+    const script = `${dir}/fakepi`;
+    await Bun.write(script, "#!/usr/bin/env node\nprocess.stdout.write('ok');\n");
+    await Bun.$`chmod +x ${script}`.quiet();
+
+    const proc = spawnInNewSession([script], {
+      // Deliberately narrow PATH — the bin dir is NOT here.
+      env: { PATH: "/usr/bin:/bin" },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    trackedPids.push(proc.pid!);
+    const out = await new Response(proc.stdout as ReadableStream).text();
+    const code = await proc.exited;
+
+    expect(code).toBe(0); // not 127
+    expect(out).toBe("ok");
+
+    await Bun.$`rm -rf ${dir}`.quiet();
   });
 });
 


### PR DESCRIPTION
## Why

When **Pi is the primary harness**, the bots answer from the **Zed / VS Code extension** but go **silent on Telegram and phantombot's own channels**. Lena (on the Pi) answers; Claude-primary works everywhere. That asymmetry is the tell.

### Root cause: shebang interpreter + narrow systemd PATH

`pi` (and any nvm/fnm/volta-installed `claude`/`gemini`/`codex`) is a **Node script** with a `#!/usr/bin/env node` shebang:

```
~/.nvm/versions/node/v24.14.1/bin/pi → ../lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js
```

Executing it makes the kernel re-invoke `env node`, which needs **`node` on PATH**. For an nvm install, `node` sits **in the same directory as the binary** — a directory that's on PATH inside a desktop/editor session but **not** under systemd's narrow unit PATH.

phantombot's `harnessSearchPath()` is already smart enough to **find** `pi` on the filesystem and spawn it by absolute path, so the spawn succeeds. But the child inherits phantombot's PATH, and under systemd that PATH has no nvm dir → the shebang's `env node` fails → **exit 127** → no reply. Even the recovery reply fails (it retries the same harness).

- **Why Zed/VS Code works:** the extension host inherits the desktop session's PATH, where nvm has already put `node`. The child `pi` inherits that richer PATH and the shebang resolves.
- **Why Telegram doesn't:** systemd launches phantombot with a stripped PATH (no `node`), so the shebang breaks.

Evidence from the journal when Pi was primary:
```
orchestrator: trying harness  harnessId:pi  attempt:1  of:1
telegram: turn failed  error:"pi exited with code 127"
```

## The fix

At the **single choke point all four harnesses share** — `spawnInNewSession` — prepend the resolved binary's own directory to the child PATH (`withCommandDirOnPath`). `node` lives right beside the binary, so the shebang resolves regardless of how narrow the parent PATH is. This makes systemd behave like the editor **without tampering with the user's shell config or the systemd unit**.

Safe by construction:
- **No-op for bare command names** (`"pi"`) — those resolve via the existing PATH, and `dirname("pi")` is `"."`, which we never inject.
- **No-op when the dir is already present** (returns the same env ref).
- **Never mutates the caller's env** — returns a fresh object (the caller often passes the shared `process.env` reference).
- Applies to all four harnesses + any future one for free.

## Tests

- Unit coverage for `withCommandDirOnPath`: absolute vs bare, empty/absent PATH, already-present, no-mutation.
- **Real-subprocess repro of the bug**: a `#!/usr/bin/env node` script placed beside a `node` symlink, spawned under a stripped `PATH=/usr/bin:/bin`, asserts **exit 0 (not 127)** and correct output.

All 11 processGroup tests + 122 harness tests pass; `tsc --noEmit` clean.
