### PR TITLE
feat(notify): broadcast to ALL authorized recipients on every channel (#249)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ phantombot/
 │   │   ├── install.ts uninstall.ts
 │   │   ├── update.ts         # phantombot update (consumes the GH releases feed)
 │   │   ├── env.ts            # phantombot env (manages ~/.env)
-│   │   ├── notify.ts         # phantombot notify (Telegram text/voice)
+│   │   ├── notify.ts         # phantombot notify (broadcasts text/voice to ALL authorized ids on EVERY channel, deduped, per-recipient independent delivery — #249)
 │   │   ├── task.ts           # phantombot task (CRUD over scheduled tasks)
 │   │   ├── tick.ts           # phantombot tick (called by phantombot-tick.timer every minute)
 │   │   ├── voice.ts          # phantombot voice (TUI: TTS/STT provider config)

--- a/README.md
+++ b/README.md
@@ -737,8 +737,11 @@ phantombot notify --voice "Backup failed on pve-3."
 phantombot notify --message "Text" --voice "Voice"
 ```
 
-Notifications are sent to the Telegram allowlist. Phantombot refuses to notify
-if no allowed users are configured.
+Notifications **broadcast to every authorized recipient on every configured
+channel** — every Telegram allowed user id and every phantomchat allowed npub,
+deduped, each delivered independently so one blocked recipient never stops the
+rest. There is no "primary only" mode. Phantombot refuses to notify if no
+allowed users are configured.
 
 Background work should stay quiet unless something material happened or the
 user explicitly asked to be interrupted.

--- a/src/channels/phantomchat/personaStore.ts
+++ b/src/channels/phantomchat/personaStore.ts
@@ -40,8 +40,8 @@
  *   }
  *
  * Allowlist semantics:
- *   - allowed_npubs non-empty → only those npubs are answered. The FIRST entry
- *     is the incident-notification target.
+ *   - allowed_npubs non-empty → only those npubs are answered. EVERY entry is an
+ *     incident-notification target (`notify` broadcasts to all, deduped — #249).
  *   - allowed_npubs empty + tofu true → TOFU: first DMer is trusted + locked.
  *   - allowed_npubs empty + tofu false/absent → open bot (answer anyone), warned.
  */

--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -6,13 +6,15 @@
  * for silence as default. The harnessed agent calls `phantombot notify`
  * inside its prompt when it decides the user should hear about something.
  *
- * ROUTING: notify reaches the FIRST owner of EVERY configured channel for the
- * persona — the first Telegram allowed_user_id AND the first phantomchat
- * allowed npub. If both channels are configured, the owner gets it on BOTH, so
- * an incident is never missed because one channel is down. The "first" owner is
- * the primary; re-order the allowlist (via `phantombot telegram` /
- * `phantombot phantomchat`) to change who's primary. This is deliberately NOT a
- * broadcast to every id — exactly one recipient per channel.
+ * ROUTING: notify BROADCASTS to EVERY authorized recipient on EVERY configured
+ * channel for the persona — every Telegram allowed_user_id AND every phantomchat
+ * allowed npub. If both channels are configured, every authorized owner gets it
+ * on BOTH, so an incident is never missed because one channel is down or one
+ * recipient wasn't the "primary". Recipients are deduped (per (bot, chatId) for
+ * Telegram, per recipientHex for phantomchat) so a repeated entry gets one send,
+ * and delivery is per-recipient with independent error handling — one recipient
+ * failing (blocked bot, dead relay) never aborts delivery to the others. This is
+ * unconditional; there is no "primary only" mode and no opt-out.
  *
  * --message  → text via sendMessage (both channels)
  * --voice    → synthesized via the configured TTS provider, sent via
@@ -114,28 +116,33 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
 
   // ── Resolve the configured channels for this persona ──────────────────
   // A channel is a notify target when it has an account/identity AND at least
-  // one owner. We notify the FIRST owner of each (the primary). Not a broadcast.
+  // one owner. We BROADCAST to every authorized owner of each, deduped.
 
-  // Telegram: persona-bound bot if present, else the default bot.
+  // Telegram: persona-bound bot if present, else the default bot. Fan out to
+  // EVERY allowed user id on that bot, deduped per chatId (an id repeated in the
+  // allowlist gets one send, not many).
   const tg: TelegramAccount | undefined =
     config.channels.telegramPersonas?.[persona] ?? config.channels.telegram;
-  const tgTarget =
+  const tgChatIds =
     tg && tg.allowedUserIds.length > 0
-      ? { account: tg, chatId: tg.allowedUserIds[0] }
-      : undefined;
+      ? [...new Set(tg.allowedUserIds.map((id) => String(id)))]
+      : [];
+  const tgTarget =
+    tg && tgChatIds.length > 0 ? { account: tg, chatIds: tgChatIds } : undefined;
 
-  // Phantomchat: the persona's own phantomchat.json (identity + allowlist).
+  // Phantomchat: the persona's own phantomchat.json (identity + allowlist). Fan
+  // out to EVERY allowed npub, deduped per recipientHex.
   let pcTarget:
-    | { secretKey: Uint8Array; relays: string[]; recipientHex: string }
+    | { secretKey: Uint8Array; relays: string[]; recipientHexes: string[] }
     | undefined;
   try {
     const pc = loadPhantomchatPersonaConfig(personaDir(config, persona));
-    const firstHex = pc?.allowedHex[0];
-    if (pc && firstHex) {
+    const hexes = pc ? [...new Set(pc.allowedHex)] : [];
+    if (pc && hexes.length > 0) {
       pcTarget = {
         secretKey: pc.identity.secretKey,
         relays: pc.relays,
-        recipientHex: firstHex,
+        recipientHexes: hexes,
       };
     }
   } catch (e) {
@@ -152,7 +159,7 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
     return 2;
   }
 
-  // ── Telegram send (first owner) ───────────────────────────────────────
+  // ── Telegram send (every authorized owner) ────────────────────────────
   let textSent = 0;
   let voiceSent = 0;
   if (tgTarget) {
@@ -187,45 +194,51 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
       }
     }
 
-    const chatId = String(tgTarget.chatId);
-    try {
-      if (input.message) {
-        await transport.sendMessage(chatId, input.message);
-        textSent++;
+    // Fan out to every authorized chatId. Per-recipient try/catch: one blocked
+    // or dead recipient is logged and swallowed, never aborting the rest.
+    for (const chatId of tgTarget.chatIds) {
+      try {
+        if (input.message) {
+          await transport.sendMessage(chatId, input.message);
+          textSent++;
+        }
+        if (voiceAudio) {
+          await transport.sendVoice(chatId, voiceAudio.data, voiceAudio.mime);
+          voiceSent++;
+        }
+      } catch (e) {
+        log.warn("notify: telegram send failed", {
+          chatId,
+          error: (e as Error).message,
+        });
       }
-      if (voiceAudio) {
-        await transport.sendVoice(chatId, voiceAudio.data, voiceAudio.mime);
-        voiceSent++;
-      }
-    } catch (e) {
-      log.warn("notify: telegram send failed", {
-        chatId,
-        error: (e as Error).message,
-      });
     }
   }
 
-  // ── Phantomchat send (first owner) ────────────────────────────────────
+  // ── Phantomchat send (every authorized owner) ─────────────────────────
   // Nostr DMs are text-only: send --message, or fall back to the --voice text
-  // so a voice-only notify still reaches the owner here as text.
+  // so a voice-only notify still reaches every owner here as text. Per-recipient
+  // try/catch so one dead relay/recipient never aborts delivery to the rest.
   let pcSent = 0;
   if (pcTarget) {
     const text = input.message ?? input.voice;
     if (text) {
       const send = input.phantomchatSend ?? defaultPhantomchatSend;
-      try {
-        await send({
-          secretKey: pcTarget.secretKey,
-          relays: pcTarget.relays,
-          recipientHex: pcTarget.recipientHex,
-          text,
-        });
-        pcSent++;
-      } catch (e) {
-        log.warn("notify: phantomchat send failed", {
-          recipient: pcTarget.recipientHex.slice(0, 12) + "…",
-          error: (e as Error).message,
-        });
+      for (const recipientHex of pcTarget.recipientHexes) {
+        try {
+          await send({
+            secretKey: pcTarget.secretKey,
+            relays: pcTarget.relays,
+            recipientHex,
+            text,
+          });
+          pcSent++;
+        } catch (e) {
+          log.warn("notify: phantomchat send failed", {
+            recipient: recipientHex.slice(0, 12) + "…",
+            error: (e as Error).message,
+          });
+        }
       }
     }
   }
@@ -260,7 +273,7 @@ export default defineCommand({
   meta: {
     name: "notify",
     description:
-      "Surface a message to the user on every configured channel (first Telegram owner + first phantomchat owner). The harnessed agent calls this when a scheduled task or background work needs to reach the user.",
+      "Surface a message to every authorized recipient on every configured channel (all Telegram allowed ids + all phantomchat allowed npubs, deduped). The harnessed agent calls this when a scheduled task or background work needs to reach the user.",
   },
   args: {
     message: {
@@ -275,7 +288,7 @@ export default defineCommand({
     persona: {
       type: "string",
       description:
-        "Which persona's channels to notify (its Telegram bot + phantomchat identity). Defaults to the default persona. Reaches the first owner of each configured channel.",
+        "Which persona's channels to notify (its Telegram bot + phantomchat identity). Defaults to the default persona. Reaches every authorized owner of each configured channel.",
     },
   },
   async run({ args }) {

--- a/src/orchestrator/screen.ts
+++ b/src/orchestrator/screen.ts
@@ -296,12 +296,13 @@ export function makeScreener(
   // persona context is the briefing.
   const recall = deps.recall;
 
-  // Route the escalation notify for THIS persona. runNotify reaches the first
-  // owner of every configured channel (persona-bound Telegram bot — falling back
-  // to the default bot — AND the persona's phantomchat identity), which is
-  // exactly the set principalConversations() grounds into, so the owner's
-  // approve/deny reply always has a referent regardless of which channel they
-  // answer on. (Generalises the PR #172 fix from telegram-only to multi-channel.)
+  // Route the escalation notify for THIS persona. runNotify broadcasts to every
+  // authorized owner of every configured channel (persona-bound Telegram bot —
+  // falling back to the default bot — AND the persona's phantomchat identity),
+  // which is exactly the set principalConversations() grounds into, so whichever
+  // owner replies approve/deny always has a referent regardless of who they are
+  // or which channel they answer on. (Generalises the PR #172 fix from
+  // telegram-only-first-owner to multi-channel broadcast, #249.)
   const notify =
     deps.notify ??
     ((message: string) => runNotify({ config, message, persona }));
@@ -423,36 +424,34 @@ export function makeScreener(
 
 /**
  * Resolve the principal conversation key(s) for this persona — one per
- * configured channel's PRIMARY (first) owner, matching where `notify` lands the
- * held-request alert. The principal's approve/deny reply arrives in one of these
- * conversations, so the held episode must be grounded into each.
+ * authorized owner on each configured channel, matching where `notify` lands
+ * the held-request alert. The principal's approve/deny reply can arrive in ANY
+ * of these conversations, so the held episode must be grounded into each.
  *
- *   - Telegram: persona-bound bot if configured, else the default bot; the
- *     first allowed user id → `telegram:<userId>`.
- *   - Phantomchat: the persona's first allowed npub → `phantomchat:<hex>` (the
- *     server keys conversations by the lowercase sender hex).
+ *   - Telegram: persona-bound bot if configured, else the default bot; EVERY
+ *     allowed user id → `telegram:<userId>`.
+ *   - Phantomchat: EVERY allowed npub → `phantomchat:<hex>` (the server keys
+ *     conversations by the lowercase sender hex).
  *
  * Empty when neither channel is configured / has an owner (grounding no-op).
  *
- * NOTE: Telegram uses the FIRST id only now (not every id), to mirror notify's
- * first-owner-per-channel routing — the grounding target must match the notify
- * recipient or the reply has no referent.
+ * NOTE: this fans out to EVERY owner to mirror notify's broadcast-to-all routing
+ * (#249) — the grounding targets must match the notify recipients or a reply
+ * from a non-first owner has no referent. Deduped (matching notify).
  */
 function principalConversations(config: Config, persona: string): string[] {
   const out: string[] = [];
 
   const account =
     config.channels.telegramPersonas?.[persona] ?? config.channels.telegram;
-  const firstId = account?.allowedUserIds[0];
-  if (firstId !== undefined) {
-    out.push(`telegram:${firstId}`);
+  for (const id of new Set(account?.allowedUserIds ?? [])) {
+    out.push(`telegram:${id}`);
   }
 
   try {
     const pc = loadPhantomchatPersonaConfig(personaDir(config, persona));
-    const firstHex = pc?.allowedHex[0];
-    if (firstHex) {
-      out.push(`phantomchat:${firstHex.toLowerCase()}`);
+    for (const hex of new Set(pc?.allowedHex ?? [])) {
+      out.push(`phantomchat:${hex.toLowerCase()}`);
     }
   } catch {
     // No phantomchat config / unresolvable persona dir — telegram-only grounding.

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -124,7 +124,7 @@ describe("runNotify input validation", () => {
 });
 
 describe("runNotify text", () => {
-  test("sends --message to the FIRST allowed user only (first-owner routing)", async () => {
+  test("broadcasts --message to EVERY allowed user (fan-out)", async () => {
     const transport = new FakeTransport();
     const out = new CaptureStream();
     const code = await runNotify({
@@ -135,16 +135,67 @@ describe("runNotify text", () => {
       err: new CaptureStream(),
     });
     expect(code).toBe(0);
-    // First-owner-per-channel: only id 42, NOT the whole [42, 99] list.
+    // Fan-out: BOTH ids in [42, 99], not just the first.
     expect(transport.sent).toEqual([
       { chatId: "42", text: "important thing" },
+      { chatId: "99", text: "important thing" },
     ]);
-    expect(out.text).toContain("text=1");
+    expect(out.text).toContain("text=2");
+  });
+
+  test("dedups a repeated allowed user id to a single send", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram!.allowedUserIds = [42, 99, 42];
+    const transport = new FakeTransport();
+    const out = new CaptureStream();
+    const code = await runNotify({
+      config: cfg,
+      transport,
+      message: "once each",
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(transport.sent).toEqual([
+      { chatId: "42", text: "once each" },
+      { chatId: "99", text: "once each" },
+    ]);
+    expect(out.text).toContain("text=2");
+  });
+
+  test("a mid-list recipient failure still delivers to the rest and is not surfaced", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram!.allowedUserIds = [42, 99, 123];
+    const transport = new FakeTransport();
+    // Make the middle recipient (99) throw; 42 and 123 must still land.
+    const origSend = transport.sendMessage.bind(transport);
+    transport.sendMessage = async (chatId: string, text: string) => {
+      if (chatId === "99") throw new Error("blocked by user");
+      return origSend(chatId, text);
+    };
+    const err = new CaptureStream();
+    const out = new CaptureStream();
+    const code = await runNotify({
+      config: cfg,
+      transport,
+      message: "resilient",
+      out,
+      err,
+    });
+    expect(code).toBe(0);
+    // 42 and 123 delivered; 99 swallowed.
+    expect(transport.sent).toEqual([
+      { chatId: "42", text: "resilient" },
+      { chatId: "123", text: "resilient" },
+    ]);
+    expect(out.text).toContain("text=2");
+    // Failures live in logs only — never surfaced to the user via stderr.
+    expect(err.text).toBe("");
   });
 });
 
 describe("runNotify persona routing", () => {
-  test("--persona routes to that persona's bot + first allowed id", async () => {
+  test("--persona routes to that persona's bot + every allowed id", async () => {
     const cfg = baseConfig();
     cfg.channels.telegramPersonas = {
       amanda: {
@@ -164,12 +215,15 @@ describe("runNotify persona routing", () => {
       err: new CaptureStream(),
     });
     expect(code).toBe(0);
-    // The persona's bot, first id only ([7]) — not the default ([42, 99]).
-    expect(transport.sent).toEqual([{ chatId: "7", text: "amanda ping" }]);
-    expect(out.text).toContain("text=1");
+    // The persona's bot, ALL ids ([7, 8]) — not the default ([42, 99]).
+    expect(transport.sent).toEqual([
+      { chatId: "7", text: "amanda ping" },
+      { chatId: "8", text: "amanda ping" },
+    ]);
+    expect(out.text).toContain("text=2");
   });
 
-  test("persona with no bot → falls back to the default bot's first id", async () => {
+  test("persona with no bot → falls back to the default bot's every id", async () => {
     const cfg = baseConfig();
     cfg.channels.telegramPersonas = {
       amanda: { token: "t", pollTimeoutS: 30, allowedUserIds: [7] },
@@ -184,10 +238,13 @@ describe("runNotify persona routing", () => {
       out,
       err: new CaptureStream(),
     });
-    // No bot for 'nobody' → default telegram, first id (42).
+    // No bot for 'nobody' → default telegram, every id ([42, 99]).
     expect(code).toBe(0);
-    expect(transport.sent).toEqual([{ chatId: "42", text: "hi" }]);
-    expect(out.text).toContain("text=1");
+    expect(transport.sent).toEqual([
+      { chatId: "42", text: "hi" },
+      { chatId: "99", text: "hi" },
+    ]);
+    expect(out.text).toContain("text=2");
   });
 });
 
@@ -208,7 +265,7 @@ describe("runNotify voice", () => {
     });
     expect(code).toBe(0);
     expect(err.text).toContain("voice synthesis unavailable");
-    expect(transport.sent.length).toBe(1); // text to first owner
+    expect(transport.sent.length).toBe(2); // text fanned out to both owners
     expect(transport.voiceSent.length).toBe(0);
   });
 
@@ -251,9 +308,9 @@ describe("runNotify voice", () => {
         err: new CaptureStream(),
       });
       expect(code).toBe(0);
-      expect(transport.voiceSent.length).toBe(1); // voice to first owner
+      expect(transport.voiceSent.length).toBe(2); // voice fanned out to both owners
       expect(transport.sent.length).toBe(0);
-      expect(out.text).toContain("voice=1");
+      expect(out.text).toContain("voice=2");
     } finally {
       (globalThis as unknown as { fetch: typeof fetch }).fetch = origFetch;
     }


### PR DESCRIPTION
Closes #249.

## What
`phantombot notify` now **broadcasts to every authorized recipient on every configured channel** instead of only the first owner per channel.

- **Telegram** — iterate all `allowedUserIds` on the resolved bot (persona-bound if present, else default), deduped per `chatId`. Each recipient gets text and/or voice.
- **Phantomchat** — iterate all `allowedHex`, deduped per `recipientHex`. Each gets the text (voice stays Telegram-only, Nostr DMs are text).
- Fan-out is **unconditional** — no "primary only" mode, no config toggle, no opt-out.

## Error handling — unchanged (fan-out only)
- Per-recipient `try/catch`; a failure is `log.warn`-logged and **swallowed** — not re-thrown, not retried.
- **No new exit codes**, no process abort on partial failure. `textSent`/`voiceSent`/`pcSent` accounting preserves today's "did anything land at all" exit semantics (0 if anything went out, 1 if nothing could).
- Delivery errors are **never surfaced to users** — logs only, no stderr summary.

## Coupled fix
`orchestrator/screen.ts` `principalConversations()` grounded the held-request episode into only the first owner's conversation, explicitly to *match notify's recipients*. Since notify now fans out, grounding fans out too (deduped) — otherwise an approve/deny reply from a non-first owner would have no referent.

## Docs
Module docstring, `notify` command + `--persona` descriptions, phantomchat `personaStore` allowlist semantics, README Notifications section, AGENTS.md file annotation.

## Tests
`tests/cli-notify.test.ts`: fan-out to every id, dedup of a repeated id, mid-list recipient failure still delivers to the rest (logged, not surfaced via stderr, not fatal), voice fan-out to all owners, persona-bot fan-out. Existing screen tests unaffected (single-owner allowlists).

Verification: `bun tsc --noEmit` clean; full suite **1814 pass / 0 fail**.

🤖 Opened by Robbie on Andrew's behalf (issue assigned to @robertclawson). Not self-merged — leaving the merge decision to Andrew.
