### PR TITLE
feat(chattiness): narrate-on by default for unconfigured / empty config

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,14 +382,16 @@ errors always come through either way):
 Scoped to Telegram + PhantomChat (voice and the CLI never emit these bubbles).
 The editor (Zed/VS Code) surface follows the config default only.
 
-**The standing default is quiet.** Unless you explicitly set `chattiness`, a
-phantom starts **quiet** and just sends the final answer — this holds whether
-there's no `config.toml`, an empty one, or a `config.toml` that simply omits
-the key. Opt in to the running commentary by setting it:
+**The standing default is on.** Unless you explicitly set `chattiness`, a
+phantom **narrates** — it streams the running commentary as it works. This is
+deliberate: the play-by-play keeps the agent anchored across long, tool-heavy
+runs and empirically produces more reliable work on large tasks. The default
+holds whether there's no `config.toml`, an empty one, or a `config.toml` that
+simply omits the key. Opt out of the commentary by setting it:
 
 ```toml
-# Top-level. true = show progress bubbles everywhere; false (or unset) = quiet.
-chattiness = true
+# Top-level. true (or unset) = show progress bubbles everywhere; false = quiet.
+chattiness = false
 ```
 
 ## PhantomChat

--- a/src/config.ts
+++ b/src/config.ts
@@ -207,12 +207,13 @@ export interface TelegramStreamingSettings {
 /**
  * Standing default for interim progress-narration bubbles whenever no
  * `chattiness` key is set — regardless of whether a `config.toml` exists.
- * OFF (quiet) so every unconfigured phantom starts calm: just the final
- * answer, no running commentary, until an operator opts in via
- * `chattiness = true` or `/chattiness on`. Also the fallback used by read
- * sites given a partial config. See lib/chattiness.ts.
+ * ON so every phantom narrates by default: the running commentary keeps the
+ * agent anchored across long tool-heavy runs (empirically it holds the thread
+ * better and produces more reliable work on large tasks), and an operator can
+ * always quiet it via `chattiness = false` or `/chattiness off`. Also the
+ * fallback used by read sites given a partial config. See lib/chattiness.ts.
  */
-export const DEFAULT_CHATTINESS = false;
+export const DEFAULT_CHATTINESS = true;
 
 export const DEFAULT_TELEGRAM_STREAMING: TelegramStreamingSettings = {
   narrationFlushMs: 4500,
@@ -287,12 +288,12 @@ export interface Config {
    * per-conversation `/chattiness` override wins over this default; the final
    * reply and error paths are never affected either way. When unset in config
    * — no `chattiness` key, an empty file, or no `config.toml` at all — the
-   * default is `false` (quiet), so any not-yet-configured phantom starts calm
-   * and only narrates once an operator opts in. Also gates the editor (ACP)
+   * default is `true` (narrate), so every phantom keeps the agent anchored on
+   * long runs until an operator opts out. Also gates the editor (ACP)
    * surface's pre-tool narration — the config default only. See
    * lib/chattiness.ts. Optional in the type (mirrors telegramStreaming?) so
    * partial test fixtures need no update; loadConfig always sets it, and read
-   * sites default to `false` (DEFAULT_CHATTINESS) when absent.
+   * sites default to `true` (DEFAULT_CHATTINESS) when absent.
    */
   chattiness?: boolean;
 
@@ -483,10 +484,9 @@ export async function loadConfig(): Promise<Config> {
 
     // Standing default for interim progress-narration bubbles. An explicit
     // value always wins (env for scripted/test setups, then `chattiness` in
-    // config.toml). Absent any explicit value the phantom starts quiet (OFF)
-    // — this holds whether or not a config.toml exists, so an existing
-    // install with no `chattiness` key or an empty file is quiet too. See
-    // DEFAULT_CHATTINESS.
+    // config.toml). Absent any explicit value the phantom narrates (ON) — this
+    // holds whether or not a config.toml exists, so an existing install with no
+    // `chattiness` key or an empty file narrates too. See DEFAULT_CHATTINESS.
     chattiness:
       asBool(process.env.PHANTOMBOT_CHATTINESS) ??
       asBool(toml.chattiness) ??

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -115,9 +115,9 @@ describe("loadConfig — defaults (no file)", () => {
       model: "",
     });
     expect(c.telegramStreaming).toEqual(DEFAULT_TELEGRAM_STREAMING);
-    // Fresh / not-yet-configured install (no config.toml on disk) starts
-    // QUIET — the standing default for new phantoms.
-    expect(c.chattiness).toBe(false);
+    // Fresh / not-yet-configured install (no config.toml on disk) NARRATES —
+    // the standing default that keeps the agent anchored on long runs.
+    expect(c.chattiness).toBe(true);
   });
 
   test("XDG paths resolve to ~/.config and ~/.local/share by default", async () => {
@@ -135,23 +135,22 @@ describe("loadConfig — chattiness default", () => {
     await writeFile(join(cfgDir, "config.toml"), body, "utf8");
   }
 
-  test("no config file at all → quiet (OFF) for fresh installs", async () => {
+  test("no config file at all → narrate (ON) for fresh installs", async () => {
     const c = await loadConfig();
-    expect(c.chattiness).toBe(false);
+    expect(c.chattiness).toBe(true);
   });
 
-  test("config.toml exists but omits chattiness → quiet (OFF)", async () => {
-    // The key is absent, so the standing quiet default applies even though
-    // the host otherwise has a config.
+  test("config.toml exists but omits chattiness → narrate (ON)", async () => {
+    // The key is absent, so the standing narrate default applies.
     await writeConfig(`default_persona = "robbie"\n`);
     const c = await loadConfig();
-    expect(c.chattiness).toBe(false);
+    expect(c.chattiness).toBe(true);
   });
 
-  test("empty config.toml → quiet (OFF)", async () => {
+  test("empty config.toml → narrate (ON)", async () => {
     await writeConfig("");
     const c = await loadConfig();
-    expect(c.chattiness).toBe(false);
+    expect(c.chattiness).toBe(true);
   });
 
   test("explicit chattiness = false in config.toml is honored", async () => {
@@ -166,11 +165,11 @@ describe("loadConfig — chattiness default", () => {
     expect(c.chattiness).toBe(true);
   });
 
-  test("PHANTOMBOT_CHATTINESS env wins over the fresh-install default", async () => {
-    // No config file → would be OFF, but the env override forces ON.
-    process.env.PHANTOMBOT_CHATTINESS = "on";
+  test("PHANTOMBOT_CHATTINESS env wins over the standing default", async () => {
+    // No config file → would be ON, but the env override forces OFF.
+    process.env.PHANTOMBOT_CHATTINESS = "off";
     const c = await loadConfig();
-    expect(c.chattiness).toBe(true);
+    expect(c.chattiness).toBe(false);
   });
 
   test("PHANTOMBOT_CHATTINESS env wins over config.toml", async () => {


### PR DESCRIPTION
## What this does

Makes the standing default **narrate-on** (`chattiness = true`) whenever the key is not explicitly set — no `config.toml`, an empty one, or a config that omits the `chattiness` key all narrate.

This reverts the quiet-by-default introduced in #252. Rationale (Andrew): narration acts as externalized working memory that keeps the agent anchored on long, tool-heavy coding runs — it should protect that risky case by default, and operators can mute the cheap case explicitly.

## Command surface — unchanged

The command stays **`/chattiness on|off|default`**. No rename. (An earlier revision of this branch experimented with `/narrateon` etc. — that has been dropped entirely; this PR is now purely the default change.)

- `/chattiness on|off` — per-conversation override
- `/chattiness on|off default` — writes `chattiness` to `config.toml` + clears the per-chat override

## Precedence (unchanged)

1. per-chat override
2. `chattiness` in `config.toml`
3. built-in default — now **on**
4. `PHANTOMBOT_CHATTINESS` env — wins over all

## Verified

- `DEFAULT_CHATTINESS = true`; config tests assert no-file / empty / missing-key all → narrate.
- Full suite **1825 pass / 0 fail**, typecheck clean.

Note: existing hosts with no `chattiness` key will narrate after this — intended; opt out with `chattiness = false` or `/chattiness off`.