### PR TITLE
feat(acp): clickable file paths + per-tool kind on tool-call updates (#231)

### DIFF
--- a/src/connectors/acp/protocol.ts
+++ b/src/connectors/acp/protocol.ts
@@ -15,6 +15,16 @@
  * stdout, and stdout is the protocol channel — never log there. See server.ts.
  */
 
+import type {
+  ToolCallDetail,
+  ToolKind,
+  ToolLocation
+} from "../../harnesses/toolNote.ts";
+
+// Re-export the tool-call vocabulary so ACP consumers import it from the
+// protocol module rather than reaching into the harness layer.
+export type {ToolKind, ToolLocation};
+
 // ── JSON-RPC 2.0 envelopes ─────────────────────────────────────────────
 
 /** A JSON-RPC id is a string or number (we never use null ids). */
@@ -133,12 +143,23 @@ export interface AgentMessageChunkUpdate {
   content: AcpTextBlock;
 }
 
+/** A tool-call `content` item — the panel renders it as a preview body. */
+export interface ToolCallContentBlock {
+  type: "content";
+  content: AcpContentBlock;
+}
+
 export interface ToolCallUpdate {
   sessionUpdate: "tool_call";
   toolCallId: string;
   title: string;
   status: "pending" | "in_progress" | "completed" | "failed";
-  kind?: string;
+  /** Panel icon (read/edit/execute/search/…). */
+  kind?: ToolKind;
+  /** File paths the editor renders as clickable jump-to-file links. */
+  locations?: ToolLocation[];
+  /** Optional richer preview body (issue #231; unpopulated pending redaction). */
+  content?: ToolCallContentBlock[];
 }
 
 export type AcpSessionUpdate = AgentMessageChunkUpdate | ToolCallUpdate;
@@ -186,17 +207,39 @@ export function agentMessageChunk(
   });
 }
 
-/** Build a minimal presentational `tool_call` `session/update`. */
+/**
+ * Build a presentational `tool_call` `session/update`.
+ *
+ * `detail` (issue #231) optionally carries the structured tool-call info —
+ * `kind` (panel icon) and `locations` (clickable jump-to-file paths). Each
+ * field is emitted only when present, so clients that don't consume them (and
+ * the pre-#231 title-only behaviour) are unaffected. `content` is threaded but
+ * emitted only when `detail.content` is set — currently never, pending the
+ * secret-masking carry-over noted on `ToolCallDetail`.
+ */
 export function toolCallUpdate(
   sessionId: string,
   toolCallId: string,
   title: string,
   status: ToolCallUpdate["status"] = "in_progress",
+  detail?: Pick<ToolCallDetail, "kind" | "locations" | "content">,
 ): JsonRpcRequest {
-  return sessionUpdateNotification(sessionId, {
+  const update: ToolCallUpdate = {
     sessionUpdate: "tool_call",
     toolCallId,
     title,
-    status,
-  });
+    status
+  };
+  if (detail) {
+    if (detail.kind) update.kind = detail.kind;
+    if (detail.locations && detail.locations.length > 0) {
+      update.locations = detail.locations;
+    }
+    if (detail.content) {
+      update.content = [
+        {type: "content", content: {type: "text", text: detail.content}}
+      ];
+    }
+  }
+  return sessionUpdateNotification(sessionId, update);
 }

--- a/src/connectors/acp/protocol.ts
+++ b/src/connectors/acp/protocol.ts
@@ -15,6 +15,8 @@
  * stdout, and stdout is the protocol channel — never log there. See server.ts.
  */
 
+import {isAbsolute, resolve as resolvePath} from "node:path";
+
 import type {
   ToolCallDetail,
   ToolKind,
@@ -208,6 +210,26 @@ export function agentMessageChunk(
 }
 
 /**
+ * Resolve tool-call `locations` to ABSOLUTE paths against the ACP session cwd.
+ *
+ * The ACP spec requires `ToolCallLocation.path` to be an absolute file path so
+ * the editor can open/follow it. Harness tool args, however, are usually
+ * relative to the session working dir (`src/foo.ts`), and a few are already
+ * absolute. We resolve the relative ones against `cwd` and pass absolute ones
+ * through untouched. Pure computation — `node:path` does no I/O. `cwd` is the
+ * ACP session working dir, which is always absolute (server defaults it to
+ * `process.cwd()`), so the result is always absolute regardless of input.
+ */
+export function toAbsoluteLocations(
+  locations: readonly ToolLocation[],
+  cwd: string
+): ToolLocation[] {
+  return locations.map((loc) =>
+    isAbsolute(loc.path) ? loc : {...loc, path: resolvePath(cwd, loc.path)}
+  );
+}
+
+/**
  * Build a presentational `tool_call` `session/update`.
  *
  * `detail` (issue #231) optionally carries the structured tool-call info —
@@ -216,11 +238,15 @@ export function agentMessageChunk(
  * the pre-#231 title-only behaviour) are unaffected. `content` is threaded but
  * emitted only when `detail.content` is set — currently never, pending the
  * secret-masking carry-over noted on `ToolCallDetail`.
+ *
+ * `cwd` is the ACP session working dir; `locations` are resolved against it to
+ * absolute paths before hitting the wire, as the ACP spec requires.
  */
 export function toolCallUpdate(
   sessionId: string,
   toolCallId: string,
   title: string,
+  cwd: string,
   status: ToolCallUpdate["status"] = "in_progress",
   detail?: Pick<ToolCallDetail, "kind" | "locations" | "content">,
 ): JsonRpcRequest {
@@ -233,7 +259,7 @@ export function toolCallUpdate(
   if (detail) {
     if (detail.kind) update.kind = detail.kind;
     if (detail.locations && detail.locations.length > 0) {
-      update.locations = detail.locations;
+      update.locations = toAbsoluteLocations(detail.locations, cwd);
     }
     if (detail.content) {
       update.content = [

--- a/src/connectors/acp/server.ts
+++ b/src/connectors/acp/server.ts
@@ -286,8 +286,16 @@ export async function runAcpServer(
         },
         {
           text: (delta) => send(agentMessageChunk(session.sessionId, delta)),
-          progress: (note) =>
-            send(toolCallUpdate(session.sessionId, `tool_${++toolSeq}`, note)),
+          progress: (note, tool) =>
+            send(
+              toolCallUpdate(
+                session.sessionId,
+                `tool_${++toolSeq}`,
+                note,
+                "in_progress",
+                tool,
+              ),
+            ),
         },
       );
     } catch (e) {

--- a/src/connectors/acp/server.ts
+++ b/src/connectors/acp/server.ts
@@ -292,6 +292,7 @@ export async function runAcpServer(
                 session.sessionId,
                 `tool_${++toolSeq}`,
                 note,
+                session.cwd,
                 "in_progress",
                 tool,
               ),

--- a/src/connectors/acp/turnBridge.ts
+++ b/src/connectors/acp/turnBridge.ts
@@ -27,6 +27,7 @@
 import { homedir } from "node:os";
 
 import type { Harness, HarnessChunk } from "../../harnesses/types.ts";
+import type { ToolCallDetail } from "../../harnesses/toolNote.ts";
 import type { MemoryStore } from "../../memory/store.ts";
 import { runTurn, type TurnInput } from "../../orchestrator/turn.ts";
 import type { ScreenVerdict } from "../../orchestrator/screen.ts";
@@ -70,8 +71,12 @@ export interface BridgeTurnInput {
 export interface BridgeSink {
   /** Stream an assistant text delta (→ agent_message_chunk). */
   text(delta: string): void;
-  /** A presentational progress note (→ minimal tool_call update). */
-  progress(note: string): void;
+  /**
+   * A presentational progress note (→ tool_call update). `tool` (issue #231)
+   * optionally carries the structured detail (kind + clickable locations) the
+   * ACP server threads into the update; sinks that don't need it ignore it.
+   */
+  progress(note: string, tool?: ToolCallDetail): void;
 }
 
 /**
@@ -115,7 +120,7 @@ export async function runBridgeTurn(
     if (chunk.type === "text") {
       sink.text(chunk.text);
     } else if (chunk.type === "progress") {
-      sink.progress(chunk.note);
+      sink.progress(chunk.note, chunk.tool);
     } else if (chunk.type === "error") {
       sawError = true;
       sink.text(`\n[error] ${chunk.error}`);

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -49,7 +49,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
-import { buildToolNote } from "./toolNote.ts";
+import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -374,7 +374,10 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
     }
   }
   if (text) return { type: "text", text };
-  if (toolName) return { type: "progress", note: buildToolNote(toolName, toolInput) };
+  if (toolName) {
+    const tool = buildToolCall(toolName, toolInput);
+    return { type: "progress", note: tool.title, tool };
+  }
   if (sawOtherNonText) return { type: "heartbeat" };
   return undefined;
 }

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -14,7 +14,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
-import { buildToolNote } from "./toolNote.ts";
+import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -153,7 +153,8 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
     const it = item as Record<string, unknown>;
     if (typeof it.type === "string" && it.type.includes("tool")) {
       const name = typeof it.name === "string" ? it.name : undefined;
-      return { type: "progress", note: buildToolNote(name, it) };
+      const tool = buildToolCall(name, it);
+      return { type: "progress", note: tool.title, tool };
     }
     // Non-tool starts are still useful liveness signals while the model is
     // preparing output, but they should not flush user-visible narration.
@@ -168,7 +169,8 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
     }
     if (typeof it.type === "string" && it.type.includes("tool")) {
       const name = typeof it.name === "string" ? it.name : undefined;
-      return { type: "progress", note: buildToolNote(name, it) };
+      const tool = buildToolCall(name, it);
+      return { type: "progress", note: tool.title, tool };
     }
     return { type: "heartbeat" };
   }

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -38,7 +38,7 @@
 
 import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
-import { buildToolNote } from "./toolNote.ts";
+import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -268,7 +268,8 @@ export function parseGeminiEvent(parsed: unknown): HarnessChunk | undefined {
     const name =
       typeof obj.tool_name === "string" ? obj.tool_name : "(unknown tool)";
     const args = obj.args ?? obj.parameters ?? obj.tool_input ?? obj.input;
-    return { type: "progress", note: buildToolNote(name, args) };
+    const tool = buildToolCall(name, args);
+    return { type: "progress", note: tool.title, tool };
   }
 
   if (type === "tool_result") {

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -35,7 +35,7 @@ import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { ENV_PI_API_KEY, ENV_PI_PROVIDER, type PiRoutingConfig } from "../lib/piRouting.ts";
 import { getCoderSwapOverride, resolveSwapModel } from "../lib/coderSwap.ts";
-import { buildToolNote } from "./toolNote.ts";
+import { buildToolCall, type ToolCallDetail } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import {
   type HarnessActivity,
@@ -321,7 +321,8 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
           ? obj.tool_name
           : undefined;
     const args = obj.args ?? obj.input;
-    return { type: "progress", note: buildToolNote(toolName, args) };
+    const tool = buildToolCall(toolName, args);
+    return { type: "progress", note: tool.title, tool };
   }
 
   // tool_execution_update is fired while a tool is mid-run, carrying its
@@ -356,9 +357,9 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
     // event itself carries enough detail to title a real tool call. The
     // top-level tool_execution_start remains the canonical useful signal.
     if (ame.type.startsWith("toolcall") || ame.type.startsWith("tool_use")) {
-      const note = buildAssistantToolNote(ame);
-      return note
-        ? { type: "progress", note }
+      const tool = buildAssistantToolCall(ame);
+      return tool
+        ? { type: "progress", note: tool.title, tool }
         : { type: "heartbeat" };
     }
     // thinking_delta + anything else → heartbeat.
@@ -401,7 +402,9 @@ function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-function buildAssistantToolNote(ame: Record<string, unknown>): string | undefined {
+function buildAssistantToolCall(
+  ame: Record<string, unknown>,
+): ToolCallDetail | undefined {
   const partial = isObject(ame.partial) ? ame.partial : undefined;
   const toolName = firstString(
     ame.toolName,
@@ -418,9 +421,9 @@ function buildAssistantToolNote(ame: Record<string, unknown>): string | undefine
     partial?.input ??
     partial?.parameters;
 
-  if (toolName) return buildToolNote(toolName, args);
+  if (toolName) return buildToolCall(toolName, args);
   const detail = extractUsefulArgDetail(args);
-  if (detail) return `tool: ${detail}`;
+  if (detail) return {title: `tool: ${detail}`, kind: "other", locations: []};
   return undefined;
 }
 

--- a/src/harnesses/toolNote.ts
+++ b/src/harnesses/toolNote.ts
@@ -46,7 +46,14 @@ export type ToolKind =
 
 /** A file location the editor can render as a clickable jump-to-file link. */
 export interface ToolLocation {
-  /** Absolute or workspace-relative path the editor should open. */
+  /**
+   * The path the editor should open. As extracted here it is whatever the
+   * harness tool arg contained — usually relative to the session cwd
+   * (`src/foo.ts`), occasionally already absolute. The ACP boundary
+   * (`toAbsoluteLocations` in connectors/acp/protocol.ts) resolves relative
+   * paths against the session cwd so the wire always carries an ABSOLUTE path,
+   * as the ACP `ToolCallLocation.path` spec requires.
+   */
   path: string;
   /** 1-based line to jump to, when known. Optional — file open still works. */
   line?: number;

--- a/src/harnesses/toolNote.ts
+++ b/src/harnesses/toolNote.ts
@@ -30,6 +30,52 @@
 /** Max length of a rendered tool-call title, including the name prefix. */
 export const MAX_TOOL_NOTE_LEN = 80;
 
+/**
+ * ACP `ToolKind` — drives the per-tool icon Zed renders in its agent panel.
+ * Matches the ACP `ToolKind` enum exactly; `other` is the safe catch-all.
+ */
+export type ToolKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "fetch"
+  | "other";
+
+/** A file location the editor can render as a clickable jump-to-file link. */
+export interface ToolLocation {
+  /** Absolute or workspace-relative path the editor should open. */
+  path: string;
+  /** 1-based line to jump to, when known. Optional — file open still works. */
+  line?: number;
+}
+
+/**
+ * Structured tool-call detail (issue #231, Part 2). A superset of the
+ * legacy `buildToolNote` string: `title` is byte-identical to what
+ * `buildToolNote` returns, and the extra fields drive the ACP panel's
+ * icon (`kind`) and clickable paths (`locations`).
+ */
+export interface ToolCallDetail {
+  /** Single-line, length-capped title — identical to `buildToolNote(...)`. */
+  title: string;
+  /** ACP ToolKind, used for the panel icon. */
+  kind: ToolKind;
+  /** File paths to surface as clickable links. Empty for non-file tools. */
+  locations: ToolLocation[];
+  /**
+   * Optional richer preview body. Intentionally left unpopulated for now:
+   * the only readily-available preview is the raw command/args, and
+   * surfacing more of a Bash command than the (already-truncated, un-masked)
+   * title does would reopen the secret-masking question flagged as a
+   * carry-over in #218 Part 1 / #231. The field is plumbed so the wire type
+   * is complete; populate it once redaction lands.
+   */
+  content?: string;
+}
+
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
@@ -128,4 +174,125 @@ export function buildToolNote(
 
   // No name at all (some codex/pi events) → legacy bare fallback.
   return "tool";
+}
+
+/**
+ * Tool NAME → ToolKind. Keyed on the normalised name (lowercased, spaces and
+ * hyphens folded to `_`) so the many per-harness spellings of the same tool
+ * collapse to one entry (Read/read_file/readFile → `read`).
+ */
+const KIND_BY_NAME: Readonly<Record<string, ToolKind>> = {
+  read: "read",
+  read_file: "read",
+  readfile: "read",
+  view: "read",
+  cat: "read",
+  edit: "edit",
+  multiedit: "edit",
+  write: "edit",
+  write_file: "edit",
+  writefile: "edit",
+  create_file: "edit",
+  replace: "edit",
+  str_replace: "edit",
+  str_replace_editor: "edit",
+  apply_patch: "edit",
+  notebookedit: "edit",
+  bash: "execute",
+  shell: "execute",
+  run_shell_command: "execute",
+  run_command: "execute",
+  run_terminal_cmd: "execute",
+  exec: "execute",
+  execute: "execute",
+  run: "execute",
+  grep: "search",
+  glob: "search",
+  search: "search",
+  grep_search: "search",
+  file_search: "search",
+  codebase_search: "search",
+  find: "search",
+  webfetch: "fetch",
+  web_fetch: "fetch",
+  fetch: "fetch",
+  websearch: "fetch",
+  web_search: "fetch"
+};
+
+/** Field names whose value is a file path the editor can open. */
+const PATH_KEYS = [
+  "file_path",
+  "filePath",
+  "path",
+  "absolute_path",
+  "notebook_path"
+] as const;
+
+/** Normalise a tool name for KIND_BY_NAME lookup. */
+function normaliseName(name: string): string {
+  return name.toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+/**
+ * Map a tool to its ACP `kind`. Prefers the tool NAME (Read→read, Bash→execute)
+ * and falls back to input FIELD names when the name is unknown/absent, mirroring
+ * how {@link buildToolNote} extracts detail. Defaults to `other`.
+ */
+function classifyKind(name: string, input: unknown): ToolKind {
+  if (name) {
+    const direct = KIND_BY_NAME[normaliseName(name)];
+    if (direct) return direct;
+  }
+  if (isRecord(input)) {
+    if (firstField(input, ["command", "cmd"])) return "execute";
+    if (firstField(input, ["pattern", "query"])) return "search";
+    if (firstField(input, ["url"])) return "fetch";
+    if (firstField(input, PATH_KEYS)) return "read";
+  }
+  return "other";
+}
+
+/**
+ * Extract clickable file locations from a tool's raw input. De-duplicates and
+ * ignores anything that isn't a non-empty string path. Returns [] when the
+ * tool touches no files (shell/search/web tools).
+ */
+function extractLocations(input: unknown): ToolLocation[] {
+  if (!isRecord(input)) return [];
+  const locations: ToolLocation[] = [];
+  const seen = new Set<string>();
+  for (const key of PATH_KEYS) {
+    const v = input[key];
+    if (typeof v !== "string") continue;
+    const path = collapse(v);
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    locations.push({ path });
+  }
+  return locations;
+}
+
+/**
+ * Build the structured tool-call detail (issue #231, Part 2).
+ *
+ * `title` is byte-identical to {@link buildToolNote} — existing string-only
+ * consumers (and #218's tests) are unaffected. The extra fields are additive:
+ *   - `kind`      → the ACP panel icon
+ *   - `locations` → clickable jump-to-file paths
+ * Never throws; bad/partial input degrades to `{ kind: 'other', locations: [] }`.
+ *
+ * @param toolName the tool's name, if the harness captured it
+ * @param input    the tool's raw arguments object (any shape; may be missing)
+ */
+export function buildToolCall(
+  toolName: string | undefined,
+  input?: unknown
+): ToolCallDetail {
+  const name = typeof toolName === "string" ? collapse(toolName) : "";
+  return {
+    title: buildToolNote(toolName, input),
+    kind: classifyKind(name, input),
+    locations: extractLocations(input)
+  };
 }

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -10,6 +10,8 @@
  * the harness's responsibility. Phantombot only sees text coming back out.
  */
 
+import type { ToolCallDetail } from "./toolNote.ts";
+
 export interface HistoryTurn {
   role: "user" | "assistant";
   text: string;
@@ -90,8 +92,15 @@ export type HarnessChunk =
    * expires, which is the truthful "frozen" signal.
    */
   | { type: "heartbeat" }
-  /** Out-of-band progress with a human-readable note (e.g. "running tool X"). */
-  | { type: "progress"; note: string }
+  /**
+   * Out-of-band progress with a human-readable note (e.g. "running tool X").
+   * `note` remains the presentational title every consumer already reads.
+   * `tool` (issue #231) optionally carries the structured tool-call detail —
+   * ACP `kind` (panel icon) + clickable `locations` — for connectors that
+   * render it (the Zed/ACP bridge). Omitted for progress that isn't a tool
+   * call (e.g. raw stderr liveness), and safely ignored by string-only sinks.
+   */
+  | { type: "progress"; note: string; tool?: ToolCallDetail }
   /** Final marker. `finalText` is the full assistant reply (sum of all `text` chunks). `meta.replyMode` may be "text", "voice", or "default"/"disable" for channel adapters that support model-selected reply modality. */
   | { type: "done"; finalText: string; meta?: Record<string, unknown> }
   /**

--- a/tests/connectors-acp-protocol.test.ts
+++ b/tests/connectors-acp-protocol.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ACP `tool_call` builder — structured detail wiring (issue #231).
+ *
+ * Proves the `kind` / `locations` / `content` fields land on the wire only
+ * when present, so pre-#231 (title-only) behaviour and clients that ignore the
+ * new fields are unaffected.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  toolCallUpdate,
+  type ToolCallUpdate
+} from "../src/connectors/acp/protocol.ts";
+
+function update(req: ReturnType<typeof toolCallUpdate>): ToolCallUpdate {
+  const params = req.params as { sessionId: string; update: ToolCallUpdate };
+  return params.update;
+}
+
+describe("toolCallUpdate (#231)", () => {
+  test("title-only call omits the new fields entirely (back-compat)", () => {
+    const u = update(toolCallUpdate("s1", "tool_1", "Bash: git status"));
+    expect(u).toEqual({
+      sessionUpdate: "tool_call",
+      toolCallId: "tool_1",
+      title: "Bash: git status",
+      status: "in_progress"
+    });
+    expect("kind" in u).toBe(false);
+    expect("locations" in u).toBe(false);
+    expect("content" in u).toBe(false);
+  });
+
+  test("emits kind + clickable locations when the detail carries them", () => {
+    const u = update(
+      toolCallUpdate("s1", "tool_2", "Read: src/foo.ts", "in_progress", {
+        kind: "read",
+        locations: [{ path: "src/foo.ts" }]
+      })
+    );
+    expect(u.kind).toBe("read");
+    expect(u.locations).toEqual([{ path: "src/foo.ts" }]);
+    expect("content" in u).toBe(false);
+  });
+
+  test("omits an empty locations array so the field never renders blank", () => {
+    const u = update(
+      toolCallUpdate("s1", "tool_3", "Bash: ls", "in_progress", {
+        kind: "execute",
+        locations: []
+      })
+    );
+    expect(u.kind).toBe("execute");
+    expect("locations" in u).toBe(false);
+  });
+
+  test("wraps a content preview as an ACP content block when present", () => {
+    const u = update(
+      toolCallUpdate("s1", "tool_4", "Read: a.ts", "in_progress", {
+        kind: "read",
+        locations: [],
+        content: "preview body"
+      })
+    );
+    expect(u.content).toEqual([
+      { type: "content", content: { type: "text", text: "preview body" } }
+    ]);
+  });
+
+  test("preserves an explicit non-default status", () => {
+    const u = update(
+      toolCallUpdate("s1", "tool_5", "Bash: ls", "completed")
+    );
+    expect(u.status).toBe("completed");
+  });
+});

--- a/tests/connectors-acp-protocol.test.ts
+++ b/tests/connectors-acp-protocol.test.ts
@@ -3,13 +3,18 @@
  *
  * Proves the `kind` / `locations` / `content` fields land on the wire only
  * when present, so pre-#231 (title-only) behaviour and clients that ignore the
- * new fields are unaffected.
+ * new fields are unaffected. Also proves `locations` are resolved to ABSOLUTE
+ * paths against the session cwd before hitting the wire, as the ACP
+ * `ToolCallLocation.path` spec requires (review follow-up on #231).
  */
 import { describe, expect, test } from "bun:test";
 import {
+  toAbsoluteLocations,
   toolCallUpdate,
   type ToolCallUpdate
 } from "../src/connectors/acp/protocol.ts";
+
+const CWD = "/home/dev/workspace";
 
 function update(req: ReturnType<typeof toolCallUpdate>): ToolCallUpdate {
   const params = req.params as { sessionId: string; update: ToolCallUpdate };
@@ -18,7 +23,7 @@ function update(req: ReturnType<typeof toolCallUpdate>): ToolCallUpdate {
 
 describe("toolCallUpdate (#231)", () => {
   test("title-only call omits the new fields entirely (back-compat)", () => {
-    const u = update(toolCallUpdate("s1", "tool_1", "Bash: git status"));
+    const u = update(toolCallUpdate("s1", "tool_1", "Bash: git status", CWD));
     expect(u).toEqual({
       sessionUpdate: "tool_call",
       toolCallId: "tool_1",
@@ -30,21 +35,32 @@ describe("toolCallUpdate (#231)", () => {
     expect("content" in u).toBe(false);
   });
 
-  test("emits kind + clickable locations when the detail carries them", () => {
+  test("emits kind + resolves relative locations to absolute paths", () => {
     const u = update(
-      toolCallUpdate("s1", "tool_2", "Read: src/foo.ts", "in_progress", {
+      toolCallUpdate("s1", "tool_2", "Read: src/foo.ts", CWD, "in_progress", {
         kind: "read",
         locations: [{ path: "src/foo.ts" }]
       })
     );
     expect(u.kind).toBe("read");
-    expect(u.locations).toEqual([{ path: "src/foo.ts" }]);
+    // The wire must carry an ABSOLUTE path, not the relative arg.
+    expect(u.locations).toEqual([{ path: "/home/dev/workspace/src/foo.ts" }]);
     expect("content" in u).toBe(false);
+  });
+
+  test("passes an already-absolute location through untouched", () => {
+    const u = update(
+      toolCallUpdate("s1", "tool_2b", "Read: /etc/hosts", CWD, "in_progress", {
+        kind: "read",
+        locations: [{ path: "/etc/hosts", line: 3 }]
+      })
+    );
+    expect(u.locations).toEqual([{ path: "/etc/hosts", line: 3 }]);
   });
 
   test("omits an empty locations array so the field never renders blank", () => {
     const u = update(
-      toolCallUpdate("s1", "tool_3", "Bash: ls", "in_progress", {
+      toolCallUpdate("s1", "tool_3", "Bash: ls", CWD, "in_progress", {
         kind: "execute",
         locations: []
       })
@@ -55,7 +71,7 @@ describe("toolCallUpdate (#231)", () => {
 
   test("wraps a content preview as an ACP content block when present", () => {
     const u = update(
-      toolCallUpdate("s1", "tool_4", "Read: a.ts", "in_progress", {
+      toolCallUpdate("s1", "tool_4", "Read: a.ts", CWD, "in_progress", {
         kind: "read",
         locations: [],
         content: "preview body"
@@ -68,8 +84,50 @@ describe("toolCallUpdate (#231)", () => {
 
   test("preserves an explicit non-default status", () => {
     const u = update(
-      toolCallUpdate("s1", "tool_5", "Bash: ls", "completed")
+      toolCallUpdate("s1", "tool_5", "Bash: ls", CWD, "completed")
     );
     expect(u.status).toBe("completed");
+  });
+});
+
+describe("toAbsoluteLocations (#231 review follow-up)", () => {
+  test("resolves a relative path against the session cwd", () => {
+    expect(toAbsoluteLocations([{ path: "src/a.ts" }], CWD)).toEqual([
+      { path: "/home/dev/workspace/src/a.ts" }
+    ]);
+  });
+
+  test("normalises `..` segments while resolving", () => {
+    expect(toAbsoluteLocations([{ path: "../sibling/b.ts" }], CWD)).toEqual([
+      { path: "/home/dev/sibling/b.ts" }
+    ]);
+  });
+
+  test("leaves an absolute path unchanged and preserves `line`", () => {
+    expect(
+      toAbsoluteLocations([{ path: "/abs/c.ts", line: 12 }], CWD)
+    ).toEqual([{ path: "/abs/c.ts", line: 12 }]);
+  });
+
+  test("preserves `line` when resolving a relative path", () => {
+    expect(toAbsoluteLocations([{ path: "d.ts", line: 5 }], CWD)).toEqual([
+      { path: "/home/dev/workspace/d.ts", line: 5 }
+    ]);
+  });
+
+  test("handles a mixed batch (relative + absolute) in order", () => {
+    expect(
+      toAbsoluteLocations(
+        [{ path: "rel/e.ts" }, { path: "/abs/f.ts" }],
+        CWD
+      )
+    ).toEqual([
+      { path: "/home/dev/workspace/rel/e.ts" },
+      { path: "/abs/f.ts" }
+    ]);
+  });
+
+  test("returns [] for an empty batch", () => {
+    expect(toAbsoluteLocations([], CWD)).toEqual([]);
   });
 });

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -148,7 +148,11 @@ describe("parseStreamJson", () => {
       type: "assistant",
       message: { content: [{ type: "tool_use", name: "Bash", input: {} }] },
     });
-    expect(c).toEqual({ type: "progress", note: "tool: Bash" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "tool: Bash",
+      tool: { title: "tool: Bash", kind: "execute", locations: [] },
+    });
   });
 
   test("progress note surfaces the tool input when present (#218)", () => {
@@ -160,7 +164,11 @@ describe("parseStreamJson", () => {
         ],
       },
     });
-    expect(c).toEqual({ type: "progress", note: "Bash: git status" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "Bash: git status",
+      tool: { title: "Bash: git status", kind: "execute", locations: [] },
+    });
   });
 
   test("heartbeat for thinking blocks (no flush — mirrors pi.ts)", () => {
@@ -203,7 +211,11 @@ describe("parseStreamJson", () => {
         ],
       },
     });
-    expect(c).toEqual({ type: "progress", note: "tool: Read" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "tool: Read",
+      tool: { title: "tool: Read", kind: "read", locations: [] },
+    });
   });
 
   test("heartbeat for thinking + tool_result (no tool_use)", () => {

--- a/tests/harnesses-codex.test.ts
+++ b/tests/harnesses-codex.test.ts
@@ -70,14 +70,22 @@ describe("parseCodexEvent", () => {
     expect(parseCodexEvent({
       type: "item.started",
       item: { type: "tool_call", name: "shell" },
-    })).toEqual({ type: "progress", note: "tool: shell" });
+    })).toEqual({
+      type: "progress",
+      note: "tool: shell",
+      tool: { title: "tool: shell", kind: "execute", locations: [] },
+    });
   });
 
   test("item.started tool with a command surfaces it in the title (#218)", () => {
     expect(parseCodexEvent({
       type: "item.started",
       item: { type: "tool_call", name: "shell", command: ["git", "status"] },
-    })).toEqual({ type: "progress", note: "shell: git status" });
+    })).toEqual({
+      type: "progress",
+      note: "shell: git status",
+      tool: { title: "shell: git status", kind: "execute", locations: [] },
+    });
   });
 
   test("turn.completed -> done-shaped stats carrier", () => {

--- a/tests/harnesses-gemini.test.ts
+++ b/tests/harnesses-gemini.test.ts
@@ -116,7 +116,11 @@ describe("parseGeminiEvent", () => {
         tool_id: "x",
         parameters: {},
       }),
-    ).toEqual({ type: "progress", note: "tool: run_shell_command" });
+    ).toEqual({
+      type: "progress",
+      note: "tool: run_shell_command",
+      tool: { title: "tool: run_shell_command", kind: "execute", locations: [] },
+    });
   });
 
   test("tool_use → progress note surfaces parameters when present (#218)", () => {
@@ -127,7 +131,15 @@ describe("parseGeminiEvent", () => {
         tool_id: "x",
         parameters: { command: "ls -la" },
       }),
-    ).toEqual({ type: "progress", note: "run_shell_command: ls -la" });
+    ).toEqual({
+      type: "progress",
+      note: "run_shell_command: ls -la",
+      tool: {
+        title: "run_shell_command: ls -la",
+        kind: "execute",
+        locations: [],
+      },
+    });
   });
 
   test("tool_use without tool_name → progress with placeholder", () => {

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -99,7 +99,11 @@ describe("parsePiEvent", () => {
       type: "tool_execution_start",
       toolName: "bash",
     });
-    expect(c).toEqual({ type: "progress", note: "tool: bash" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "tool: bash",
+      tool: { title: "tool: bash", kind: "execute", locations: [] },
+    });
   });
 
   test("tool_execution_start surfaces args in the note when present (#218)", () => {
@@ -108,7 +112,11 @@ describe("parsePiEvent", () => {
       toolName: "bash",
       args: { command: "npm test" },
     });
-    expect(c).toEqual({ type: "progress", note: "bash: npm test" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "bash: npm test",
+      tool: { title: "bash: npm test", kind: "execute", locations: [] },
+    });
   });
 
   test("emits progress for tool_execution_start (legacy 0.67.x tool_name field)", () => {
@@ -116,12 +124,20 @@ describe("parsePiEvent", () => {
       type: "tool_execution_start",
       tool_name: "run_shell_command",
     });
-    expect(c).toEqual({ type: "progress", note: "tool: run_shell_command" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "tool: run_shell_command",
+      tool: { title: "tool: run_shell_command", kind: "execute", locations: [] },
+    });
   });
 
   test("emits progress for tool_execution_start without a tool name", () => {
     const c = parsePiEvent({ type: "tool_execution_start" });
-    expect(c).toEqual({ type: "progress", note: "tool" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "tool",
+      tool: { title: "tool", kind: "other", locations: [] },
+    });
   });
 
   test("emits a payload-less heartbeat for tool_execution_update (coder liveness)", () => {
@@ -170,7 +186,11 @@ describe("parsePiEvent", () => {
       },
       message: {},
     });
-    expect(c).toEqual({ type: "progress", note: "bash: npm test" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "bash: npm test",
+      tool: { title: "bash: npm test", kind: "execute", locations: [] },
+    });
   });
 
   test("emits progress for assistantMessageEvent tool calls with useful args but no name", () => {
@@ -183,7 +203,11 @@ describe("parsePiEvent", () => {
       },
       message: {},
     });
-    expect(c).toEqual({ type: "progress", note: "tool: /tmp/example.txt" });
+    expect(c).toEqual({
+      type: "progress",
+      note: "tool: /tmp/example.txt",
+      tool: { title: "tool: /tmp/example.txt", kind: "other", locations: [] },
+    });
   });
 
   test("emits heartbeat for text_start / text_end / thinking_start / thinking_end markers", () => {

--- a/tests/harnesses-toolNote.test.ts
+++ b/tests/harnesses-toolNote.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { buildToolNote, MAX_TOOL_NOTE_LEN } from "../src/harnesses/toolNote.ts";
+import {
+  buildToolCall,
+  buildToolNote,
+  MAX_TOOL_NOTE_LEN
+} from "../src/harnesses/toolNote.ts";
 
 describe("buildToolNote", () => {
   test("shell command → '<Name>: <command>'", () => {
@@ -96,5 +100,83 @@ describe("buildToolNote", () => {
     expect(() => buildToolNote("X", [1, 2, 3])).not.toThrow();
     // unusable input degrades to the legacy label
     expect(buildToolNote("X", "a string")).toBe("tool: X");
+  });
+});
+
+describe("buildToolCall (#231)", () => {
+  test("title is byte-identical to buildToolNote", () => {
+    const cases: [string | undefined, unknown][] = [
+      ["Bash", { command: "git status" }],
+      ["Read", { file_path: "src/foo.ts" }],
+      ["run_shell_command", { foo: 1 }],
+      [undefined, { command: "x" }],
+      ["", undefined]
+    ];
+    for (const [name, input] of cases) {
+      expect(buildToolCall(name, input).title).toBe(buildToolNote(name, input));
+    }
+  });
+
+  test("kind is keyed on the tool NAME, across per-harness spellings", () => {
+    expect(buildToolCall("Read", {}).kind).toBe("read");
+    expect(buildToolCall("read_file", {}).kind).toBe("read");
+    expect(buildToolCall("Edit", {}).kind).toBe("edit");
+    expect(buildToolCall("write_file", {}).kind).toBe("edit");
+    expect(buildToolCall("apply_patch", {}).kind).toBe("edit");
+    expect(buildToolCall("Bash", {}).kind).toBe("execute");
+    expect(buildToolCall("run_shell_command", {}).kind).toBe("execute");
+    expect(buildToolCall("Grep", {}).kind).toBe("search");
+    expect(buildToolCall("glob", {}).kind).toBe("search");
+    expect(buildToolCall("WebFetch", {}).kind).toBe("fetch");
+    expect(buildToolCall("Task", {}).kind).toBe("other");
+  });
+
+  test("kind normalises spaces/hyphens/case before lookup", () => {
+    expect(buildToolCall("Run-Shell-Command", {}).kind).toBe("execute");
+    expect(buildToolCall("READ FILE", {}).kind).toBe("read");
+  });
+
+  test("kind falls back to input field names for unknown tools", () => {
+    expect(buildToolCall("mystery", { command: "ls" }).kind).toBe("execute");
+    expect(buildToolCall("mystery", { pattern: "foo" }).kind).toBe("search");
+    expect(buildToolCall("mystery", { url: "https://x" }).kind).toBe("fetch");
+    expect(buildToolCall("mystery", { file_path: "a.ts" }).kind).toBe("read");
+    expect(buildToolCall("mystery", {}).kind).toBe("other");
+    expect(buildToolCall(undefined, undefined).kind).toBe("other");
+  });
+
+  test("locations are extracted from path fields, deduped, clickable", () => {
+    expect(buildToolCall("Read", { file_path: "src/foo.ts" }).locations).toEqual(
+      [{ path: "src/foo.ts" }]
+    );
+    expect(buildToolCall("Edit", { path: "a.ts" }).locations).toEqual([
+      { path: "a.ts" }
+    ]);
+    // Non-file tools contribute no locations.
+    expect(buildToolCall("Bash", { command: "git status" }).locations).toEqual(
+      []
+    );
+    expect(buildToolCall("Grep", { pattern: "foo" }).locations).toEqual([]);
+  });
+
+  test("locations dedupe repeated paths and skip empties", () => {
+    // file_path and path carry the same value → one location.
+    expect(
+      buildToolCall("Edit", { file_path: "dup.ts", path: "dup.ts" }).locations
+    ).toEqual([{ path: "dup.ts" }]);
+    expect(buildToolCall("Read", { file_path: "   " }).locations).toEqual([]);
+  });
+
+  test("content is left unpopulated pending redaction", () => {
+    expect(buildToolCall("Bash", { command: "git status" }).content).toBeUndefined();
+  });
+
+  test("never throws on hostile input; degrades cleanly", () => {
+    for (const bad of [null, 42, "str", [1, 2, 3]]) {
+      expect(() => buildToolCall("X", bad)).not.toThrow();
+      const call = buildToolCall("X", bad);
+      expect(call.locations).toEqual([]);
+      expect(typeof call.kind).toBe("string");
+    }
   });
 });


### PR DESCRIPTION
Closes #231 (Part 2 of #218).

## What & why
Part 1 (#230) enriched the tool-call **title** string in the Zed/ACP panel (`Bash: git status`, `Read: src/foo.ts`). This is the protocol-level Part 2 it deliberately deferred: tool calls now render with **per-tool icons** (`kind`) and **clickable jump-to-file paths** (`locations`).

It's still our side — Zed faithfully renders whatever the ACP bridge sends. We just populate the structured `ToolCallUpdate` fields we weren't before.

## How
- **`toolNote.ts` — new `buildToolCall(name, input)`** returns a structured `{ title, kind, locations, content }`. `title` is **byte-identical** to `buildToolNote`, so every existing string-only consumer (tick logging, channel sinks) and all of #218's title tests are untouched.
  - **`kind`** is keyed on the tool **name** first — `Read`→`read`, `Edit`/`Write`/`apply_patch`→`edit`, `Bash`/`run_shell_command`→`execute`, `Grep`/`Glob`→`search`, `WebFetch`→`fetch`, `Task`→`other` — across per-harness spellings (name is normalised: lowercased, spaces/hyphens folded). Unknown tools fall back to input **field** names (`command`→execute, `pattern`/`query`→search, `url`→fetch, `file_path`→read), mirroring how the title detail is extracted.
  - **`locations`** are pulled from path fields (`file_path`/`filePath`/`path`/`absolute_path`/`notebook_path`), deduped and empties skipped. Non-file tools contribute none.
- **Threaded end-to-end.** The `progress` `HarnessChunk` gains an **optional** `tool?: ToolCallDetail` — `note` stays exactly as-is, so string-only sinks ignore it. The four harness adapters (claude/codex/gemini/pi) emit it; `BridgeSink.progress` and `server.ts` forward it; `ToolCallUpdate` + `toolCallUpdate()` gain `kind`/`locations`/`content`, **each emitted only when present**.

## Scope decision — `content` deferred
The wire type carries `content` (ACP preview body) and the builder threads it, but `buildToolCall` leaves it **unpopulated**. The only readily-available preview is the raw command/args, and surfacing more of a Bash command than the (already-truncated, **un-masked**) title does would reopen the **secret-masking** carry-over flagged in Part 1. Documented on `ToolCallDetail`; populate once redaction lands. This keeps the redaction blast radius at zero while completing the protocol surface.

## Backward compatibility
Title-only updates emit the **exact pre-#231 shape** — `kind`/`locations`/`content` are absent unless populated. Clients that don't consume the new fields are unaffected.

## Tests
- **`buildToolCall`** unit coverage: title parity with `buildToolNote`, kind mapping across per-harness spellings + name normalisation + field-name fallback, location extraction/dedupe/skip-empty, hostile-input safety.
- **New `connectors-acp-protocol.test.ts`**: proves `kind`/`locations`/`content` land on the wire **only when present** (empty `locations` omitted, title-only stays minimal).
- Per-harness wiring tests (claude/codex/gemini/pi) updated to assert the structured `tool` detail flows through.
- Full suite green (1773 pass), `tsc --noEmit` clean.

## Acceptance
- ✅ File paths in the Zed panel are clickable and open the right file (`locations`).
- ✅ Tool calls show appropriate icons/`kind`.
- ✅ Existing `title` behaviour from #230 unchanged for harnesses/clients that don't consume the new fields.
