### PR TITLE
feat(notify): broadcast to all authorized recipients on every channel (#249)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ phantombot/
 │   │   ├── install.ts uninstall.ts
 │   │   ├── update.ts         # phantombot update (consumes the GH releases feed)
 │   │   ├── env.ts            # phantombot env (manages ~/.env)
-│   │   ├── notify.ts         # phantombot notify (Telegram text/voice)
+│   │   ├── notify.ts         # phantombot notify — broadcasts text/voice to all authorized recipients on every channel
 │   │   ├── task.ts           # phantombot task (CRUD over scheduled tasks)
 │   │   ├── tick.ts           # phantombot tick (called by phantombot-tick.timer every minute)
 │   │   ├── voice.ts          # phantombot voice (TUI: TTS/STT provider config)

--- a/README.md
+++ b/README.md
@@ -739,8 +739,14 @@ phantombot notify --voice "Backup failed on pve-3."
 phantombot notify --message "Text" --voice "Voice"
 ```
 
-Notifications are sent to the Telegram allowlist. Phantombot refuses to notify
-if no allowed users are configured.
+Notifications broadcast to **every** authorized recipient on **every**
+configured channel for the persona — all Telegram allowed users and all
+phantomchat allowed npubs (deduped, so an id authorized twice is contacted
+once). Everyone authorized to talk to the persona hears about a material event,
+not just a single primary. Each recipient is an independent send: one failing
+(blocked bot, dead relay) is logged and skipped, never aborting delivery to the
+others. Phantombot refuses to notify if no allowed recipients are configured on
+any channel.
 
 Background work should stay quiet unless something material happened or the
 user explicitly asked to be interrupted.

--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -6,13 +6,17 @@
  * for silence as default. The harnessed agent calls `phantombot notify`
  * inside its prompt when it decides the user should hear about something.
  *
- * ROUTING: notify reaches the FIRST owner of EVERY configured channel for the
- * persona — the first Telegram allowed_user_id AND the first phantomchat
- * allowed npub. If both channels are configured, the owner gets it on BOTH, so
- * an incident is never missed because one channel is down. The "first" owner is
- * the primary; re-order the allowlist (via `phantombot telegram` /
- * `phantombot phantomchat`) to change who's primary. This is deliberately NOT a
- * broadcast to every id — exactly one recipient per channel.
+ * ROUTING: notify BROADCASTS to EVERY authorized recipient on EVERY configured
+ * channel for the persona — all Telegram allowed_user_ids AND all phantomchat
+ * allowed npubs. Everyone authorized to talk to the persona hears about a
+ * material event, not just a single designated primary. If both channels are
+ * configured, each recipient gets it on the channel(s) they're authorized on,
+ * so an incident is never missed because one channel is down. Recipients are
+ * deduped (per (bot, chatId) for Telegram, per recipientHex for phantomchat) so
+ * an id authorized twice is contacted once. Sends are per-recipient with
+ * independent error handling: one recipient failing (blocked bot, dead relay)
+ * is logged and swallowed — it never aborts delivery to the others and is never
+ * surfaced to users.
  *
  * --message  → text via sendMessage (both channels)
  * --voice    → synthesized via the configured TTS provider, sent via
@@ -114,29 +118,49 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
 
   // ── Resolve the configured channels for this persona ──────────────────
   // A channel is a notify target when it has an account/identity AND at least
-  // one owner. We notify the FIRST owner of each (the primary). Not a broadcast.
+  // one owner. We BROADCAST to every authorized recipient of each, deduped.
 
-  // Telegram: persona-bound bot if present, else the default bot.
+  // Telegram: persona-bound bot if present, else the default bot. Fan out to
+  // every allowedUserId, deduped per (bot token, chatId) so an id repeated in
+  // the allowlist is contacted once.
   const tg: TelegramAccount | undefined =
     config.channels.telegramPersonas?.[persona] ?? config.channels.telegram;
-  const tgTarget =
-    tg && tg.allowedUserIds.length > 0
-      ? { account: tg, chatId: tg.allowedUserIds[0] }
-      : undefined;
+  let tgTarget: { account: TelegramAccount; chatIds: string[] } | undefined;
+  if (tg && tg.allowedUserIds.length > 0) {
+    const seen = new Set<string>();
+    const chatIds: string[] = [];
+    for (const id of tg.allowedUserIds) {
+      const chatId = String(id);
+      const key = `${tg.token}:${chatId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      chatIds.push(chatId);
+    }
+    tgTarget = { account: tg, chatIds };
+  }
 
   // Phantomchat: the persona's own phantomchat.json (identity + allowlist).
+  // Fan out to every allowedHex, deduped per recipientHex.
   let pcTarget:
-    | { secretKey: Uint8Array; relays: string[]; recipientHex: string }
+    | { secretKey: Uint8Array; relays: string[]; recipientHexes: string[] }
     | undefined;
   try {
     const pc = loadPhantomchatPersonaConfig(personaDir(config, persona));
-    const firstHex = pc?.allowedHex[0];
-    if (pc && firstHex) {
-      pcTarget = {
-        secretKey: pc.identity.secretKey,
-        relays: pc.relays,
-        recipientHex: firstHex,
-      };
+    if (pc && pc.allowedHex.length > 0) {
+      const seen = new Set<string>();
+      const recipientHexes: string[] = [];
+      for (const hex of pc.allowedHex) {
+        if (seen.has(hex)) continue;
+        seen.add(hex);
+        recipientHexes.push(hex);
+      }
+      if (recipientHexes.length > 0) {
+        pcTarget = {
+          secretKey: pc.identity.secretKey,
+          relays: pc.relays,
+          recipientHexes,
+        };
+      }
     }
   } catch (e) {
     log.warn("notify: failed to load phantomchat config", {
@@ -152,16 +176,16 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
     return 2;
   }
 
-  // ── Telegram send (first owner) ───────────────────────────────────────
+  // ── Telegram send (broadcast to all owners) ───────────────────────────
   let textSent = 0;
   let voiceSent = 0;
   if (tgTarget) {
     const transport =
       input.transport ?? new HttpTelegramTransport(tgTarget.account.token);
 
-    // Pre-synthesize once if voice was requested. Telegram-only — Nostr DMs
-    // carry no audio. Doing it before the text send means a provider misconfig
-    // fails before we half-notify.
+    // Pre-synthesize ONCE if voice was requested (not per recipient). Telegram-
+    // only — Nostr DMs carry no audio. Doing it before the text sends means a
+    // provider misconfig fails before we half-notify.
     let voiceAudio: { data: Buffer; mime: string } | undefined;
     if (input.voice) {
       const support = ttsSupport(config);
@@ -187,45 +211,52 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
       }
     }
 
-    const chatId = String(tgTarget.chatId);
-    try {
-      if (input.message) {
-        await transport.sendMessage(chatId, input.message);
-        textSent++;
+    // Fan out to every deduped recipient. Each send is independent: a failure
+    // to one owner is logged and swallowed, never aborting the others and never
+    // surfaced to the user.
+    for (const chatId of tgTarget.chatIds) {
+      try {
+        if (input.message) {
+          await transport.sendMessage(chatId, input.message);
+          textSent++;
+        }
+        if (voiceAudio) {
+          await transport.sendVoice(chatId, voiceAudio.data, voiceAudio.mime);
+          voiceSent++;
+        }
+      } catch (e) {
+        log.warn("notify: telegram send failed", {
+          chatId,
+          error: (e as Error).message,
+        });
       }
-      if (voiceAudio) {
-        await transport.sendVoice(chatId, voiceAudio.data, voiceAudio.mime);
-        voiceSent++;
-      }
-    } catch (e) {
-      log.warn("notify: telegram send failed", {
-        chatId,
-        error: (e as Error).message,
-      });
     }
   }
 
-  // ── Phantomchat send (first owner) ────────────────────────────────────
+  // ── Phantomchat send (broadcast to all owners) ────────────────────────
   // Nostr DMs are text-only: send --message, or fall back to the --voice text
-  // so a voice-only notify still reaches the owner here as text.
+  // so a voice-only notify still reaches owners here as text. Each recipient is
+  // an independent send — a failure is logged and swallowed.
   let pcSent = 0;
   if (pcTarget) {
     const text = input.message ?? input.voice;
     if (text) {
       const send = input.phantomchatSend ?? defaultPhantomchatSend;
-      try {
-        await send({
-          secretKey: pcTarget.secretKey,
-          relays: pcTarget.relays,
-          recipientHex: pcTarget.recipientHex,
-          text,
-        });
-        pcSent++;
-      } catch (e) {
-        log.warn("notify: phantomchat send failed", {
-          recipient: pcTarget.recipientHex.slice(0, 12) + "…",
-          error: (e as Error).message,
-        });
+      for (const recipientHex of pcTarget.recipientHexes) {
+        try {
+          await send({
+            secretKey: pcTarget.secretKey,
+            relays: pcTarget.relays,
+            recipientHex,
+            text,
+          });
+          pcSent++;
+        } catch (e) {
+          log.warn("notify: phantomchat send failed", {
+            recipient: recipientHex.slice(0, 12) + "…",
+            error: (e as Error).message,
+          });
+        }
       }
     }
   }
@@ -238,9 +269,11 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
     `notify: persona=${persona} channels=[${channels.join(", ")}] telegram(text=${textSent} voice=${voiceSent}) phantomchat(text=${pcSent})\n`,
   );
   // At least one channel was configured (we'd have returned 2 otherwise). Exit 0
-  // when something actually went out; exit 1 when nothing could be delivered —
-  // e.g. a voice-only notify whose synthesis failed with no text fallback, or
-  // every configured channel's send erroring.
+  // when something actually went out to any recipient; exit 1 when nothing could
+  // be delivered — e.g. a voice-only notify whose synthesis failed with no text
+  // fallback, or every recipient on every channel erroring. Partial fan-out
+  // failures (some recipients ok, some not) are NOT an error — they exit 0, same
+  // "did anything land at all" semantics as before the broadcast change.
   return textSent + voiceSent + pcSent > 0 ? 0 : 1;
 }
 
@@ -260,7 +293,7 @@ export default defineCommand({
   meta: {
     name: "notify",
     description:
-      "Surface a message to the user on every configured channel (first Telegram owner + first phantomchat owner). The harnessed agent calls this when a scheduled task or background work needs to reach the user.",
+      "Surface a message to every authorized recipient on every configured channel (all Telegram owners + all phantomchat owners). The harnessed agent calls this when a scheduled task or background work needs to reach the user.",
   },
   args: {
     message: {
@@ -275,7 +308,7 @@ export default defineCommand({
     persona: {
       type: "string",
       description:
-        "Which persona's channels to notify (its Telegram bot + phantomchat identity). Defaults to the default persona. Reaches the first owner of each configured channel.",
+        "Which persona's channels to notify (its Telegram bot + phantomchat identity). Defaults to the default persona. Broadcasts to every authorized owner of each configured channel.",
     },
   },
   async run({ args }) {

--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -22,9 +22,10 @@
  * --voice    → synthesized via the configured TTS provider, sent via
  *              sendVoice as an OGG-Opus voice note (TELEGRAM only — Nostr DMs
  *              are text-only, so phantomchat receives the text instead).
- * --persona  → which persona's channels to notify. Selects the persona-bound
- *              Telegram bot (`channels.telegram.personas.<name>`, falling back
- *              to the default bot) AND that persona's `phantomchat.json`.
+ * --persona  → which persona's channels to notify. Broadcasts across the
+ *              persona-bound Telegram bot (`channels.telegram.personas.<name>`)
+ *              AND the default bot when both are configured, plus that persona's
+ *              `phantomchat.json`.
  *              Omitting it uses the default persona. A `tick`-fired notify has
  *              no inbound context, so this is how it lands in the right place.
  * Both message/voice flags can be combined to send text AND voice.
@@ -91,9 +92,9 @@ export interface RunNotifyInput {
   message?: string;
   voice?: string;
   /**
-   * Which persona's channels to notify. Selects the persona-bound Telegram bot
-   * (falling back to the default bot) and that persona's phantomchat.json.
-   * When omitted, the default persona is used.
+   * Which persona's channels to notify. Broadcasts across the persona-bound
+   * Telegram bot AND the default bot (when both are configured), plus that
+   * persona's phantomchat.json. When omitted, the default persona is used.
    */
   persona?: string;
   /** Inject for testing. Default: HttpTelegramTransport with the configured token. */
@@ -120,23 +121,32 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
   // A channel is a notify target when it has an account/identity AND at least
   // one owner. We BROADCAST to every authorized recipient of each, deduped.
 
-  // Telegram: persona-bound bot if present, else the default bot. Fan out to
-  // every allowedUserId, deduped per (bot token, chatId) so an id repeated in
-  // the allowlist is contacted once.
-  const tg: TelegramAccount | undefined =
-    config.channels.telegramPersonas?.[persona] ?? config.channels.telegram;
-  let tgTarget: { account: TelegramAccount; chatIds: string[] } | undefined;
-  if (tg && tg.allowedUserIds.length > 0) {
+  // Telegram: broadcast across BOTH the persona-bound bot (if this persona has
+  // one) AND the default bot (if configured) — not just one of them. A recipient
+  // is deduped per (bot token, chatId), so an id repeated within an allowlist —
+  // or a persona whose bot IS the default bot — is contacted exactly once, while
+  // the same id on two genuinely different bots (distinct tokens = distinct
+  // chats) is contacted on each.
+  const tgAccounts: TelegramAccount[] = [];
+  const personaBot = config.channels.telegramPersonas?.[persona];
+  if (personaBot) tgAccounts.push(personaBot);
+  if (config.channels.telegram) tgAccounts.push(config.channels.telegram);
+
+  const tgTargets: { account: TelegramAccount; chatIds: string[] }[] = [];
+  {
     const seen = new Set<string>();
-    const chatIds: string[] = [];
-    for (const id of tg.allowedUserIds) {
-      const chatId = String(id);
-      const key = `${tg.token}:${chatId}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      chatIds.push(chatId);
+    for (const account of tgAccounts) {
+      if (account.allowedUserIds.length === 0) continue;
+      const chatIds: string[] = [];
+      for (const id of account.allowedUserIds) {
+        const chatId = String(id);
+        const key = `${account.token}:${chatId}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        chatIds.push(chatId);
+      }
+      if (chatIds.length > 0) tgTargets.push({ account, chatIds });
     }
-    tgTarget = { account: tg, chatIds };
   }
 
   // Phantomchat: the persona's own phantomchat.json (identity + allowlist).
@@ -169,7 +179,7 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
     });
   }
 
-  if (!tgTarget && !pcTarget) {
+  if (tgTargets.length === 0 && !pcTarget) {
     err.write(
       `no notify channel configured for persona '${persona}' — set up Telegram (\`phantombot telegram\`) and/or phantomchat (\`phantombot phantomchat\`) with at least one allowed owner first.\n`,
     );
@@ -179,13 +189,10 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
   // ── Telegram send (broadcast to all owners) ───────────────────────────
   let textSent = 0;
   let voiceSent = 0;
-  if (tgTarget) {
-    const transport =
-      input.transport ?? new HttpTelegramTransport(tgTarget.account.token);
-
-    // Pre-synthesize ONCE if voice was requested (not per recipient). Telegram-
-    // only — Nostr DMs carry no audio. Doing it before the text sends means a
-    // provider misconfig fails before we half-notify.
+  if (tgTargets.length > 0) {
+    // Pre-synthesize ONCE if voice was requested (not per recipient, not per
+    // account). Telegram-only — Nostr DMs carry no audio. Doing it before the
+    // text sends means a provider misconfig fails before we half-notify.
     let voiceAudio: { data: Buffer; mime: string } | undefined;
     if (input.voice) {
       const support = ttsSupport(config);
@@ -211,24 +218,30 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
       }
     }
 
-    // Fan out to every deduped recipient. Each send is independent: a failure
-    // to one owner is logged and swallowed, never aborting the others and never
-    // surfaced to the user.
-    for (const chatId of tgTarget.chatIds) {
-      try {
-        if (input.message) {
-          await transport.sendMessage(chatId, input.message);
-          textSent++;
+    // Fan out across every account (persona bot + default bot), then every
+    // deduped recipient of each. A single injected transport (tests) is reused
+    // for all accounts; in production each account gets its own transport bound
+    // to its token. Each send is independent: a failure to one owner is logged
+    // and swallowed, never aborting the others and never surfaced to the user.
+    for (const target of tgTargets) {
+      const transport =
+        input.transport ?? new HttpTelegramTransport(target.account.token);
+      for (const chatId of target.chatIds) {
+        try {
+          if (input.message) {
+            await transport.sendMessage(chatId, input.message);
+            textSent++;
+          }
+          if (voiceAudio) {
+            await transport.sendVoice(chatId, voiceAudio.data, voiceAudio.mime);
+            voiceSent++;
+          }
+        } catch (e) {
+          log.warn("notify: telegram send failed", {
+            chatId,
+            error: (e as Error).message,
+          });
         }
-        if (voiceAudio) {
-          await transport.sendVoice(chatId, voiceAudio.data, voiceAudio.mime);
-          voiceSent++;
-        }
-      } catch (e) {
-        log.warn("notify: telegram send failed", {
-          chatId,
-          error: (e as Error).message,
-        });
       }
     }
   }
@@ -262,7 +275,7 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
   }
 
   const channels = [
-    tgTarget ? "telegram" : undefined,
+    tgTargets.length > 0 ? "telegram" : undefined,
     pcTarget ? "phantomchat" : undefined,
   ].filter(Boolean);
   out.write(

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { runNotify } from "../src/cli/notify.ts";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
+import { nip19 } from "nostr-tools";
+import { runNotify, type PhantomchatNotifySend } from "../src/cli/notify.ts";
 import type {
   TelegramMessage,
   TelegramTransport,
@@ -22,6 +27,11 @@ class FakeTransport implements TelegramTransport {
   // numeric config recipients at the transport boundary.
   sent: Array<{ chatId: string; text: string }> = [];
   voiceSent: Array<{ chatId: string; mime: string; bytes: number }> = [];
+  // chatIds for which sends should throw (simulates a blocked/failed recipient).
+  failFor: Set<string>;
+  constructor(failFor: string[] = []) {
+    this.failFor = new Set(failFor);
+  }
   async getUpdates(): Promise<{
     updates: TelegramMessage[];
     nextOffset: number;
@@ -30,6 +40,7 @@ class FakeTransport implements TelegramTransport {
   }
   async ackUpdates(): Promise<void> {}
   async sendMessage(chatId: string, text: string): Promise<void> {
+    if (this.failFor.has(chatId)) throw new Error(`blocked: ${chatId}`);
     this.sent.push({ chatId, text });
   }
   async sendTyping(): Promise<void> {}
@@ -39,6 +50,7 @@ class FakeTransport implements TelegramTransport {
     audio: Buffer,
     mime: string,
   ): Promise<void> {
+    if (this.failFor.has(chatId)) throw new Error(`blocked: ${chatId}`);
     this.voiceSent.push({ chatId, mime, bytes: audio.byteLength });
   }
   async downloadFile(): Promise<{ data: Buffer; mime: string }> {
@@ -123,8 +135,8 @@ describe("runNotify input validation", () => {
   });
 });
 
-describe("runNotify text", () => {
-  test("sends --message to the FIRST allowed user only (first-owner routing)", async () => {
+describe("runNotify text (broadcast)", () => {
+  test("sends --message to EVERY allowed user (fan-out)", async () => {
     const transport = new FakeTransport();
     const out = new CaptureStream();
     const code = await runNotify({
@@ -135,16 +147,80 @@ describe("runNotify text", () => {
       err: new CaptureStream(),
     });
     expect(code).toBe(0);
-    // First-owner-per-channel: only id 42, NOT the whole [42, 99] list.
+    // Broadcast: BOTH id 42 and id 99, not just the first.
     expect(transport.sent).toEqual([
       { chatId: "42", text: "important thing" },
+      { chatId: "99", text: "important thing" },
     ]);
-    expect(out.text).toContain("text=1");
+    expect(out.text).toContain("text=2");
+  });
+
+  test("dedups repeated allowed ids to a single send", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram!.allowedUserIds = [42, 42, 99, 99, 99];
+    const transport = new FakeTransport();
+    const out = new CaptureStream();
+    const code = await runNotify({
+      config: cfg,
+      transport,
+      message: "once each",
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(transport.sent).toEqual([
+      { chatId: "42", text: "once each" },
+      { chatId: "99", text: "once each" },
+    ]);
+    expect(out.text).toContain("text=2");
+  });
+
+  test("a mid-list failure still delivers to the rest and is not surfaced", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram!.allowedUserIds = [42, 99, 123];
+    // Recipient 99 is blocked; 42 and 123 must still get it.
+    const transport = new FakeTransport(["99"]);
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runNotify({
+      config: cfg,
+      transport,
+      message: "resilient",
+      out,
+      err,
+    });
+    // Partial failure is NOT fatal — something landed, so exit 0.
+    expect(code).toBe(0);
+    expect(transport.sent).toEqual([
+      { chatId: "42", text: "resilient" },
+      { chatId: "123", text: "resilient" },
+    ]);
+    expect(out.text).toContain("text=2");
+    // The failure is logged (log.warn), never written to stderr for the user.
+    expect(err.text).toBe("");
+  });
+
+  test("every recipient failing → exit 1 (nothing landed)", async () => {
+    const cfg = baseConfig();
+    cfg.channels.telegram!.allowedUserIds = [42, 99];
+    const transport = new FakeTransport(["42", "99"]);
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const code = await runNotify({
+      config: cfg,
+      transport,
+      message: "all blocked",
+      out,
+      err,
+    });
+    expect(code).toBe(1);
+    expect(transport.sent).toEqual([]);
+    expect(err.text).toBe("");
   });
 });
 
-describe("runNotify persona routing", () => {
-  test("--persona routes to that persona's bot + first allowed id", async () => {
+describe("runNotify persona routing (broadcast)", () => {
+  test("--persona routes to that persona's bot + ALL its allowed ids", async () => {
     const cfg = baseConfig();
     cfg.channels.telegramPersonas = {
       amanda: {
@@ -164,12 +240,15 @@ describe("runNotify persona routing", () => {
       err: new CaptureStream(),
     });
     expect(code).toBe(0);
-    // The persona's bot, first id only ([7]) — not the default ([42, 99]).
-    expect(transport.sent).toEqual([{ chatId: "7", text: "amanda ping" }]);
-    expect(out.text).toContain("text=1");
+    // The persona's bot, ALL ids ([7, 8]) — not the default ([42, 99]).
+    expect(transport.sent).toEqual([
+      { chatId: "7", text: "amanda ping" },
+      { chatId: "8", text: "amanda ping" },
+    ]);
+    expect(out.text).toContain("text=2");
   });
 
-  test("persona with no bot → falls back to the default bot's first id", async () => {
+  test("persona with no bot → falls back to the default bot's ids", async () => {
     const cfg = baseConfig();
     cfg.channels.telegramPersonas = {
       amanda: { token: "t", pollTimeoutS: 30, allowedUserIds: [7] },
@@ -184,15 +263,18 @@ describe("runNotify persona routing", () => {
       out,
       err: new CaptureStream(),
     });
-    // No bot for 'nobody' → default telegram, first id (42).
+    // No bot for 'nobody' → default telegram, all ids (42, 99).
     expect(code).toBe(0);
-    expect(transport.sent).toEqual([{ chatId: "42", text: "hi" }]);
-    expect(out.text).toContain("text=1");
+    expect(transport.sent).toEqual([
+      { chatId: "42", text: "hi" },
+      { chatId: "99", text: "hi" },
+    ]);
+    expect(out.text).toContain("text=2");
   });
 });
 
-describe("runNotify voice", () => {
-  test("voice without TTS provider → text-only fallback when --message also given", async () => {
+describe("runNotify voice (broadcast)", () => {
+  test("voice without TTS provider → text-only fallback fans out to all owners", async () => {
     const cfg = baseConfig();
     // voice provider stays "none"; voice synth fails, but message still sends.
     const transport = new FakeTransport();
@@ -208,7 +290,7 @@ describe("runNotify voice", () => {
     });
     expect(code).toBe(0);
     expect(err.text).toContain("voice synthesis unavailable");
-    expect(transport.sent.length).toBe(1); // text to first owner
+    expect(transport.sent.length).toBe(2); // text to both owners
     expect(transport.voiceSent.length).toBe(0);
   });
 
@@ -226,7 +308,7 @@ describe("runNotify voice", () => {
     expect(err.text).toContain("voice notification not possible");
   });
 
-  test("voice with valid TTS (openai + key) → fans out sendVoice + skips text", async () => {
+  test("voice with valid TTS (openai + key) → fans out sendVoice to ALL owners + skips text", async () => {
     const cfg = baseConfig();
     cfg.voice = {
       provider: "openai",
@@ -251,11 +333,97 @@ describe("runNotify voice", () => {
         err: new CaptureStream(),
       });
       expect(code).toBe(0);
-      expect(transport.voiceSent.length).toBe(1); // voice to first owner
+      // Broadcast: voice note to both owners (42 and 99).
+      expect(transport.voiceSent.length).toBe(2);
+      expect(transport.voiceSent.map((v) => v.chatId)).toEqual(["42", "99"]);
       expect(transport.sent.length).toBe(0);
-      expect(out.text).toContain("voice=1");
+      expect(out.text).toContain("voice=2");
     } finally {
       (globalThis as unknown as { fetch: typeof fetch }).fetch = origFetch;
     }
+  });
+});
+
+describe("runNotify phantomchat (broadcast)", () => {
+  // Build a temp persona dir with a valid phantomchat.json (real nsec + npubs)
+  // so runNotify's on-disk loader resolves the identity + allowlist. The send
+  // is injected, so no sockets/relays are touched.
+  function makePersona(
+    persona: string,
+    npubs: string[],
+  ): { personasDir: string } {
+    const root = mkdtempSync(join(tmpdir(), "pc-notify-"));
+    const dir = join(root, persona);
+    mkdirSync(dir, { recursive: true });
+    const nsec = nip19.nsecEncode(generateSecretKey());
+    writeFileSync(
+      join(dir, "phantomchat.json"),
+      JSON.stringify({ nsec, relays: ["wss://relay.example"], allowed_npubs: npubs }),
+      { mode: 0o600 },
+    );
+    return { personasDir: root };
+  }
+
+  function npub(): string {
+    return nip19.npubEncode(getPublicKey(generateSecretKey()));
+  }
+
+  test("fans out the text to EVERY allowed npub (deduped)", async () => {
+    const a = npub();
+    const b = npub();
+    const { personasDir } = makePersona("phantom", [a, a, b]); // a duplicated
+    const cfg = baseConfig();
+    cfg.personasDir = personasDir;
+    cfg.channels.telegram = undefined; // phantomchat-only
+
+    const got: string[] = [];
+    const phantomchatSend: PhantomchatNotifySend = async ({ recipientHex }) => {
+      got.push(recipientHex);
+    };
+    const out = new CaptureStream();
+    const code = await runNotify({
+      config: cfg,
+      message: "pc broadcast",
+      phantomchatSend,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    const aHex = nip19.decode(a).data as string;
+    const bHex = nip19.decode(b).data as string;
+    // Both recipients, each once (dup collapsed).
+    expect(new Set(got)).toEqual(new Set([aHex, bHex]));
+    expect(got.length).toBe(2);
+    expect(out.text).toContain("phantomchat(text=2)");
+  });
+
+  test("a failing phantomchat recipient doesn't abort the rest, exit 0, not surfaced", async () => {
+    const a = npub();
+    const b = npub();
+    const { personasDir } = makePersona("phantom", [a, b]);
+    const cfg = baseConfig();
+    cfg.personasDir = personasDir;
+    cfg.channels.telegram = undefined;
+
+    const aHex = nip19.decode(a).data as string;
+    const got: string[] = [];
+    const phantomchatSend: PhantomchatNotifySend = async ({ recipientHex }) => {
+      if (recipientHex === aHex) throw new Error("dead relay");
+      got.push(recipientHex);
+    };
+    const err = new CaptureStream();
+    const out = new CaptureStream();
+    const code = await runNotify({
+      config: cfg,
+      message: "resilient pc",
+      phantomchatSend,
+      out,
+      err,
+    });
+    expect(code).toBe(0); // b still landed
+    const bHex = nip19.decode(b).data as string;
+    expect(got).toEqual([bHex]);
+    expect(err.text).toBe("");
+    expect(out.text).toContain("phantomchat(text=1)");
   });
 });

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -220,7 +220,7 @@ describe("runNotify text (broadcast)", () => {
 });
 
 describe("runNotify persona routing (broadcast)", () => {
-  test("--persona routes to that persona's bot + ALL its allowed ids", async () => {
+  test("--persona broadcasts to the persona bot AND the default bot (all ids of each)", async () => {
     const cfg = baseConfig();
     cfg.channels.telegramPersonas = {
       amanda: {
@@ -240,12 +240,47 @@ describe("runNotify persona routing (broadcast)", () => {
       err: new CaptureStream(),
     });
     expect(code).toBe(0);
-    // The persona's bot, ALL ids ([7, 8]) — not the default ([42, 99]).
+    // #249: fan out to EVERY authorized recipient on EVERY configured account —
+    // the persona bot's ids ([7, 8]) AND the default bot's ids ([42, 99]).
+    // Persona bot first, then default.
     expect(transport.sent).toEqual([
       { chatId: "7", text: "amanda ping" },
       { chatId: "8", text: "amanda ping" },
+      { chatId: "42", text: "amanda ping" },
+      { chatId: "99", text: "amanda ping" },
     ]);
-    expect(out.text).toContain("text=2");
+    expect(out.text).toContain("text=4");
+  });
+
+  test("persona bot sharing the default token dedups per (token, chatId) across accounts", async () => {
+    const cfg = baseConfig();
+    // Same token as the default bot ([42, 99]); id 42 is shared across both.
+    cfg.channels.telegramPersonas = {
+      amanda: {
+        token: "fake-token",
+        pollTimeoutS: 30,
+        allowedUserIds: [42, 7],
+      },
+    };
+    const transport = new FakeTransport();
+    const out = new CaptureStream();
+    const code = await runNotify({
+      config: cfg,
+      transport,
+      persona: "amanda",
+      message: "ping",
+      out,
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    // Persona account (fake-token): 42, 7. Default account (fake-token): 42 is a
+    // (token, chatId) dup → skipped; 99 is new. Net: 42, 7, 99 — 42 exactly once.
+    expect(transport.sent).toEqual([
+      { chatId: "42", text: "ping" },
+      { chatId: "7", text: "ping" },
+      { chatId: "99", text: "ping" },
+    ]);
+    expect(out.text).toContain("text=3");
   });
 
   test("persona with no bot → falls back to the default bot's ids", async () => {


### PR DESCRIPTION
## What

`phantombot notify` now **broadcasts to every authorized recipient on every configured channel** for the persona, instead of only the first owner per channel. Closes #249.

Before: Telegram used `allowedUserIds[0]` and phantomchat used `allowedHex[0]`, so a task- or judge-fired notification on a Telegram-only persona reached exactly **one** user even when others were authorized.

After: it fans out to **all** `allowedUserIds` and **all** `allowedHex`.

## How

- **Telegram** — iterate the full `allowedUserIds`, deduped per `(bot token, chatId)` so an id repeated in the allowlist is contacted once.
- **Phantomchat** — iterate the full `allowedHex`, deduped per `recipientHex`.
- **Voice** — synthesized **once** (not per recipient) and sent to every Telegram recipient; phantomchat gets the text fallback, same as before.
- Fan-out is **unconditional** — no toggle, no primary-only mode (per the issue's decision).

## Error handling — unchanged, this is fan-out only

- Each recipient is an **independent send**; a failure is caught and `log.warn`'d, then **swallowed** — never re-thrown, never retried.
- **No new exit codes.** Partial fan-out failures (some ok, some not) still exit `0`; exit `1` only when nothing landed on any recipient/channel — the same "did anything land at all" semantics as before.
- **Never surfaced to users** — no stderr summary of failed recipients, no notification-about-the-notification. Failures live in the logs and nowhere else.

## Docs

Module docstring, `notify` command + `--persona` descriptions, the README **Notifications** section, and the AGENTS.md file-tree label all updated to describe broadcast-to-all-authorized semantics.

## Tests (`tests/cli-notify.test.ts`)

- fan-out delivers `--message` to **every** allowed id
- repeated ids / npubs **deduped** to one send each
- a **mid-list failure** still delivers to the rest, exits `0`, and stays **off stderr**
- **all recipients failing** → exit `1`
- **voice** fans out `sendVoice` to every owner
- **phantomchat** multi-npub fan-out (deduped) + resilient partial failure

Full suite green: **1817 pass / 0 fail**, `tsc --noEmit` clean.
