### PR TITLE
feat(chattiness): /chattiness quiet-mode toggle for narration bubbles (#243)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ phantombot/
 │   │   ├── telegram.ts       # backward-compat barrel re-export (preserves the old public surface)
 │   │   ├── telegramFormat.ts # markdown → Telegram HTML
 │   │   ├── streamSegmenter.ts # splits a streaming reply into Telegram-sized segments (fence/table/list-aware)
-│   │   └── commands.ts       # slash-command handling (/stop, /update, …)
+│   │   └── commands.ts       # slash-command handling (/stop, /update, /coder, /chattiness, …)
 │   ├── cli/                  # one file per Citty subcommand
 │   │   ├── index.ts          # dispatcher; subcommand registration list lives here
 │   │   ├── run.ts            # the long-running listener
@@ -115,6 +115,7 @@ phantombot/
 │   │   └── codex.ts          # Bun.spawn `codex …` (OpenAI Codex CLI harness)
 │   └── lib/
 │       ├── logger.ts io.ts configWriter.ts envFile.ts format.ts
+│       ├── coderSwap.ts chattiness.ts  # per-conversation overrides: coding-brain swap + progress-bubble on/off (JSON state under xdgStateHome)
 │       ├── threatJudge.ts    # tool-less untrusted-input judge (see "Security perimeter")
 │       ├── redact.ts         # secret redaction for log lines + task_runs audit table
 │       ├── platform.ts       # cross-platform service-manager router (systemd ↔ launchd)
@@ -263,6 +264,8 @@ Every merged PR auto-releases `v1.0.<PR_NUMBER>`. The workflow at `.github/workf
 11. **Reply modality is mirror-input by default, with a per-message text override available.** `processChatMessage` in `src/channels/core/engine.ts` picks the wire format (sendMessage vs sendVoice) via `replyModalityOverride()` from `src/lib/audio.ts`: when the user's message (post-STT, so voice transcripts count) contains an explicit directive like *"reply in text"*, *"no voice"*, or *"send a voice note"*, that wins; otherwise modality mirrors input. The override is parsed by a small, deliberately conservative regex set — anchored on reply-verbs and unmistakable shorthand, no bare-noun matches ("text message to John" must not trigger). Voice is still capped by `ttsSupported(config)`: an override asking for voice when no TTS provider is configured degrades to text gracefully, same as the original no-TTS fallback. If you extend the regex set, add cases to `replyModalityOverride` in `tests/lib-audio.test.ts` AND to the three end-to-end scenarios in `tests/channels-telegram.test.ts` (voice-in→text, text-in→voice, text-in→voice-without-TTS).
 
 12. **`GITHUB_TOKEN` for `phantombot update` isn't always safe to send.** GitHub App installation tokens are scoped to a single org's repos; using one against the public `phantomyard/phantombot` releases endpoint returns 401 even though the endpoint is anonymously reachable. `findLatestRelease` in `src/lib/githubReleases.ts` therefore retries once *without* the auth header on 401/403 before failing, and the final error mentions org-scoping explicitly. If you add another auth'd GitHub API call (e.g. for changelog fetch, asset metadata, etc.), reuse the `buildHeaders(withAuth)` helper and replicate the unauth-retry path — otherwise users with org-scoped tokens hit a dead end on what should be a public read. See issue #115 / PR #120.
+
+13. **The narration/streaming loop is DUPLICATED across the two chat channels — gate both.** `src/channels/core/engine.ts` (Telegram) and `src/channels/phantomchat/server.ts` (PhantomChat) each carry their own near-identical `flushNarration` + segment-send state machine; PhantomChat *mirrors* engine.ts rather than calling into it. Any change to how interim progress bubbles are emitted (the `/chattiness` gate is the current example — a `resolveNarrationEnabled()` check at the top of both `flushNarration`s) must be applied in **both** files or half of it silently doesn't work. Both sites carry a `TODO(dedup)` breadcrumb. Scope is Telegram + PhantomChat only — the editor (ACP) surface is deliberately left untouched. Per-conversation overrides live in `src/lib/chattiness.ts` (JSON under `xdgStateHome`, mirroring `coderSwap.ts`). See issue #243.
 
 ## Process for updating this file
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ overwrites stale BotFather commands. The supported commands are:
 | `/harness` | List or switch the active harness |
 | `/update` | Install the latest phantombot release |
 | `/restart` | Restart the phantombot service |
+| `/coder` | Force the coding brain on for this chat (`off` / `default` to revert) |
+| `/chattiness` | Show or hide progress bubbles in this chat (`on` / `off` / `<on\|off> default`) |
 | `/help` | Show the command list |
 
 Unknown slash commands fall through to the harness so personas can define
@@ -345,7 +347,7 @@ their own conventions.
 
 ### Reply Pacing
 
-Telegram replies are shaped for phone chats:
+Telegram and PhantomChat replies are shaped for phone chats:
 
 - Progress narration is coalesced instead of sent once per tool call.
 - Final replies are split into readable bubbles.
@@ -361,6 +363,31 @@ bubble_max_sentences = 4
 bubble_max_chars = 700
 bubble_delay_ms = 800
 voice_max_sentences = 3
+```
+
+### Chattiness (quiet mode)
+
+While a phantom works, it streams interim **progress bubbles** — the running
+"checking your calendar…" commentary that fills the silence before a tool call.
+Some people like the play-by-play; others just want the answer. `/chattiness`
+toggles those interim bubbles **per conversation** (the final reply and any
+errors always come through either way):
+
+- `/chattiness off` — quiet: no progress bubbles, just the final reply.
+- `/chattiness on` — show the progress bubbles (the default).
+- `/chattiness default` — clear this chat's setting; follow the standing default.
+- `/chattiness off default` (or `on default`) — also write the standing default
+  to `config.toml` so **new** chats start that way.
+
+Scoped to Telegram + PhantomChat (voice and the CLI never emit these bubbles).
+The editor (Zed/VS Code) surface follows the config default only.
+
+Set the standing default directly in config — `true` (show bubbles) is the
+default, so nothing changes unless you opt out:
+
+```toml
+# Top-level. Set false to make phantombot quiet-by-default everywhere.
+chattiness = true
 ```
 
 ## PhantomChat

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,6 +75,21 @@ phantombot ask "what's on my calendar?"
   → exit 0 / 1 / 2
 ```
 
+### Progress narration in the chat channels
+
+`progress` chunks (and the model text streamed *before* a tool call) become
+interim "progress bubbles" — the running "checking your calendar…" commentary.
+This is emitted by a per-channel streaming state machine, and that machine is
+**duplicated**: `src/channels/core/engine.ts` (Telegram) and
+`src/channels/phantomchat/server.ts` (PhantomChat) each carry their own
+`flushNarration`. Whether those bubbles appear is gated **per conversation** by
+`/chattiness` (`src/lib/chattiness.ts`): a per-conversation override wins, else
+the `chattiness` config default decides. The gate lives in **both**
+`flushNarration`s — the final reply and error paths are never gated. Scope is
+Telegram + PhantomChat only; the editor (ACP) surface is deliberately left
+untouched. Any change here touches both channel files (see the `TODO(dedup)`
+breadcrumbs) — a future refactor should centralize the loop.
+
 ## Memory subsystem
 
 Memory is two layers — see the README `## Memory` section for the operator-facing

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -32,6 +32,11 @@ import {
   applyCoderSwapRequest,
   normalizeCoderSwapRequest,
 } from "../lib/coderSwap.ts";
+import {
+  applyChattinessRequest,
+  normalizeChattinessRequest,
+} from "../lib/chattiness.ts";
+import { setIn, updateConfigToml } from "../lib/configWriter.ts";
 import type { MemoryStore } from "../memory/store.ts";
 import { DEFAULT_HISTORY_LIMIT } from "../orchestrator/turn.ts";
 import { VERSION } from "../version.ts";
@@ -138,6 +143,10 @@ export const TELEGRAM_BOT_COMMANDS: Array<{
     command: "coder",
     description: "Force the coding brain on for this chat (off | default to revert)",
   },
+  {
+    command: "chattiness",
+    description: "Show/hide progress bubbles here (on | off | <on|off> default)",
+  },
   { command: "help", description: "Show this command list" },
 ];
 
@@ -221,6 +230,8 @@ export async function handleSlashCommand(
     case "/coder":
       // Bare `/coder` forces on; `/coder off|default` is also accepted.
       return await handleCoderSwap(arg || "on", ctx);
+    case "/chattiness":
+      return await handleChattiness(arg, ctx);
     case "/start":
     case "/help":
       return { reply: HELP };
@@ -347,6 +358,103 @@ async function handleCoderSwap(
       : request === "off"
         ? "coding brain: forced OFF for this chat — no auto-swap, stays on the primary"
         : "coding brain: reset to auto — the scorer decides each turn";
+  return { reply };
+}
+
+/**
+ * /chattiness [on|off|default] — per-conversation toggle for the interim
+ * "progress narration" bubbles ("checking your calendar…") that stream while a
+ * turn runs. Scoped to Telegram + PhantomChat; the final reply and error paths
+ * are never affected.
+ *
+ *   on              → show interim bubbles in this chat
+ *   off             → quiet: no interim bubbles, just the final reply
+ *   default         → clear this chat's override; defer to the config default
+ *   <on|off> default → ALSO write `chattiness` in config.toml as the standing
+ *                       default (and clear this chat's override so it follows it)
+ *
+ * Persistent (no idle expiry). The per-conversation override wins over the
+ * config default; absent an override, `config.chattiness` decides.
+ */
+async function handleChattiness(
+  arg: string,
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  const usage =
+    "usage: /chattiness on|off|default\n" +
+    "  on              — show progress bubbles in this chat\n" +
+    "  off             — quiet: just the final reply, no interim bubbles\n" +
+    "  default         — clear this chat's setting; use the standing default\n" +
+    "  <on|off> default — also make on/off the standing default everywhere";
+
+  const tokens = arg.toLowerCase().split(/\s+/).filter((t) => t.length > 0);
+  // Bare `/chattiness` → show the options rather than silently clearing.
+  if (tokens.length === 0) return { reply: usage };
+  const setDefault = tokens.length > 1 && tokens[tokens.length - 1] === "default";
+  // With the trailing "default" modifier, the leading token is the value to
+  // persist globally; without it, the whole (single) token is the request.
+  const head = setDefault ? tokens[0]! : (tokens[0] ?? "");
+  const request = normalizeChattinessRequest(head);
+
+  // `<on|off> default` must resolve to a concrete on/off to write to config.
+  if (setDefault && request !== "on" && request !== "off") {
+    return { reply: usage };
+  }
+  if (!setDefault && !request) {
+    return { reply: usage };
+  }
+
+  // Writing the standing default: flip config.toml, then clear this chat's
+  // per-conversation override so it follows the new default (consistent with
+  // what the user just asked for right here).
+  if (setDefault) {
+    const enable = request === "on";
+    if (!ctx.config) {
+      return {
+        reply:
+          "can't set the default: channel didn't pass config to the dispatcher",
+      };
+    }
+    await updateConfigToml(ctx.config.configPath, (c) => {
+      setIn(c, ["chattiness"], enable);
+    });
+    await applyChattinessRequest({
+      persona: ctx.persona,
+      conversation: ctx.conversation,
+      request: "default",
+    });
+    log.info("commands: /chattiness set default", {
+      chatId: ctx.chatId,
+      persona: ctx.persona,
+      conversation: ctx.conversation,
+      enable,
+    });
+    return {
+      reply: enable
+        ? "chattiness default: ON everywhere — new chats show progress bubbles (this chat follows the default now)"
+        : "chattiness default: OFF everywhere — new chats stay quiet (this chat follows the default now)",
+    };
+  }
+
+  // Per-conversation sticky toggle (or clear).
+  await applyChattinessRequest({
+    persona: ctx.persona,
+    conversation: ctx.conversation,
+    request: request!,
+  });
+  log.info("commands: /chattiness", {
+    chatId: ctx.chatId,
+    persona: ctx.persona,
+    conversation: ctx.conversation,
+    request,
+  });
+
+  const reply =
+    request === "on"
+      ? "chattiness: ON for this chat — you'll see progress bubbles while I work"
+      : request === "off"
+        ? "chattiness: OFF for this chat — I'll work quietly and just send the final reply"
+        : "chattiness: reset to the standing default for this chat";
   return { reply };
 }
 

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -418,6 +418,12 @@ async function handleChattiness(
     await updateConfigToml(ctx.config.configPath, (c) => {
       setIn(c, ["chattiness"], enable);
     });
+    // Keep the live Config in sync with what we just wrote to disk. Without
+    // this, the running process keeps resolving against the old default until
+    // a restart/reload — and since we also clear this chat's override below,
+    // this chat (and every override-less chat) would silently keep the old
+    // behavior despite the reply saying the default changed.
+    ctx.config.chattiness = enable;
     await applyChattinessRequest({
       persona: ctx.persona,
       conversation: ctx.conversation,

--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -20,6 +20,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 
 import {
+  DEFAULT_CHATTINESS,
   DEFAULT_TELEGRAM_STREAMING,
   type Config,
 } from "../../config.ts";
@@ -43,6 +44,7 @@ import {
 import { DEFAULT_STT_TIMEOUT_MS } from "../../lib/voice.ts";
 import type { WriteSink } from "../../lib/io.ts";
 import { log } from "../../lib/logger.ts";
+import { resolveNarrationEnabled } from "../../lib/chattiness.ts";
 import type { ServiceControl } from "../../lib/systemd.ts";
 import type { MemoryStore } from "../../memory/store.ts";
 import { runTurn } from "../../orchestrator/turn.ts";
@@ -1004,11 +1006,28 @@ async function processChatMessage(
     finalCandidateSentChars = 0;
   };
 
+  // /chattiness gate: does this conversation want interim progress bubbles?
+  // Per-conversation override wins; absent, the config default decides. Resolved
+  // once per turn — a mid-turn toggle takes effect on the next message, matching
+  // the sticky semantics. Suppresses ONLY narration; the final reply and error
+  // paths are untouched.
+  //
+  // TODO(dedup): this narration streaming loop is MIRRORED in
+  // src/channels/phantomchat/server.ts (its own flushNarration + sendBubble).
+  // The gate below is applied in BOTH files — keep them in sync until the two
+  // loops are centralized in a future refactor.
+  const narrationEnabled = await resolveNarrationEnabled({
+    persona: input.persona,
+    conversation: conversationKey,
+    configDefault: input.config.chattiness ?? DEFAULT_CHATTINESS,
+  });
+
   // Flush coalesced progress narration on a clock, not on every tool
   // boundary. Tool boundaries classify preceding text as narration; this
   // timer decides when, if ever, that narration becomes a progress bubble.
   const flushNarration = async (force = false) => {
     if (willReplyWithVoice) return;
+    if (!narrationEnabled) return;
     if (narrationBuffer.trim().length === 0) return;
     const now = Date.now();
     if (!force && now - lastNarrationFlushAt < streaming.narrationFlushMs) {

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -23,10 +23,11 @@
  */
 
 import type { Config } from "../../config.ts";
-import { DEFAULT_TELEGRAM_STREAMING } from "../../config.ts";
+import { DEFAULT_CHATTINESS, DEFAULT_TELEGRAM_STREAMING } from "../../config.ts";
 import type { Harness } from "../../harnesses/types.ts";
 import type { WriteSink } from "../../lib/io.ts";
 import { log } from "../../lib/logger.ts";
+import { resolveNarrationEnabled } from "../../lib/chattiness.ts";
 import type { MemoryStore } from "../../memory/store.ts";
 import { runTurn } from "../../orchestrator/turn.ts";
 import { makeRetriever } from "../../orchestrator/retrieval.ts";
@@ -762,11 +763,26 @@ export async function runPhantomchatServer(
       }
     };
 
+    // /chattiness gate: does this conversation want interim progress bubbles?
+    // Per-conversation override wins; absent, the config default decides.
+    // Suppresses ONLY narration — the final reply is untouched.
+    //
+    // TODO(dedup): this narration streaming loop MIRRORS
+    // src/channels/core/engine.ts (its own flushNarration + sendTextSegment).
+    // The gate below is applied in BOTH files — keep them in sync until the two
+    // loops are centralized in a future refactor.
+    const narrationEnabled = await resolveNarrationEnabled({
+      persona: input.persona,
+      conversation: conversationKey,
+      configDefault: input.config.chattiness ?? DEFAULT_CHATTINESS,
+    });
+
     // Flush coalesced progress narration on a clock (like core/engine.ts), not
     // on every tool boundary — tool boundaries classify preceding text as
     // narration; this decides when that text becomes a bubble. Driven by both
     // the typing interval below and the chunk boundaries in the loop.
     const flushNarration = async (force = false): Promise<void> => {
+      if (!narrationEnabled) return;
       if (narrationBuffer.trim().length === 0) return;
       const now = Date.now();
       if (!force && now - lastNarrationFlushAt < streaming.narrationFlushMs) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -204,6 +204,13 @@ export interface TelegramStreamingSettings {
   voiceMaxSentences: number;
 }
 
+/**
+ * Standing default for interim progress-narration bubbles when neither a
+ * per-conversation override nor a config value is set. ON so behaviour is
+ * unchanged for existing users. See lib/chattiness.ts.
+ */
+export const DEFAULT_CHATTINESS = true;
+
 export const DEFAULT_TELEGRAM_STREAMING: TelegramStreamingSettings = {
   narrationFlushMs: 4500,
   bubbleMaxSentences: 4,
@@ -269,6 +276,20 @@ export interface Config {
   };
 
   telegramStreaming?: TelegramStreamingSettings;
+
+  /**
+   * Standing default for interim "progress narration" bubbles in the chat
+   * channels (Telegram + PhantomChat). `true` = stream the running commentary
+   * ("checking your calendar…"); `false` = quiet, final reply only. A
+   * per-conversation `/chattiness` override wins over this default; the final
+   * reply and error paths are never affected either way. Defaults to `true` so
+   * behaviour is unchanged unless a user opts into quiet mode. Also gates the
+   * editor (ACP) surface's pre-tool narration — the config default only. See
+   * lib/chattiness.ts. Optional in the type (mirrors telegramStreaming?) so
+   * partial test fixtures need no update; loadConfig always sets it, and read
+   * sites default to `true` (DEFAULT_CHATTINESS) when absent.
+   */
+  chattiness?: boolean;
 
   embeddings: {
     /** "gemini" | "none". "none" = FTS5-only search. */
@@ -454,6 +475,14 @@ export async function loadConfig(): Promise<Config> {
     },
 
     telegramStreaming: buildTelegramStreamingConfig(tomlTelegram),
+
+    // Standing default for interim progress-narration bubbles. Defaults ON so
+    // nothing changes for existing users; a persona/host can flip it OFF here
+    // (or per-chat via /chattiness). Env override for scripted/test setups.
+    chattiness:
+      asBool(process.env.PHANTOMBOT_CHATTINESS) ??
+      asBool(toml.chattiness) ??
+      DEFAULT_CHATTINESS,
 
     embeddings: buildEmbeddingsConfig(tomlEmbeddings, tomlGemini),
 

--- a/src/lib/chattiness.ts
+++ b/src/lib/chattiness.ts
@@ -1,0 +1,185 @@
+/**
+ * Chattiness: a per-conversation toggle for the interim "progress narration"
+ * bubbles the chat channels stream while a turn is running.
+ *
+ * WHAT it controls
+ *   While a phantom works, text the model emits BEFORE a tool call ("checking
+ *   your calendar…") is classified as progress narration, buffered, and flushed
+ *   to the chat on a timer. Some users like that running commentary; others feel
+ *   spammed by it. Chattiness lets a conversation turn those interim bubbles OFF
+ *   without touching anything else — the FINAL answer always posts, and the
+ *   error paths are untouched (narration suppression never sees them).
+ *
+ * SCOPE (deliberate)
+ *   Telegram + PhantomChat only. Both channels stream narration through their
+ *   own mirrored `flushNarration` loop (src/channels/core/engine.ts and
+ *   src/channels/phantomchat/server.ts) — the gate lives in BOTH, keep them in
+ *   sync. CLI and voice never emit narration bubbles, so they're out of scope
+ *   for free. The editor (ACP) surface respects only the config DEFAULT, not the
+ *   per-conversation override (see connectors/acp).
+ *
+ * MODEL (mirrors coderSwap.ts's override store)
+ *   - `on`  → narration bubbles stream (the informative default).
+ *   - `off` → quiet: no interim bubbles, just the final reply.
+ *   - A per-conversation override is persistent (no TTL) and WINS over the
+ *     config default. Absence of an entry = "defer to the config default".
+ *   - `chattiness = true/false` in config.toml is the standing default when a
+ *     conversation has no override; `/chattiness <on|off> default` writes it.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { xdgStateHome } from "../config.ts";
+
+/** Persisted override. "default" is represented as the absence of an entry. */
+export type ChattinessMode = "on" | "off";
+export type ChattinessRequest = ChattinessMode | "default";
+
+/**
+ * Parse a free-text argument into a normalized request. Accepts a handful of
+ * friendly synonyms so `/chattiness quiet` or `/chattiness auto` just work.
+ * Returns undefined for anything unrecognized (caller shows usage).
+ */
+export function normalizeChattinessRequest(
+  value: unknown,
+): ChattinessRequest | undefined {
+  if (
+    value === "on" ||
+    value === "enable" ||
+    value === "enabled" ||
+    value === "loud" ||
+    value === "verbose"
+  )
+    return "on";
+  if (
+    value === "off" ||
+    value === "disable" ||
+    value === "disabled" ||
+    value === "quiet" ||
+    value === "silent" ||
+    value === "no"
+  )
+    return "off";
+  if (
+    value === "default" ||
+    value === "clear" ||
+    value === "auto" ||
+    value === "reset" ||
+    value === ""
+  )
+    return "default";
+  return undefined;
+}
+
+interface StoredOverride {
+  mode: ChattinessMode;
+  touchedAt: string;
+}
+
+type StoredOverrides = Record<string, StoredOverride>;
+
+export function chattinessStatePath(): string {
+  return (
+    process.env.PHANTOMBOT_CHATTINESS_STATE ??
+    join(xdgStateHome(), "phantombot", "chattiness-overrides.json")
+  );
+}
+
+function key(persona: string, conversation: string): string {
+  return `${persona} ${conversation}`;
+}
+
+async function load(path = chattinessStatePath()): Promise<StoredOverrides> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8"));
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as StoredOverrides)
+      : {};
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw e;
+  }
+}
+
+async function save(
+  state: StoredOverrides,
+  path = chattinessStatePath(),
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf8");
+}
+
+/** Read the persistent override for a conversation, or undefined (defer to default). */
+export async function getChattinessOverride(input: {
+  persona: string;
+  conversation: string;
+}): Promise<ChattinessMode | undefined> {
+  const state = await load();
+  return state[key(input.persona, input.conversation)]?.mode;
+}
+
+/** Force the override to "on" or "off" for a conversation. */
+export async function setChattinessOverride(input: {
+  persona: string;
+  conversation: string;
+  mode: ChattinessMode;
+  now?: Date;
+}): Promise<void> {
+  const path = chattinessStatePath();
+  const state = await load(path);
+  state[key(input.persona, input.conversation)] = {
+    mode: input.mode,
+    touchedAt: (input.now ?? new Date()).toISOString(),
+  };
+  await save(state, path);
+}
+
+/** Clear the override → conversation defers to the config default. */
+export async function clearChattinessOverride(input: {
+  persona: string;
+  conversation: string;
+}): Promise<void> {
+  const path = chattinessStatePath();
+  const state = await load(path);
+  delete state[key(input.persona, input.conversation)];
+  await save(state, path);
+}
+
+/** Apply a normalized request: "on"/"off" persist; "default" clears. */
+export async function applyChattinessRequest(input: {
+  persona: string;
+  conversation: string;
+  request: ChattinessRequest;
+  now?: Date;
+}): Promise<void> {
+  if (input.request === "default") {
+    await clearChattinessOverride(input);
+    return;
+  }
+  await setChattinessOverride({
+    persona: input.persona,
+    conversation: input.conversation,
+    mode: input.request,
+    now: input.now,
+  });
+}
+
+/**
+ * Resolve whether interim narration bubbles should be SHOWN for a conversation.
+ *
+ * Precedence: a per-conversation override wins; absent, fall back to the config
+ * default (`chattiness = true/false`). This is the single decision the two
+ * channel `flushNarration` loops consult before emitting a progress bubble.
+ */
+export async function resolveNarrationEnabled(input: {
+  persona: string;
+  conversation: string;
+  configDefault: boolean;
+}): Promise<boolean> {
+  const override = await getChattinessOverride({
+    persona: input.persona,
+    conversation: input.conversation,
+  });
+  if (override) return override === "on";
+  return input.configDefault;
+}

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -18,7 +18,10 @@ import {
 } from "../src/channels/commands.ts";
 import type { Harness, HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
 import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
-import { getChattinessOverride } from "../src/lib/chattiness.ts";
+import {
+  getChattinessOverride,
+  resolveNarrationEnabled,
+} from "../src/lib/chattiness.ts";
 import { getIn, readConfigToml } from "../src/lib/configWriter.ts";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -550,6 +553,37 @@ describe("/chattiness", () => {
     expect(r!.reply).toContain("ON everywhere");
     const toml = await readConfigToml(configPath);
     expect(getIn(toml, ["chattiness"])).toBe(true);
+  });
+
+  test("/chattiness off default updates the live config so override-less chats resolve to the new default immediately", async () => {
+    const configPath = join(dir, "config.toml");
+    // Start with the default ON, matching a fresh install.
+    const config = { configPath, chattiness: true } as unknown as import(
+      "../src/config.ts"
+    ).Config;
+    // Before the change, an override-less chat follows the ON default.
+    expect(
+      await resolveNarrationEnabled({
+        persona: "phantom",
+        conversation: "telegram:99",
+        configDefault: config.chattiness!,
+      }),
+    ).toBe(true);
+
+    const r = await handleSlashCommand("/chattiness off default", ctx({ config }));
+    expect(r!.reply).toContain("OFF everywhere");
+
+    // The live Config object was mutated in place — not just the file on disk.
+    expect(config.chattiness).toBe(false);
+    // So a *different*, override-less chat resolving against the same config
+    // object now goes quiet without any restart/reload.
+    expect(
+      await resolveNarrationEnabled({
+        persona: "phantom",
+        conversation: "telegram:99",
+        configDefault: config.chattiness!,
+      }),
+    ).toBe(false);
   });
 
   test("/chattiness <garbage> default is rejected with usage", async () => {

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -18,6 +18,11 @@ import {
 } from "../src/channels/commands.ts";
 import type { Harness, HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
 import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
+import { getChattinessOverride } from "../src/lib/chattiness.ts";
+import { getIn, readConfigToml } from "../src/lib/configWriter.ts";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 class StubHarness implements Harness {
   constructor(
@@ -478,6 +483,80 @@ describe("/restart", () => {
     const r = await handleSlashCommand("/restart", ctx());
     expect(r).not.toBeNull();
     expect(typeof r!.afterSend).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /chattiness
+// ---------------------------------------------------------------------------
+
+describe("/chattiness", () => {
+  const SAVED = process.env.PHANTOMBOT_CHATTINESS_STATE;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "phantombot-cmd-chattiness-"));
+    process.env.PHANTOMBOT_CHATTINESS_STATE = join(dir, "state.json");
+  });
+  afterEach(async () => {
+    if (SAVED === undefined) delete process.env.PHANTOMBOT_CHATTINESS_STATE;
+    else process.env.PHANTOMBOT_CHATTINESS_STATE = SAVED;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("bare /chattiness with no arg shows usage", async () => {
+    const r = await handleSlashCommand("/chattiness", ctx());
+    expect(r).not.toBeNull();
+    expect(r!.reply).toContain("usage:");
+  });
+
+  test("/chattiness off sets a per-conversation override", async () => {
+    const r = await handleSlashCommand("/chattiness off", ctx());
+    expect(r!.reply).toContain("OFF for this chat");
+    expect(await getChattinessOverride({ persona: "phantom", conversation: "telegram:42" })).toBe("off");
+  });
+
+  test("/chattiness on sets a per-conversation override", async () => {
+    const r = await handleSlashCommand("/chattiness on", ctx());
+    expect(r!.reply).toContain("ON for this chat");
+    expect(await getChattinessOverride({ persona: "phantom", conversation: "telegram:42" })).toBe("on");
+  });
+
+  test("/chattiness default clears the override", async () => {
+    await handleSlashCommand("/chattiness off", ctx());
+    const r = await handleSlashCommand("/chattiness default", ctx());
+    expect(r!.reply).toContain("standing default");
+    expect(await getChattinessOverride({ persona: "phantom", conversation: "telegram:42" })).toBeUndefined();
+  });
+
+  test("/chattiness off default writes config.toml and clears the override", async () => {
+    const configPath = join(dir, "config.toml");
+    const config = { configPath } as unknown as import("../src/config.ts").Config;
+    // Seed an override so we can prove `default` clears it while writing config.
+    await handleSlashCommand("/chattiness on", ctx({ config }));
+    const r = await handleSlashCommand("/chattiness off default", ctx({ config }));
+    expect(r!.reply).toContain("OFF everywhere");
+    // Config file got the standing default.
+    const toml = await readConfigToml(configPath);
+    expect(getIn(toml, ["chattiness"])).toBe(false);
+    // And this chat's override was cleared so it follows the new default.
+    expect(await getChattinessOverride({ persona: "phantom", conversation: "telegram:42" })).toBeUndefined();
+  });
+
+  test("/chattiness on default writes true to config.toml", async () => {
+    const configPath = join(dir, "config.toml");
+    const config = { configPath } as unknown as import("../src/config.ts").Config;
+    const r = await handleSlashCommand("/chattiness on default", ctx({ config }));
+    expect(r!.reply).toContain("ON everywhere");
+    const toml = await readConfigToml(configPath);
+    expect(getIn(toml, ["chattiness"])).toBe(true);
+  });
+
+  test("/chattiness <garbage> default is rejected with usage", async () => {
+    const configPath = join(dir, "config.toml");
+    const config = { configPath } as unknown as import("../src/config.ts").Config;
+    const r = await handleSlashCommand("/chattiness maybe default", ctx({ config }));
+    expect(r!.reply).toContain("usage:");
   });
 });
 

--- a/tests/lib-chattiness.test.ts
+++ b/tests/lib-chattiness.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the /chattiness per-conversation override store and the
+ * narration-enabled resolver (override wins; else config default).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applyChattinessRequest,
+  chattinessStatePath,
+  clearChattinessOverride,
+  getChattinessOverride,
+  normalizeChattinessRequest,
+  resolveNarrationEnabled,
+  setChattinessOverride,
+} from "../src/lib/chattiness.ts";
+
+describe("normalizeChattinessRequest", () => {
+  test("on + synonyms", () => {
+    expect(normalizeChattinessRequest("on")).toBe("on");
+    expect(normalizeChattinessRequest("loud")).toBe("on");
+    expect(normalizeChattinessRequest("verbose")).toBe("on");
+  });
+  test("off + synonyms", () => {
+    expect(normalizeChattinessRequest("off")).toBe("off");
+    expect(normalizeChattinessRequest("quiet")).toBe("off");
+    expect(normalizeChattinessRequest("silent")).toBe("off");
+  });
+  test("default + synonyms", () => {
+    expect(normalizeChattinessRequest("default")).toBe("default");
+    expect(normalizeChattinessRequest("auto")).toBe("default");
+    expect(normalizeChattinessRequest("clear")).toBe("default");
+    expect(normalizeChattinessRequest("")).toBe("default");
+  });
+  test("rejects unknown", () => {
+    expect(normalizeChattinessRequest("maybe")).toBeUndefined();
+  });
+});
+
+describe("override store", () => {
+  const SAVED = process.env.PHANTOMBOT_CHATTINESS_STATE;
+  let dir: string;
+  const who = { persona: "lena", conversation: "telegram:1" };
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "phantombot-chattiness-"));
+    process.env.PHANTOMBOT_CHATTINESS_STATE = join(dir, "state.json");
+  });
+  afterEach(async () => {
+    if (SAVED === undefined) delete process.env.PHANTOMBOT_CHATTINESS_STATE;
+    else process.env.PHANTOMBOT_CHATTINESS_STATE = SAVED;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("path honors the env override", () => {
+    expect(chattinessStatePath()).toBe(join(dir, "state.json"));
+  });
+
+  test("unset → undefined", async () => {
+    expect(await getChattinessOverride(who)).toBeUndefined();
+  });
+
+  test("set/get/clear round-trip", async () => {
+    await setChattinessOverride({ ...who, mode: "off" });
+    expect(await getChattinessOverride(who)).toBe("off");
+    await setChattinessOverride({ ...who, mode: "on" });
+    expect(await getChattinessOverride(who)).toBe("on");
+    await clearChattinessOverride(who);
+    expect(await getChattinessOverride(who)).toBeUndefined();
+  });
+
+  test("applyChattinessRequest: default clears", async () => {
+    await applyChattinessRequest({ ...who, request: "off" });
+    expect(await getChattinessOverride(who)).toBe("off");
+    await applyChattinessRequest({ ...who, request: "default" });
+    expect(await getChattinessOverride(who)).toBeUndefined();
+  });
+
+  test("overrides are scoped per persona+conversation", async () => {
+    await setChattinessOverride({ ...who, mode: "off" });
+    expect(
+      await getChattinessOverride({ persona: "kai", conversation: "telegram:1" }),
+    ).toBeUndefined();
+    expect(
+      await getChattinessOverride({ persona: "lena", conversation: "telegram:2" }),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveNarrationEnabled — precedence", () => {
+  const SAVED = process.env.PHANTOMBOT_CHATTINESS_STATE;
+  let dir: string;
+  const who = { persona: "lena", conversation: "telegram:1" };
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "phantombot-chattiness-"));
+    process.env.PHANTOMBOT_CHATTINESS_STATE = join(dir, "state.json");
+  });
+  afterEach(async () => {
+    if (SAVED === undefined) delete process.env.PHANTOMBOT_CHATTINESS_STATE;
+    else process.env.PHANTOMBOT_CHATTINESS_STATE = SAVED;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("no override → follows the config default", async () => {
+    expect(await resolveNarrationEnabled({ ...who, configDefault: true })).toBe(
+      true,
+    );
+    expect(await resolveNarrationEnabled({ ...who, configDefault: false })).toBe(
+      false,
+    );
+  });
+
+  test("override ON wins even when default is OFF", async () => {
+    await setChattinessOverride({ ...who, mode: "on" });
+    expect(await resolveNarrationEnabled({ ...who, configDefault: false })).toBe(
+      true,
+    );
+  });
+
+  test("override OFF wins even when default is ON", async () => {
+    await setChattinessOverride({ ...who, mode: "off" });
+    expect(await resolveNarrationEnabled({ ...who, configDefault: true })).toBe(
+      false,
+    );
+  });
+
+  test("clearing the override falls back to the default again", async () => {
+    await setChattinessOverride({ ...who, mode: "off" });
+    await clearChattinessOverride(who);
+    expect(await resolveNarrationEnabled({ ...who, configDefault: true })).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `/chattiness` slash command to let users suppress **narration bubbles** — the model's interim "let me check… / now let me…" chatter that streams while a turn runs. Closes #243.

In a chat, some users don't want to see the running reasoning/progress commentary — just the final answer. This gives them the switch. Default stays **ON** (current behaviour), and can be flipped **OFF globally** for people who never want it.

## Behaviour

- `/chattiness on` — narration bubbles stream as they do today.
- `/chattiness off` — quiet mode: no interim narration, user gets the **final reply** only.
- `/chattiness <on|off> default` — writes the standing default to `config.toml`.
- **Per-conversation sticky** — a toggle holds for that chat until changed, overriding the config default.
- Final reply + error paths are **never** touched — only the narration flush is gated.

## Scope

- **Telegram + PhantomChat only.** CLI, voice, and the editor (ACP) surface are deliberately left untouched.
- Gated at **both** `flushNarration` sites — `engine.ts` (Telegram) and the mirrored loop in `phantomchat/server.ts` — each with a `TODO(dedup)` breadcrumb.

## Implementation

- **`src/lib/chattiness.ts`** (new) — per-conversation override store (cloned from `coderSwap.ts`) + `resolveNarrationEnabled()`: per-conversation override wins, else the config default.
- **`src/channels/commands.ts`** — `/chattiness` case, handler, and `TELEGRAM_BOT_COMMANDS` entry (shared by both channels).
- **`src/config.ts`** — top-level `chattiness` bool (default `true`), env + toml parse.
- **`src/channels/core/engine.ts` / `phantomchat/server.ts`** — one-line gate on `flushNarration`, resolved once per turn (sticky).

## Follow-up

The two streaming loops are near-duplicates. Rather than fold a risky refactor into this feature, that tech debt is tracked separately in #245 (Tier A cheap/safe extraction, Tier B its own design pass).

## Docs

README (new quiet-mode section + command table + config key), AGENTS.md, and docs/architecture.md all updated.

## Tests

- `tests/lib-chattiness.test.ts` — store + precedence.
- `tests/channels-commands.test.ts` — `/chattiness` on/off/default, config-write path, garbage rejection.

Typecheck clean; affected suites green.