### PR TITLE
feat(vault): encrypted per-persona secrets store keyed by persona identity (#253)

### DIFF
--- a/src/channels/phantomchat/personaStore.ts
+++ b/src/channels/phantomchat/personaStore.ts
@@ -66,6 +66,7 @@ import {
   identityFromNsec,
   type NostrIdentity,
 } from "../../lib/nostrIdentity.ts";
+import { readPersonaIdentityNsec } from "../../lib/personaIdentity.ts";
 
 /** Filename of the per-persona phantomchat config inside an agent dir. */
 export const PHANTOMCHAT_FILE = "phantomchat.json";
@@ -193,14 +194,25 @@ export function loadPhantomchatPersonaConfig(
     });
     return undefined;
   }
-  if (!parsed || typeof parsed.nsec !== "string" || parsed.nsec.trim() === "") {
+  // The nsec now lives in the shared `identity.json` (lib/personaIdentity.ts).
+  // Prefer it; fall back to a legacy nsec still inside phantomchat.json so
+  // pre-migration persona folders keep working. The channel is enabled as long
+  // as EITHER source yields a usable nsec — phantomchat.json still carries the
+  // channel config (relays / allowlist / group bots).
+  const sharedNsec = readPersonaIdentityNsec(agentDir);
+  const nsec =
+    sharedNsec ??
+    (typeof parsed.nsec === "string" && parsed.nsec.trim() !== ""
+      ? parsed.nsec.trim()
+      : undefined);
+  if (!nsec) {
     return undefined;
   }
   let identity: NostrIdentity;
   try {
-    identity = identityFromNsec(parsed.nsec);
+    identity = identityFromNsec(nsec);
   } catch (e) {
-    log.warn(`phantomchat: invalid nsec in ${path} — skipping`, {
+    log.warn(`phantomchat: invalid nsec for ${agentDir} — skipping`, {
       error: (e as Error).message,
     });
     return undefined;

--- a/src/channels/phantomchat/personaStore.ts
+++ b/src/channels/phantomchat/personaStore.ts
@@ -66,7 +66,11 @@ import {
   identityFromNsec,
   type NostrIdentity,
 } from "../../lib/nostrIdentity.ts";
-import { readPersonaIdentityNsec } from "../../lib/personaIdentity.ts";
+import {
+  personaIdentityPath,
+  readPersonaIdentityNsec,
+  writePersonaIdentity,
+} from "../../lib/personaIdentity.ts";
 
 /** Filename of the per-persona phantomchat config inside an agent dir. */
 export const PHANTOMCHAT_FILE = "phantomchat.json";
@@ -234,9 +238,17 @@ export function loadPhantomchatPersonaConfig(
 }
 
 /**
- * Atomically write a persona's phantomchat.json at mode 0600 (the nsec is a
- * secret). Creates the agent dir if needed. Tempfile + rename avoids the
- * world-readable window a write-then-chmod would leave.
+ * Atomically write a persona's phantomchat.json at mode 0600. Creates the agent
+ * dir if needed. Tempfile + rename avoids the world-readable window a
+ * write-then-chmod would leave.
+ *
+ * The persona's root secret (nsec) is NO LONGER written here — it lives solely
+ * in the shared `identity.json` (lib/personaIdentity.ts), which both this
+ * channel and the encrypted vault derive from. `data.nsec` is still accepted so
+ * callers (and legacy files whose nsec we just read back) can seed identity.json
+ * on the first save that follows a migration; it is persisted there
+ * (create-if-absent, never clobbering an existing identity) and then kept OUT of
+ * phantomchat.json, which now carries channel settings only.
  */
 export async function savePhantomchatPersonaConfig(
   agentDir: string,
@@ -251,8 +263,14 @@ export async function savePhantomchatPersonaConfig(
 ): Promise<string> {
   const path = phantomchatConfigPath(agentDir);
   await mkdir(dirname(path), { recursive: true });
+  // Ensure the root secret lives in identity.json before we drop it from this
+  // file. Create-if-absent: a legacy persona's nsec (read out of the old
+  // phantomchat.json) is promoted here exactly once; an identity.json that
+  // already exists (the common case) is left untouched so we never clobber it.
+  if (data.nsec && !existsSync(personaIdentityPath(agentDir))) {
+    await writePersonaIdentity(agentDir, data.nsec);
+  }
   const body: PhantomchatFileShape = {
-    nsec: data.nsec,
     relays: data.relays,
     allowed_npubs: data.allowedNpubs,
   };

--- a/src/channels/phantomchat/personaStore.ts
+++ b/src/channels/phantomchat/personaStore.ts
@@ -67,9 +67,8 @@ import {
   type NostrIdentity,
 } from "../../lib/nostrIdentity.ts";
 import {
-  personaIdentityPath,
+  createPersonaIdentityIfAbsent,
   readPersonaIdentityNsec,
-  writePersonaIdentity,
 } from "../../lib/personaIdentity.ts";
 
 /** Filename of the per-persona phantomchat config inside an agent dir. */
@@ -263,12 +262,14 @@ export async function savePhantomchatPersonaConfig(
 ): Promise<string> {
   const path = phantomchatConfigPath(agentDir);
   await mkdir(dirname(path), { recursive: true });
-  // Ensure the root secret lives in identity.json before we drop it from this
-  // file. Create-if-absent: a legacy persona's nsec (read out of the old
-  // phantomchat.json) is promoted here exactly once; an identity.json that
-  // already exists (the common case) is left untouched so we never clobber it.
-  if (data.nsec && !existsSync(personaIdentityPath(agentDir))) {
-    await writePersonaIdentity(agentDir, data.nsec);
+  // Ensure the root secret is durably in identity.json before we drop it from
+  // this channel file. Atomic create-if-absent (no existsSync check-then-write):
+  // a legacy persona's nsec is promoted exactly once; an identity.json that
+  // already exists — including one the vault just minted concurrently — is never
+  // overwritten, so we can't clobber the canonical identity and orphan its
+  // encrypted rows.
+  if (data.nsec) {
+    await createPersonaIdentityIfAbsent(agentDir, data.nsec);
   }
   const body: PhantomchatFileShape = {
     relays: data.relays,

--- a/src/cli/env.ts
+++ b/src/cli/env.ts
@@ -1,23 +1,17 @@
 /**
- * `phantombot env` — manage credentials in the user's ~/.env file.
+ * `phantombot env` — DEPRECATED ALIAS for `phantombot vault`.
  *
- * This is the agent's sanctioned write path. Direct `echo … >> ~/.env`
- * by the harnessed agent would lose atomic-rename + 0o600 — the same
- * race PR #31 fixed for phantombot's own .env. Going through this
- * subcommand reuses src/lib/envFile.ts so the agent inherits those
- * guarantees for free.
+ * The credential store moved from the plaintext `~/.env` file to a per-persona
+ * ENCRYPTED vault (`<personaDir>/vault.sqlite`, AES-256-GCM at rest — see
+ * lib/vault.ts and cli/vault.ts). `phantombot env` still works so existing
+ * agent muscle-memory and scripts don't break, but it now prints a one-line
+ * deprecation notice to stderr and forwards straight to the vault runners.
  *
- * What lives where:
- *   ~/.config/phantombot/.env  — phantombot's own runtime secrets
- *                                 (TTS keys; written by `phantombot voice`).
- *   ~/.env                     — the agent's general-purpose credentials
- *                                 (GITHUB_TOKEN, ssh passphrases, etc.).
- *                                 phantombot sources both via systemd
- *                                 EnvironmentFile= so the running service
- *                                 sees keys from either file.
- *
- * `phantombot env` operates on ~/.env only. The phantombot-owned file
- * stays under voice/install management.
+ * `userEnvPath()` is still exported here because harness.ts writes the Pi
+ * routing key to it via updateEnvFile — that write path stays intact so
+ * nothing fails to compile or run. (Those writes feed the plaintext-file
+ * migration on the next startup, which fans keys into the vault and then
+ * removes the file.)
  */
 
 import { defineCommand } from "citty";
@@ -25,120 +19,128 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import {
-  loadEnvFile,
-  updateEnvFile,
-} from "../lib/envFile.ts";
+  runVaultGet,
+  runVaultList,
+  runVaultSet,
+  runVaultUnset,
+} from "./vault.ts";
+import type { Vault } from "../lib/vault.ts";
 import type { WriteSink } from "../lib/io.ts";
 
 /**
- * Path to the user's centralized credentials file. Override via env var
- * for testing (no need to touch the real ~/.env).
+ * Path to the user's legacy centralized credentials file. Override via env var
+ * for testing. Still used by harness.ts for the Pi routing key write; the
+ * startup migration then folds that file's keys into the vault.
  */
 export function userEnvPath(): string {
   return process.env.PHANTOMBOT_USER_ENV_FILE ?? join(homedir(), ".env");
 }
 
-const ENV_VAR_NAME = /^[A-Z_][A-Z0-9_]*$/i;
+/** One-shot deprecation notice to stderr (never to stdout, which carries values). */
+function deprecationNotice(err: WriteSink): void {
+  err.write(
+    "note: `phantombot env` is deprecated — use `phantombot vault`. Forwarding to the encrypted vault.\n",
+  );
+}
 
 export interface EnvSetInput {
   name: string;
   value: string;
-  envPath?: string;
+  persona?: string;
+  personaDir?: string;
+  vault?: Vault;
   out?: WriteSink;
   err?: WriteSink;
 }
 
 export async function runEnvSet(input: EnvSetInput): Promise<number> {
-  const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
-  if (!ENV_VAR_NAME.test(input.name)) {
-    err.write(
-      `'${input.name}' is not a valid env var name (alphanumerics + underscore, must start with letter or underscore).\n`,
-    );
-    return 2;
-  }
-  await updateEnvFile(input.envPath ?? userEnvPath(), {
-    [input.name]: input.value,
+  deprecationNotice(err);
+  return runVaultSet({
+    name: input.name,
+    value: input.value,
+    persona: input.persona,
+    personaDir: input.personaDir,
+    vault: input.vault,
+    out: input.out,
+    err: input.err,
   });
-  // Acknowledge by name only — never echo the value back. The agent
-  // builder section drills this into the persona prompt; this matches.
-  out.write(`saved ${input.name} to ${input.envPath ?? userEnvPath()}\n`);
-  return 0;
 }
 
 export interface EnvGetInput {
   name: string;
-  envPath?: string;
+  persona?: string;
+  personaDir?: string;
+  vault?: Vault;
   out?: WriteSink;
   err?: WriteSink;
 }
 
 export async function runEnvGet(input: EnvGetInput): Promise<number> {
-  const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
-  const vars = await loadEnvFile(input.envPath ?? userEnvPath());
-  const v = vars[input.name];
-  if (v === undefined) {
-    err.write(`${input.name} not set\n`);
-    return 1;
-  }
-  // Print raw value so callers can `VAR=$(phantombot env get NAME)`.
-  // Doc warning: agents should not interactively `env get` because the
-  // value lands in conversation history.
-  out.write(`${v}\n`);
-  return 0;
+  deprecationNotice(err);
+  return runVaultGet({
+    name: input.name,
+    persona: input.persona,
+    personaDir: input.personaDir,
+    vault: input.vault,
+    out: input.out,
+    err: input.err,
+  });
 }
 
 export interface EnvListInput {
-  envPath?: string;
+  persona?: string;
+  personaDir?: string;
+  vault?: Vault;
   out?: WriteSink;
+  err?: WriteSink;
 }
 
 export async function runEnvList(input: EnvListInput = {}): Promise<number> {
-  const out = input.out ?? process.stdout;
-  const vars = await loadEnvFile(input.envPath ?? userEnvPath());
-  const names = Object.keys(vars).sort();
-  if (names.length === 0) {
-    out.write(`(no entries in ${input.envPath ?? userEnvPath()})\n`);
-    return 0;
-  }
-  // Names only — values would leak via terminal scrollback.
-  for (const n of names) out.write(`${n}\n`);
-  return 0;
+  const err = input.err ?? process.stderr;
+  deprecationNotice(err);
+  return runVaultList({
+    persona: input.persona,
+    personaDir: input.personaDir,
+    vault: input.vault,
+    out: input.out,
+  });
 }
 
 export interface EnvUnsetInput {
   name: string;
-  envPath?: string;
+  persona?: string;
+  personaDir?: string;
+  vault?: Vault;
   out?: WriteSink;
   err?: WriteSink;
 }
 
 export async function runEnvUnset(input: EnvUnsetInput): Promise<number> {
-  const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
-  if (!ENV_VAR_NAME.test(input.name)) {
-    err.write(`'${input.name}' is not a valid env var name.\n`);
-    return 2;
-  }
-  // updateEnvFile treats empty-string value as "delete the key" (existing
-  // semantics from PR #29). We rely on that here.
-  await updateEnvFile(input.envPath ?? userEnvPath(), { [input.name]: "" });
-  out.write(`removed ${input.name} from ${input.envPath ?? userEnvPath()}\n`);
-  return 0;
+  deprecationNotice(err);
+  return runVaultUnset({
+    name: input.name,
+    persona: input.persona,
+    personaDir: input.personaDir,
+    vault: input.vault,
+    out: input.out,
+    err: input.err,
+  });
 }
 
 export default defineCommand({
   meta: {
     name: "env",
     description:
-      "Manage credentials in ~/.env. Atomic write, mode 0o600, idempotent. The harnessed agent should call `phantombot env set NAME value` instead of editing the file directly.",
+      "DEPRECATED alias for `phantombot vault`. Forwards to the encrypted secrets vault (values are stored AES-256-GCM at rest, no longer in plaintext ~/.env).",
   },
   subCommands: {
     set: defineCommand({
-      meta: { name: "set", description: "Add or update the NAME=value entry in ~/.env." },
+      meta: { name: "set", description: "Deprecated — see `phantombot vault set`." },
       args: {
-        name: { type: "positional", required: true, description: "Env var name (e.g. GITHUB_TOKEN)" },
+        name: { type: "positional", required: true, description: "Secret name (e.g. GITHUB_TOKEN)" },
         value: { type: "positional", required: true, description: "Value to store" },
       },
       async run({ args }) {
@@ -149,24 +151,24 @@ export default defineCommand({
       },
     }),
     get: defineCommand({
-      meta: { name: "get", description: "Print the value of NAME from ~/.env." },
+      meta: { name: "get", description: "Deprecated — see `phantombot vault get`." },
       args: {
-        name: { type: "positional", required: true, description: "Env var name to read" },
+        name: { type: "positional", required: true, description: "Secret name to read" },
       },
       async run({ args }) {
         process.exitCode = await runEnvGet({ name: args.name as string });
       },
     }),
     list: defineCommand({
-      meta: { name: "list", description: "List variable names in ~/.env (values not printed)." },
+      meta: { name: "list", description: "Deprecated — see `phantombot vault list`." },
       async run() {
         process.exitCode = await runEnvList();
       },
     }),
     unset: defineCommand({
-      meta: { name: "unset", description: "Remove NAME from ~/.env." },
+      meta: { name: "unset", description: "Deprecated — see `phantombot vault unset`." },
       args: {
-        name: { type: "positional", required: true, description: "Env var name to remove" },
+        name: { type: "positional", required: true, description: "Secret name to remove" },
       },
       async run({ args }) {
         process.exitCode = await runEnvUnset({ name: args.name as string });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,6 +35,7 @@ import heartbeatCmd from "./heartbeat.ts";
 import nightlyCmd from "./nightly.ts";
 import doctorCmd from "./doctor.ts";
 import envCmd from "./env.ts";
+import vaultCmd from "./vault.ts";
 import notifyCmd from "./notify.ts";
 import taskCmd from "./task.ts";
 import tickCmd from "./tick.ts";
@@ -56,6 +57,7 @@ export const mainCommand = defineCommand({
     harness: harnessCmd,
     embedding: embeddingCmd,
     env: envCmd,
+    vault: vaultCmd,
     init: initCmd,
     install: installCmd,
     uninstall: uninstallCmd,

--- a/src/cli/phantomchat.ts
+++ b/src/cli/phantomchat.ts
@@ -163,8 +163,10 @@ export async function runPhantomchat(input: RunInput = {}): Promise<number> {
         `Generated a new Nostr keypair for '${persona}'. The secret (nsec) will be\n` +
           `saved to <persona-dir>/identity.json (mode 0600). Back it up — this\n` +
           `nsec now also derives the persona's VAULT encryption key, so losing it\n` +
-          `means a new identity (re-add the new npub in the app) AND every secret\n` +
-          `stored in the vault becomes permanently unrecoverable.\n\n` +
+          `means a new identity (re-add the new npub in the app) AND the existing\n` +
+          `vault ciphertext can no longer be decrypted. This is a reconfigure, not\n` +
+          `a catastrophe: if you lose it, mint a fresh identity, re-add your secrets\n` +
+          `with 'phantombot vault set', and re-pair PhantomChat with the new npub.\n\n` +
           `  nsec (one-time display): ${nsec}\n\n` +
           `Its npub (paste this into the PhantomChat app to DM '${persona}'):\n\n` +
           `  ${npub}`,

--- a/src/cli/phantomchat.ts
+++ b/src/cli/phantomchat.ts
@@ -40,8 +40,12 @@ import {
 import {
   decodeNpubToHex,
   generateIdentity,
+  identityFromNsec,
 } from "../lib/nostrIdentity.ts";
-import { writePersonaIdentity } from "../lib/personaIdentity.ts";
+import {
+  readPersonaIdentityNsec,
+  writePersonaIdentity,
+} from "../lib/personaIdentity.ts";
 import { fetchCanonicalRelays } from "../channels/phantomchat/relaysSource.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
 import type { WriteSink } from "../lib/io.ts";
@@ -129,21 +133,38 @@ export async function runPhantomchat(input: RunInput = {}): Promise<number> {
       "Existing identity",
     );
   } else {
-    const identity = generate();
-    nsec = identity.nsec;
-    npub = identity.npub;
-    // The nsec is the persona's SHARED identity (used by the vault too), so it
-    // lives in <persona-dir>/identity.json (mode 0600), not phantomchat.json.
-    await writePersonaIdentity(agentDir, nsec);
-    p.note(
-      `Generated a new Nostr keypair for '${persona}'. The secret (nsec) will be\n` +
-        `saved to <persona-dir>/identity.json (mode 0600). Back it up — losing\n` +
-        `it means a new identity (and re-adding the new npub in the app).\n\n` +
-        `  nsec (one-time display): ${identity.nsec}\n\n` +
-        `Its npub (paste this into the PhantomChat app to DM '${persona}'):\n\n` +
-        `  ${npub}`,
-      "New identity created",
-    );
+    // No phantomchat.json yet — but identity.json may already exist (e.g. the
+    // vault minted it first). ADOPT an existing identity rather than generating
+    // a fresh nsec, which would orphan everything the vault already encrypted
+    // under the old key. Only mint when there is genuinely no identity yet.
+    const adopted = readPersonaIdentityNsec(agentDir);
+    if (adopted) {
+      const identity = identityFromNsec(adopted);
+      nsec = identity.nsec;
+      npub = identity.npub;
+      p.note(
+        `Persona '${persona}' already has a Nostr identity (identity.json). Reusing it.\n\n` +
+          `Its npub (paste this into the PhantomChat app to DM '${persona}'):\n\n` +
+          `  ${npub}`,
+        "Existing identity",
+      );
+    } else {
+      const identity = generate();
+      nsec = identity.nsec;
+      npub = identity.npub;
+      // The nsec is the persona's SHARED identity (used by the vault too), so it
+      // lives in <persona-dir>/identity.json (mode 0600), not phantomchat.json.
+      await writePersonaIdentity(agentDir, nsec);
+      p.note(
+        `Generated a new Nostr keypair for '${persona}'. The secret (nsec) will be\n` +
+          `saved to <persona-dir>/identity.json (mode 0600). Back it up — losing\n` +
+          `it means a new identity (and re-adding the new npub in the app).\n\n` +
+          `  nsec (one-time display): ${identity.nsec}\n\n` +
+          `Its npub (paste this into the PhantomChat app to DM '${persona}'):\n\n` +
+          `  ${npub}`,
+        "New identity created",
+      );
+    }
   }
 
   // 2. Relays are NOT prompted any more — they come from the canonical

--- a/src/cli/phantomchat.ts
+++ b/src/cli/phantomchat.ts
@@ -43,8 +43,8 @@ import {
   identityFromNsec,
 } from "../lib/nostrIdentity.ts";
 import {
+  createPersonaIdentityIfAbsent,
   readPersonaIdentityNsec,
-  writePersonaIdentity,
 } from "../lib/personaIdentity.ts";
 import { fetchCanonicalRelays } from "../channels/phantomchat/relaysSource.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
@@ -150,16 +150,20 @@ export async function runPhantomchat(input: RunInput = {}): Promise<number> {
       );
     } else {
       const identity = generate();
-      nsec = identity.nsec;
-      npub = identity.npub;
       // The nsec is the persona's SHARED identity (used by the vault too), so it
       // lives in <persona-dir>/identity.json (mode 0600), not phantomchat.json.
-      await writePersonaIdentity(agentDir, nsec);
+      // Atomic create-if-absent: if the vault minted one between the read above
+      // and here, we adopt its identity rather than overwriting it — and display
+      // whatever is durably on disk so the npub we show is the real one.
+      const persistedNsec = await createPersonaIdentityIfAbsent(agentDir, identity.nsec);
+      const persisted = identityFromNsec(persistedNsec);
+      nsec = persisted.nsec;
+      npub = persisted.npub;
       p.note(
         `Generated a new Nostr keypair for '${persona}'. The secret (nsec) will be\n` +
           `saved to <persona-dir>/identity.json (mode 0600). Back it up — losing\n` +
           `it means a new identity (and re-adding the new npub in the app).\n\n` +
-          `  nsec (one-time display): ${identity.nsec}\n\n` +
+          `  nsec (one-time display): ${nsec}\n\n` +
           `Its npub (paste this into the PhantomChat app to DM '${persona}'):\n\n` +
           `  ${npub}`,
         "New identity created",

--- a/src/cli/phantomchat.ts
+++ b/src/cli/phantomchat.ts
@@ -161,8 +161,10 @@ export async function runPhantomchat(input: RunInput = {}): Promise<number> {
       npub = persisted.npub;
       p.note(
         `Generated a new Nostr keypair for '${persona}'. The secret (nsec) will be\n` +
-          `saved to <persona-dir>/identity.json (mode 0600). Back it up — losing\n` +
-          `it means a new identity (and re-adding the new npub in the app).\n\n` +
+          `saved to <persona-dir>/identity.json (mode 0600). Back it up — this\n` +
+          `nsec now also derives the persona's VAULT encryption key, so losing it\n` +
+          `means a new identity (re-add the new npub in the app) AND every secret\n` +
+          `stored in the vault becomes permanently unrecoverable.\n\n` +
           `  nsec (one-time display): ${nsec}\n\n` +
           `Its npub (paste this into the PhantomChat app to DM '${persona}'):\n\n` +
           `  ${npub}`,

--- a/src/cli/phantomchat.ts
+++ b/src/cli/phantomchat.ts
@@ -41,6 +41,7 @@ import {
   decodeNpubToHex,
   generateIdentity,
 } from "../lib/nostrIdentity.ts";
+import { writePersonaIdentity } from "../lib/personaIdentity.ts";
 import { fetchCanonicalRelays } from "../channels/phantomchat/relaysSource.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
 import type { WriteSink } from "../lib/io.ts";
@@ -131,9 +132,12 @@ export async function runPhantomchat(input: RunInput = {}): Promise<number> {
     const identity = generate();
     nsec = identity.nsec;
     npub = identity.npub;
+    // The nsec is the persona's SHARED identity (used by the vault too), so it
+    // lives in <persona-dir>/identity.json (mode 0600), not phantomchat.json.
+    await writePersonaIdentity(agentDir, nsec);
     p.note(
       `Generated a new Nostr keypair for '${persona}'. The secret (nsec) will be\n` +
-        `saved to <persona-dir>/phantomchat.json (mode 0600). Back it up — losing\n` +
+        `saved to <persona-dir>/identity.json (mode 0600). Back it up — losing\n` +
         `it means a new identity (and re-adding the new npub in the app).\n\n` +
         `  nsec (one-time display): ${identity.nsec}\n\n` +
         `Its npub (paste this into the PhantomChat app to DM '${persona}'):\n\n` +

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -1,0 +1,222 @@
+/**
+ * `phantombot vault` — manage the persona's ENCRYPTED secrets store.
+ *
+ * This is the canonical credential store, replacing the old plaintext `~/.env`
+ * that `phantombot env` wrote (which now forwards here — see cli/env.ts). Each
+ * persona has its own `<personaDir>/vault.sqlite`, encrypted at rest with a key
+ * derived from that persona's nsec (see lib/vault.ts). Secrets are decrypted
+ * only in-process; the on-disk form is AES-256-GCM ciphertext.
+ *
+ * The subcommands mirror `phantombot env` 1:1 (set/get/list/unset), including
+ * the "saved NAME" ack that never echoes the value and the names-only listing.
+ * The harnessed agent calls `phantombot vault set NAME value` — this is its
+ * sanctioned, atomic, encrypted write path.
+ */
+
+import { defineCommand } from "citty";
+
+import { loadConfig, personaDir, type Config } from "../config.ts";
+import { openPersonaVault, type Vault } from "../lib/vault.ts";
+import type { WriteSink } from "../lib/io.ts";
+
+const ENV_VAR_NAME = /^[A-Z_][A-Z0-9_]*$/i;
+
+/**
+ * Resolve which persona's vault to operate on. Same precedence the rest of the
+ * CLI uses: an explicit --persona wins, then the harness-injected
+ * PHANTOMBOT_PERSONA, then the resolved default persona.
+ */
+export async function resolveVaultPersonaDir(
+  explicitPersona?: string,
+  config?: Config,
+): Promise<string> {
+  const cfg = config ?? (await loadConfig());
+  const persona =
+    explicitPersona || process.env.PHANTOMBOT_PERSONA || cfg.defaultPersona;
+  return personaDir(cfg, persona);
+}
+
+/**
+ * Open the vault for a run: either a caller-supplied one (tests) or the active
+ * persona's. Returns the vault plus whether we own it (and must close it).
+ */
+async function resolveVault(input: {
+  vault?: Vault;
+  personaDir?: string;
+  persona?: string;
+}): Promise<{ vault: Vault; owned: boolean }> {
+  if (input.vault) return { vault: input.vault, owned: false };
+  const dir = input.personaDir ?? (await resolveVaultPersonaDir(input.persona));
+  return { vault: await openPersonaVault(dir), owned: true };
+}
+
+export interface VaultSetInput {
+  name: string;
+  value: string;
+  persona?: string;
+  personaDir?: string;
+  vault?: Vault;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runVaultSet(input: VaultSetInput): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  if (!ENV_VAR_NAME.test(input.name)) {
+    err.write(
+      `'${input.name}' is not a valid env var name (alphanumerics + underscore, must start with letter or underscore).\n`,
+    );
+    return 2;
+  }
+  const { vault, owned } = await resolveVault(input);
+  try {
+    vault.set(input.name, input.value);
+  } finally {
+    if (owned) vault.close();
+  }
+  // Acknowledge by name only — never echo the value back.
+  out.write(`saved ${input.name} to the vault\n`);
+  return 0;
+}
+
+export interface VaultGetInput {
+  name: string;
+  persona?: string;
+  personaDir?: string;
+  vault?: Vault;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runVaultGet(input: VaultGetInput): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const { vault, owned } = await resolveVault(input);
+  let v: string | undefined;
+  try {
+    v = vault.get(input.name);
+  } finally {
+    if (owned) vault.close();
+  }
+  if (v === undefined) {
+    err.write(`${input.name} not set\n`);
+    return 1;
+  }
+  // Print raw value so callers can `VAR=$(phantombot vault get NAME)`.
+  out.write(`${v}\n`);
+  return 0;
+}
+
+export interface VaultListInput {
+  persona?: string;
+  personaDir?: string;
+  vault?: Vault;
+  out?: WriteSink;
+}
+
+export async function runVaultList(input: VaultListInput = {}): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const { vault, owned } = await resolveVault(input);
+  let names: string[];
+  try {
+    names = vault.list();
+  } finally {
+    if (owned) vault.close();
+  }
+  if (names.length === 0) {
+    out.write(`(no entries in the vault)\n`);
+    return 0;
+  }
+  // Names only — values would leak via terminal scrollback.
+  for (const n of names) out.write(`${n}\n`);
+  return 0;
+}
+
+export interface VaultUnsetInput {
+  name: string;
+  persona?: string;
+  personaDir?: string;
+  vault?: Vault;
+  out?: WriteSink;
+  err?: WriteSink;
+}
+
+export async function runVaultUnset(input: VaultUnsetInput): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  if (!ENV_VAR_NAME.test(input.name)) {
+    err.write(`'${input.name}' is not a valid env var name.\n`);
+    return 2;
+  }
+  const { vault, owned } = await resolveVault(input);
+  try {
+    vault.unset(input.name);
+  } finally {
+    if (owned) vault.close();
+  }
+  out.write(`removed ${input.name} from the vault\n`);
+  return 0;
+}
+
+export default defineCommand({
+  meta: {
+    name: "vault",
+    description:
+      "Manage the persona's encrypted secrets vault. AES-256-GCM at rest, key derived from the persona's identity. The harnessed agent should call `phantombot vault set NAME value` instead of editing files directly.",
+  },
+  subCommands: {
+    set: defineCommand({
+      meta: { name: "set", description: "Add or update the NAME=value entry in the vault." },
+      args: {
+        name: { type: "positional", required: true, description: "Secret name (e.g. GITHUB_TOKEN)" },
+        value: { type: "positional", required: true, description: "Value to store" },
+        persona: { type: "string", description: "Persona whose vault to use. Defaults to PHANTOMBOT_PERSONA / default persona." },
+      },
+      async run({ args }) {
+        process.exitCode = await runVaultSet({
+          name: args.name as string,
+          value: args.value as string,
+          persona: args.persona ? String(args.persona) : undefined,
+        });
+      },
+    }),
+    get: defineCommand({
+      meta: { name: "get", description: "Print the value of NAME from the vault." },
+      args: {
+        name: { type: "positional", required: true, description: "Secret name to read" },
+        persona: { type: "string", description: "Persona whose vault to use." },
+      },
+      async run({ args }) {
+        process.exitCode = await runVaultGet({
+          name: args.name as string,
+          persona: args.persona ? String(args.persona) : undefined,
+        });
+      },
+    }),
+    list: defineCommand({
+      meta: { name: "list", description: "List secret names in the vault (values not printed)." },
+      args: {
+        persona: { type: "string", description: "Persona whose vault to use." },
+      },
+      async run({ args }) {
+        process.exitCode = await runVaultList({
+          persona: args.persona ? String(args.persona) : undefined,
+        });
+      },
+    }),
+    unset: defineCommand({
+      meta: { name: "unset", description: "Remove NAME from the vault." },
+      args: {
+        name: { type: "positional", required: true, description: "Secret name to remove" },
+        persona: { type: "string", description: "Persona whose vault to use." },
+      },
+      async run({ args }) {
+        process.exitCode = await runVaultUnset({
+          name: args.name as string,
+          persona: args.persona ? String(args.persona) : undefined,
+        });
+      },
+    }),
+  },
+});

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -51,6 +51,7 @@ import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
+import { reloadVaultForPersona } from "../lib/vault.ts";
 import {
   type HarnessActivity,
   runHarnessProcess,
@@ -97,6 +98,11 @@ export class ClaudeHarness implements Harness {
     // visible in this turn's env without needing a daemon restart.
     // Shell-exported keys remain sticky — see envBootstrap.ts header.
     await reloadEnvFiles();
+    // Then reconcile THIS persona's encrypted vault into the env (the canonical
+    // credential store; the .env files above are only the legacy transitional
+    // path). This makes a `vault set` from the previous turn visible now and
+    // ensures the subprocess sees only this persona's secrets.
+    await reloadVaultForPersona(req.persona);
 
     // OAuth-on-host: don't leak any ANTHROPIC_* / CLAUDE_CODE_* auth or
     // routing var into the subprocess env (reloadEnvFiles just re-sourced

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -16,6 +16,7 @@ import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
+import { reloadVaultForPersona } from "../lib/vault.ts";
 import {
   type HarnessActivity,
   runHarnessProcess,
@@ -52,6 +53,8 @@ export class CodexHarness implements Harness {
     });
 
     await reloadEnvFiles();
+    // Reconcile this persona's encrypted vault into the env (see claude.ts).
+    await reloadVaultForPersona(req.persona);
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -40,6 +40,7 @@ import { access, constants } from "node:fs/promises";
 import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
 import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
+import { reloadVaultForPersona } from "../lib/vault.ts";
 import {
   type HarnessActivity,
   runHarnessProcess,
@@ -143,6 +144,8 @@ export class GeminiHarness implements Harness {
     // (`phantombot env set FOO bar`) are visible here without a daemon
     // restart. See envBootstrap.ts for the sticky-vs-reloadable rules.
     await reloadEnvFiles();
+    // Reconcile this persona's encrypted vault into the env (see claude.ts).
+    await reloadVaultForPersona(req.persona);
 
     const proc = spawnInNewSession([this.config.bin, ...args], {
       cwd: req.workingDir,

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -37,6 +37,7 @@ import { ENV_PI_API_KEY, ENV_PI_PROVIDER, type PiRoutingConfig } from "../lib/pi
 import { getCoderSwapOverride, resolveSwapModel } from "../lib/coderSwap.ts";
 import { buildToolCall, type ToolCallDetail } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
+import { reloadVaultForPersona } from "../lib/vault.ts";
 import {
   type HarnessActivity,
   runHarnessProcess,
@@ -188,6 +189,9 @@ export class PiHarness implements Harness {
     // restart — and so the Pi API key below is read fresh. See envBootstrap.ts
     // for the sticky-vs-reloadable rules.
     await reloadEnvFiles();
+    // Reconcile this persona's encrypted vault into the env BEFORE the Pi API
+    // key is read below — the key is a vault secret post-migration. See claude.ts.
+    await reloadVaultForPersona(req.persona);
 
     // Per-turn Pi auth: thread the API key onto `--api-key` exactly the way the
     // model is threaded onto `--model`. We do NOT persist it into Pi's own auth

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,17 +5,42 @@
  * Imports the Citty dispatcher and runs it. The dispatcher itself lives in
  * src/cli/index.ts so it can be imported by tests without auto-running.
  *
- * Before dispatch, we self-load credentials from `~/.env` and
- * `~/.config/phantombot/.env` into process.env. On Linux the systemd unit
- * already sources these via `EnvironmentFile=`, so the lines we'd add are
- * no-ops (existing values win — see preloadEnvFiles). On macOS launchd
- * has no equivalent of EnvironmentFile, so this self-load is the only
- * way credentials reach the running agent.
+ * Before dispatch we bootstrap credentials, in order:
+ *
+ *   1. `migratePlaintextToVault` — an idempotent, best-effort migration of any
+ *      leftover plaintext `~/.env` / `~/.config/phantombot/.env` into the
+ *      per-persona ENCRYPTED vaults, deleting each plaintext file only after
+ *      every key read back byte-for-byte. A no-op once the files are gone.
+ *   2. `loadVaultIntoEnv` — decrypt the ACTIVE persona's vault and inject its
+ *      secrets into process.env, with the same "existing value wins" policy the
+ *      old plaintext loader used (a shell export / systemd EnvironmentFile= key
+ *      is never overwritten). This is the vault replacement for the old
+ *      plaintext self-source.
+ *   3. `preloadEnvFiles` — retained for the transitional path: harness.ts still
+ *      writes the Pi routing key to `~/.env` mid-session, and the harnesses
+ *      re-source it before each spawn; the NEXT startup migration folds it into
+ *      the vault. Once no plaintext files remain this is a cheap no-op.
+ *
+ * Wrapped so a bootstrap hiccup never blocks the CLI from running.
  */
 
 import { runMain } from "citty";
 import { mainCommand } from "./cli/index.ts";
+import { loadConfig, personaDir } from "./config.ts";
 import { preloadEnvFiles } from "./lib/envBootstrap.ts";
+import { log } from "./lib/logger.ts";
+import { loadVaultIntoEnv } from "./lib/vault.ts";
+import { migratePlaintextToVault } from "./lib/vaultMigrate.ts";
 
+try {
+  const config = await loadConfig();
+  await migratePlaintextToVault(config);
+  const activePersona = process.env.PHANTOMBOT_PERSONA || config.defaultPersona;
+  await loadVaultIntoEnv(personaDir(config, activePersona));
+} catch (e) {
+  // Never let credential bootstrap wedge the CLI — log and carry on. The
+  // subcommand may still work (e.g. `phantombot persona` on a fresh box).
+  log.warn("startup: vault bootstrap failed", { error: (e as Error).message });
+}
 await preloadEnvFiles();
 runMain(mainCommand);

--- a/src/lib/personaIdentity.ts
+++ b/src/lib/personaIdentity.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared per-persona Nostr identity — the single source of the persona's
+ * long-lived secret key (`nsec`), used by BOTH the phantomchat channel and
+ * the encrypted secrets vault (lib/vault.ts).
+ *
+ * Storage: `<personaDir>/identity.json` (mode 0600), shape:
+ *   { "nsec": "nsec1…" }
+ *
+ * Historically the nsec lived only inside `<personaDir>/phantomchat.json`
+ * (see channels/phantomchat/personaStore.ts) — coupling the persona's crypto
+ * identity to one channel. The vault needs the same key to derive its AES
+ * encryption key, so the identity is hoisted here into its own file. Both
+ * consumers now read from `identity.json`.
+ *
+ * `getOrCreatePersonaIdentity` is idempotent and does an at-most-once,
+ * best-effort MIGRATION: if `identity.json` is absent but a legacy
+ * `phantomchat.json` in the same dir already holds an nsec, that nsec is
+ * MOVED into `identity.json` (the channel file keeps its copy — it is left
+ * untouched so the channel keeps working; only the identity is now sourced
+ * from the shared file). Otherwise a fresh key is generated in-process.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { generateSecretKey } from "nostr-tools/pure";
+
+import {
+  identityFromNsec,
+  nsecEncode,
+  type NostrIdentity,
+} from "./nostrIdentity.ts";
+
+/** Filename of the shared per-persona identity file inside a persona dir. */
+export const IDENTITY_FILE = "identity.json";
+
+/** Legacy channel file that used to be the sole nsec home. */
+const LEGACY_PHANTOMCHAT_FILE = "phantomchat.json";
+
+/** Path to a persona's identity.json given its dir. */
+export function personaIdentityPath(personaDir: string): string {
+  return join(personaDir, IDENTITY_FILE);
+}
+
+/** On-disk shape of identity.json. */
+interface IdentityFileShape {
+  nsec?: string;
+}
+
+/** Read an nsec string out of a JSON file, or undefined if absent/unusable. */
+function readNsecFromJson(path: string): string | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as IdentityFileShape;
+    if (parsed && typeof parsed.nsec === "string" && parsed.nsec.trim() !== "") {
+      return parsed.nsec.trim();
+    }
+  } catch {
+    // Unparseable file — treat as absent so a fresh identity is created.
+  }
+  return undefined;
+}
+
+/**
+ * Atomically write `<personaDir>/identity.json` at mode 0600 (the nsec is a
+ * secret). Tempfile + rename avoids the world-readable window a
+ * write-then-chmod would leave — same guarantee as savePhantomchatPersonaConfig.
+ * Public so setup flows (e.g. `phantombot phantomchat`) that mint an identity
+ * with their own generator can persist it to the shared file.
+ */
+export async function writePersonaIdentity(
+  personaDir: string,
+  nsec: string,
+): Promise<void> {
+  return writeIdentityFile(personaDir, nsec);
+}
+
+async function writeIdentityFile(personaDir: string, nsec: string): Promise<void> {
+  const path = personaIdentityPath(personaDir);
+  await mkdir(dirname(path), { recursive: true });
+  const body: IdentityFileShape = { nsec };
+  const tmp = `${path}.tmp`;
+  try {
+    await writeFile(tmp, JSON.stringify(body, null, 2) + "\n", {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(tmp, path);
+  } catch (e) {
+    try {
+      await unlink(tmp);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw e;
+  }
+}
+
+/**
+ * Synchronously read the persona's nsec from `identity.json`, or undefined if
+ * absent/unusable. Read-only companion to getOrCreatePersonaIdentity for
+ * callers that must stay synchronous (e.g. loadPhantomchatPersonaConfig) and
+ * only want to PREFER the shared identity, falling back to their own file.
+ * Never creates or migrates anything.
+ */
+export function readPersonaIdentityNsec(personaDir: string): string | undefined {
+  return readNsecFromJson(personaIdentityPath(personaDir));
+}
+
+/**
+ * Resolve the persona's Nostr identity, creating it on first use. Idempotent.
+ *
+ * Resolution order:
+ *   1. `<personaDir>/identity.json` — the canonical shared file.
+ *   2. Legacy `<personaDir>/phantomchat.json` nsec — MOVED into identity.json.
+ *   3. A freshly generated random secret key, written to identity.json.
+ *
+ * Returns the full NostrIdentity (secret bytes + npub/nsec/hex encodings).
+ */
+export async function getOrCreatePersonaIdentity(
+  personaDir: string,
+): Promise<NostrIdentity> {
+  // 1. Canonical file already present.
+  const existing = readNsecFromJson(personaIdentityPath(personaDir));
+  if (existing) {
+    return identityFromNsec(existing);
+  }
+
+  // 2. Legacy migration: hoist the nsec out of phantomchat.json if present.
+  const legacy = readNsecFromJson(join(personaDir, LEGACY_PHANTOMCHAT_FILE));
+  if (legacy) {
+    await writeIdentityFile(personaDir, legacy);
+    return identityFromNsec(legacy);
+  }
+
+  // 3. Generate a fresh identity in-process and persist it.
+  const secretKey = generateSecretKey();
+  const nsec = nsecEncode(secretKey);
+  await writeIdentityFile(personaDir, nsec);
+  return identityFromNsec(nsec);
+}

--- a/src/lib/personaIdentity.ts
+++ b/src/lib/personaIdentity.ts
@@ -21,7 +21,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { link, mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { link, mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { generateSecretKey } from "nostr-tools/pure";
@@ -62,61 +62,33 @@ function readNsecFromJson(path: string): string | undefined {
   return undefined;
 }
 
-/**
- * Atomically write `<personaDir>/identity.json` at mode 0600 (the nsec is a
- * secret). Tempfile + rename avoids the world-readable window a
- * write-then-chmod would leave — same guarantee as savePhantomchatPersonaConfig.
- * Public so setup flows (e.g. `phantombot phantomchat`) that mint an identity
- * with their own generator can persist it to the shared file.
- */
-export async function writePersonaIdentity(
-  personaDir: string,
-  nsec: string,
-): Promise<void> {
-  return writeIdentityFile(personaDir, nsec);
-}
-
-async function writeIdentityFile(personaDir: string, nsec: string): Promise<void> {
-  const path = personaIdentityPath(personaDir);
-  await mkdir(dirname(path), { recursive: true });
-  const body: IdentityFileShape = { nsec };
-  // Per-process-unique tmp name so two concurrent writers don't collide on a
-  // shared `.tmp` and corrupt each other's partial write before the swap.
-  const tmp = uniqueTmpPath(path);
-  try {
-    await writeFile(tmp, JSON.stringify(body, null, 2) + "\n", {
-      encoding: "utf8",
-      mode: 0o600,
-    });
-    await rename(tmp, path);
-  } catch (e) {
-    try {
-      await unlink(tmp);
-    } catch {
-      /* best-effort cleanup */
-    }
-    throw e;
-  }
-}
-
 /** A collision-resistant tempfile path alongside `path`. */
 function uniqueTmpPath(path: string): string {
   return `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
 }
 
 /**
- * Create identity.json holding `nsec` ONLY IF it doesn't already exist, closing
- * the check-then-act race in getOrCreatePersonaIdentity: two processes that both
- * see "no identity.json" and mint fresh keys must NOT end up with divergent
- * nsecs (whichever's write landed last would orphan everything the other had
- * already encrypted under its key — undecryptable forever).
+ * Create identity.json holding `nsec` ONLY IF it doesn't already exist, returning
+ * the nsec that is DURABLY PERSISTED on disk (ours if we won, the incumbent's if
+ * we lost). Atomic create-if-absent: safe to call concurrently, and safe to call
+ * when the file may already exist — an existing identity.json is NEVER overwritten.
+ * This is the single race-safe primitive for minting the shared identity; callers
+ * must not do check-then-write (existsSync + unconditional rename) themselves.
  *
  * Mechanism: write a per-process-unique tempfile (mode 0600), then hard-LINK it
  * into place. `link()` is atomic and fails with EEXIST if the target already
  * exists, so exactly one racer wins; every loser reads the winner's nsec back
- * and adopts it. Returns the nsec actually persisted on disk.
+ * and adopts it. This closes the check-then-act race where two processes that
+ * both saw "no identity.json" mint divergent nsecs — whichever wrote last would
+ * orphan everything the other had already encrypted under its key.
+ *
+ * Fails CLOSED: if identity.json already exists but its nsec can't be read back
+ * (malformed / truncated file), this THROWS rather than returning the caller's
+ * in-process `nsec` — because that value never reached disk, and handing it back
+ * would let the vault encrypt rows under a key the next process can't reproduce
+ * (silent, permanent data loss). A thrown error surfaces the corrupt file instead.
  */
-async function createIdentityFileExclusive(
+export async function createPersonaIdentityIfAbsent(
   personaDir: string,
   nsec: string,
 ): Promise<string> {
@@ -134,11 +106,15 @@ async function createIdentityFileExclusive(
       return nsec; // we won the race
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code === "EEXIST") {
-        // Lost the race — adopt the winner's identity, discard ours.
+        // Lost the race — adopt the winner's durably-stored identity.
         const winner = readNsecFromJson(path);
         if (winner) return winner;
-        // Present-but-unreadable is pathological; fall back to our own value.
-        return nsec;
+        // Present-but-unreadable identity.json: fail closed rather than hand back
+        // an nsec that isn't on disk (see the doc comment above).
+        throw new Error(
+          `identity.json exists at ${path} but its nsec is unreadable; refusing ` +
+            `to return a transient identity that would orphan encrypted vault data`,
+        );
       }
       throw e;
     }
@@ -187,7 +163,7 @@ export async function getOrCreatePersonaIdentity(
   //    the race-safe path keeps the invariant "first write wins, losers adopt").
   const legacy = readNsecFromJson(join(personaDir, LEGACY_PHANTOMCHAT_FILE));
   if (legacy) {
-    const persisted = await createIdentityFileExclusive(personaDir, legacy);
+    const persisted = await createPersonaIdentityIfAbsent(personaDir, legacy);
     return identityFromNsec(persisted);
   }
 
@@ -196,6 +172,6 @@ export async function getOrCreatePersonaIdentity(
   //    adopt theirs rather than clobbering (which would orphan their vault).
   const secretKey = generateSecretKey();
   const nsec = nsecEncode(secretKey);
-  const persisted = await createIdentityFileExclusive(personaDir, nsec);
+  const persisted = await createPersonaIdentityIfAbsent(personaDir, nsec);
   return identityFromNsec(persisted);
 }

--- a/src/lib/personaIdentity.ts
+++ b/src/lib/personaIdentity.ts
@@ -21,7 +21,7 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { link, mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { generateSecretKey } from "nostr-tools/pure";
@@ -80,7 +80,9 @@ async function writeIdentityFile(personaDir: string, nsec: string): Promise<void
   const path = personaIdentityPath(personaDir);
   await mkdir(dirname(path), { recursive: true });
   const body: IdentityFileShape = { nsec };
-  const tmp = `${path}.tmp`;
+  // Per-process-unique tmp name so two concurrent writers don't collide on a
+  // shared `.tmp` and corrupt each other's partial write before the swap.
+  const tmp = uniqueTmpPath(path);
   try {
     await writeFile(tmp, JSON.stringify(body, null, 2) + "\n", {
       encoding: "utf8",
@@ -94,6 +96,58 @@ async function writeIdentityFile(personaDir: string, nsec: string): Promise<void
       /* best-effort cleanup */
     }
     throw e;
+  }
+}
+
+/** A collision-resistant tempfile path alongside `path`. */
+function uniqueTmpPath(path: string): string {
+  return `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+}
+
+/**
+ * Create identity.json holding `nsec` ONLY IF it doesn't already exist, closing
+ * the check-then-act race in getOrCreatePersonaIdentity: two processes that both
+ * see "no identity.json" and mint fresh keys must NOT end up with divergent
+ * nsecs (whichever's write landed last would orphan everything the other had
+ * already encrypted under its key — undecryptable forever).
+ *
+ * Mechanism: write a per-process-unique tempfile (mode 0600), then hard-LINK it
+ * into place. `link()` is atomic and fails with EEXIST if the target already
+ * exists, so exactly one racer wins; every loser reads the winner's nsec back
+ * and adopts it. Returns the nsec actually persisted on disk.
+ */
+async function createIdentityFileExclusive(
+  personaDir: string,
+  nsec: string,
+): Promise<string> {
+  const path = personaIdentityPath(personaDir);
+  await mkdir(dirname(path), { recursive: true });
+  const body: IdentityFileShape = { nsec };
+  const tmp = uniqueTmpPath(path);
+  try {
+    await writeFile(tmp, JSON.stringify(body, null, 2) + "\n", {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    try {
+      await link(tmp, path);
+      return nsec; // we won the race
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+        // Lost the race — adopt the winner's identity, discard ours.
+        const winner = readNsecFromJson(path);
+        if (winner) return winner;
+        // Present-but-unreadable is pathological; fall back to our own value.
+        return nsec;
+      }
+      throw e;
+    }
+  } finally {
+    try {
+      await unlink(tmp);
+    } catch {
+      /* best-effort cleanup of the tmp hard-link source */
+    }
   }
 }
 
@@ -128,15 +182,20 @@ export async function getOrCreatePersonaIdentity(
   }
 
   // 2. Legacy migration: hoist the nsec out of phantomchat.json if present.
+  //    Exclusive-create so a concurrent racer can't end up migrating to a
+  //    different value (both would read the same legacy nsec here anyway, but
+  //    the race-safe path keeps the invariant "first write wins, losers adopt").
   const legacy = readNsecFromJson(join(personaDir, LEGACY_PHANTOMCHAT_FILE));
   if (legacy) {
-    await writeIdentityFile(personaDir, legacy);
-    return identityFromNsec(legacy);
+    const persisted = await createIdentityFileExclusive(personaDir, legacy);
+    return identityFromNsec(persisted);
   }
 
-  // 3. Generate a fresh identity in-process and persist it.
+  // 3. Generate a fresh identity in-process and persist it race-safely: if
+  //    another process generated one between our read above and this write, we
+  //    adopt theirs rather than clobbering (which would orphan their vault).
   const secretKey = generateSecretKey();
   const nsec = nsecEncode(secretKey);
-  await writeIdentityFile(personaDir, nsec);
-  return identityFromNsec(nsec);
+  const persisted = await createIdentityFileExclusive(personaDir, nsec);
+  return identityFromNsec(persisted);
 }

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -31,6 +31,7 @@ import { hkdf } from "@noble/hashes/hkdf.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 
 import { loadConfig, personaDir as resolvePersonaDir, type Config } from "../config.ts";
+import { log } from "./logger.ts";
 import { getOrCreatePersonaIdentity } from "./personaIdentity.ts";
 
 /** Filename of the per-persona encrypted secrets DB inside a persona dir. */
@@ -217,13 +218,21 @@ export async function openPersonaVault(personaDir: string): Promise<Vault> {
 
 /**
  * Read EVERY secret out of a persona's vault into a decrypted Map, then close
- * the vault. Best-effort: returns `null` if the vault can't be opened (fresh
- * install, corruption) so callers can distinguish "no vault" from "empty vault".
- * Never logs secret values.
+ * the vault. Best-effort: returns `null` if the vault can't be OPENED (fresh
+ * install, missing identity, DB-level corruption) so callers can distinguish
+ * "no vault" from "empty vault". Never logs secret values.
+ *
+ * Decryption is PER-ROW resilient: a single undecryptable row (corrupt nonce/
+ * ciphertext/tag, or a value written under a different key) is skipped and its
+ * name collected in `badKeys` — it must NOT abort the read and blank every
+ * OTHER secret for the turn. This is fail-*partial*, not fail-open: we never
+ * invent or substitute a value, so a row we can't decrypt (already unusable) is
+ * simply dropped, with no security regression. The caller decides how to
+ * surface `badKeys`.
  */
 async function readAllVaultValues(
   personaDirPath: string,
-): Promise<Map<string, string> | null> {
+): Promise<{ values: Map<string, string>; badKeys: string[] } | null> {
   let vault: Vault;
   try {
     vault = await openPersonaVault(personaDirPath);
@@ -231,15 +240,48 @@ async function readAllVaultValues(
     return null;
   }
   const values = new Map<string, string>();
+  const badKeys: string[] = [];
   try {
     for (const name of vault.list()) {
-      const value = vault.get(name);
-      if (value !== undefined) values.set(name, value);
+      try {
+        const value = vault.get(name);
+        if (value !== undefined) values.set(name, value);
+      } catch {
+        // One poisoned row shouldn't cost the persona its other secrets.
+        // Record the name (never the value) and keep loading the good rows.
+        badKeys.push(name);
+      }
     }
   } finally {
     vault.close();
   }
-  return values;
+  return { values, badKeys };
+}
+
+/**
+ * Key-set signatures we've already warned about. An undecryptable vault row is
+ * surfaced ONCE per process start, deduped by the exact set of bad keys, so
+ * corruption stays visible without spamming a warning on every per-turn reload.
+ */
+const _warnedBadKeySets = new Set<string>();
+
+/** For tests: reset the warn-once-per-process dedupe of undecryptable keys. */
+export function _resetVaultWarningsForTesting(): void {
+  _warnedBadKeySets.clear();
+}
+
+/** Warn once per process start about undecryptable vault rows. Never logs values. */
+function warnBadVaultKeys(badKeys: string[]): void {
+  if (badKeys.length === 0) return;
+  const sorted = [...badKeys].sort();
+  const signature = sorted.join(" ");
+  if (_warnedBadKeySets.has(signature)) return;
+  _warnedBadKeySets.add(signature);
+  log.warn(
+    `vault: ${sorted.length} undecryptable key${sorted.length === 1 ? "" : "s"} ` +
+      `(${sorted.join(", ")}) — skipped; other secrets loaded normally`,
+    { count: sorted.length, keys: sorted },
+  );
 }
 
 /**
@@ -285,15 +327,18 @@ export async function loadVaultIntoEnv(
   personaDirPath: string,
   env: NodeJS.ProcessEnv = process.env,
   tracked: Set<string> = _vaultTracked,
-): Promise<{ updated: string[]; removed: string[] }> {
+): Promise<{ updated: string[]; removed: string[]; badKeys: string[] }> {
   const updated: string[] = [];
   const removed: string[] = [];
-  const values = await readAllVaultValues(personaDirPath);
+  const result = await readAllVaultValues(personaDirPath);
 
-  if (values === null) {
+  if (result === null) {
+    // A null (unopenable) vault is a distinct failure mode from per-row
+    // corruption: there are no decryptable-or-not rows to report, so badKeys
+    // is empty. This is what lets a caller tell "no vault" from "1 bad row".
     if (personaDirPath === _vaultLoadedPersonaDir) {
       // Same persona, transient open failure — keep what we already injected.
-      return { updated, removed };
+      return { updated, removed, badKeys: [] };
     }
     // Different/first persona we can't read: fail closed, strip prior keys.
     for (const k of [...tracked]) {
@@ -302,8 +347,15 @@ export async function loadVaultIntoEnv(
       removed.push(k);
     }
     _vaultLoadedPersonaDir = undefined;
-    return { updated, removed };
+    return { updated, removed, badKeys: [] };
   }
+
+  const { values, badKeys } = result;
+
+  // Corruption becomes visible instead of silent: surface undecryptable rows
+  // once per process start. The good rows below still load — a bad SENTRY_DSN
+  // no longer costs the persona its GITHUB_TOKEN.
+  warnBadVaultKeys(badKeys);
 
   // Phase 1: reconcile previously vault-injected keys against this persona.
   for (const k of [...tracked]) {
@@ -329,7 +381,7 @@ export async function loadVaultIntoEnv(
   }
 
   _vaultLoadedPersonaDir = personaDirPath;
-  return { updated, removed };
+  return { updated, removed, badKeys };
 }
 
 /**
@@ -360,12 +412,12 @@ export function _resetConfigCacheForTesting(): void {
 export async function reloadVaultForPersona(
   persona: string | undefined,
   env: NodeJS.ProcessEnv = process.env,
-): Promise<{ updated: string[]; removed: string[] }> {
+): Promise<{ updated: string[]; removed: string[]; badKeys: string[] }> {
   try {
     const config = await cachedConfig();
     const name = persona || process.env.PHANTOMBOT_PERSONA || config.defaultPersona;
     return await loadVaultIntoEnv(resolvePersonaDir(config, name), env);
   } catch {
-    return { updated: [], removed: [] };
+    return { updated: [], removed: [], badKeys: [] };
   }
 }

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -30,6 +30,7 @@ import { dirname, join } from "node:path";
 import { hkdf } from "@noble/hashes/hkdf.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 
+import { loadConfig, personaDir as resolvePersonaDir, type Config } from "../config.ts";
 import { getOrCreatePersonaIdentity } from "./personaIdentity.ts";
 
 /** Filename of the per-persona encrypted secrets DB inside a persona dir. */
@@ -186,7 +187,18 @@ export function openVaultWithSecret(
   const path = vaultPath(personaDir);
   mkdirSync(dirname(path), { recursive: true });
   const db = new Database(path, { create: true });
-  db.exec("PRAGMA journal_mode = WAL");
+  // journal_mode = DELETE (rollback journal, not WAL): the vault is tiny and
+  // low-traffic, so WAL's concurrency win is irrelevant, and WAL would leave a
+  // `vault.sqlite-wal` sidecar holding uncheckpointed rows. That sidecar breaks
+  // the portability promise — "copy the persona folder and its secrets travel"
+  // must hold for the single `vault.sqlite` alone. DELETE mode keeps everything
+  // in the one file at rest (the -journal file exists only mid-transaction).
+  db.exec("PRAGMA journal_mode = DELETE");
+  // synchronous = FULL: fsync on every commit. The migration deletes the ONLY
+  // plaintext copy of a secret right after writing it here, so the ciphertext
+  // must be durably on disk before that unlink — NORMAL could lose the last
+  // write on power loss and leave neither copy. Perf cost is nil at this volume.
+  db.exec("PRAGMA synchronous = FULL");
   db.exec("PRAGMA busy_timeout = 5000");
   const keyRaw = deriveVaultKey(secretKey);
   return new SqliteVault(db, keyRaw);
@@ -204,36 +216,156 @@ export async function openPersonaVault(personaDir: string): Promise<Vault> {
 }
 
 /**
- * Decrypt a persona's vault and copy each secret into `env`, with the same
- * "existing value wins" policy the old plaintext env loader used
- * (preloadEnvFiles): a key already present in the environment (shell export,
- * systemd EnvironmentFile=) is never overwritten. Returns the names loaded.
- *
- * Best-effort: a missing / unopenable vault yields an empty result rather than
- * throwing, so a fresh install with no vault yet starts cleanly. Never logs
- * secret values.
+ * Read EVERY secret out of a persona's vault into a decrypted Map, then close
+ * the vault. Best-effort: returns `null` if the vault can't be opened (fresh
+ * install, corruption) so callers can distinguish "no vault" from "empty vault".
+ * Never logs secret values.
  */
-export async function loadVaultIntoEnv(
-  personaDir: string,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<{ loaded: string[] }> {
-  const loaded: string[] = [];
+async function readAllVaultValues(
+  personaDirPath: string,
+): Promise<Map<string, string> | null> {
   let vault: Vault;
   try {
-    vault = await openPersonaVault(personaDir);
+    vault = await openPersonaVault(personaDirPath);
   } catch {
-    return { loaded };
+    return null;
   }
+  const values = new Map<string, string>();
   try {
     for (const name of vault.list()) {
-      if (env[name] !== undefined) continue; // existing wins
       const value = vault.get(name);
-      if (value === undefined) continue;
-      env[name] = value;
-      loaded.push(name);
+      if (value !== undefined) values.set(name, value);
     }
   } finally {
     vault.close();
   }
-  return { loaded };
+  return values;
+}
+
+/**
+ * Module-scope set of env keys THIS process injected from a vault. Mirrors
+ * envBootstrap's `_moduleTracked`: it lets a later reload for a DIFFERENT
+ * persona reconcile — updating a key to the new persona's value, or removing it
+ * if the new persona doesn't have it — without ever touching a key that was
+ * already in the environment at boot (shell export / systemd EnvironmentFile=).
+ */
+const _vaultTracked = new Set<string>();
+
+/** The persona dir whose vault we last successfully injected, for transient-fail handling. */
+let _vaultLoadedPersonaDir: string | undefined;
+
+/** For tests: reset the module-scope vault env tracking. */
+export function _resetVaultTrackingForTesting(): void {
+  _vaultTracked.clear();
+  _vaultLoadedPersonaDir = undefined;
+}
+
+/**
+ * Decrypt a persona's vault and RECONCILE it into `env`, so `env` ends up
+ * holding exactly this persona's vault secrets (plus any sticky boot keys).
+ *
+ * This is both the startup loader AND the per-turn reload: it mirrors
+ * envBootstrap.reloadEnvFiles' semantics against the vault instead of a file.
+ *
+ *   - Phase 1: every key WE previously injected from a vault (in `tracked`) is
+ *     reconciled — updated to this persona's value, or DELETED if this persona
+ *     doesn't have it. This is what stops persona A's GITHUB_TOKEN leaking into
+ *     persona B's turn, and what makes a `vault set` from the previous turn
+ *     visible on the next one (the value changed on disk → we overwrite env).
+ *   - Phase 2: new vault keys not already present are loaded + tracked. A key
+ *     already in the env from boot (never tracked) is left alone — sticky
+ *     shell/systemd wins, same guarantee the plaintext loader gave.
+ *
+ * Fail-closed on an unopenable vault: if this is a DIFFERENT persona than the
+ * one last loaded we strip the tracked keys (better no secret than the wrong
+ * persona's); if it's the SAME persona we treat it as a transient blip and
+ * leave the already-injected secrets in place. Never throws, never logs values.
+ */
+export async function loadVaultIntoEnv(
+  personaDirPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+  tracked: Set<string> = _vaultTracked,
+): Promise<{ updated: string[]; removed: string[] }> {
+  const updated: string[] = [];
+  const removed: string[] = [];
+  const values = await readAllVaultValues(personaDirPath);
+
+  if (values === null) {
+    if (personaDirPath === _vaultLoadedPersonaDir) {
+      // Same persona, transient open failure — keep what we already injected.
+      return { updated, removed };
+    }
+    // Different/first persona we can't read: fail closed, strip prior keys.
+    for (const k of [...tracked]) {
+      if (env[k] !== undefined) delete env[k];
+      tracked.delete(k);
+      removed.push(k);
+    }
+    _vaultLoadedPersonaDir = undefined;
+    return { updated, removed };
+  }
+
+  // Phase 1: reconcile previously vault-injected keys against this persona.
+  for (const k of [...tracked]) {
+    const fresh = values.get(k);
+    if (fresh === undefined) {
+      if (env[k] !== undefined) delete env[k];
+      tracked.delete(k);
+      removed.push(k);
+    } else if (env[k] !== fresh) {
+      env[k] = fresh;
+      updated.push(k);
+    }
+  }
+
+  // Phase 2: load new vault keys the env doesn't already hold (sticky wins).
+  for (const [k, v] of values) {
+    if (tracked.has(k)) continue;
+    if (env[k] === undefined) {
+      env[k] = v;
+      tracked.add(k);
+      updated.push(k);
+    }
+  }
+
+  _vaultLoadedPersonaDir = personaDirPath;
+  return { updated, removed };
+}
+
+/**
+ * Config is stable for the daemon's lifetime (a config change restarts the
+ * service), so cache it for the hot per-spawn reload path rather than re-reading
+ * config.toml + state.json on every turn.
+ */
+let _cachedConfig: Config | undefined;
+async function cachedConfig(): Promise<Config> {
+  if (!_cachedConfig) _cachedConfig = await loadConfig();
+  return _cachedConfig;
+}
+
+/** For tests: drop the cached config so a fresh one is loaded next call. */
+export function _resetConfigCacheForTesting(): void {
+  _cachedConfig = undefined;
+}
+
+/**
+ * Reconcile the given persona's vault into `process.env` before a harness spawn.
+ * Resolves the persona the same way the CLI does (explicit name → the turn's
+ * PHANTOMBOT_PERSONA → default persona). This is the vault equivalent of
+ * envBootstrap.reloadEnvFiles — the harnesses call it right after that so a
+ * secret saved via `phantombot vault set` on the previous turn is visible to
+ * the subprocess on this one, AND so each persona's turn only ever sees its own
+ * secrets. Best-effort: never throws.
+ */
+export async function reloadVaultForPersona(
+  persona: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ updated: string[]; removed: string[] }> {
+  try {
+    const config = await cachedConfig();
+    const name = persona || process.env.PHANTOMBOT_PERSONA || config.defaultPersona;
+    return await loadVaultIntoEnv(resolvePersonaDir(config, name), env);
+  } catch {
+    return { updated: [], removed: [] };
+  }
 }

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,0 +1,239 @@
+/**
+ * Per-persona encrypted secrets vault.
+ *
+ * Replaces the plaintext `~/.env` / `~/.config/phantombot/.env` credential
+ * store with an at-rest-encrypted, per-persona SQLite database. Each persona
+ * owns its own `<personaDir>/vault.sqlite` — self-contained and portable, the
+ * same design principle as phantomchat.json and identity.json: copy a persona
+ * folder to another box and its secrets travel with it (still encrypted; only
+ * that persona's nsec can decrypt them).
+ *
+ * Crypto:
+ *   - The AES key is DERIVED from the persona's nsec secret bytes via
+ *     HKDF-SHA256 with the domain-separation label "phantombot-vault-v1".
+ *     The raw nsec is NEVER used directly as the key — HKDF isolates the vault
+ *     key from any other use of the same secret (e.g. Nostr ECDH), so a bug in
+ *     one can't compromise the other.
+ *   - Each entry is encrypted with AES-256-GCM under a fresh random 12-byte
+ *     nonce. Nonce + ciphertext (which includes the GCM auth tag) are stored
+ *     per row. Wrong key → GCM auth failure → decrypt throws (never silent).
+ *
+ * API mirrors `phantombot env` 1:1: set / get / list (names only) / unset.
+ * Values only ever exist decrypted in-process.
+ */
+
+import { Database } from "bun:sqlite";
+import { createCipheriv, createDecipheriv } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { hkdf } from "@noble/hashes/hkdf.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+
+import { getOrCreatePersonaIdentity } from "./personaIdentity.ts";
+
+/** Filename of the per-persona encrypted secrets DB inside a persona dir. */
+export const VAULT_FILE = "vault.sqlite";
+
+/**
+ * HKDF domain-separation label. Versioned so a future key-schedule change can
+ * coexist / migrate. Bump the suffix only alongside a migration path.
+ */
+const VAULT_HKDF_INFO = "phantombot-vault-v1";
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS secrets (
+  name        TEXT PRIMARY KEY,
+  nonce       BLOB NOT NULL,
+  ciphertext  BLOB NOT NULL,
+  updated_at  TEXT NOT NULL
+);
+`;
+
+/** Path to a persona's vault DB given its dir. */
+export function vaultPath(personaDir: string): string {
+  return join(personaDir, VAULT_FILE);
+}
+
+/**
+ * Derive the 32-byte AES-256 vault key from the persona's nsec secret bytes.
+ * HKDF-SHA256, no salt, info = the versioned domain label. Deterministic: the
+ * same secret always yields the same key (so a reopened vault decrypts), and a
+ * DIFFERENT secret yields a different key (so another persona can't decrypt).
+ */
+export function deriveVaultKey(secretKey: Uint8Array): Uint8Array {
+  const info = new TextEncoder().encode(VAULT_HKDF_INFO);
+  return hkdf(sha256, secretKey, undefined, info, 32);
+}
+
+/** An open, key-loaded vault for one persona. */
+export interface Vault {
+  /** Encrypt + store (or replace) NAME=value. Idempotent per name. */
+  set(name: string, value: string): void;
+  /** Decrypt + return the value for NAME, or undefined if absent. */
+  get(name: string): string | undefined;
+  /** All stored secret NAMES (values never returned), sorted. */
+  list(): string[];
+  /** Remove NAME. No-op if absent. */
+  unset(name: string): void;
+  /** Close the underlying SQLite connection. Idempotent. */
+  close(): void;
+}
+
+class SqliteVault implements Vault {
+  private setStmt;
+  private getStmt;
+  private listStmt;
+  private unsetStmt;
+  private closed = false;
+
+  constructor(
+    private db: Database,
+    private aesKeyRaw: Uint8Array,
+  ) {
+    db.exec(SCHEMA);
+    this.setStmt = db.prepare(
+      "INSERT INTO secrets (name, nonce, ciphertext, updated_at) VALUES (?, ?, ?, ?) " +
+        "ON CONFLICT(name) DO UPDATE SET nonce = excluded.nonce, " +
+        "ciphertext = excluded.ciphertext, updated_at = excluded.updated_at",
+    );
+    this.getStmt = db.prepare(
+      "SELECT nonce, ciphertext FROM secrets WHERE name = ?",
+    );
+    this.listStmt = db.prepare("SELECT name FROM secrets ORDER BY name ASC");
+    this.unsetStmt = db.prepare("DELETE FROM secrets WHERE name = ?");
+  }
+
+  set(name: string, value: string): void {
+    const nonce = crypto.getRandomValues(new Uint8Array(12));
+    const plaintext = new TextEncoder().encode(value);
+    const ciphertext = encryptGcmSync(this.aesKeyRaw, nonce, plaintext);
+    this.setStmt.run(
+      name,
+      Buffer.from(nonce),
+      Buffer.from(ciphertext),
+      new Date().toISOString(),
+    );
+  }
+
+  get(name: string): string | undefined {
+    const row = this.getStmt.get(name) as
+      | { nonce: Uint8Array; ciphertext: Uint8Array }
+      | null;
+    if (!row) return undefined;
+    const nonce = new Uint8Array(row.nonce);
+    const ciphertext = new Uint8Array(row.ciphertext);
+    const plain = decryptGcmSync(this.aesKeyRaw, nonce, ciphertext);
+    return new TextDecoder().decode(plain);
+  }
+
+  list(): string[] {
+    return (this.listStmt.all() as Array<{ name: string }>).map((r) => r.name);
+  }
+
+  unset(name: string): void {
+    this.unsetStmt.run(name);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.db.close();
+  }
+}
+
+// AES-256-GCM via node:crypto (synchronous), matching the byte layout the
+// codebase's crypto uses elsewhere (12-byte nonce, GCM 16-byte tag appended to
+// the ciphertext so decrypt can split it off). node:crypto gives us a
+// synchronous cipher so the vault API stays synchronous like bun:sqlite.
+function encryptGcmSync(
+  keyRaw: Uint8Array,
+  nonce: Uint8Array,
+  plaintext: Uint8Array,
+): Uint8Array {
+  const cipher = createCipheriv("aes-256-gcm", keyRaw, nonce);
+  const body = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  // Store ciphertext||tag so one BLOB round-trips the whole thing.
+  return new Uint8Array(Buffer.concat([body, tag]));
+}
+
+function decryptGcmSync(
+  keyRaw: Uint8Array,
+  nonce: Uint8Array,
+  ciphertextWithTag: Uint8Array,
+): Uint8Array {
+  if (ciphertextWithTag.length < 16) {
+    throw new Error("vault: ciphertext too short (missing GCM auth tag)");
+  }
+  const body = ciphertextWithTag.slice(0, ciphertextWithTag.length - 16);
+  const tag = ciphertextWithTag.slice(ciphertextWithTag.length - 16);
+  const decipher = createDecipheriv("aes-256-gcm", keyRaw, nonce);
+  decipher.setAuthTag(tag);
+  // .final() throws on auth-tag mismatch — this is the wrong-key rejection.
+  return new Uint8Array(Buffer.concat([decipher.update(body), decipher.final()]));
+}
+
+/**
+ * Open (creating if needed) a persona's vault, deriving the encryption key from
+ * a supplied 32-byte secret key. Lower-level entry point used by tests and by
+ * openPersonaVault (which resolves the persona's nsec first).
+ */
+export function openVaultWithSecret(
+  personaDir: string,
+  secretKey: Uint8Array,
+): Vault {
+  const path = vaultPath(personaDir);
+  mkdirSync(dirname(path), { recursive: true });
+  const db = new Database(path, { create: true });
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 5000");
+  const keyRaw = deriveVaultKey(secretKey);
+  return new SqliteVault(db, keyRaw);
+}
+
+/**
+ * Open (creating if needed) a persona's vault, resolving the persona's shared
+ * identity (identity.json, migrating from phantomchat.json / generating as
+ * needed) and deriving the vault key from its nsec. This is the entry point CLI
+ * + migration use.
+ */
+export async function openPersonaVault(personaDir: string): Promise<Vault> {
+  const identity = await getOrCreatePersonaIdentity(personaDir);
+  return openVaultWithSecret(personaDir, identity.secretKey);
+}
+
+/**
+ * Decrypt a persona's vault and copy each secret into `env`, with the same
+ * "existing value wins" policy the old plaintext env loader used
+ * (preloadEnvFiles): a key already present in the environment (shell export,
+ * systemd EnvironmentFile=) is never overwritten. Returns the names loaded.
+ *
+ * Best-effort: a missing / unopenable vault yields an empty result rather than
+ * throwing, so a fresh install with no vault yet starts cleanly. Never logs
+ * secret values.
+ */
+export async function loadVaultIntoEnv(
+  personaDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ loaded: string[] }> {
+  const loaded: string[] = [];
+  let vault: Vault;
+  try {
+    vault = await openPersonaVault(personaDir);
+  } catch {
+    return { loaded };
+  }
+  try {
+    for (const name of vault.list()) {
+      if (env[name] !== undefined) continue; // existing wins
+      const value = vault.get(name);
+      if (value === undefined) continue;
+      env[name] = value;
+      loaded.push(name);
+    }
+  } finally {
+    vault.close();
+  }
+  return { loaded };
+}

--- a/src/lib/vaultMigrate.ts
+++ b/src/lib/vaultMigrate.ts
@@ -1,0 +1,240 @@
+/**
+ * One-time (idempotent) migration of the legacy PLAINTEXT credential files
+ * into the per-persona encrypted vaults.
+ *
+ * Two source files, two policies:
+ *
+ *   1. `~/.env` (legacy per-account secrets) → migrated into the DEFAULT/active
+ *      persona's vault ONLY. These were always the single-box operator's own
+ *      credentials, so they belong to the one active persona.
+ *
+ *   2. `~/.config/phantombot/.env` (central phantombot-managed secrets, e.g.
+ *      TTS keys) → FANNED OUT into EVERY persona's vault, since any persona's
+ *      turn might need them. On a per-key COLLISION (a persona already received
+ *      that key from `~/.env`), the persona-local value from `~/.env` WINS — so
+ *      we skip overwriting it during the central fan-out.
+ *
+ * Safety (per source file):
+ *   - VALIDATION GATE: after every encrypted write we read the value back
+ *     THROUGH the vault (decrypt) and assert byte-for-byte equality with the
+ *     source. For the central fan-out this is verified in EVERY persona written
+ *     to. Only if ALL keys from a source file pass read-back do we DELETE that
+ *     plaintext file (clean delete, no .bak). If ANY key fails, we abort the
+ *     delete, LEAVE the file, and log-only — never a user-facing error, never
+ *     a process exit.
+ *   - Idempotent: a re-run with the plaintext files already gone is a no-op.
+ *     A partial prior run (file still present because one key failed) is simply
+ *     retried — the vault writes are upserts, so re-writing an already-migrated
+ *     key is harmless.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { type Config, personaDir } from "../config.ts";
+import { defaultEnvFilePath, loadEnvFile } from "./envFile.ts";
+import { log } from "./logger.ts";
+import { openPersonaVault, type Vault } from "./vault.ts";
+
+/** Legacy per-account secrets file. */
+export function legacyUserEnvPath(): string {
+  return process.env.PHANTOMBOT_USER_ENV_FILE ?? join(homedir(), ".env");
+}
+
+/** Every persona name that has a directory under personasDir. */
+function listPersonaNames(config: Config): string[] {
+  if (!existsSync(config.personasDir)) return [];
+  try {
+    return readdirSync(config.personasDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write each `[name, value]` into `vault`, then read each back and confirm it
+ * decrypts to exactly the source value. Returns true only if every key both
+ * wrote and read back byte-for-byte. `skip` names are not written (used to let
+ * a persona-local `~/.env` value win over a central-file value).
+ */
+function writeAndVerify(
+  vault: Vault,
+  entries: Array<[string, string]>,
+  skip: Set<string> = new Set(),
+): boolean {
+  let allOk = true;
+  for (const [name, value] of entries) {
+    if (skip.has(name)) continue;
+    try {
+      vault.set(name, value);
+      const readBack = vault.get(name);
+      if (readBack !== value) {
+        allOk = false;
+        // Name only — never the value.
+        log.warn("vault-migrate: read-back mismatch", { name });
+      }
+    } catch (e) {
+      allOk = false;
+      log.warn("vault-migrate: write/read-back failed", {
+        name,
+        error: (e as Error).message,
+      });
+    }
+  }
+  return allOk;
+}
+
+/**
+ * Migrate `~/.env` into the default/active persona's vault. Returns true if the
+ * plaintext file was (or already is) fully migrated and removed. Best-effort —
+ * never throws to the caller.
+ */
+async function migrateUserEnv(
+  config: Config,
+  defaultPersona: string,
+): Promise<{ removed: boolean; keys: string[] }> {
+  const path = legacyUserEnvPath();
+  if (!existsSync(path)) return { removed: false, keys: [] };
+  let vars: Record<string, string>;
+  try {
+    vars = await loadEnvFile(path);
+  } catch (e) {
+    log.warn("vault-migrate: could not parse ~/.env — leaving it in place", {
+      error: (e as Error).message,
+    });
+    return { removed: false, keys: [] };
+  }
+  const entries = Object.entries(vars);
+  const keys = entries.map(([k]) => k);
+  const vault = await openPersonaVault(personaDir(config, defaultPersona));
+  let ok: boolean;
+  try {
+    ok = writeAndVerify(vault, entries);
+  } finally {
+    vault.close();
+  }
+  if (ok) {
+    try {
+      await unlink(path);
+      log.info("vault-migrate: migrated ~/.env into vault, removed plaintext", {
+        persona: defaultPersona,
+        keyCount: keys.length,
+      });
+      return { removed: true, keys };
+    } catch (e) {
+      log.warn("vault-migrate: verified but could not remove ~/.env", {
+        error: (e as Error).message,
+      });
+    }
+  } else {
+    log.warn(
+      "vault-migrate: ~/.env read-back failed — leaving plaintext file in place",
+    );
+  }
+  return { removed: false, keys };
+}
+
+/**
+ * Migrate the central `~/.config/phantombot/.env` into EVERY persona's vault.
+ * On a per-key collision with a key that came from `~/.env` (in `localKeys`),
+ * the persona-local value wins — so we skip that key in the persona that
+ * already has it. Read-back is verified in every persona written to; the file
+ * is deleted only if ALL personas passed. Best-effort — never throws.
+ *
+ * `localKeys` maps persona name → the set of keys that persona already got from
+ * `~/.env` (only ever the default persona, in practice).
+ */
+async function migrateCentralEnv(
+  config: Config,
+  personas: string[],
+  localKeys: Map<string, Set<string>>,
+): Promise<boolean> {
+  const path = defaultEnvFilePath();
+  if (!existsSync(path)) return false;
+  let vars: Record<string, string>;
+  try {
+    vars = await loadEnvFile(path);
+  } catch (e) {
+    log.warn(
+      "vault-migrate: could not parse central .env — leaving it in place",
+      { error: (e as Error).message },
+    );
+    return false;
+  }
+  const entries = Object.entries(vars);
+  if (personas.length === 0) {
+    // No personas to fan out to — nothing we can safely migrate into. Leave the
+    // file so a later run (once a persona exists) can migrate it.
+    return false;
+  }
+
+  let allOk = true;
+  for (const persona of personas) {
+    const skip = localKeys.get(persona) ?? new Set<string>();
+    const vault = await openPersonaVault(personaDir(config, persona));
+    try {
+      const ok = writeAndVerify(vault, entries, skip);
+      if (!ok) allOk = false;
+    } finally {
+      vault.close();
+    }
+  }
+
+  if (allOk) {
+    try {
+      await unlink(path);
+      log.info(
+        "vault-migrate: fanned central .env into all persona vaults, removed plaintext",
+        { personaCount: personas.length, keyCount: entries.length },
+      );
+      return true;
+    } catch (e) {
+      log.warn("vault-migrate: verified but could not remove central .env", {
+        error: (e as Error).message,
+      });
+    }
+  } else {
+    log.warn(
+      "vault-migrate: central .env read-back failed in at least one persona — leaving plaintext file in place",
+    );
+  }
+  return false;
+}
+
+/**
+ * Run the full plaintext→vault migration. Idempotent and best-effort: any
+ * failure is logged (never surfaced, never a process exit) and the plaintext
+ * file is left in place so a later run can retry. Safe to call on every
+ * startup — with no plaintext files present it does nothing.
+ *
+ * Order matters: `~/.env` migrates first so its keys are recorded as
+ * persona-local; the central fan-out then honours "local wins" by skipping
+ * those keys in the persona that already has them.
+ */
+export async function migratePlaintextToVault(config: Config): Promise<void> {
+  const defaultPersona = config.defaultPersona;
+
+  // Enumerate personas for the central fan-out. Ensure the default persona is
+  // included even if it has no dir yet (openPersonaVault creates it), so its
+  // ~/.env keys land somewhere.
+  const personaSet = new Set(listPersonaNames(config));
+  personaSet.add(defaultPersona);
+  const personas = [...personaSet];
+
+  // 1. ~/.env → default persona.
+  const userResult = await migrateUserEnv(config, defaultPersona);
+
+  // Record which keys the default persona already got locally, so the central
+  // fan-out lets those win (skips them for that persona only).
+  const localKeys = new Map<string, Set<string>>();
+  if (userResult.keys.length > 0) {
+    localKeys.set(defaultPersona, new Set(userResult.keys));
+  }
+
+  // 2. central .env → every persona (local wins on collision).
+  await migrateCentralEnv(config, personas, localKeys);
+}

--- a/src/lib/vaultMigrate.ts
+++ b/src/lib/vaultMigrate.ts
@@ -43,12 +43,17 @@ export function legacyUserEnvPath(): string {
   return process.env.PHANTOMBOT_USER_ENV_FILE ?? join(homedir(), ".env");
 }
 
-/** Every persona name that has a directory under personasDir. */
+/**
+ * Every persona name that has a directory under personasDir. Hidden dirs
+ * (leading dot — `.git`, `.DS_Store` dirs, editor scratch) are skipped so the
+ * central fan-out doesn't spray an identity.json + a vault full of secrets into
+ * non-persona junk. Real persona folders are never dot-prefixed.
+ */
 function listPersonaNames(config: Config): string[] {
   if (!existsSync(config.personasDir)) return [];
   try {
     return readdirSync(config.personasDir, { withFileTypes: true })
-      .filter((e) => e.isDirectory())
+      .filter((e) => e.isDirectory() && !e.name.startsWith("."))
       .map((e) => e.name);
   } catch {
     return [];
@@ -110,7 +115,18 @@ async function migrateUserEnv(
   }
   const entries = Object.entries(vars);
   const keys = entries.map(([k]) => k);
-  const vault = await openPersonaVault(personaDir(config, defaultPersona));
+  let vault: Vault;
+  try {
+    vault = await openPersonaVault(personaDir(config, defaultPersona));
+  } catch (e) {
+    // Can't open the persona's vault (identity mint failed, disk error) —
+    // leave the plaintext in place for a later retry. Never throw (best-effort).
+    log.warn("vault-migrate: could not open vault for ~/.env — leaving it in place", {
+      persona: defaultPersona,
+      error: (e as Error).message,
+    });
+    return { removed: false, keys: [] };
+  }
   let ok: boolean;
   try {
     ok = writeAndVerify(vault, entries);
@@ -175,7 +191,20 @@ async function migrateCentralEnv(
   let allOk = true;
   for (const persona of personas) {
     const skip = localKeys.get(persona) ?? new Set<string>();
-    const vault = await openPersonaVault(personaDir(config, persona));
+    let vault: Vault;
+    try {
+      vault = await openPersonaVault(personaDir(config, persona));
+    } catch (e) {
+      // One persona's vault won't open — don't delete the plaintext (some
+      // persona would be left without the central secrets), but keep going so
+      // the others still get migrated. Never throw (best-effort).
+      allOk = false;
+      log.warn("vault-migrate: could not open vault for central fan-out", {
+        persona,
+        error: (e as Error).message,
+      });
+      continue;
+    }
     try {
       const ok = writeAndVerify(vault, entries, skip);
       if (!ok) allOk = false;
@@ -229,9 +258,13 @@ export async function migratePlaintextToVault(config: Config): Promise<void> {
   const userResult = await migrateUserEnv(config, defaultPersona);
 
   // Record which keys the default persona already got locally, so the central
-  // fan-out lets those win (skips them for that persona only).
+  // fan-out lets those win (skips them for that persona only). ONLY when the
+  // ~/.env migration actually SUCCEEDED (removed === true, i.e. every key wrote
+  // and read back): if it failed and we skipped these keys, the default persona
+  // could end up with the value from NEITHER source. On failure we let the
+  // central value populate it, and a later ~/.env retry re-asserts local-wins.
   const localKeys = new Map<string, Set<string>>();
-  if (userResult.keys.length > 0) {
+  if (userResult.removed && userResult.keys.length > 0) {
     localKeys.set(defaultPersona, new Set(userResult.keys));
   }
 

--- a/src/lib/vaultMigrate.ts
+++ b/src/lib/vaultMigrate.ts
@@ -2,17 +2,21 @@
  * One-time (idempotent) migration of the legacy PLAINTEXT credential files
  * into the per-persona encrypted vaults.
  *
- * Two source files, two policies:
+ * Two source files, both FANNED OUT to every persona:
  *
- *   1. `~/.env` (legacy per-account secrets) → migrated into the DEFAULT/active
- *      persona's vault ONLY. These were always the single-box operator's own
- *      credentials, so they belong to the one active persona.
+ *   1. `~/.env` (legacy per-account secrets) → FANNED OUT into EVERY persona's
+ *      vault. In the old world these were loaded globally (systemd
+ *      `EnvironmentFile=` / `preloadEnvFiles`), so every persona could read
+ *      them; on a single-operator multi-persona box (the dogfood plan: Lena +
+ *      Kai) they must stay available to all personas, not just the default one,
+ *      or the non-default personas silently lose `GITHUB_TOKEN` etc. once the
+ *      plaintext file is deleted.
  *
  *   2. `~/.config/phantombot/.env` (central phantombot-managed secrets, e.g.
  *      TTS keys) → FANNED OUT into EVERY persona's vault, since any persona's
- *      turn might need them. On a per-key COLLISION (a persona already received
- *      that key from `~/.env`), the persona-local value from `~/.env` WINS — so
- *      we skip overwriting it during the central fan-out.
+ *      turn might need them. On a per-key COLLISION (a key that also came from
+ *      `~/.env`), the `~/.env` value WINS in every persona — so we skip
+ *      overwriting it during the central fan-out.
  *
  * Safety (per source file):
  *   - VALIDATION GATE: after every encrypted write we read the value back
@@ -94,13 +98,15 @@ function writeAndVerify(
 }
 
 /**
- * Migrate `~/.env` into the default/active persona's vault. Returns true if the
- * plaintext file was (or already is) fully migrated and removed. Best-effort —
- * never throws to the caller.
+ * Migrate `~/.env` by FANNING IT OUT into EVERY persona's vault (mirroring the
+ * old global `EnvironmentFile=` behaviour, so non-default personas keep their
+ * credentials). Read-back is verified in every persona written to; the plaintext
+ * file is deleted only if ALL personas passed. Returns `removed: true` (with the
+ * migrated keys) only on full success. Best-effort — never throws to the caller.
  */
 async function migrateUserEnv(
   config: Config,
-  defaultPersona: string,
+  personas: string[],
 ): Promise<{ removed: boolean; keys: string[] }> {
   const path = legacyUserEnvPath();
   if (!existsSync(path)) return { removed: false, keys: [] };
@@ -115,29 +121,40 @@ async function migrateUserEnv(
   }
   const entries = Object.entries(vars);
   const keys = entries.map(([k]) => k);
-  let vault: Vault;
-  try {
-    vault = await openPersonaVault(personaDir(config, defaultPersona));
-  } catch (e) {
-    // Can't open the persona's vault (identity mint failed, disk error) —
-    // leave the plaintext in place for a later retry. Never throw (best-effort).
-    log.warn("vault-migrate: could not open vault for ~/.env — leaving it in place", {
-      persona: defaultPersona,
-      error: (e as Error).message,
-    });
-    return { removed: false, keys: [] };
+  if (personas.length === 0) {
+    // No personas to fan out to — leave the file for a later run.
+    return { removed: false, keys };
   }
-  let ok: boolean;
-  try {
-    ok = writeAndVerify(vault, entries);
-  } finally {
-    vault.close();
+
+  let allOk = true;
+  for (const persona of personas) {
+    let vault: Vault;
+    try {
+      vault = await openPersonaVault(personaDir(config, persona));
+    } catch (e) {
+      // One persona's vault won't open (identity mint failed, disk error) —
+      // don't delete the plaintext (that persona would be left without the
+      // secrets), but keep going so the others still migrate. Never throw.
+      allOk = false;
+      log.warn("vault-migrate: could not open vault for ~/.env fan-out — leaving it in place", {
+        persona,
+        error: (e as Error).message,
+      });
+      continue;
+    }
+    try {
+      const ok = writeAndVerify(vault, entries);
+      if (!ok) allOk = false;
+    } finally {
+      vault.close();
+    }
   }
-  if (ok) {
+
+  if (allOk) {
     try {
       await unlink(path);
-      log.info("vault-migrate: migrated ~/.env into vault, removed plaintext", {
-        persona: defaultPersona,
+      log.info("vault-migrate: fanned ~/.env into all persona vaults, removed plaintext", {
+        personaCount: personas.length,
         keyCount: keys.length,
       });
       return { removed: true, keys };
@@ -148,7 +165,7 @@ async function migrateUserEnv(
     }
   } else {
     log.warn(
-      "vault-migrate: ~/.env read-back failed — leaving plaintext file in place",
+      "vault-migrate: ~/.env read-back failed in at least one persona — leaving plaintext file in place",
     );
   }
   return { removed: false, keys };
@@ -254,18 +271,19 @@ export async function migratePlaintextToVault(config: Config): Promise<void> {
   personaSet.add(defaultPersona);
   const personas = [...personaSet];
 
-  // 1. ~/.env → default persona.
-  const userResult = await migrateUserEnv(config, defaultPersona);
+  // 1. ~/.env → fanned out to EVERY persona.
+  const userResult = await migrateUserEnv(config, personas);
 
-  // Record which keys the default persona already got locally, so the central
-  // fan-out lets those win (skips them for that persona only). ONLY when the
-  // ~/.env migration actually SUCCEEDED (removed === true, i.e. every key wrote
-  // and read back): if it failed and we skipped these keys, the default persona
-  // could end up with the value from NEITHER source. On failure we let the
-  // central value populate it, and a later ~/.env retry re-asserts local-wins.
+  // Record which keys came from `~/.env` so the central fan-out lets those win
+  // (skips them) in EVERY persona. ONLY when the ~/.env migration actually
+  // SUCCEEDED (removed === true, i.e. every key wrote and read back in every
+  // persona): if it failed and we skipped these keys, a persona could end up
+  // with the value from NEITHER source. On failure we let the central value
+  // populate it, and a later ~/.env retry re-asserts local-wins.
   const localKeys = new Map<string, Set<string>>();
   if (userResult.removed && userResult.keys.length > 0) {
-    localKeys.set(defaultPersona, new Set(userResult.keys));
+    const won = new Set(userResult.keys);
+    for (const persona of personas) localKeys.set(persona, won);
   }
 
   // 2. central .env → every persona (local wins on collision).

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -464,6 +464,12 @@ safe-write CLI:
 NEVER \`echo … >> ~/.env\` directly — that file is defunct, unencrypted,
 and its contents are migrated away on the next startup. Use the vault.
 
+BLAST RADIUS — the vault is encrypted with a key DERIVED FROM the
+persona's nsec in \`<persona-dir>/identity.json\`. Losing or corrupting
+that one file makes EVERY secret in the vault permanently
+unrecoverable (not just the Nostr identity). It is the single most
+important file to keep backed up; never delete or overwrite it.
+
 After saving, ACKNOWLEDGE BY NAME ONLY: "saved GITHUB_TOKEN". Do not
 echo the value back. The user pasted it once (or you just discovered
 it); further reflection in the conversation is leakage that ends up

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -386,39 +386,49 @@ is in, just answer.`;
  * credentials and saving new ones, regardless of which persona is
  * loaded. Persona-specific tools.md sections can override.
  *
- * Framing note: the store (\`~/.env\` via \`phantombot env set\`) is a
- * *convenience layer*, not a cage. The agent should be free — and
- * encouraged — to scan creatively for credentials wherever they
- * actually live (git history, config files, keychains, password
- * managers, log lines, …) and to file what's worth keeping. The
- * starter-spots list below is a fast path, not a wall.
+ * Framing note: the canonical store is now the phantombot VAULT — a
+ * per-persona, encrypted-at-rest secrets database (write via
+ * \`phantombot vault set\`). Secrets are ALWAYS stored in and read from
+ * the vault; the plaintext \`~/.env\` era is over (migrated on startup).
+ * The vault is a *convenience layer*, not a cage: the agent should still
+ * scan creatively for credentials wherever they actually live (git
+ * history, config files, keychains, password managers, log lines, …) and
+ * file what's worth keeping. The starter-spots list below is a fast path,
+ * not a wall.
  */
 export const CREDENTIALS_SECTION =
   `# Credentials
 
-Phantombot keeps a small, atomic credential store at \`~/.env\` (write
-via \`phantombot env set\`). Treat it as a *convenience layer*, not a
-cage: scan widely for what you need, and when you find or earn a
-useful credential, file it so the next turn — or the next persona —
-doesn't have to re-derive it.
+Secrets are ALWAYS stored in and read from the **phantombot vault** — a
+per-persona, encrypted-at-rest secrets store (write via \`phantombot
+vault set\`). To FIND a secret, look in the vault; to STORE one, use
+\`phantombot vault set\`. Treat the vault as a *convenience layer*, not a
+cage: scan widely for what you need, and when you find or earn a useful
+credential, file it in the vault so the next turn — or the next persona —
+doesn't have to re-derive it. (The legacy plaintext \`~/.env\` was
+migrated into the vault at startup and no longer holds secrets.)
 
 ## Where to look first — the fast path
 
 These are the *starter spots*. Most things will be here. Don't ask
 the user for anything in this list that you can read directly:
 
-  1. process.env  — already loaded; phantombot sources both \`~/.env\` and
-                    \`~/.config/phantombot/.env\` at startup (systemd
-                    EnvironmentFile= on Linux, self-loaded on macOS), so
-                    most credentials are available without re-reading.
-  2. ~/.env       — the canonical credentials file. GITHUB_TOKEN,
-                    OPENAI_API_KEY, ssh passphrases, API keys.
+  1. process.env  — already loaded; phantombot decrypts your persona's
+                    vault at startup and injects every secret into the
+                    environment, so most credentials are available
+                    without re-reading anything.
+  2. vault        — the canonical secrets store. \`phantombot vault list\`
+                    shows the names; a value already in process.env came
+                    from here. GITHUB_TOKEN, OPENAI_API_KEY, API keys.
   3. ~/.ssh/      — SSH keys + config (Host aliases, IdentityFile entries).
-  4. ~/.bashrc, ~/.zshrc — exported shell vars (often the same keys as
-                    ~/.env but exported into interactive shells too).
+  4. ~/.bashrc, ~/.zshrc — exported shell vars (sometimes the same keys as
+                    the vault, but exported into interactive shells too).
   5. Memory store: \`phantombot memory search "<credential name>"\` — anything
                     a previous turn stashed under your persona memory.
   6. Knowledge base — embedded notes, runbooks, infra docs.
+
+(For reference, the vault replaced the old plaintext \`~/.env\` file —
+if a runbook still mentions \`~/.env\`, the secret now lives in the vault.)
 
 ## Follow your nose if those fail
 
@@ -443,15 +453,16 @@ redo the search.
 ## Persistence — save what you find
 
 When the user gives you a credential, OR when you discover one in
-the wild that's worth keeping, persist it via the safe-write CLI:
+the wild that's worth keeping, persist it INTO THE VAULT via the
+safe-write CLI:
 
-  phantombot env set NAME "value"           # atomic write to ~/.env, mode 0o600
-  phantombot env get NAME                   # read (avoid in interactive: leaks to scrollback)
-  phantombot env list                       # variable names only, no values
-  phantombot env unset NAME
+  phantombot vault set NAME "value"         # encrypt + store (AES-256-GCM at rest)
+  phantombot vault get NAME                 # read (avoid in interactive: leaks to scrollback)
+  phantombot vault list                     # secret names only, no values
+  phantombot vault unset NAME
 
-NEVER \`echo … >> ~/.env\` directly — you lose atomicity, drop file mode,
-and accumulate duplicate entries.
+NEVER \`echo … >> ~/.env\` directly — that file is defunct, unencrypted,
+and its contents are migrated away on the next startup. Use the vault.
 
 After saving, ACKNOWLEDGE BY NAME ONLY: "saved GITHUB_TOKEN". Do not
 echo the value back. The user pasted it once (or you just discovered
@@ -469,7 +480,7 @@ not the literal value. Example:
   gh api -H "Authorization: Bearer ghp_actualtokenhere..."
 
 Credentials don't go in memory drawers, KB notes, or task prompts.
-They're a runtime concern — \`~/.env\` and the process env are the
+They're a runtime concern — the vault and the process env are the
 only places they live.
 
 ## Last resort

--- a/tests/channels-phantomchat-personaStore.test.ts
+++ b/tests/channels-phantomchat-personaStore.test.ts
@@ -20,6 +20,8 @@ import {
   savePhantomchatPersonaConfig,
 } from "../src/channels/phantomchat/personaStore.ts";
 import { decodeNpubToHex, generateIdentity } from "../src/lib/nostrIdentity.ts";
+import { readPersonaIdentityNsec } from "../src/lib/personaIdentity.ts";
+import { readFile } from "node:fs/promises";
 
 let workdir: string;
 
@@ -53,6 +55,52 @@ describe("save/load round-trip", () => {
     expect(loaded!.allowedNpubs).toEqual([allowed]);
     // allowedHex is the decoded lowercase-hex form used by the auth gate.
     expect(loaded!.allowedHex).toEqual([decodeNpubToHex(allowed)]);
+  });
+
+  test("nsec is stored in identity.json, NOT phantomchat.json (Kai #253)", async () => {
+    const id = generateIdentity();
+    const agentDir = join(workdir, "lena");
+    await mkdir(agentDir, { recursive: true });
+
+    await savePhantomchatPersonaConfig(agentDir, {
+      nsec: id.nsec,
+      relays: ["wss://a.example"],
+      allowedNpubs: [],
+    });
+
+    // The root secret lives in identity.json ...
+    expect(readPersonaIdentityNsec(agentDir)).toBe(id.nsec);
+    // ... and is NOT duplicated into the channel-config file.
+    const pcRaw = JSON.parse(
+      await readFile(phantomchatConfigPath(agentDir), "utf8"),
+    ) as Record<string, unknown>;
+    expect(pcRaw.nsec).toBeUndefined();
+    expect(pcRaw.relays).toEqual(["wss://a.example"]);
+    // The channel still loads fine, sourcing the nsec from identity.json.
+    expect(loadPhantomchatPersonaConfig(agentDir)!.identity.npub).toBe(id.npub);
+  });
+
+  test("a legacy phantomchat.json nsec is promoted to identity.json on next save", async () => {
+    const legacy = generateIdentity();
+    const agentDir = join(workdir, "legacy");
+    await mkdir(agentDir, { recursive: true });
+    // Simulate a pre-migration file with the nsec inline.
+    await writeFile(
+      phantomchatConfigPath(agentDir),
+      JSON.stringify({ nsec: legacy.nsec, relays: [], allowed_npubs: [] }),
+    );
+    // It still loads (legacy fallback read).
+    expect(loadPhantomchatPersonaConfig(agentDir)!.identity.npub).toBe(legacy.npub);
+
+    // A subsequent save (e.g. recordGreeted/cacheRelays) promotes it and drops
+    // the inline nsec, without losing the identity.
+    await recordTrustedNpub(agentDir, generateIdentity().npub);
+    expect(readPersonaIdentityNsec(agentDir)).toBe(legacy.nsec);
+    const pcRaw = JSON.parse(
+      await readFile(phantomchatConfigPath(agentDir), "utf8"),
+    ) as Record<string, unknown>;
+    expect(pcRaw.nsec).toBeUndefined();
+    expect(loadPhantomchatPersonaConfig(agentDir)!.identity.npub).toBe(legacy.npub);
   });
 
   test("tofu round-trips: persisted only when enabled, defaults false", async () => {

--- a/tests/cli-env.test.ts
+++ b/tests/cli-env.test.ts
@@ -1,5 +1,18 @@
+/**
+ * `phantombot env` is now a DEPRECATED ALIAS that forwards to the encrypted
+ * vault (src/cli/vault.ts). These tests pin two things:
+ *   - the deprecation notice is printed to stderr (never stdout, which carries
+ *     values), and
+ *   - each runner forwards to the vault so a set/get/list/unset round-trips
+ *     through the encrypted store with the same value/name hygiene as before.
+ *
+ * The runners accept an injectable `vault` seam (mirroring the vault runners),
+ * so we drive them against an in-memory persona vault with no filesystem env
+ * file at all.
+ */
+
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -8,6 +21,14 @@ import {
   runEnvSet,
   runEnvUnset,
 } from "../src/cli/env.ts";
+import {
+  runVaultGet,
+  runVaultList,
+  runVaultSet,
+  runVaultUnset,
+} from "../src/cli/vault.ts";
+import { openVaultWithSecret, type Vault } from "../src/lib/vault.ts";
+import { generateSecretKey } from "nostr-tools/pure";
 
 class CaptureStream {
   chunks: string[] = [];
@@ -21,120 +42,131 @@ class CaptureStream {
 }
 
 let workdir: string;
-let envPath: string;
+let vault: Vault;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-env-cli-"));
-  envPath = join(workdir, ".env");
+  vault = openVaultWithSecret(join(workdir, "persona"), generateSecretKey());
 });
 
 afterEach(async () => {
+  vault.close();
   await rm(workdir, { recursive: true, force: true });
 });
 
-describe("runEnvSet", () => {
-  test("writes the var, file is mode 0o600, ack message names the var only", async () => {
+describe("runEnvSet (deprecated → vault)", () => {
+  test("forwards to the vault; ack names the var only, notice on stderr", async () => {
     const out = new CaptureStream();
+    const err = new CaptureStream();
     const code = await runEnvSet({
       name: "GITHUB_TOKEN",
       value: "ghp_supersecret",
-      envPath,
+      vault,
       out,
+      err,
     });
     expect(code).toBe(0);
-    // File mode is owner-only (the existing envFile.ts atomic-rename guarantee).
-    const s = await stat(envPath);
-    expect((s.mode & 0o077).toString(8)).toBe("0");
+    // Deprecation notice on stderr, not stdout.
+    expect(err.text).toMatch(/deprecated/i);
+    expect(out.text).not.toMatch(/deprecated/i);
     // Ack mentions the name but NOT the value (hygiene rule).
     expect(out.text).toContain("GITHUB_TOKEN");
     expect(out.text).not.toContain("ghp_supersecret");
-    // Round-trip via a real read.
-    const content = await readFile(envPath, "utf8");
-    expect(content).toContain("GITHUB_TOKEN=ghp_supersecret");
+    // The value actually landed in the encrypted vault.
+    expect(vault.get("GITHUB_TOKEN")).toBe("ghp_supersecret");
   });
 
   test("rejects invalid env var names", async () => {
     const err = new CaptureStream();
-    const code = await runEnvSet({
-      name: "weird-name",
-      value: "x",
-      envPath,
-      err,
-    });
+    const code = await runEnvSet({ name: "weird-name", value: "x", vault, err });
     expect(code).toBe(2);
     expect(err.text).toContain("not a valid env var name");
   });
 
-  test("set is idempotent — replaces existing entries, no duplicates", async () => {
-    await runEnvSet({ name: "K", value: "v1", envPath, out: new CaptureStream() });
-    await runEnvSet({ name: "K", value: "v2", envPath, out: new CaptureStream() });
-    const text = await readFile(envPath, "utf8");
-    // Exactly one K= line.
-    const matches = text.match(/^K=/gm);
-    expect(matches?.length).toBe(1);
-    expect(text).toContain("K=v2");
+  test("set is idempotent — replaces the value, one entry", async () => {
+    await runEnvSet({ name: "K", value: "v1", vault, out: new CaptureStream(), err: new CaptureStream() });
+    await runEnvSet({ name: "K", value: "v2", vault, out: new CaptureStream(), err: new CaptureStream() });
+    expect(vault.get("K")).toBe("v2");
+    expect(vault.list()).toEqual(["K"]);
   });
 });
 
-describe("runEnvGet", () => {
+describe("runEnvGet (deprecated → vault)", () => {
   test("prints raw value when set", async () => {
-    await writeFile(envPath, "TOKEN=hello\n", { encoding: "utf8", mode: 0o600 });
+    vault.set("TOKEN", "hello");
     const out = new CaptureStream();
-    const code = await runEnvGet({ name: "TOKEN", envPath, out });
+    const code = await runEnvGet({ name: "TOKEN", vault, out });
     expect(code).toBe(0);
     expect(out.text).toBe("hello\n");
   });
 
   test("exit 1 when not set", async () => {
     const err = new CaptureStream();
-    const code = await runEnvGet({ name: "MISSING", envPath, err });
+    const code = await runEnvGet({ name: "MISSING", vault, err });
     expect(code).toBe(1);
     expect(err.text).toContain("not set");
   });
 });
 
-describe("runEnvList", () => {
+describe("runEnvList (deprecated → vault)", () => {
   test("prints names only, sorted, never values", async () => {
-    await writeFile(
-      envPath,
-      "ZED=z\nALPHA=a\nMID=m\n",
-      { encoding: "utf8", mode: 0o600 },
-    );
+    vault.set("ZED", "z");
+    vault.set("ALPHA", "a");
+    vault.set("MID", "m");
     const out = new CaptureStream();
-    const code = await runEnvList({ envPath, out });
+    const code = await runEnvList({ vault, out });
     expect(code).toBe(0);
     expect(out.text).toBe("ALPHA\nMID\nZED\n");
     expect(out.text).not.toContain("=");
   });
 
-  test("empty file → friendly placeholder", async () => {
+  test("empty vault → friendly placeholder", async () => {
     const out = new CaptureStream();
-    const code = await runEnvList({ envPath, out });
+    const code = await runEnvList({ vault, out });
     expect(code).toBe(0);
     expect(out.text).toContain("(no entries");
   });
 });
 
-describe("runEnvUnset", () => {
+describe("runEnvUnset (deprecated → vault)", () => {
   test("removes the entry, leaves others intact", async () => {
-    await writeFile(
-      envPath,
-      "KEEP=k\nGONE=g\n",
-      { encoding: "utf8", mode: 0o600 },
-    );
+    vault.set("KEEP", "k");
+    vault.set("GONE", "g");
     const out = new CaptureStream();
-    const code = await runEnvUnset({ name: "GONE", envPath, out });
+    const code = await runEnvUnset({ name: "GONE", vault, out });
     expect(code).toBe(0);
     expect(out.text).toContain("removed GONE");
-    const text = await readFile(envPath, "utf8");
-    expect(text).toContain("KEEP=k");
-    expect(text).not.toContain("GONE=");
+    expect(vault.get("KEEP")).toBe("k");
+    expect(vault.get("GONE")).toBeUndefined();
   });
 
-  test("rejects invalid names without touching the file", async () => {
+  test("rejects invalid names without touching the vault", async () => {
     const err = new CaptureStream();
-    const code = await runEnvUnset({ name: "1bad", envPath, err });
+    const code = await runEnvUnset({ name: "1bad", vault, err });
     expect(code).toBe(2);
     expect(err.text).toContain("not a valid");
+  });
+});
+
+// The vault runners are the forward target; a quick direct check that they
+// behave identically (the env runners just prepend a deprecation notice).
+describe("vault runners (forward target)", () => {
+  test("set/get/list/unset round-trip through the encrypted vault", async () => {
+    const out = new CaptureStream();
+    expect(await runVaultSet({ name: "A", value: "1", vault, out })).toBe(0);
+    expect(out.text).toContain("saved A");
+    expect(out.text).not.toContain("1\n"); // value not echoed in the ack
+
+    const getOut = new CaptureStream();
+    expect(await runVaultGet({ name: "A", vault, out: getOut })).toBe(0);
+    expect(getOut.text).toBe("1\n");
+
+    const listOut = new CaptureStream();
+    expect(await runVaultList({ vault, out: listOut })).toBe(0);
+    expect(listOut.text).toBe("A\n");
+
+    const unsetOut = new CaptureStream();
+    expect(await runVaultUnset({ name: "A", vault, out: unsetOut })).toBe(0);
+    expect(vault.get("A")).toBeUndefined();
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -41,6 +41,7 @@ describe("phantombot CLI dispatcher", () => {
       "tick",
       "uninstall",
       "update",
+      "vault",
       "voice",
     ]);
   });

--- a/tests/persona-builder-credentials.test.ts
+++ b/tests/persona-builder-credentials.test.ts
@@ -6,12 +6,12 @@
  * credentials and how to persist new ones, regardless of which persona
  * is loaded.
  *
- * Framing: the section presents `~/.env` (write via `phantombot env set`)
- * as a *convenience layer*, not a cage. The agent must be free to scan
- * creatively for credentials wherever they live, and to file what's
- * worth keeping. These tests pin both halves: starter spots are
- * documented (fast path), AND the section explicitly licenses
- * follow-your-nose discovery with concrete examples.
+ * Framing: the section presents the phantombot VAULT (write via
+ * `phantombot vault set`) as the canonical store — a *convenience layer*,
+ * not a cage. The agent must be free to scan creatively for credentials
+ * wherever they live, and to file what's worth keeping. These tests pin
+ * both halves: starter spots are documented (fast path), AND the section
+ * explicitly licenses follow-your-nose discovery with concrete examples.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -42,7 +42,7 @@ describe("buildSystemPrompt — credentials section", () => {
 
   test("frames the store as a convenience layer, not a cage", () => {
     // The literal phrase is load-bearing. It's how the agent learns
-    // that `phantombot env` is a place to *file* credentials, not a
+    // that the vault is a place to *file* credentials, not a
     // wall around them. If you change the wording, update both here
     // and the persona docs at the same time.
     expect(CREDENTIALS_SECTION).toMatch(/convenience layer/i);
@@ -50,9 +50,18 @@ describe("buildSystemPrompt — credentials section", () => {
     expect(CREDENTIALS_SECTION).toMatch(/not a\s+cage/i);
   });
 
-  test("documents the starter-spots fast path with ~/.env, ssh, shell, memory, KB", () => {
+  test("names the vault as the canonical, always-used secrets store", () => {
+    // The whole point of #253: the vault is where secrets ALWAYS live.
+    expect(CREDENTIALS_SECTION).toMatch(/phantombot vault/i);
+    expect(CREDENTIALS_SECTION).toMatch(/always/i);
+    expect(CREDENTIALS_SECTION).toMatch(/encrypted/i);
+  });
+
+  test("documents the starter-spots fast path with vault, ssh, shell, memory, KB", () => {
     expect(CREDENTIALS_SECTION).toContain("process.env");
-    expect(CREDENTIALS_SECTION).toContain("~/.env");
+    // The canonical store is the vault now; ~/.env only survives as a
+    // pointer note explaining where secrets moved.
+    expect(CREDENTIALS_SECTION).toMatch(/vault/i);
     expect(CREDENTIALS_SECTION).toContain("~/.ssh/");
     expect(CREDENTIALS_SECTION).toContain("~/.bashrc");
     expect(CREDENTIALS_SECTION).toContain("phantombot memory search");
@@ -81,11 +90,11 @@ describe("buildSystemPrompt — credentials section", () => {
     expect(CREDENTIALS_SECTION).toMatch(/save it/i);
   });
 
-  test("documents the env-set/get/list/unset CLI as the safe-write path", () => {
-    expect(CREDENTIALS_SECTION).toContain("phantombot env set");
-    expect(CREDENTIALS_SECTION).toContain("phantombot env get");
-    expect(CREDENTIALS_SECTION).toContain("phantombot env list");
-    expect(CREDENTIALS_SECTION).toContain("phantombot env unset");
+  test("documents the vault set/get/list/unset CLI as the safe-write path", () => {
+    expect(CREDENTIALS_SECTION).toContain("phantombot vault set");
+    expect(CREDENTIALS_SECTION).toContain("phantombot vault get");
+    expect(CREDENTIALS_SECTION).toContain("phantombot vault list");
+    expect(CREDENTIALS_SECTION).toContain("phantombot vault unset");
   });
 
   test("explicitly forbids `echo … >> ~/.env`", () => {

--- a/tests/persona-identity.test.ts
+++ b/tests/persona-identity.test.ts
@@ -17,10 +17,10 @@ import { join } from "node:path";
 
 import { generateIdentity } from "../src/lib/nostrIdentity.ts";
 import {
+  createPersonaIdentityIfAbsent,
   getOrCreatePersonaIdentity,
   personaIdentityPath,
   readPersonaIdentityNsec,
-  writePersonaIdentity,
 } from "../src/lib/personaIdentity.ts";
 
 let workdir: string;
@@ -73,7 +73,7 @@ describe("getOrCreatePersonaIdentity", () => {
     await mkdir(dir, { recursive: true });
     const shared = generateIdentity();
     const legacy = generateIdentity();
-    await writePersonaIdentity(dir, shared.nsec);
+    await createPersonaIdentityIfAbsent(dir, shared.nsec);
     await writeFile(
       join(dir, "phantomchat.json"),
       JSON.stringify({ nsec: legacy.nsec }),
@@ -95,19 +95,44 @@ describe("getOrCreatePersonaIdentity", () => {
   });
 });
 
-describe("readPersonaIdentityNsec / writePersonaIdentity", () => {
+describe("createPersonaIdentityIfAbsent", () => {
   test("read returns undefined before write, the value after", async () => {
     const dir = join(workdir, "p");
     expect(readPersonaIdentityNsec(dir)).toBeUndefined();
     const id = generateIdentity();
-    await writePersonaIdentity(dir, id.nsec);
+    await createPersonaIdentityIfAbsent(dir, id.nsec);
     expect(readPersonaIdentityNsec(dir)).toBe(id.nsec);
   });
 
-  test("writePersonaIdentity persists at mode 0600", async () => {
+  test("persists at mode 0600", async () => {
     const dir = join(workdir, "p");
-    await writePersonaIdentity(dir, generateIdentity().nsec);
+    await createPersonaIdentityIfAbsent(dir, generateIdentity().nsec);
     const st = await stat(personaIdentityPath(dir));
     expect(st.mode & 0o777).toBe(0o600);
+  });
+
+  test("never overwrites an existing identity — returns the incumbent nsec", async () => {
+    const dir = join(workdir, "p");
+    const first = generateIdentity();
+    const second = generateIdentity();
+    const got1 = await createPersonaIdentityIfAbsent(dir, first.nsec);
+    // A second caller (e.g. the phantomchat channel writing after the vault
+    // already minted the identity) must NOT clobber the file.
+    const got2 = await createPersonaIdentityIfAbsent(dir, second.nsec);
+    expect(got1).toBe(first.nsec);
+    expect(got2).toBe(first.nsec); // adopted the incumbent, not `second`
+    expect(readPersonaIdentityNsec(dir)).toBe(first.nsec);
+  });
+
+  test("fails closed when identity.json exists but is unreadable", async () => {
+    const dir = join(workdir, "p");
+    await mkdir(dir, { recursive: true });
+    // A present-but-malformed identity.json: readNsecFromJson can't recover an
+    // nsec, so the create-if-absent primitive must THROW rather than hand back a
+    // transient in-process key that would orphan encrypted vault data.
+    await writeFile(personaIdentityPath(dir), "{ this is not json");
+    await expect(
+      createPersonaIdentityIfAbsent(dir, generateIdentity().nsec),
+    ).rejects.toThrow(/unreadable/);
   });
 });

--- a/tests/persona-identity.test.ts
+++ b/tests/persona-identity.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared per-persona identity (identity.json) — the root secret both the
+ * phantomchat channel and the encrypted vault derive from (PR #253).
+ *
+ * Covers:
+ *   - fresh generation, 0600 perms, and idempotency,
+ *   - legacy MIGRATION of an nsec out of phantomchat.json into identity.json,
+ *   - identity.json PRECEDENCE over a legacy phantomchat.json nsec,
+ *   - the concurrent-create RACE: many parallel first-use calls must converge
+ *     on ONE nsec (a divergent write would orphan a vault forever).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, stat, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { generateIdentity } from "../src/lib/nostrIdentity.ts";
+import {
+  getOrCreatePersonaIdentity,
+  personaIdentityPath,
+  readPersonaIdentityNsec,
+  writePersonaIdentity,
+} from "../src/lib/personaIdentity.ts";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-identity-"));
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("getOrCreatePersonaIdentity", () => {
+  test("generates, persists identity.json at mode 0600, returns a valid identity", async () => {
+    const dir = join(workdir, "p");
+    const identity = await getOrCreatePersonaIdentity(dir);
+
+    expect(identity.nsec).toMatch(/^nsec1/);
+    expect(identity.npub).toMatch(/^npub1/);
+    expect(identity.secretKey.length).toBe(32);
+
+    const st = await stat(personaIdentityPath(dir));
+    expect(st.mode & 0o777).toBe(0o600);
+    expect(readPersonaIdentityNsec(dir)).toBe(identity.nsec);
+  });
+
+  test("is idempotent — a second call returns the same nsec", async () => {
+    const dir = join(workdir, "p");
+    const first = await getOrCreatePersonaIdentity(dir);
+    const second = await getOrCreatePersonaIdentity(dir);
+    expect(second.nsec).toBe(first.nsec);
+  });
+
+  test("migrates a legacy phantomchat.json nsec into identity.json", async () => {
+    const dir = join(workdir, "p");
+    await mkdir(dir, { recursive: true });
+    const legacy = generateIdentity();
+    await writeFile(
+      join(dir, "phantomchat.json"),
+      JSON.stringify({ nsec: legacy.nsec, relays: [] }),
+    );
+
+    const identity = await getOrCreatePersonaIdentity(dir);
+    expect(identity.nsec).toBe(legacy.nsec); // same identity preserved
+    expect(readPersonaIdentityNsec(dir)).toBe(legacy.nsec); // now in identity.json
+  });
+
+  test("identity.json takes precedence over a legacy phantomchat.json nsec", async () => {
+    const dir = join(workdir, "p");
+    await mkdir(dir, { recursive: true });
+    const shared = generateIdentity();
+    const legacy = generateIdentity();
+    await writePersonaIdentity(dir, shared.nsec);
+    await writeFile(
+      join(dir, "phantomchat.json"),
+      JSON.stringify({ nsec: legacy.nsec }),
+    );
+
+    const identity = await getOrCreatePersonaIdentity(dir);
+    expect(identity.nsec).toBe(shared.nsec);
+  });
+
+  test("concurrent first-use calls all converge on ONE nsec (no divergent write)", async () => {
+    const dir = join(workdir, "p");
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => getOrCreatePersonaIdentity(dir)),
+    );
+    const nsecs = new Set(results.map((r) => r.nsec));
+    expect(nsecs.size).toBe(1); // exactly one identity won the race
+    // And it's the one persisted on disk.
+    expect(readPersonaIdentityNsec(dir)).toBe(results[0]!.nsec);
+  });
+});
+
+describe("readPersonaIdentityNsec / writePersonaIdentity", () => {
+  test("read returns undefined before write, the value after", async () => {
+    const dir = join(workdir, "p");
+    expect(readPersonaIdentityNsec(dir)).toBeUndefined();
+    const id = generateIdentity();
+    await writePersonaIdentity(dir, id.nsec);
+    expect(readPersonaIdentityNsec(dir)).toBe(id.nsec);
+  });
+
+  test("writePersonaIdentity persists at mode 0600", async () => {
+    const dir = join(workdir, "p");
+    await writePersonaIdentity(dir, generateIdentity().nsec);
+    const st = await stat(personaIdentityPath(dir));
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+});

--- a/tests/vault-migrate.test.ts
+++ b/tests/vault-migrate.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Plaintext → encrypted-vault migration (PR #253). This is the SAFETY-CRITICAL
+ * path: it deletes the only plaintext copy of each secret, so it must prove the
+ * ciphertext read back first.
+ *
+ * Covers:
+ *   - ~/.env → the DEFAULT persona's vault, decryptable, plaintext deleted,
+ *   - central .env → FANNED OUT into every persona's vault,
+ *   - COLLISION: a persona-local ~/.env value WINS over the central one,
+ *   - IDEMPOTENCY: a re-run with the files already gone is a clean no-op,
+ *   - hidden/non-persona dirs are NOT sprayed with an identity + secrets.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { Config } from "../src/config.ts";
+import { personaDir } from "../src/config.ts";
+import { saveEnvFile } from "../src/lib/envFile.ts";
+import { openPersonaVault, vaultPath } from "../src/lib/vault.ts";
+import { migratePlaintextToVault } from "../src/lib/vaultMigrate.ts";
+
+let workdir: string;
+let userEnv: string;
+let centralEnv: string;
+let personasDir: string;
+let savedUserEnvVar: string | undefined;
+let savedCentralEnvVar: string | undefined;
+
+/** Minimal Config — the migrate path only reads defaultPersona + personasDir. */
+function cfg(): Config {
+  return { defaultPersona: "robbie", personasDir } as unknown as Config;
+}
+
+/** Decrypt one key out of a persona's vault. */
+async function readVault(persona: string, name: string): Promise<string | undefined> {
+  const v = await openPersonaVault(personaDir(cfg(), persona));
+  try {
+    return v.get(name);
+  } finally {
+    v.close();
+  }
+}
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-migrate-"));
+  userEnv = join(workdir, "user.env");
+  centralEnv = join(workdir, "central.env");
+  personasDir = join(workdir, "personas");
+  await mkdir(personasDir, { recursive: true });
+
+  savedUserEnvVar = process.env.PHANTOMBOT_USER_ENV_FILE;
+  savedCentralEnvVar = process.env.PHANTOMBOT_ENV_FILE;
+  process.env.PHANTOMBOT_USER_ENV_FILE = userEnv;
+  process.env.PHANTOMBOT_ENV_FILE = centralEnv;
+});
+
+afterEach(async () => {
+  if (savedUserEnvVar === undefined) delete process.env.PHANTOMBOT_USER_ENV_FILE;
+  else process.env.PHANTOMBOT_USER_ENV_FILE = savedUserEnvVar;
+  if (savedCentralEnvVar === undefined) delete process.env.PHANTOMBOT_ENV_FILE;
+  else process.env.PHANTOMBOT_ENV_FILE = savedCentralEnvVar;
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("migratePlaintextToVault", () => {
+  test("~/.env migrates into the default persona's vault, then deletes the plaintext", async () => {
+    await saveEnvFile(userEnv, { GITHUB_TOKEN: "ghp_local", API_KEY: "abc123" });
+
+    await migratePlaintextToVault(cfg());
+
+    expect(await readVault("robbie", "GITHUB_TOKEN")).toBe("ghp_local");
+    expect(await readVault("robbie", "API_KEY")).toBe("abc123");
+    expect(existsSync(userEnv)).toBe(false); // plaintext removed after read-back
+  });
+
+  test("central .env fans out into EVERY persona's vault", async () => {
+    // Pre-create two persona dirs so the fan-out reaches both.
+    await mkdir(join(personasDir, "lena"), { recursive: true });
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    await saveEnvFile(centralEnv, { TTS_KEY: "shared-tts" });
+
+    await migratePlaintextToVault(cfg());
+
+    expect(await readVault("robbie", "TTS_KEY")).toBe("shared-tts");
+    expect(await readVault("lena", "TTS_KEY")).toBe("shared-tts");
+    expect(await readVault("kai", "TTS_KEY")).toBe("shared-tts");
+    expect(existsSync(centralEnv)).toBe(false);
+  });
+
+  test("collision: a persona-local ~/.env value wins over the central one", async () => {
+    await saveEnvFile(userEnv, { SHARED: "local-wins" });
+    await saveEnvFile(centralEnv, { SHARED: "central-value", ONLY_CENTRAL: "x" });
+
+    await migratePlaintextToVault(cfg());
+
+    expect(await readVault("robbie", "SHARED")).toBe("local-wins");
+    expect(await readVault("robbie", "ONLY_CENTRAL")).toBe("x");
+  });
+
+  test("idempotent: a re-run with files already gone is a clean no-op", async () => {
+    await saveEnvFile(userEnv, { K: "v" });
+    await migratePlaintextToVault(cfg());
+    expect(existsSync(userEnv)).toBe(false);
+
+    // Second run must not throw and must leave the vault value intact.
+    await migratePlaintextToVault(cfg());
+    expect(await readVault("robbie", "K")).toBe("v");
+  });
+
+  test("hidden/non-persona dirs are not sprayed with an identity or vault", async () => {
+    await mkdir(join(personasDir, ".git"), { recursive: true });
+    await saveEnvFile(centralEnv, { TTS_KEY: "shared" });
+
+    await migratePlaintextToVault(cfg());
+
+    // The default persona got it; the hidden dir did NOT get a vault.
+    expect(await readVault("robbie", "TTS_KEY")).toBe("shared");
+    expect(existsSync(vaultPath(join(personasDir, ".git")))).toBe(false);
+    expect(existsSync(join(personasDir, ".git", "identity.json"))).toBe(false);
+  });
+
+  test("no plaintext files present → nothing happens, no throw", async () => {
+    await migratePlaintextToVault(cfg());
+    // default persona vault may exist but is empty of these keys.
+    expect(await readVault("robbie", "ANYTHING")).toBeUndefined();
+  });
+});

--- a/tests/vault-migrate.test.ts
+++ b/tests/vault-migrate.test.ts
@@ -4,9 +4,10 @@
  * ciphertext read back first.
  *
  * Covers:
- *   - ~/.env → the DEFAULT persona's vault, decryptable, plaintext deleted,
+ *   - ~/.env → FANNED OUT into every persona's vault (default AND non-default),
+ *     decryptable, plaintext deleted,
  *   - central .env → FANNED OUT into every persona's vault,
- *   - COLLISION: a persona-local ~/.env value WINS over the central one,
+ *   - COLLISION: a ~/.env value WINS over the central one, in every persona,
  *   - IDEMPOTENCY: a re-run with the files already gone is a clean no-op,
  *   - hidden/non-persona dirs are NOT sprayed with an identity + secrets.
  */
@@ -75,6 +76,31 @@ describe("migratePlaintextToVault", () => {
     expect(await readVault("robbie", "GITHUB_TOKEN")).toBe("ghp_local");
     expect(await readVault("robbie", "API_KEY")).toBe("abc123");
     expect(existsSync(userEnv)).toBe(false); // plaintext removed after read-back
+  });
+
+  test("~/.env fans out into NON-default personas too (Lena/Kai keep their creds)", async () => {
+    // Pre-create non-default persona dirs so the fan-out reaches them.
+    await mkdir(join(personasDir, "lena"), { recursive: true });
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    await saveEnvFile(userEnv, { GITHUB_TOKEN: "ghp_shared" });
+
+    await migratePlaintextToVault(cfg());
+
+    // Every persona — not just the default — must have the ~/.env secret.
+    expect(await readVault("robbie", "GITHUB_TOKEN")).toBe("ghp_shared");
+    expect(await readVault("lena", "GITHUB_TOKEN")).toBe("ghp_shared");
+    expect(await readVault("kai", "GITHUB_TOKEN")).toBe("ghp_shared");
+    expect(existsSync(userEnv)).toBe(false); // deleted only after all read back
+  });
+
+  test("collision: ~/.env value wins over central in a NON-default persona", async () => {
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    await saveEnvFile(userEnv, { SHARED: "local-wins" });
+    await saveEnvFile(centralEnv, { SHARED: "central-value" });
+
+    await migratePlaintextToVault(cfg());
+
+    expect(await readVault("kai", "SHARED")).toBe("local-wins");
   });
 
   test("central .env fans out into EVERY persona's vault", async () => {

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Encrypted vault: the security-critical core of PR #253.
+ *
+ * These tests exercise the REAL crypto and storage (no injected fakes):
+ *   - AES-256-GCM encrypt→decrypt round-trips and survives reopen.
+ *   - the WRONG persona key is REJECTED (GCM auth failure), not silently
+ *     mis-decrypted — the whole per-persona isolation guarantee.
+ *   - HKDF key derivation is deterministic and secret-separating.
+ *   - the vault is a SINGLE self-contained file (no WAL sidecar) so the
+ *     "copy the persona folder and secrets travel" promise holds.
+ *   - loadVaultIntoEnv reconciles per-persona: sticky boot keys win, a
+ *     freshly-saved value appears, and switching personas strips the previous
+ *     persona's secrets (no cross-persona leak).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { generateSecretKey } from "nostr-tools/pure";
+
+import {
+  _resetVaultTrackingForTesting,
+  deriveVaultKey,
+  loadVaultIntoEnv,
+  openPersonaVault,
+  openVaultWithSecret,
+  vaultPath,
+} from "../src/lib/vault.ts";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-vault-"));
+  _resetVaultTrackingForTesting();
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("vault crypto round-trip", () => {
+  test("set → get returns the exact value", () => {
+    const secret = generateSecretKey();
+    const dir = join(workdir, "p");
+    const vault = openVaultWithSecret(dir, secret);
+    try {
+      vault.set("GITHUB_TOKEN", "ghp_supersecret_value");
+      expect(vault.get("GITHUB_TOKEN")).toBe("ghp_supersecret_value");
+    } finally {
+      vault.close();
+    }
+  });
+
+  test("values survive close + reopen with the same secret", () => {
+    const secret = generateSecretKey();
+    const dir = join(workdir, "p");
+    let v = openVaultWithSecret(dir, secret);
+    v.set("API_KEY", "value-one");
+    v.close();
+
+    v = openVaultWithSecret(dir, secret);
+    try {
+      expect(v.get("API_KEY")).toBe("value-one");
+    } finally {
+      v.close();
+    }
+  });
+
+  test("empty-string and unicode values round-trip", () => {
+    const secret = generateSecretKey();
+    const v = openVaultWithSecret(join(workdir, "p"), secret);
+    try {
+      v.set("EMPTY", "");
+      v.set("UNICODE", "clé—日本語—🔐");
+      expect(v.get("EMPTY")).toBe("");
+      expect(v.get("UNICODE")).toBe("clé—日本語—🔐");
+    } finally {
+      v.close();
+    }
+  });
+
+  test("get on an absent name returns undefined", () => {
+    const v = openVaultWithSecret(join(workdir, "p"), generateSecretKey());
+    try {
+      expect(v.get("NOPE")).toBeUndefined();
+    } finally {
+      v.close();
+    }
+  });
+
+  test("set replaces (upsert), unset removes", () => {
+    const v = openVaultWithSecret(join(workdir, "p"), generateSecretKey());
+    try {
+      v.set("K", "first");
+      v.set("K", "second");
+      expect(v.get("K")).toBe("second");
+      v.unset("K");
+      expect(v.get("K")).toBeUndefined();
+      // unset of an absent key is a no-op, not an error.
+      v.unset("K");
+    } finally {
+      v.close();
+    }
+  });
+
+  test("list returns names only, sorted, never values", () => {
+    const v = openVaultWithSecret(join(workdir, "p"), generateSecretKey());
+    try {
+      v.set("ZEBRA", "z");
+      v.set("ALPHA", "a");
+      v.set("MIKE", "m");
+      expect(v.list()).toEqual(["ALPHA", "MIKE", "ZEBRA"]);
+    } finally {
+      v.close();
+    }
+  });
+});
+
+describe("per-persona key isolation", () => {
+  test("a DIFFERENT secret cannot decrypt — GCM rejects, never silent", () => {
+    const dir = join(workdir, "p");
+    const secretA = generateSecretKey();
+    const secretB = generateSecretKey();
+
+    const a = openVaultWithSecret(dir, secretA);
+    a.set("SECRET", "only-A-can-read");
+    a.close();
+
+    // Reopen the SAME db file with a WRONG key. The row is there, but decrypt
+    // must throw on the auth-tag mismatch — not return garbage, not return the
+    // value.
+    const b = openVaultWithSecret(dir, secretB);
+    try {
+      expect(() => b.get("SECRET")).toThrow();
+    } finally {
+      b.close();
+    }
+  });
+
+  test("deriveVaultKey is deterministic, 32 bytes, and secret-separating", () => {
+    const s1 = generateSecretKey();
+    const s2 = generateSecretKey();
+    const k1a = deriveVaultKey(s1);
+    const k1b = deriveVaultKey(s1);
+    const k2 = deriveVaultKey(s2);
+
+    expect(k1a.length).toBe(32);
+    expect(Buffer.from(k1a).equals(Buffer.from(k1b))).toBe(true); // deterministic
+    expect(Buffer.from(k1a).equals(Buffer.from(k2))).toBe(false); // separates
+  });
+
+  test("the derived key is NOT the raw nsec bytes (HKDF isolation)", () => {
+    const secret = generateSecretKey();
+    const key = deriveVaultKey(secret);
+    expect(Buffer.from(key).equals(Buffer.from(secret))).toBe(false);
+  });
+});
+
+describe("single-file portability (no WAL sidecar)", () => {
+  test("after close, no -wal/-shm sidecar remains beside vault.sqlite", () => {
+    const dir = join(workdir, "p");
+    const v = openVaultWithSecret(dir, generateSecretKey());
+    v.set("K", "v");
+    v.close();
+
+    const base = vaultPath(dir);
+    expect(existsSync(base)).toBe(true);
+    expect(existsSync(`${base}-wal`)).toBe(false);
+    expect(existsSync(`${base}-shm`)).toBe(false);
+  });
+
+  test("copying ONLY vault.sqlite to another dir still decrypts", async () => {
+    const secret = generateSecretKey();
+    const srcDir = join(workdir, "src");
+    const v = openVaultWithSecret(srcDir, secret);
+    v.set("PORTABLE", "travels-with-the-folder");
+    v.close();
+
+    const dstDir = join(workdir, "dst");
+    await mkdir(dstDir, { recursive: true });
+    await copyFile(vaultPath(srcDir), vaultPath(dstDir));
+
+    const moved = openVaultWithSecret(dstDir, secret);
+    try {
+      expect(moved.get("PORTABLE")).toBe("travels-with-the-folder");
+    } finally {
+      moved.close();
+    }
+  });
+});
+
+describe("loadVaultIntoEnv reconcile", () => {
+  test("loads new vault keys into an empty env and tracks them", async () => {
+    const dir = join(workdir, "p");
+    const v = await openPersonaVault(dir);
+    v.set("BAR", "from-vault");
+    v.close();
+
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    const { updated, removed } = await loadVaultIntoEnv(dir, env, tracked);
+
+    expect(env.BAR).toBe("from-vault");
+    expect(updated).toContain("BAR");
+    expect(removed).toEqual([]);
+    expect(tracked.has("BAR")).toBe(true);
+  });
+
+  test("existing env value is sticky — vault never overwrites it", async () => {
+    const dir = join(workdir, "p");
+    const v = await openPersonaVault(dir);
+    v.set("FOO", "vault-value");
+    v.close();
+
+    const env: NodeJS.ProcessEnv = { FOO: "shell-export" };
+    const tracked = new Set<string>();
+    const { updated } = await loadVaultIntoEnv(dir, env, tracked);
+
+    expect(env.FOO).toBe("shell-export"); // sticky wins
+    expect(updated).not.toContain("FOO");
+    expect(tracked.has("FOO")).toBe(false);
+  });
+
+  test("switching personas swaps the token and strips the previous persona's keys", async () => {
+    const dirA = join(workdir, "A");
+    const a = await openPersonaVault(dirA);
+    a.set("TOKEN", "aaa");
+    a.set("ONLY_A", "1");
+    a.close();
+
+    const dirB = join(workdir, "B");
+    const b = await openPersonaVault(dirB);
+    b.set("TOKEN", "bbb");
+    b.close();
+
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+
+    await loadVaultIntoEnv(dirA, env, tracked);
+    expect(env.TOKEN).toBe("aaa");
+    expect(env.ONLY_A).toBe("1");
+
+    const r = await loadVaultIntoEnv(dirB, env, tracked);
+    expect(env.TOKEN).toBe("bbb"); // updated to persona B's value
+    expect(env.ONLY_A).toBeUndefined(); // persona A's key stripped
+    expect(r.removed).toContain("ONLY_A");
+    expect(tracked.has("ONLY_A")).toBe(false);
+  });
+
+  test("a value saved to the vault becomes visible on the next reconcile", async () => {
+    const dir = join(workdir, "p");
+    let v = await openPersonaVault(dir);
+    v.set("SECRET", "v1");
+    v.close();
+
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    await loadVaultIntoEnv(dir, env, tracked);
+    expect(env.SECRET).toBe("v1");
+
+    // Simulate a `vault set` from a later turn: rewrite the value on disk.
+    v = await openPersonaVault(dir);
+    v.set("SECRET", "v2");
+    v.close();
+
+    const r = await loadVaultIntoEnv(dir, env, tracked);
+    expect(env.SECRET).toBe("v2");
+    expect(r.updated).toContain("SECRET");
+  });
+
+  test("fail-closed: an unreadable different-persona vault strips prior keys", async () => {
+    const dirA = join(workdir, "A");
+    const a = await openPersonaVault(dirA);
+    a.set("TOKEN", "aaa");
+    a.close();
+
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    await loadVaultIntoEnv(dirA, env, tracked);
+    expect(env.TOKEN).toBe("aaa");
+
+    // Point at a path that is a FILE, so opening a vault under it throws
+    // (mkdir over a file fails) → readAllVaultValues returns null.
+    const badPath = join(workdir, "not-a-dir");
+    await writeFile(badPath, "x");
+    const r = await loadVaultIntoEnv(badPath, env, tracked);
+
+    expect(env.TOKEN).toBeUndefined(); // stripped — no leak into the failed turn
+    expect(r.removed).toContain("TOKEN");
+  });
+});

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -21,8 +21,11 @@ import { join } from "node:path";
 
 import { generateSecretKey } from "nostr-tools/pure";
 
+import { Database } from "bun:sqlite";
+
 import {
   _resetVaultTrackingForTesting,
+  _resetVaultWarningsForTesting,
   deriveVaultKey,
   loadVaultIntoEnv,
   openPersonaVault,
@@ -35,6 +38,7 @@ let workdir: string;
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-vault-"));
   _resetVaultTrackingForTesting();
+  _resetVaultWarningsForTesting();
 });
 
 afterEach(async () => {
@@ -290,5 +294,58 @@ describe("loadVaultIntoEnv reconcile", () => {
 
     expect(env.TOKEN).toBeUndefined(); // stripped — no leak into the failed turn
     expect(r.removed).toContain("TOKEN");
+  });
+});
+
+describe("per-row resilience — one bad row never blanks the vault", () => {
+  /** Corrupt a single row's ciphertext in place so GCM auth rejects it. */
+  function corruptRow(dir: string, name: string): void {
+    const db = new Database(vaultPath(dir));
+    db.prepare("UPDATE secrets SET ciphertext = ? WHERE name = ?").run(
+      Buffer.from(crypto.getRandomValues(new Uint8Array(48))),
+      name,
+    );
+    db.close();
+  }
+
+  test("a corrupt row is skipped; every other secret still loads", async () => {
+    const dir = join(workdir, "p");
+    const v = await openPersonaVault(dir);
+    v.set("GITHUB_TOKEN", "good-1");
+    v.set("SENTRY_DSN", "poisoned");
+    v.set("OPENAI_API_KEY", "good-2");
+    v.close();
+
+    corruptRow(dir, "SENTRY_DSN");
+
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    await loadVaultIntoEnv(dir, env, tracked);
+
+    // The good secrets are untouched by the one poisoned neighbour.
+    expect(env.GITHUB_TOKEN).toBe("good-1");
+    expect(env.OPENAI_API_KEY).toBe("good-2");
+    // The bad row is skipped, not injected.
+    expect(env.SENTRY_DSN).toBeUndefined();
+  });
+
+  test("the undecryptable key is reported (name only), not silently swallowed", async () => {
+    const dir = join(workdir, "p");
+    const v = await openPersonaVault(dir);
+    v.set("GITHUB_TOKEN", "good");
+    v.set("SENTRY_DSN", "poisoned");
+    v.close();
+
+    corruptRow(dir, "SENTRY_DSN");
+
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    const r = await loadVaultIntoEnv(dir, env, tracked);
+
+    // "1 bad row" is distinguishable from "empty vault": the name surfaces.
+    expect(r.badKeys).toEqual(["SENTRY_DSN"]);
+    expect(r.updated).toContain("GITHUB_TOKEN");
+    // A vault with a bad row is NOT the same as a null (unopenable) vault.
+    expect(env.GITHUB_TOKEN).toBe("good");
   });
 });


### PR DESCRIPTION
Implements #253 — replaces the plaintext `~/.env` credential store with an encrypted, per-persona vault so persona folders are self-contained and portable (copy a persona dir to another box and its secrets travel with it, still encrypted).

## What changed
1. **`phantombot vault`** (set/get/list/unset) is the new canonical command. `phantombot env` is kept as a **deprecated forwarding alias** for one release (prints a deprecation note, forwards to the vault) so existing scripts/tasks don't break.
2. **Encrypted at rest** — secrets live in `<personaDir>/vault.sqlite`, AES-256-GCM per entry with a random 12-byte nonce. The AES key is derived via **HKDF-SHA256** (label `phantombot-vault-v1`) from the persona's nsec secret bytes — never the raw nsec, so a vault-key leak can't compromise the Nostr signing key.
3. **Persona identity** — the nsec is promoted to a first-class identity in a neutral **`identity.json`** (mode 0600), generated on demand via `nostr-tools`. Both vault and phantomchat derive from it; phantomchat sources its nsec from `identity.json`, falling back to legacy `phantomchat.json` and migrating it across.
4. **Auto-migration** — on startup, legacy `~/.env` migrates into the active persona; central `~/.config/phantombot/.env` **fans out into every persona** (shared secrets preserved). Persona-local values win on collision. Every value is **read back, decrypted, and byte-compared** before its plaintext file is deleted; on any mismatch the delete aborts and plaintext is left in place.
5. **Loader** injects the decrypted vault into `process.env` at startup and per turn, same "existing env wins" semantics as before — nothing changes for the personas, they still read `process.env`.
6. **Docs** — credential-guidance section updated so every persona knows the vault is the canonical store for reading and writing secrets.

## Verification
- `tsc --noEmit` clean; full suite **1827 pass / 0 fail**.
- Live end-to-end against the built binary: set/get/list/unset round-trip; secret confirmed **not present in plaintext** in the DB; `~/.env` + central `.env` both migrated then deleted; collision precedence (persona-local wins); central secret fanned out to **both** lena and kai; deprecated `env` alias forwards correctly.

Dogfood plan: **Lena and Kai** first.

Closes #253