### PR TITLE
refactor(channels): extract shared streaming helpers (Tier A of #245)

### DIFF
--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -63,6 +63,11 @@ import {
   StreamSegmenter,
 } from "../streamSegmenter.ts";
 import {
+  createNarrationController,
+  resolveOutgoingSuffix,
+  segmenterOptionsFor,
+} from "./streaming.ts";
+import {
   formatAttachmentUserText,
   formatReplyToContext,
   inboxDir,
@@ -881,10 +886,7 @@ async function processChatMessage(
       ? input.transport.sendRecording(msg.conversationId)
       : input.transport.sendTyping(msg.conversationId);
   const streaming = input.config.telegramStreaming ?? DEFAULT_TELEGRAM_STREAMING;
-  const segmenterOptions = {
-    maxSentences: streaming.bubbleMaxSentences,
-    maxChars: streaming.bubbleMaxChars,
-  };
+  const segmenterOptions = segmenterOptionsFor(streaming);
 
   // Indicator policy: refresh on EVERY harness chunk (text, heartbeat,
   // progress). When chunks stop, the indicator naturally expires after
@@ -915,7 +917,7 @@ async function processChatMessage(
     if (toolRefreshTimer) return; // already running
     toolRefreshTimer = setInterval(() => {
       refreshIndicator();
-      void flushNarration();
+      void narration.flush();
     }, Math.min(1000, streaming.narrationFlushMs));
   };
   const stopToolRefresh = () => {
@@ -949,8 +951,8 @@ async function processChatMessage(
   //   consumedReplyChars  — prefix length already delivered as final text OR
   //                         classified as narration and intentionally removed
   //                         from the final answer
-  //   narrationBuffer     — classified progress text waiting for the timed
-  //                         progress flush, coalesced across tool calls
+  //   narration           — coalesces classified progress text and flushes it
+  //                         on a clock (see core/streaming.ts)
   //   finalSegmenter      — markdown-aware live splitter for candidate final
   //                         answer text
   //   finalReply          — set on the `done` chunk; authoritative full text
@@ -959,7 +961,6 @@ async function processChatMessage(
   // clips after the full reply is known.
   let streamedReply = "";
   let consumedReplyChars = 0;
-  let narrationBuffer = "";
   let narrationBubblesSent = 0;
   let finalSegmenter = new StreamSegmenter(segmenterOptions);
   let finalCandidateText = "";
@@ -970,7 +971,6 @@ async function processChatMessage(
   let errored: string | undefined;
   let progressCount = 0;
   let chosenHarness: string | undefined;
-  let lastNarrationFlushAt = Date.now();
 
   const sendTextSegment = async (
     text: string,
@@ -1012,32 +1012,29 @@ async function processChatMessage(
   // the sticky semantics. Suppresses ONLY narration; the final reply and error
   // paths are untouched.
   //
-  // TODO(dedup): this narration streaming loop is MIRRORED in
-  // src/channels/phantomchat/server.ts (its own flushNarration + sendBubble).
-  // The gate below is applied in BOTH files — keep them in sync until the two
-  // loops are centralized in a future refactor.
+  // NOTE(dedup): the shared pieces of this loop (segmenter options, the
+  // narration buffer/flush controller, the streamed-suffix reconciliation) live
+  // in core/streaming.ts and are used by both this file and
+  // src/channels/phantomchat/server.ts. The surrounding orchestration is still
+  // mirrored on purpose — the two channels diverge in transport addressing and
+  // Telegram's failure-handling; see issue #245 (Tier B, not planned).
   const narrationEnabled = await resolveNarrationEnabled({
     persona: input.persona,
     conversation: conversationKey,
     configDefault: input.config.chattiness ?? DEFAULT_CHATTINESS,
   });
 
-  // Flush coalesced progress narration on a clock, not on every tool
-  // boundary. Tool boundaries classify preceding text as narration; this
-  // timer decides when, if ever, that narration becomes a progress bubble.
-  const flushNarration = async (force = false) => {
-    if (willReplyWithVoice) return;
-    if (!narrationEnabled) return;
-    if (narrationBuffer.trim().length === 0) return;
-    const now = Date.now();
-    if (!force && now - lastNarrationFlushAt < streaming.narrationFlushMs) {
-      return;
-    }
-    const pending = narrationBuffer;
-    narrationBuffer = "";
-    lastNarrationFlushAt = now;
-    await sendTextSegment(pending, "narration");
-  };
+  // Coalesce progress narration and flush it on a clock (see core/streaming.ts).
+  // Tool boundaries `append()` the preceding un-sent text; `flush()` decides
+  // when it becomes a bubble. `suppress` mirrors the old `if (willReplyWithVoice)
+  // return` guard: voice-out synthesizes once at the end, so interim narration
+  // would just lengthen the spoken output.
+  const narration = createNarrationController({
+    streaming,
+    enabled: narrationEnabled,
+    send: (text) => sendTextSegment(text, "narration"),
+    suppress: () => willReplyWithVoice,
+  });
 
   // Mechanical capture nudge: every CAPTURE_NUDGE_INTERVAL user turns
   // without a `memory capture`, append a reminder to the system-prompt
@@ -1149,7 +1146,7 @@ async function processChatMessage(
         // tool-refresh timer and show the indicator naturally.
         stopToolRefresh();
         refreshIndicator();
-        await flushNarration();
+        await narration.flush();
       }
       if (chunk.type === "progress") {
         progressCount++;
@@ -1169,11 +1166,11 @@ async function processChatMessage(
           finalCandidateSentChars,
         );
         if (unsentCandidate.trim().length > 0) {
-          narrationBuffer += unsentCandidate;
+          narration.append(unsentCandidate);
         }
         consumedReplyChars = streamedReply.length;
         resetFinalCandidate();
-        await flushNarration();
+        await narration.flush();
         // Start a background timer to keep the typing/recording
         // indicator visible during tool execution. Without this,
         // gemini-cli's multi-minute tool runs cause Telegram's
@@ -1310,13 +1307,12 @@ async function processChatMessage(
       narrationBubblesSent > 0 || finalBubblesSent > 0 || isGroupChat
         ? ""
         : "(no reply)";
-  } else if (
-    consumedReplyChars > 0 &&
-    fullReply.startsWith(streamedReply.slice(0, consumedReplyChars))
-  ) {
-    outText = fullReply.slice(consumedReplyChars);
   } else {
-    outText = fullReply;
+    outText = resolveOutgoingSuffix(
+      fullReply,
+      streamedReply,
+      consumedReplyChars,
+    );
   }
 
   if (requestedReplyMode === "default") {

--- a/src/channels/core/streaming.ts
+++ b/src/channels/core/streaming.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared streaming helpers for the chat channels.
+ *
+ * Both the Telegram engine (`src/channels/core/engine.ts`) and the PhantomChat
+ * server (`src/channels/phantomchat/server.ts`) run the same progressive-bubble
+ * state machine: a markdown-aware splitter turns streamed `text` chunks into
+ * bubbles, tool boundaries reclassify the un-sent remainder as progress
+ * narration, and a post-loop step reconciles the streamed prefix against the
+ * harness's authoritative final answer.
+ *
+ * This module extracts the pieces of that machine that were byte-identical (or
+ * trivially different) between the two loops so there is a single source of
+ * truth. It intentionally does NOT try to unify the whole loop — the two
+ * channels diverge in transport addressing (Telegram's opaque `conversationId`
+ * vs PhantomChat's `senderHex`/`groupId` + group routing) and in Telegram's
+ * extra failure-handling (recovery, abort persistence, `(no reply)`). That
+ * larger unification is deliberately out of scope; see issue #245 (Tier B).
+ */
+
+import type { TelegramStreamingSettings } from "../../config.ts";
+import type { StreamSegmenterOptions } from "../streamSegmenter.ts";
+
+/**
+ * Build the markdown-aware splitter options from the streaming config. Used for
+ * both the live `StreamSegmenter` and the post-loop `splitIntoSegments` calls,
+ * so the same bubble sizing applies to streamed and trailing text alike.
+ */
+export function segmenterOptionsFor(
+  streaming: TelegramStreamingSettings,
+): StreamSegmenterOptions {
+  return {
+    maxSentences: streaming.bubbleMaxSentences,
+    maxChars: streaming.bubbleMaxChars,
+  };
+}
+
+/**
+ * Reconcile the authoritative full reply against what already streamed live.
+ *
+ *   - consumed prefix matches: return only the suffix the user hasn't seen yet
+ *     (the part after live final bubbles and classified narration).
+ *   - consumed prefix doesn't match (harness reformatted the answer, or a
+ *     recovery reply unrelated to the streamed text): return the full reply. We
+ *     accept some duplication over silently truncating.
+ *
+ * Callers handle the empty / unrecoverable / `(no reply)` cases around this;
+ * this helper is only the "suffix vs full" decision, which was byte-identical
+ * across the two channels.
+ */
+export function resolveOutgoingSuffix(
+  fullReply: string,
+  streamedReply: string,
+  consumedReplyChars: number,
+): string {
+  if (
+    consumedReplyChars > 0 &&
+    fullReply.startsWith(streamedReply.slice(0, consumedReplyChars))
+  ) {
+    return fullReply.slice(consumedReplyChars);
+  }
+  return fullReply;
+}
+
+export interface NarrationControllerOptions {
+  /** Streaming config; only `narrationFlushMs` (the flush cadence) is read. */
+  streaming: TelegramStreamingSettings;
+  /**
+   * Whether interim narration bubbles are wanted for this conversation (the
+   * `/chattiness` gate). When false, buffered narration is silently dropped —
+   * the final reply path is unaffected.
+   */
+  enabled: boolean;
+  /** Publish one coalesced narration bubble (channel-specific transport). */
+  send: (text: string) => Promise<void>;
+  /**
+   * Optional extra suppression, evaluated live on each flush. Telegram uses
+   * this for `willReplyWithVoice` (voice-out synthesizes once at the end, so
+   * interim narration would just lengthen the spoken output). PhantomChat
+   * passes nothing.
+   */
+  suppress?: () => boolean;
+}
+
+/**
+ * Coalesce progress narration and flush it on a clock rather than on every tool
+ * boundary. Tool boundaries `append()` the preceding un-sent text as narration;
+ * `flush()` decides when — if ever — that buffered text becomes a bubble,
+ * throttled to at most one bubble per `narrationFlushMs`.
+ *
+ * Owns its buffer + last-flush clock internally so both channels share one
+ * implementation. The final-answer splitter state stays in the caller because
+ * its per-segment send is interleaved with channel-specific transport calls.
+ */
+export interface NarrationController {
+  /** Add classified narration text to the pending buffer. */
+  append(text: string): void;
+  /**
+   * Emit the buffered narration as a single bubble if the throttle window has
+   * elapsed (or `force` is set) and narration is enabled + not suppressed.
+   */
+  flush(force?: boolean): Promise<void>;
+}
+
+export function createNarrationController(
+  opts: NarrationControllerOptions,
+): NarrationController {
+  let buffer = "";
+  let lastFlushAt = Date.now();
+
+  return {
+    append(text: string): void {
+      buffer += text;
+    },
+    async flush(force = false): Promise<void> {
+      if (opts.suppress?.()) return;
+      if (!opts.enabled) return;
+      if (buffer.trim().length === 0) return;
+      const now = Date.now();
+      if (!force && now - lastFlushAt < opts.streaming.narrationFlushMs) {
+        return;
+      }
+      const pending = buffer;
+      buffer = "";
+      lastFlushAt = now;
+      await opts.send(pending);
+    },
+  };
+}

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -55,6 +55,11 @@ import {
   splitIntoSegments,
   StreamSegmenter,
 } from "../streamSegmenter.ts";
+import {
+  createNarrationController,
+  resolveOutgoingSuffix,
+  segmenterOptionsFor,
+} from "../core/streaming.ts";
 import type { ServiceControl } from "../../lib/systemd.ts";
 import type { NostrProfileMeta, PhantomchatTransport } from "./transport.ts";
 import { sttSupport, synthesize, transcribe, ttsSupported } from "../../lib/audio.ts";
@@ -660,24 +665,20 @@ export async function runPhantomchatServer(
 
     const streaming =
       input.config.telegramStreaming ?? DEFAULT_TELEGRAM_STREAMING;
-    const segmenterOptions = {
-      maxSentences: streaming.bubbleMaxSentences,
-      maxChars: streaming.bubbleMaxChars,
-    };
+    const segmenterOptions = segmenterOptionsFor(streaming);
     // Streaming accumulators — mirror core/engine.ts so the PWA gets the same
     // progressive bubbles Telegram does. `streamedReply` is the running sum of
     // text chunks; `consumedReplyChars` is the prefix already delivered as a
     // final bubble OR classified as progress narration and dropped from the
-    // answer; `narrationBuffer` holds classified narration awaiting the timed
-    // flush; `finalSegmenter` is the markdown-aware live splitter.
+    // answer; the narration controller (core/streaming.ts) coalesces classified
+    // narration and flushes it on a clock; `finalSegmenter` is the
+    // markdown-aware live splitter.
     let streamedReply = "";
     let consumedReplyChars = 0;
-    let narrationBuffer = "";
     let finalSegmenter = new StreamSegmenter(segmenterOptions);
     let finalCandidateText = "";
     let finalCandidateSentChars = 0;
     let finalReply: string | undefined;
-    let lastNarrationFlushAt = Date.now();
     let requestedReplyMode: ReplyModeRequest | undefined;
 
     // Reply-modality routing (mirrors core/engine.ts). Default: mirror the
@@ -767,32 +768,28 @@ export async function runPhantomchatServer(
     // Per-conversation override wins; absent, the config default decides.
     // Suppresses ONLY narration — the final reply is untouched.
     //
-    // TODO(dedup): this narration streaming loop MIRRORS
-    // src/channels/core/engine.ts (its own flushNarration + sendTextSegment).
-    // The gate below is applied in BOTH files — keep them in sync until the two
-    // loops are centralized in a future refactor.
+    // NOTE(dedup): the shared pieces of this loop (segmenter options, the
+    // narration buffer/flush controller, the streamed-suffix reconciliation)
+    // live in core/streaming.ts and are used by both this file and
+    // src/channels/core/engine.ts. The surrounding orchestration is still
+    // mirrored on purpose — the two channels diverge in transport addressing
+    // (group vs 1:1 routing) and Telegram's failure-handling; see issue #245
+    // (Tier B, not planned).
     const narrationEnabled = await resolveNarrationEnabled({
       persona: input.persona,
       conversation: conversationKey,
       configDefault: input.config.chattiness ?? DEFAULT_CHATTINESS,
     });
 
-    // Flush coalesced progress narration on a clock (like core/engine.ts), not
-    // on every tool boundary — tool boundaries classify preceding text as
-    // narration; this decides when that text becomes a bubble. Driven by both
-    // the typing interval below and the chunk boundaries in the loop.
-    const flushNarration = async (force = false): Promise<void> => {
-      if (!narrationEnabled) return;
-      if (narrationBuffer.trim().length === 0) return;
-      const now = Date.now();
-      if (!force && now - lastNarrationFlushAt < streaming.narrationFlushMs) {
-        return;
-      }
-      const pending = narrationBuffer;
-      narrationBuffer = "";
-      lastNarrationFlushAt = now;
-      await sendBubble(pending);
-    };
+    // Coalesce progress narration and flush it on a clock (see core/streaming.ts),
+    // not on every tool boundary. Driven by both the typing interval below and
+    // the chunk boundaries in the loop. No `suppress` here: unlike Telegram,
+    // PhantomChat voice replies are DM-only and gated elsewhere.
+    const narration = createNarrationController({
+      streaming,
+      enabled: narrationEnabled,
+      send: sendBubble,
+    });
 
     const resetFinalCandidate = (): void => {
       finalSegmenter = new StreamSegmenter(segmenterOptions);
@@ -805,7 +802,7 @@ export async function runPhantomchatServer(
     // "working on…" line buffered before the tool started.
     const typingTimer = setInterval(() => {
       sendTypingTick();
-      void flushNarration();
+      void narration.flush();
     }, 2000);
 
     // Register this turn so a /stop or /reset slash command can abort it and
@@ -892,7 +889,7 @@ export async function runPhantomchatServer(
         }
         if (chunk.type === "heartbeat") {
           // Tool completed or model is thinking — a chance to surface narration.
-          await flushNarration();
+          await narration.flush();
         }
         if (chunk.type === "progress") {
           // Surface the latest progress note on the turn handle so /status can
@@ -903,10 +900,10 @@ export async function runPhantomchatServer(
           // narration ("checking your calendar…"): buffer it for the timed
           // flush, then consume it so it is not duplicated in the final answer.
           const unsent = finalCandidateText.slice(finalCandidateSentChars);
-          if (unsent.trim().length > 0) narrationBuffer += unsent;
+          if (unsent.trim().length > 0) narration.append(unsent);
           consumedReplyChars = streamedReply.length;
           resetFinalCandidate();
-          await flushNarration();
+          await narration.flush();
         }
         if (chunk.type === "done") {
           finalReply = chunk.finalText;
@@ -958,13 +955,12 @@ export async function runPhantomchatServer(
     let outText: string;
     if (fullReply.trim().length === 0) {
       outText = "";
-    } else if (
-      consumedReplyChars > 0 &&
-      fullReply.startsWith(streamedReply.slice(0, consumedReplyChars))
-    ) {
-      outText = fullReply.slice(consumedReplyChars);
     } else {
-      outText = fullReply;
+      outText = resolveOutgoingSuffix(
+        fullReply,
+        streamedReply,
+        consumedReplyChars,
+      );
     }
 
     // Persist a model-requested reply-mode change (via meta.replyMode) for

--- a/tests/channels-core-streaming.test.ts
+++ b/tests/channels-core-streaming.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_TELEGRAM_STREAMING } from "../src/config.ts";
+import {
+  createNarrationController,
+  resolveOutgoingSuffix,
+  segmenterOptionsFor,
+} from "../src/channels/core/streaming.ts";
+
+const streamingWith = (narrationFlushMs: number) => ({
+  ...DEFAULT_TELEGRAM_STREAMING,
+  narrationFlushMs,
+});
+
+describe("segmenterOptionsFor", () => {
+  test("maps bubble sizing from the streaming config", () => {
+    expect(
+      segmenterOptionsFor({
+        ...DEFAULT_TELEGRAM_STREAMING,
+        bubbleMaxSentences: 3,
+        bubbleMaxChars: 512,
+      }),
+    ).toEqual({ maxSentences: 3, maxChars: 512 });
+  });
+});
+
+describe("resolveOutgoingSuffix", () => {
+  test("returns only the un-sent suffix when the consumed prefix matches", () => {
+    const streamed = "Hello there. ";
+    const full = "Hello there. And the rest.";
+    expect(resolveOutgoingSuffix(full, streamed, streamed.length)).toBe(
+      "And the rest.",
+    );
+  });
+
+  test("returns the full reply when nothing was consumed", () => {
+    const full = "Hello there. And the rest.";
+    expect(resolveOutgoingSuffix(full, "Hello there. ", 0)).toBe(full);
+  });
+
+  test("returns the full reply when the harness reformatted the prefix", () => {
+    // The done.finalText diverges from what streamed live (reformatted), so the
+    // consumed prefix no longer matches — we resend the whole thing rather than
+    // silently truncate.
+    const streamed = "hello there";
+    const full = "Hello there — reformatted.";
+    expect(resolveOutgoingSuffix(full, streamed, streamed.length)).toBe(full);
+  });
+
+  test("empty full reply yields empty output", () => {
+    expect(resolveOutgoingSuffix("", "", 0)).toBe("");
+  });
+});
+
+describe("createNarrationController", () => {
+  test("flush emits the buffered narration as a single bubble", async () => {
+    const sent: string[] = [];
+    const narration = createNarrationController({
+      streaming: streamingWith(0),
+      enabled: true,
+      send: async (t) => void sent.push(t),
+    });
+    narration.append("checking ");
+    narration.append("your calendar…");
+    await narration.flush();
+    expect(sent).toEqual(["checking your calendar…"]);
+  });
+
+  test("buffer is cleared after a flush", async () => {
+    const sent: string[] = [];
+    const narration = createNarrationController({
+      streaming: streamingWith(0),
+      enabled: true,
+      send: async (t) => void sent.push(t),
+    });
+    narration.append("first");
+    await narration.flush();
+    await narration.flush(); // nothing new buffered
+    expect(sent).toEqual(["first"]);
+  });
+
+  test("empty / whitespace-only buffer never sends", async () => {
+    const sent: string[] = [];
+    const narration = createNarrationController({
+      streaming: streamingWith(0),
+      enabled: true,
+      send: async (t) => void sent.push(t),
+    });
+    await narration.flush(true);
+    narration.append("   \n  ");
+    await narration.flush(true);
+    expect(sent).toEqual([]);
+  });
+
+  test("disabled controller drops narration entirely", async () => {
+    const sent: string[] = [];
+    const narration = createNarrationController({
+      streaming: streamingWith(0),
+      enabled: false,
+      send: async (t) => void sent.push(t),
+    });
+    narration.append("should never appear");
+    await narration.flush(true);
+    expect(sent).toEqual([]);
+  });
+
+  test("suppress() gates the flush even when enabled", async () => {
+    const sent: string[] = [];
+    let suppressed = true;
+    const narration = createNarrationController({
+      streaming: streamingWith(0),
+      enabled: true,
+      send: async (t) => void sent.push(t),
+      suppress: () => suppressed,
+    });
+    narration.append("hidden while suppressed");
+    await narration.flush(true);
+    expect(sent).toEqual([]);
+    // suppress is evaluated live on each flush — lift it and the buffered
+    // narration surfaces on the next flush.
+    suppressed = false;
+    await narration.flush(true);
+    expect(sent).toEqual(["hidden while suppressed"]);
+  });
+
+  test("throttles to at most one bubble per narrationFlushMs", async () => {
+    const sent: string[] = [];
+    // Large window: the initial flush clock is set at construction, so an
+    // immediate non-forced flush is inside the window and stays quiet.
+    const narration = createNarrationController({
+      streaming: streamingWith(60_000),
+      enabled: true,
+      send: async (t) => void sent.push(t),
+    });
+    narration.append("too soon");
+    await narration.flush();
+    expect(sent).toEqual([]);
+    // force bypasses the throttle window.
+    await narration.flush(true);
+    expect(sent).toEqual(["too soon"]);
+  });
+});


### PR DESCRIPTION
Tier A of #245 — extract the byte-identical pieces of the mirrored streaming loop into a single shared module so narration/bubble logic has one source of truth. Pure refactor: **no behaviour change**.

## What moved

New `src/channels/core/streaming.ts`, consumed by both `core/engine.ts` (Telegram) and `phantomchat/server.ts` (PhantomChat):

- **`segmenterOptionsFor(streaming)`** — the `{ maxSentences, maxChars }` bubble-sizing options (was constructed inline in both).
- **`resolveOutgoingSuffix(fullReply, streamedReply, consumedReplyChars)`** — the post-loop "suffix vs full" reconciliation (was a byte-identical `else if / else` in both).
- **`createNarrationController({ streaming, enabled, send, suppress? })`** — owns the narration buffer + flush clock and the throttled `flush()`. The optional `suppress()` callback carries Telegram's `if (willReplyWithVoice) return` guard; PhantomChat passes nothing (voice is DM-only and gated elsewhere).

## Behaviour-preserving

- Guard **ordering** is identical (`suppress` → `enabled` → empty-buffer → throttle), matching the old inlined `flushNarration` in each file.
- Throttle window and dedupe semantics unchanged.
- The final-answer splitter state stays in each caller — its per-segment send is interleaved with channel-specific transport, so it's not part of this extraction.
- The paired `TODO(dedup)` breadcrumbs are replaced with a short `NOTE(dedup)` pointer to the shared module + #245.

## Why not the whole loop (Tier B)

Deliberately out of scope, and per the decision on #245, **not planned**. The two loops diverge for real reasons — transport addressing (`conversationId` vs `senderHex`/`groupId` + group routing) and Telegram-only failure handling (recovery, abort persistence, `(no reply)`) — that don't co-evolve, so merging them would trade a clean, revertable state for a rewrite of the most silent-failure-prone code in the app for no real payoff. Full reasoning is in #245.

## Tests

- New `tests/channels-core-streaming.test.ts` (11 cases): segmenter mapping, dedupe suffix/full/reformatted/empty, and the narration controller (flush, buffer-clear, empty guard, disabled drop, live `suppress`, throttle + `force`).
- Full suite green: **1812 pass / 0 fail**, `tsc --noEmit` clean.

Net: `+338 / −76` across the two channels + the new module + tests.
