### PR TITLE
feat(chattiness): quiet-by-default whenever chattiness is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,14 +382,13 @@ errors always come through either way):
 Scoped to Telegram + PhantomChat (voice and the CLI never emit these bubbles).
 The editor (Zed/VS Code) surface follows the config default only.
 
-**The standing default depends on whether the host is configured.** A fresh /
-not-yet-configured install (no `config.toml` on disk) starts **quiet** — new
-phantoms just send the final answer until you opt in. An install that already
-has a `config.toml` keeps bubbles **on** unless you set otherwise, so existing
-users are never flipped underneath them. Set it explicitly either way:
+**The standing default is quiet.** Unless you explicitly set `chattiness`, a
+phantom starts **quiet** and just sends the final answer — this holds whether
+there's no `config.toml`, an empty one, or a `config.toml` that simply omits
+the key. Opt in to the running commentary by setting it:
 
 ```toml
-# Top-level. true = show progress bubbles everywhere; false = quiet-by-default.
+# Top-level. true = show progress bubbles everywhere; false (or unset) = quiet.
 chattiness = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ toggles those interim bubbles **per conversation** (the final reply and any
 errors always come through either way):
 
 - `/chattiness off` — quiet: no progress bubbles, just the final reply.
-- `/chattiness on` — show the progress bubbles (the default).
+- `/chattiness on` — show the progress bubbles.
 - `/chattiness default` — clear this chat's setting; follow the standing default.
 - `/chattiness off default` (or `on default`) — also write the standing default
   to `config.toml` so **new** chats start that way.
@@ -382,11 +382,14 @@ errors always come through either way):
 Scoped to Telegram + PhantomChat (voice and the CLI never emit these bubbles).
 The editor (Zed/VS Code) surface follows the config default only.
 
-Set the standing default directly in config — `true` (show bubbles) is the
-default, so nothing changes unless you opt out:
+**The standing default depends on whether the host is configured.** A fresh /
+not-yet-configured install (no `config.toml` on disk) starts **quiet** — new
+phantoms just send the final answer until you opt in. An install that already
+has a `config.toml` keeps bubbles **on** unless you set otherwise, so existing
+users are never flipped underneath them. Set it explicitly either way:
 
 ```toml
-# Top-level. Set false to make phantombot quiet-by-default everywhere.
+# Top-level. true = show progress bubbles everywhere; false = quiet-by-default.
 chattiness = true
 ```
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -205,11 +205,22 @@ export interface TelegramStreamingSettings {
 }
 
 /**
- * Standing default for interim progress-narration bubbles when neither a
- * per-conversation override nor a config value is set. ON so behaviour is
- * unchanged for existing users. See lib/chattiness.ts.
+ * Standing default for interim progress-narration bubbles on an *already
+ * configured* host (a `config.toml` exists but sets no `chattiness` key),
+ * and the fallback used by read sites given a partial config. ON so
+ * behaviour is unchanged for existing users. See lib/chattiness.ts.
  */
 export const DEFAULT_CHATTINESS = true;
+
+/**
+ * Standing default for a fresh / not-yet-configured install — no
+ * `config.toml` on disk. OFF (quiet) so new phantoms start calm: just the
+ * final answer, no running commentary, until an operator opts in via
+ * `chattiness = true` or `/chattiness on`. This only affects hosts with no
+ * config file; the moment one exists, DEFAULT_CHATTINESS applies instead so
+ * existing users are never flipped underneath them.
+ */
+export const DEFAULT_CHATTINESS_UNCONFIGURED = false;
 
 export const DEFAULT_TELEGRAM_STREAMING: TelegramStreamingSettings = {
   narrationFlushMs: 4500,
@@ -282,12 +293,15 @@ export interface Config {
    * channels (Telegram + PhantomChat). `true` = stream the running commentary
    * ("checking your calendar…"); `false` = quiet, final reply only. A
    * per-conversation `/chattiness` override wins over this default; the final
-   * reply and error paths are never affected either way. Defaults to `true` so
-   * behaviour is unchanged unless a user opts into quiet mode. Also gates the
-   * editor (ACP) surface's pre-tool narration — the config default only. See
-   * lib/chattiness.ts. Optional in the type (mirrors telegramStreaming?) so
-   * partial test fixtures need no update; loadConfig always sets it, and read
-   * sites default to `true` (DEFAULT_CHATTINESS) when absent.
+   * reply and error paths are never affected either way. When unset in config,
+   * the default depends on whether the host is configured at all: an existing
+   * install (config.toml present) stays `true` so nothing changes underneath
+   * it, while a fresh / not-yet-configured install defaults to `false` (quiet).
+   * Also gates the editor (ACP) surface's pre-tool narration — the config
+   * default only. See lib/chattiness.ts. Optional in the type (mirrors
+   * telegramStreaming?) so partial test fixtures need no update; loadConfig
+   * always sets it, and read sites default to `true` (DEFAULT_CHATTINESS) when
+   * absent.
    */
   chattiness?: boolean;
 
@@ -332,7 +346,7 @@ export async function loadConfig(): Promise<Config> {
     process.env.PHANTOMBOT_CONFIG ??
     join(xdgConfigHome(), "phantombot", "config.toml");
 
-  const toml = await tryReadToml(configPath);
+  const { data: toml, existed: configExisted } = await tryReadToml(configPath);
   const state = await loadState();
 
   const dataDir = join(xdgDataHome(), "phantombot");
@@ -476,13 +490,17 @@ export async function loadConfig(): Promise<Config> {
 
     telegramStreaming: buildTelegramStreamingConfig(tomlTelegram),
 
-    // Standing default for interim progress-narration bubbles. Defaults ON so
-    // nothing changes for existing users; a persona/host can flip it OFF here
-    // (or per-chat via /chattiness). Env override for scripted/test setups.
+    // Standing default for interim progress-narration bubbles. An explicit
+    // value always wins (env for scripted/test setups, then `chattiness` in
+    // config.toml). Absent an explicit value the default depends on whether
+    // this host is configured at all: an existing install (config.toml on
+    // disk) stays ON so nothing changes underneath it, while a fresh /
+    // not-yet-configured install starts quiet (OFF). See DEFAULT_CHATTINESS
+    // / DEFAULT_CHATTINESS_UNCONFIGURED.
     chattiness:
       asBool(process.env.PHANTOMBOT_CHATTINESS) ??
       asBool(toml.chattiness) ??
-      DEFAULT_CHATTINESS,
+      (configExisted ? DEFAULT_CHATTINESS : DEFAULT_CHATTINESS_UNCONFIGURED),
 
     embeddings: buildEmbeddingsConfig(tomlEmbeddings, tomlGemini),
 
@@ -902,12 +920,23 @@ export function memoryIndexPath(persona: string): string {
   return join(xdgDataHome(), "phantombot", "memory-index", `${persona}.sqlite`);
 }
 
-async function tryReadToml(path: string): Promise<Record<string, unknown>> {
+/**
+ * Read + parse config.toml, reporting whether the file actually existed.
+ * `existed` is the signal that distinguishes a configured host (has a
+ * config.toml on disk) from a fresh/unconfigured install (no file yet) —
+ * which is what decides the chattiness default. A present-but-empty file
+ * still counts as `existed: true`: the operator has a config, they just
+ * didn't set this key.
+ */
+async function tryReadToml(
+  path: string,
+): Promise<{ data: Record<string, unknown>; existed: boolean }> {
   try {
     const content = await readFile(path, "utf8");
-    return parseToml(content) as Record<string, unknown>;
+    return { data: parseToml(content) as Record<string, unknown>, existed: true };
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    if ((err as NodeJS.ErrnoException).code === "ENOENT")
+      return { data: {}, existed: false };
     throw err;
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -205,22 +205,14 @@ export interface TelegramStreamingSettings {
 }
 
 /**
- * Standing default for interim progress-narration bubbles on an *already
- * configured* host (a `config.toml` exists but sets no `chattiness` key),
- * and the fallback used by read sites given a partial config. ON so
- * behaviour is unchanged for existing users. See lib/chattiness.ts.
+ * Standing default for interim progress-narration bubbles whenever no
+ * `chattiness` key is set — regardless of whether a `config.toml` exists.
+ * OFF (quiet) so every unconfigured phantom starts calm: just the final
+ * answer, no running commentary, until an operator opts in via
+ * `chattiness = true` or `/chattiness on`. Also the fallback used by read
+ * sites given a partial config. See lib/chattiness.ts.
  */
-export const DEFAULT_CHATTINESS = true;
-
-/**
- * Standing default for a fresh / not-yet-configured install — no
- * `config.toml` on disk. OFF (quiet) so new phantoms start calm: just the
- * final answer, no running commentary, until an operator opts in via
- * `chattiness = true` or `/chattiness on`. This only affects hosts with no
- * config file; the moment one exists, DEFAULT_CHATTINESS applies instead so
- * existing users are never flipped underneath them.
- */
-export const DEFAULT_CHATTINESS_UNCONFIGURED = false;
+export const DEFAULT_CHATTINESS = false;
 
 export const DEFAULT_TELEGRAM_STREAMING: TelegramStreamingSettings = {
   narrationFlushMs: 4500,
@@ -293,15 +285,14 @@ export interface Config {
    * channels (Telegram + PhantomChat). `true` = stream the running commentary
    * ("checking your calendar…"); `false` = quiet, final reply only. A
    * per-conversation `/chattiness` override wins over this default; the final
-   * reply and error paths are never affected either way. When unset in config,
-   * the default depends on whether the host is configured at all: an existing
-   * install (config.toml present) stays `true` so nothing changes underneath
-   * it, while a fresh / not-yet-configured install defaults to `false` (quiet).
-   * Also gates the editor (ACP) surface's pre-tool narration — the config
-   * default only. See lib/chattiness.ts. Optional in the type (mirrors
-   * telegramStreaming?) so partial test fixtures need no update; loadConfig
-   * always sets it, and read sites default to `true` (DEFAULT_CHATTINESS) when
-   * absent.
+   * reply and error paths are never affected either way. When unset in config
+   * — no `chattiness` key, an empty file, or no `config.toml` at all — the
+   * default is `false` (quiet), so any not-yet-configured phantom starts calm
+   * and only narrates once an operator opts in. Also gates the editor (ACP)
+   * surface's pre-tool narration — the config default only. See
+   * lib/chattiness.ts. Optional in the type (mirrors telegramStreaming?) so
+   * partial test fixtures need no update; loadConfig always sets it, and read
+   * sites default to `false` (DEFAULT_CHATTINESS) when absent.
    */
   chattiness?: boolean;
 
@@ -346,7 +337,7 @@ export async function loadConfig(): Promise<Config> {
     process.env.PHANTOMBOT_CONFIG ??
     join(xdgConfigHome(), "phantombot", "config.toml");
 
-  const { data: toml, existed: configExisted } = await tryReadToml(configPath);
+  const toml = await tryReadToml(configPath);
   const state = await loadState();
 
   const dataDir = join(xdgDataHome(), "phantombot");
@@ -492,15 +483,14 @@ export async function loadConfig(): Promise<Config> {
 
     // Standing default for interim progress-narration bubbles. An explicit
     // value always wins (env for scripted/test setups, then `chattiness` in
-    // config.toml). Absent an explicit value the default depends on whether
-    // this host is configured at all: an existing install (config.toml on
-    // disk) stays ON so nothing changes underneath it, while a fresh /
-    // not-yet-configured install starts quiet (OFF). See DEFAULT_CHATTINESS
-    // / DEFAULT_CHATTINESS_UNCONFIGURED.
+    // config.toml). Absent any explicit value the phantom starts quiet (OFF)
+    // — this holds whether or not a config.toml exists, so an existing
+    // install with no `chattiness` key or an empty file is quiet too. See
+    // DEFAULT_CHATTINESS.
     chattiness:
       asBool(process.env.PHANTOMBOT_CHATTINESS) ??
       asBool(toml.chattiness) ??
-      (configExisted ? DEFAULT_CHATTINESS : DEFAULT_CHATTINESS_UNCONFIGURED),
+      DEFAULT_CHATTINESS,
 
     embeddings: buildEmbeddingsConfig(tomlEmbeddings, tomlGemini),
 
@@ -920,23 +910,13 @@ export function memoryIndexPath(persona: string): string {
   return join(xdgDataHome(), "phantombot", "memory-index", `${persona}.sqlite`);
 }
 
-/**
- * Read + parse config.toml, reporting whether the file actually existed.
- * `existed` is the signal that distinguishes a configured host (has a
- * config.toml on disk) from a fresh/unconfigured install (no file yet) —
- * which is what decides the chattiness default. A present-but-empty file
- * still counts as `existed: true`: the operator has a config, they just
- * didn't set this key.
- */
-async function tryReadToml(
-  path: string,
-): Promise<{ data: Record<string, unknown>; existed: boolean }> {
+/** Read + parse config.toml; a missing file parses as an empty config. */
+async function tryReadToml(path: string): Promise<Record<string, unknown>> {
   try {
     const content = await readFile(path, "utf8");
-    return { data: parseToml(content) as Record<string, unknown>, existed: true };
+    return parseToml(content) as Record<string, unknown>;
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT")
-      return { data: {}, existed: false };
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
     throw err;
   }
 }

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -125,6 +125,10 @@ const baseConfig = (): Config => ({
     gemini: { bin: "gemini", model: "" },
   },
   channels: {},
+  // Streaming tests below exercise the progress-bubble path, so enable
+  // chattiness explicitly. The standing default is now quiet (OFF); the
+  // install-time default resolution is covered in config.test.ts.
+  chattiness: true,
   embeddings: { provider: "none" },
   // Retrieval disabled so the test doesn't need an embeddings index.
   retrieval: undefined,

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -673,6 +673,10 @@ const baseConfig = (
     bubbleDelayMs: 0,
     voiceMaxSentences: 3,
   },
+  // Narration mechanics tests below exercise the progress-bubble path, so
+  // enable chattiness explicitly. The standing default is now quiet (OFF);
+  // resolving the install-time default is covered in config.test.ts.
+  chattiness: true,
   embeddings: { provider: "none" },
   voice: { provider: "none" },
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -140,18 +140,18 @@ describe("loadConfig — chattiness default", () => {
     expect(c.chattiness).toBe(false);
   });
 
-  test("config.toml exists but omits chattiness → stays ON (existing users unchanged)", async () => {
-    // Any config content is enough to mark the host as 'configured'; the
-    // key itself is absent, so we keep the historical ON default.
+  test("config.toml exists but omits chattiness → quiet (OFF)", async () => {
+    // The key is absent, so the standing quiet default applies even though
+    // the host otherwise has a config.
     await writeConfig(`default_persona = "robbie"\n`);
     const c = await loadConfig();
-    expect(c.chattiness).toBe(true);
+    expect(c.chattiness).toBe(false);
   });
 
-  test("empty config.toml still counts as configured → stays ON", async () => {
+  test("empty config.toml → quiet (OFF)", async () => {
     await writeConfig("");
     const c = await loadConfig();
-    expect(c.chattiness).toBe(true);
+    expect(c.chattiness).toBe(false);
   });
 
   test("explicit chattiness = false in config.toml is honored", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -67,6 +67,7 @@ const ENV_KEYS = [
   "PHANTOMBOT_TELEGRAM_BUBBLE_MAX_CHARS",
   "PHANTOMBOT_TELEGRAM_BUBBLE_DELAY_MS",
   "PHANTOMBOT_TELEGRAM_VOICE_MAX_SENTENCES",
+  "PHANTOMBOT_CHATTINESS",
 ];
 
 let workdir: string;
@@ -114,6 +115,9 @@ describe("loadConfig — defaults (no file)", () => {
       model: "",
     });
     expect(c.telegramStreaming).toEqual(DEFAULT_TELEGRAM_STREAMING);
+    // Fresh / not-yet-configured install (no config.toml on disk) starts
+    // QUIET — the standing default for new phantoms.
+    expect(c.chattiness).toBe(false);
   });
 
   test("XDG paths resolve to ~/.config and ~/.local/share by default", async () => {
@@ -121,6 +125,59 @@ describe("loadConfig — defaults (no file)", () => {
     expect(c.personasDir).toBe(join(workdir, "data", "phantombot", "personas"));
     expect(c.memoryDbPath).toBe(join(workdir, "data", "phantombot", "memory.sqlite"));
     expect(c.configPath).toBe(join(workdir, "config", "phantombot", "config.toml"));
+  });
+});
+
+describe("loadConfig — chattiness default", () => {
+  async function writeConfig(body: string): Promise<void> {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(join(cfgDir, "config.toml"), body, "utf8");
+  }
+
+  test("no config file at all → quiet (OFF) for fresh installs", async () => {
+    const c = await loadConfig();
+    expect(c.chattiness).toBe(false);
+  });
+
+  test("config.toml exists but omits chattiness → stays ON (existing users unchanged)", async () => {
+    // Any config content is enough to mark the host as 'configured'; the
+    // key itself is absent, so we keep the historical ON default.
+    await writeConfig(`default_persona = "robbie"\n`);
+    const c = await loadConfig();
+    expect(c.chattiness).toBe(true);
+  });
+
+  test("empty config.toml still counts as configured → stays ON", async () => {
+    await writeConfig("");
+    const c = await loadConfig();
+    expect(c.chattiness).toBe(true);
+  });
+
+  test("explicit chattiness = false in config.toml is honored", async () => {
+    await writeConfig(`chattiness = false\n`);
+    const c = await loadConfig();
+    expect(c.chattiness).toBe(false);
+  });
+
+  test("explicit chattiness = true in config.toml is honored", async () => {
+    await writeConfig(`chattiness = true\n`);
+    const c = await loadConfig();
+    expect(c.chattiness).toBe(true);
+  });
+
+  test("PHANTOMBOT_CHATTINESS env wins over the fresh-install default", async () => {
+    // No config file → would be OFF, but the env override forces ON.
+    process.env.PHANTOMBOT_CHATTINESS = "on";
+    const c = await loadConfig();
+    expect(c.chattiness).toBe(true);
+  });
+
+  test("PHANTOMBOT_CHATTINESS env wins over config.toml", async () => {
+    await writeConfig(`chattiness = true\n`);
+    process.env.PHANTOMBOT_CHATTINESS = "off";
+    const c = await loadConfig();
+    expect(c.chattiness).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What

Makes **quiet mode the standing default** for any phantom that hasn't explicitly opted into progress narration. If `chattiness` is unset, the phantom starts quiet — just the final answer, no running commentary — until an operator turns it on via `chattiness = true` or `/chattiness on`.

This holds uniformly, regardless of install state:

| Situation | default |
|---|---|
| No `config.toml` on disk | **OFF** — quiet |
| `config.toml` exists but omits `chattiness` | **OFF** — quiet |
| Empty `config.toml` | **OFF** — quiet |
| `chattiness = true` / `false` set | honored |
| `PHANTOMBOT_CHATTINESS` env | honored, wins over all |

## Why this shape

Original revision made the default *install-aware* (quiet only when no `config.toml` existed, ON otherwise). Per Andrew's follow-up, that distinction is dropped: **existing hosts with no `chattiness` key — or an empty config — should be quiet too.** So the rule collapses to the single, predictable "quiet unless explicitly set."

## How

- `DEFAULT_CHATTINESS` is now `false` and is the single fallback at both loadConfig and read sites.
- Removed `DEFAULT_CHATTINESS_UNCONFIGURED` and the `configExisted` plumbing in `tryReadToml` (that helper is back to plain `Record<string, unknown>`).
- `/chattiness` command, per-conversation overrides, and the #246 config-write path are untouched.

## Tests

- `config.test.ts`: no-file → OFF, present-but-no-key → OFF, empty → OFF, explicit true/false honored, env wins both ways.
- Narration-mechanics fixtures (`channels-telegram`, `channels-phantomchat-server`) set `chattiness: true` explicitly since they exercise the progress-bubble path.
- Full suite **1819 pass / 0 fail**, `tsc` clean.

## Operator note

A host that already sets `chattiness = true` is unaffected. A host relying on the *implicit* old ON default (config present, key absent) will go quiet after this — that's the intended change. Set `chattiness = true` to keep the bubbles.