### PR TITLE
Windows Port (#201)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,61 @@ jobs:
           bun-version: 1.x
       - run: bun install --frozen-lockfile
       - run: bun test
+
+  # Windows gate for the Windows port. Runs in PARALLEL with the Linux jobs,
+  # on the same `pull_request` trigger — no path filter. The port shares ~95%
+  # of its code with Linux and its Windows-specific behaviour lives in shared
+  # modules (config paths, processGroup, runLock, vault ACL, taskScheduler),
+  # so a regression can arrive from a file that looks Windows-neutral. A
+  # paths filter would therefore give false confidence; the honest gate is
+  # "run on every PR push."
+  #
+  # Scope is by TEST SELECTION, not trigger: Linux (`test` above) stays the
+  # full-suite gate; Windows runs a curated subset of the suites that
+  # actually exercise the win32 branches. Many other suites bake in POSIX
+  # `sh`/`/tmp`/`:` assumptions and are out of scope for the port.
+  test-windows:
+    runs-on: windows-latest
+    concurrency:
+      group: ci-test-windows-${{ github.head_ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.x
+      # Cache Bun's global install cache so Windows runs don't re-download the
+      # dependency graph every push (Windows installs are the slow ones). Miss
+      # is harmless — bun install just repopulates it.
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-windows-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-windows-
+      - run: bun install --frozen-lockfile
+      # Typecheck on Windows too — cheap, and catches platform-conditional
+      # type errors the Linux typecheck can't see.
+      - run: bun tsc --noEmit
+      # Curated Windows-relevant subset. Keep this list in sync when a new
+      # suite starts exercising win32-specific code. `--coverage` prints a
+      # per-file table in the run logs — the visible coverage baseline for the
+      # win32 code paths. Kept as reporting (not a hard threshold) on purpose:
+      # a floor over a partial suite is brittle and would fail on unrelated
+      # changes. Promote to a bunfig coverageThreshold once numbers prove
+      # stable across several runs.
+      - name: Run Windows-relevant test suites
+        run: >
+          bun test --coverage
+          tests/windows-port.test.ts
+          tests/lib-processGroup.test.ts
+          tests/lib-runLock.test.ts
+          tests/lib-platform.test.ts
+          tests/config.test.ts
+          tests/persona-identity.test.ts
+          tests/vault.test.ts
+          tests/vault-migrate.test.ts
+          tests/lib-taskScheduler.test.ts
+          tests/cli-install.test.ts
+          tests/cli-heartbeat.test.ts
+          tests/lib-heartbeat.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,7 @@ jobs:
           tests/cli-install.test.ts
           tests/cli-heartbeat.test.ts
           tests/lib-heartbeat.test.ts
+          tests/lib-binaryUpdate.test.ts
+          tests/lib-githubReleases.test.ts
+          tests/cli-update.test.ts
+          tests/lib-updateNotify.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,3 @@ jobs:
           tests/cli-install.test.ts
           tests/cli-heartbeat.test.ts
           tests/lib-heartbeat.test.ts
-          tests/lib-binaryUpdate.test.ts
-          tests/lib-githubReleases.test.ts
-          tests/cli-update.test.ts
-          tests/lib-updateNotify.test.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release on PR merge
 # Fires on every push to main (i.e. every PR merge — branch protection
 # requires PRs, so a push to main IS a merge). Cuts a GitHub Release tagged
 # v1.1.<RUN_NUMBER> with cross-compiled binaries (linux x64-baseline +
-# arm64, darwin x64 + arm64) and a SHA256SUMS file. `phantombot update`
-# reads this feed.
+# arm64, darwin x64 + arm64, windows x64 + arm64) and a SHA256SUMS file.
+# `phantombot update` reads this feed.
 #
 # Why `push: main` and NOT `pull_request: closed`: a PR merged from a
 # FORK runs the closed-PR workflow with a *read-only* GITHUB_TOKEN —
@@ -177,6 +177,29 @@ jobs:
             ./src/index.ts \
             --outfile "dist/phantombot-${TAG}-darwin-arm64"
 
+      - name: Build windows-x64
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # Cross-compiled from the Linux runner; Bun emits an unsigned PE
+          # (.exe). Windows SmartScreen may warn on first run for an
+          # unsigned binary - see release notes. --windows-hide-console is
+          # NOT set: phantombot is a console agent and needs its stdio.
+          bun build --compile --target=bun-windows-x64 \
+            ./src/index.ts \
+            --outfile "dist/phantombot-${TAG}-windows-x64.exe"
+
+      - name: Build windows-arm64
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # ARM64 Windows (e.g. Surface Pro X, Dev Kit). Bun's compile
+          # target id is bun-windows-arm64; the emitted PE is Aarch64.
+          # Same unsigned/SmartScreen caveat as windows-x64.
+          bun build --compile --target=bun-windows-arm64 \
+            ./src/index.ts \
+            --outfile "dist/phantombot-${TAG}-windows-arm64.exe"
+
       - name: Compute SHA256SUMS
         working-directory: dist
         env:
@@ -187,6 +210,8 @@ jobs:
             "phantombot-${TAG}-linux-arm64" \
             "phantombot-${TAG}-darwin-x64" \
             "phantombot-${TAG}-darwin-arm64" \
+            "phantombot-${TAG}-windows-x64.exe" \
+            "phantombot-${TAG}-windows-arm64.exe" \
             > SHA256SUMS
           cat SHA256SUMS
 
@@ -223,6 +248,8 @@ jobs:
           - phantombot-${TAG}-linux-arm64 — ARM64
           - phantombot-${TAG}-darwin-x64 — macOS x86-64 (unsigned; see below)
           - phantombot-${TAG}-darwin-arm64 — macOS Apple Silicon (unsigned; see below)
+          - phantombot-${TAG}-windows-x64.exe - Windows x86-64 (unsigned; see below)
+          - phantombot-${TAG}-windows-arm64.exe - Windows ARM64 (unsigned; see below)
 
           Verify with: sha256sum -c SHA256SUMS
 
@@ -234,6 +261,11 @@ jobs:
           attribute on first run:
             xattr -d com.apple.quarantine ./phantombot-${TAG}-darwin-arm64
             xattr -d com.apple.quarantine ./phantombot-${TAG}-darwin-x64
+
+          Windows note: the .exe binaries are cross-compiled and unsigned, so
+          SmartScreen may show a "Windows protected your PC" prompt on first
+          run - choose More info then Run anyway, or unblock the file:
+            Unblock-File .\\phantombot-${TAG}-windows-x64.exe
           EOF
 
       - name: Create GitHub Release with binary assets
@@ -263,4 +295,6 @@ jobs:
             "dist/phantombot-${TAG}-linux-arm64" \
             "dist/phantombot-${TAG}-darwin-x64" \
             "dist/phantombot-${TAG}-darwin-arm64" \
+            "dist/phantombot-${TAG}-windows-x64.exe" \
+            "dist/phantombot-${TAG}-windows-arm64.exe" \
             "dist/SHA256SUMS"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Supported harnesses:
 - [Why Phantombot Exists](#why-phantombot-exists)
 - [Install](#install)
 - [Quick Start](#quick-start)
+- [Windows (preview)](#windows-preview)
 - [Configuration](#configuration)
 - [Command Reference](#command-reference)
 - [Telegram](#telegram)
@@ -193,6 +194,68 @@ running after logout:
 ```bash
 sudo loginctl enable-linger "$USER"
 ```
+
+## Windows (preview)
+
+Phantombot runs on Windows (x64). The port shares ~95% of its code with the
+Linux and macOS builds; the platform-specific pieces (data paths, process
+tree-kill, run-lock, credential-store ACL, and the background service) have
+native Windows implementations. There is no prebuilt Windows release yet, so
+you build the binary from source.
+
+**Build the binary** (needs [Bun](https://bun.sh) on the Windows machine):
+
+```powershell
+git clone https://github.com/phantomyard/phantombot.git
+cd phantombot
+bun install
+bun run build:win        # produces dist\phantombot.exe
+
+# Put it somewhere stable and on your PATH, e.g.:
+mkdir "$env:LOCALAPPDATA\Programs\phantombot"
+copy dist\phantombot.exe "$env:LOCALAPPDATA\Programs\phantombot\phantombot.exe"
+```
+
+Then configure it exactly as on Linux (`phantombot persona`, `harness`,
+`telegram`, …).
+
+**Data location.** Everything lives under a single root,
+`%LOCALAPPDATA%\phantombot` (config, personas, memory database, logs, and the
+run-lock). Nothing roams between machines. The crown-jewel `identity.json` is
+created with an owner-only ACL (`icacls`, inheritance stripped) so other
+accounts on the box cannot read it.
+
+**Install as a background service.**
+
+```powershell
+phantombot install      # registers per-user Task Scheduler tasks under \Phantombot\
+phantombot uninstall    # removes them
+```
+
+`install` registers four logon-triggered scheduled tasks (`run`, `heartbeat`,
+`nightly`, `tick`). They run as **you**, using an interactive-token principal —
+**no admin rights and no stored password required**.
+
+**Important — the agent runs only while you are logged in.** This mirrors the
+macOS (launchd `Aqua`) model, not the Linux `enable-linger` model. When you log
+out, Windows tears down your session and the tasks stop; they start again at
+your next logon. A LogonTrigger plus a one-minute keep-alive re-launches the
+agent if it crashes while you are logged in.
+
+For a **true headless service** that runs without an interactive login (a
+kiosk, a server, or a machine that reboots unattended), wrap `phantombot run`
+in a service supervisor such as [WinSW](https://github.com/winsw/winsw) or NSSM
+and run it under a dedicated service account. That path is not yet scripted by
+`phantombot install`; it is the documented escape hatch for now.
+
+**Logs.** Service stdout/stderr are redirected to
+`%LOCALAPPDATA%\phantombot\logs\*.out.log` / `*.err.log`. These currently grow
+unbounded (no built-in rotation yet) — prune them periodically if the box runs
+for a long time.
+
+Status: the Windows port is exercised by a dedicated `windows-latest` CI job on
+every pull request. Treat it as a **preview** — solid enough to run, but newer
+than the Linux/macOS paths.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -197,23 +197,30 @@ sudo loginctl enable-linger "$USER"
 
 ## Windows (preview)
 
-Phantombot runs on Windows (x64). The port shares ~95% of its code with the
-Linux and macOS builds; the platform-specific pieces (data paths, process
-tree-kill, run-lock, credential-store ACL, and the background service) have
-native Windows implementations. There is no prebuilt Windows release yet, so
-you build the binary from source.
+Phantombot runs on Windows (x64 and arm64). The port shares ~95% of its code
+with the Linux and macOS builds; the platform-specific pieces (data paths,
+process tree-kill, run-lock, credential-store ACL, the background service, and
+self-update) have native Windows implementations.
 
-**Build the binary** (needs [Bun](https://bun.sh) on the Windows machine):
+Every release publishes prebuilt, unsigned Windows binaries -
+`phantombot-<tag>-windows-x64.exe` and `phantombot-<tag>-windows-arm64.exe` -
+alongside the SHA256SUMS file. Download the one for your architecture, verify
+its checksum, and drop it somewhere stable on your PATH:
+
+```powershell
+# Unblock the downloaded file (SmartScreen marks internet downloads):
+Unblock-File .\phantombot-<tag>-windows-x64.exe
+mkdir "$env:LOCALAPPDATA\Programs\phantombot"
+copy .\phantombot-<tag>-windows-x64.exe "$env:LOCALAPPDATA\Programs\phantombot\phantombot.exe"
+```
+
+**Or build from source** (needs [Bun](https://bun.sh) on the Windows machine):
 
 ```powershell
 git clone https://github.com/phantomyard/phantombot.git
 cd phantombot
 bun install
 bun run build:win        # produces dist\phantombot.exe
-
-# Put it somewhere stable and on your PATH, e.g.:
-mkdir "$env:LOCALAPPDATA\Programs\phantombot"
-copy dist\phantombot.exe "$env:LOCALAPPDATA\Programs\phantombot\phantombot.exe"
 ```
 
 Then configure it exactly as on Linux (`phantombot persona`, `harness`,
@@ -247,6 +254,16 @@ kiosk, a server, or a machine that reboots unattended), wrap `phantombot run`
 in a service supervisor such as [WinSW](https://github.com/winsw/winsw) or NSSM
 and run it under a dedicated service account. That path is not yet scripted by
 `phantombot install`; it is the documented escape hatch for now.
+
+**Self-update.** `phantombot update` and the `/update` chat command work on
+Windows. Because Windows locks a running `.exe` against overwrite, the updater
+renames the live binary aside to `phantombot.exe.old` (allowed while it runs),
+drops the verified new binary into place, then exits cleanly - the one-minute
+keep-alive trigger relaunches the agent on the new binary within ≈60 seconds
+(no console windows, no manual restart). The relaunched process deletes the
+leftover `.old` on startup once it is unlocked. In-place self-update needs the
+service installed (`phantombot install`) so the keep-alive is present to bring
+the agent back up.
 
 **Logs.** Service stdout/stderr are redirected to
 `%LOCALAPPDATA%\phantombot\logs\*.out.log` / `*.err.log`. These currently grow

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "gen:vscode-vsix": "bun scripts/genVscodeVsix.ts",
     "build": "bun run build:x64",
     "build:x64": "mkdir -p dist && bun build --compile --target=bun-linux-x64-baseline ./src/index.ts --outfile dist/phantombot",
-    "build:arm64": "mkdir -p dist && bun build --compile --target=bun-linux-arm64 ./src/index.ts --outfile dist/phantombot-arm64"
+    "build:arm64": "mkdir -p dist && bun build --compile --target=bun-linux-arm64 ./src/index.ts --outfile dist/phantombot-arm64",
+    "build:win": "mkdir -p dist && bun build --compile --target=bun-windows-x64 ./src/index.ts --outfile dist/phantombot.exe"
   },
   "dependencies": {
     "@clack/prompts": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "gen:pi-extension": "bun scripts/genPiExtensionAssets.ts",
     "gen:vscode-vsix": "bun scripts/genVscodeVsix.ts",
     "build": "bun run build:x64",
-    "build:x64": "mkdir -p dist && bun build --compile --target=bun-linux-x64-baseline ./src/index.ts --outfile dist/phantombot",
-    "build:arm64": "mkdir -p dist && bun build --compile --target=bun-linux-arm64 ./src/index.ts --outfile dist/phantombot-arm64",
-    "build:win": "mkdir -p dist && bun build --compile --target=bun-windows-x64 ./src/index.ts --outfile dist/phantombot.exe"
+    "build:x64": "bun build --compile --target=bun-linux-x64-baseline ./src/index.ts --outfile dist/phantombot",
+    "build:arm64": "bun build --compile --target=bun-linux-arm64 ./src/index.ts --outfile dist/phantombot-arm64",
+    "build:win": "bun build --compile --target=bun-windows-x64 ./src/index.ts --outfile dist/phantombot.exe"
   },
   "dependencies": {
     "@clack/prompts": "^1.3.0",

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -25,7 +25,7 @@ import type { Harness } from "../harnesses/types.ts";
 import { formatElapsedSeconds, truncateLine } from "../lib/format.ts";
 import { log } from "../lib/logger.ts";
 import { MemoryIndex } from "../lib/memoryIndex.ts";
-import { defaultServiceControl } from "../lib/platform.ts";
+import { defaultServiceControl, selfRestart } from "../lib/platform.ts";
 import type { ServiceControl } from "../lib/systemd.ts";
 import { runUpdateFlow } from "../lib/updateNotify.ts";
 import {
@@ -286,20 +286,18 @@ async function handleUpdate(
 /**
  * /restart — restart the phantombot service.
  *
- * Sends "restarting…" to the user, then triggers a service restart via
- * the platform-appropriate backend (systemctl --user on Linux, launchctl
- * on macOS). The restart is fired via `afterSend` so the channel layer
- * sends the heads-up message FIRST, then SIGTERMs us.
- *
- * On unsupported platforms (Windows, BSD) where there's no service
- * manager backend, we tell the user restart isn't supported rather than
- * failing cryptically.
+ * Sends "restarting…" to the user, then triggers an IN-PROCESS restart via
+ * `selfRestart`: on Linux/macOS the supervisor bounces us (systemctl --user /
+ * launchctl); on Windows we exit cleanly and the always-on task's keep-alive
+ * trigger relaunches us (calling schtasks End/Run from our own task tree would
+ * race the relaunch — see selfRestart). The restart is fired via `afterSend`
+ * so the channel layer sends the heads-up message FIRST, then we go down.
  */
 function handleRestart(ctx: SlashCommandContext): SlashCommandResult {
   const svc = ctx.serviceControl ?? defaultServiceControl();
 
   const afterSend = async (): Promise<void> => {
-    const r = await svc.restart();
+    const r = await selfRestart({ serviceControl: svc });
     if (!r.ok) {
       log.error("commands: /restart failed", {
         chatId: ctx.chatId,

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -7,9 +7,9 @@
 
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename } from "node:path";
 
-import { type Config, loadConfig, personaDir } from "../config.ts";
+import { type Config, loadConfig, memoryIndexPath, personaDir } from "../config.ts";
 import { runHeartbeat } from "../lib/heartbeat.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
@@ -25,13 +25,11 @@ import {
 import { recordHeartbeatFired } from "../lib/timerHealth.ts";
 import { VERSION } from "../version.ts";
 
+// Delegates to the shared, platform-aware resolver in config.ts so the
+// path is correct on Windows (%LOCALAPPDATA%) as well as XDG systems,
+// rather than re-deriving `~/.local/share` with a POSIX literal.
 function indexPath(persona: string): string {
-  return join(
-    process.env.XDG_DATA_HOME || join(process.env.HOME ?? "", ".local/share"),
-    "phantombot",
-    "memory-index",
-    `${persona}.sqlite`,
-  );
+  return memoryIndexPath(persona);
 }
 
 export interface RunHeartbeatCliInput {

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -22,6 +22,10 @@ import {
   ensureSystemdUnitsCurrent,
   ensureUserSystemdEnv,
 } from "../lib/systemd.ts";
+import {
+  BunSchtasksRunner,
+  ensureTasksCurrent,
+} from "../lib/taskScheduler.ts";
 import { recordHeartbeatFired } from "../lib/timerHealth.ts";
 import { VERSION } from "../version.ts";
 
@@ -104,21 +108,21 @@ export async function runHeartbeatCli(
     });
   }
 
-  // Self-heal systemd units on the heartbeat's regular cadence. This
-  // is the long-uptime cure for the broken-symlink class of bug — a
-  // box that never restarts still gets a re-check every 30 minutes,
-  // and any drift is fixed in-place without operator action. Wrapped
-  // in try/catch so a transient systemctl failure doesn't break the
-  // primary heartbeat work.
+  // Self-heal the service-manager units on the heartbeat's regular cadence.
+  // This is the long-uptime cure for the drifted-unit class of bug (a broken
+  // symlink on Linux, a moved binary on Windows) — a box that never restarts
+  // still gets a re-check every 30 minutes, and any drift is fixed in-place
+  // without operator action. Wrapped in try/catch so a transient failure
+  // doesn't break the primary heartbeat work.
   if (input.healSystemd !== false) {
     try {
       if (input.healSystemd) {
         await input.healSystemd();
       } else {
-        await defaultHealSystemd();
+        await defaultHealService();
       }
     } catch (e) {
-      log.warn("heartbeat: systemd self-heal threw unexpectedly", {
+      log.warn("heartbeat: service self-heal threw unexpectedly", {
         error: (e as Error).message,
       });
     }
@@ -143,13 +147,27 @@ export async function runHeartbeatCli(
 }
 
 /**
- * Production self-heal: idempotently ensure all phantombot systemd
- * units are present and timers are armed. Silent on healthy boxes,
- * logs a notice on repair. Skips on macOS and on Linux hosts where
- * the user-systemd bus isn't reachable (e.g. SSH without lingering).
+ * Production self-heal, dispatched to the host's service-manager backend.
+ * Silent on healthy boxes; logs a notice only on repair. A no-op on any
+ * platform without a backend.
+ */
+async function defaultHealService(): Promise<void> {
+  switch (currentPlatform()) {
+    case "linux":
+      return defaultHealSystemd();
+    case "windows":
+      return defaultHealTaskScheduler();
+    default:
+      return; // macOS (launchd self-heals via KeepAlive) and unsupported hosts
+  }
+}
+
+/**
+ * Idempotently ensure all phantombot systemd units are present and timers are
+ * armed. Skips on Linux hosts where the user-systemd bus isn't reachable (e.g.
+ * SSH without lingering).
  */
 async function defaultHealSystemd(): Promise<void> {
-  if (currentPlatform() !== "linux") return;
   const binPath = process.execPath;
   if (basename(binPath) !== "phantombot") return;
   const sysEnv = ensureUserSystemdEnv();
@@ -161,6 +179,24 @@ async function defaultHealSystemd(): Promise<void> {
       rewrote: r.rewrote,
       repairedTimers: r.repairedTimers,
     });
+  }
+}
+
+/**
+ * Windows analogue of `defaultHealSystemd`: re-register any of the four
+ * scheduled tasks that drifted from the current binary path (the moved- or
+ * updated-binary case). Only fires when we ARE the compiled binary
+ * (`phantombot.exe`), so a dev `bun src/index.ts` run never rewrites tasks.
+ */
+async function defaultHealTaskScheduler(): Promise<void> {
+  const binPath = process.execPath;
+  if (!basename(binPath).startsWith("phantombot")) return;
+  const r = await ensureTasksCurrent({
+    binPath,
+    schtasks: new BunSchtasksRunner(),
+  });
+  if (r.rewrote.length > 0) {
+    log.info("heartbeat: healed scheduled tasks", { rewrote: r.rewrote });
   }
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -2,8 +2,9 @@
  * `phantombot install` — write the host-appropriate service-manager
  * units for `phantombot run` and start them.
  *
- *   - Linux  → systemd --user units in ~/.config/systemd/user/
- *   - macOS  → launchd plists in ~/Library/LaunchAgents/
+ *   - Linux   → systemd --user units in ~/.config/systemd/user/
+ *   - macOS   → launchd plists in ~/Library/LaunchAgents/
+ *   - Windows → Task Scheduler logon tasks under \Phantombot\
  *
  * Requires the compiled binary (process.execPath ends in 'phantombot' or
  * the user passes --bin). Running from `bun src/index.ts` won't work
@@ -34,6 +35,11 @@ import {
   type SystemctlRunner,
   type UserSystemdEnv,
 } from "../lib/systemd.ts";
+import {
+  BunSchtasksRunner,
+  installPhantombotTasks,
+  type SchtasksRunner,
+} from "../lib/taskScheduler.ts";
 import type { WriteSink } from "../lib/io.ts";
 
 
@@ -65,13 +71,19 @@ export interface RunInstallInput {
   systemctl?: SystemctlRunner;
   /** Override launchctl runner for testing. */
   launchctl?: LaunchctlRunner;
+  /** Override schtasks runner for testing (Windows). */
+  schtasks?: SchtasksRunner;
+  /** Override the current-user SID for testing (Windows). */
+  sid?: string;
+  /** Directory for transient Task Scheduler XML import files (Windows tests). */
+  xmlDir?: string;
   /** Override systemd-env detection for testing. */
   ensureSystemdEnv?: () => UserSystemdEnv;
   /**
    * Override the platform check for testing. Defaults to currentPlatform()
    * which reads process.platform.
    */
-  platform?: "linux" | "darwin" | "unsupported";
+  platform?: "linux" | "darwin" | "windows" | "unsupported";
   /** Override gui domain (e.g. "gui/501") on darwin. Defaults to gui/<current uid>. */
   domain?: string;
 }
@@ -81,7 +93,14 @@ export async function runInstall(input: RunInstallInput = {}): Promise<number> {
   const err = input.err ?? process.stderr;
 
   const binPath = input.binPath ?? process.execPath;
-  if (basename(binPath) !== "phantombot") {
+  // The compiled binary is `phantombot` on POSIX and `phantombot.exe` on
+  // Windows — accept either. Running from `bun src/index.ts` (basename `bun`)
+  // is rejected because the resulting unit would point at the bun runtime.
+  // Split on both separators so the check is correct regardless of which
+  // platform's path we're handed (matters for cross-platform unit tests).
+  const rawName = binPath.split(/[/\\]/).pop() ?? binPath;
+  const binName = rawName.replace(/\.exe$/i, "");
+  if (binName !== "phantombot") {
     err.write(
       `phantombot install needs the compiled binary, not '${basename(binPath)}'. ` +
         `Build it with \`bun run build\`, then run install via \`./dist/phantombot install\`.\n`,
@@ -95,9 +114,11 @@ export async function runInstall(input: RunInstallInput = {}): Promise<number> {
       return runInstallLinux(input, binPath, out, err);
     case "darwin":
       return runInstallDarwin(input, binPath, out, err);
+    case "windows":
+      return runInstallWindows(input, binPath, out, err);
     default:
       err.write(
-        `phantombot install supports linux and darwin only; this host reports platform=${process.platform}\n`,
+        `phantombot install supports linux, darwin and windows only; this host reports platform=${process.platform}\n`,
       );
       return 2;
   }
@@ -186,11 +207,40 @@ async function runInstallDarwin(
   return 0;
 }
 
+async function runInstallWindows(
+  input: RunInstallInput,
+  binPath: string,
+  out: WriteSink,
+  err: WriteSink,
+): Promise<number> {
+  const schtasks = input.schtasks ?? new BunSchtasksRunner();
+
+  const result = await installPhantombotTasks({
+    binPath,
+    sid: input.sid,
+    xmlDir: input.xmlDir,
+    schtasks,
+    out,
+    err,
+  });
+  if (!result.installed) return 1;
+
+  out.write(
+    `\nThese tasks run only while you are logged in (the macOS model). For\n` +
+      `true headless-without-login, install a real service — see the README\n` +
+      `(WinSW is the recommended route).\n` +
+      `\nview logs:    ${logsCommand()}\n` +
+      `restart:      ${restartCommand()}\n` +
+      `uninstall:    phantombot uninstall\n`,
+  );
+  return 0;
+}
+
 export default defineCommand({
   meta: {
     name: "install",
     description:
-      "Install the host-appropriate service unit for `phantombot run` (systemd --user on Linux, launchd LaunchAgent on macOS) and start it.",
+      "Install the host-appropriate service unit for `phantombot run` (systemd --user on Linux, launchd LaunchAgent on macOS, Task Scheduler logon task on Windows) and start it.",
   },
   async run() {
     const code = await runInstall();

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -32,6 +32,7 @@ import {
   fetchCanonicalRelays,
   sameRelays,
 } from "../channels/phantomchat/relaysSource.ts";
+import { cleanupStaleUpdateArtifacts } from "../lib/binaryUpdate.ts";
 import { npubEncode } from "../lib/nostrIdentity.ts";
 import {
   type Config,
@@ -303,6 +304,25 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         "stop the other instance first, or remove the lock if it's stale.\n",
     );
     return 1;
+  }
+
+  // Windows self-update leaves the previous binary renamed aside as
+  // `${exe}.old` (a running .exe can't be deleted, so the swap moves it out of
+  // the way). It's unlocked once the old process has exited, so this freshly-
+  // relaunched process sweeps it up. No-op on POSIX and best-effort — a
+  // still-locked artifact is retried on the next boot. Gated to the real
+  // compiled binary so `bun src/index.ts`/tests never touch the dev box.
+  if (basename(process.execPath).toLowerCase().startsWith("phantombot")) {
+    try {
+      const removed = await cleanupStaleUpdateArtifacts(process.execPath);
+      if (removed.length > 0) {
+        log.info("run: removed stale self-update artifacts", { removed });
+      }
+    } catch (e) {
+      log.warn("run: self-update artifact cleanup threw", {
+        error: (e as Error).message,
+      });
+    }
   }
 
   const memory = await openMemoryStore(config.memoryDbPath);

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -3,8 +3,9 @@
  * service-manager units. Best-effort; missing units / inactive services
  * are not errors.
  *
- *   - Linux  → systemctl --user stop/disable + remove unit files
- *   - macOS  → launchctl bootout + remove plists
+ *   - Linux   → systemctl --user stop/disable + remove unit files
+ *   - macOS   → launchctl bootout + remove plists
+ *   - Windows → schtasks /Delete of the \Phantombot\ tasks
  */
 
 import { defineCommand } from "citty";
@@ -29,6 +30,11 @@ import {
   type SystemctlRunner,
   type UserSystemdEnv,
 } from "../lib/systemd.ts";
+import {
+  BunSchtasksRunner,
+  type SchtasksRunner,
+  uninstallPhantombotTasks,
+} from "../lib/taskScheduler.ts";
 import type { WriteSink } from "../lib/io.ts";
 
 export interface RunUninstallInput {
@@ -39,10 +45,11 @@ export interface RunUninstallInput {
   tickPlistPath?: string;
   systemctl?: SystemctlRunner;
   launchctl?: LaunchctlRunner;
+  schtasks?: SchtasksRunner;
   out?: WriteSink;
   err?: WriteSink;
   ensureSystemdEnv?: () => UserSystemdEnv;
-  platform?: "linux" | "darwin" | "unsupported";
+  platform?: "linux" | "darwin" | "windows" | "unsupported";
   domain?: string;
 }
 
@@ -58,9 +65,11 @@ export async function runUninstall(
       return runUninstallLinux(input, out, err);
     case "darwin":
       return runUninstallDarwin(input, out, err);
+    case "windows":
+      return runUninstallWindows(input, out, err);
     default:
       err.write(
-        `phantombot uninstall supports linux and darwin only; this host reports platform=${process.platform}\n`,
+        `phantombot uninstall supports linux, darwin and windows only; this host reports platform=${process.platform}\n`,
       );
       return 2;
   }
@@ -120,11 +129,22 @@ async function runUninstallDarwin(
   return 0;
 }
 
+async function runUninstallWindows(
+  input: RunUninstallInput,
+  out: WriteSink,
+  err: WriteSink,
+): Promise<number> {
+  const schtasks = input.schtasks ?? new BunSchtasksRunner();
+  await uninstallPhantombotTasks({ schtasks, out, err });
+  out.write("uninstall complete\n");
+  return 0;
+}
+
 export default defineCommand({
   meta: {
     name: "uninstall",
     description:
-      "Stop, disable, and remove the phantombot service-manager units (systemd --user on Linux, launchd LaunchAgent on macOS).",
+      "Stop, disable, and remove the phantombot service-manager units (systemd --user on Linux, launchd LaunchAgent on macOS, Task Scheduler tasks on Windows).",
   },
   async run() {
     const code = await runUninstall();

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -94,7 +94,8 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
 
   if (!target) {
     err.write(
-      `phantombot is only released for linux-x64, linux-arm64, and darwin-arm64; ` +
+      `phantombot is only released for linux-x64, linux-arm64, darwin-arm64, ` +
+        `windows-x64, and windows-arm64; ` +
         `this machine reports platform=${procPlatform} arch=${procArch}\n`,
     );
     return 1;
@@ -111,7 +112,10 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
     binPath = rawBinPath;
   }
 
-  if (basename(binPath) !== "phantombot") {
+  // Accept both the POSIX `phantombot` and the Windows `phantombot.exe`.
+  const binBase = basename(binPath).toLowerCase();
+  const binStem = binBase.endsWith(".exe") ? binBase.slice(0, -4) : binBase;
+  if (binStem !== "phantombot") {
     err.write(
       `not a phantombot binary at ${binPath} (basename=${basename(binPath)}). ` +
         `Are you running from source via 'bun src/index.ts'? ` +
@@ -179,8 +183,8 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
   }
   out.write(`verified ${formatBytes(dl.bytes)} (sha256 ok).\n`);
 
-  // 7. Atomic swap.
-  const swap = await applyUpdate({ tempPath, targetPath: binPath });
+  // 7. Atomic swap (rename-over on POSIX; rename-aside on Windows).
+  const swap = await applyUpdate({ tempPath, targetPath: binPath, procPlatform });
   if (!swap.ok) {
     err.write(`install failed: ${swap.error}\n`);
     return 1;

--- a/src/config.ts
+++ b/src/config.ts
@@ -321,14 +321,32 @@ export interface Config {
   voice: import("./lib/voice.ts").VoiceConfig;
 }
 
+/**
+ * Windows local-application-data root (`%LOCALAPPDATA%`, e.g.
+ * `C:\Users\<you>\AppData\Local`). On the Windows port we deliberately
+ * collapse config, data AND state under this single non-roaming root:
+ * every caller appends `"phantombot"`, so all three resolve to
+ * `%LOCALAPPDATA%\phantombot`. One predictable home, nothing roams
+ * across machines (which `%APPDATA%` would).
+ */
+function windowsLocalAppData(): string {
+  return process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local");
+}
+
 export function xdgConfigHome(): string {
-  return process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  if (process.env.XDG_CONFIG_HOME) return process.env.XDG_CONFIG_HOME;
+  if (process.platform === "win32") return windowsLocalAppData();
+  return join(homedir(), ".config");
 }
 export function xdgDataHome(): string {
-  return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  if (process.env.XDG_DATA_HOME) return process.env.XDG_DATA_HOME;
+  if (process.platform === "win32") return windowsLocalAppData();
+  return join(homedir(), ".local", "share");
 }
 export function xdgStateHome(): string {
-  return process.env.XDG_STATE_HOME || join(homedir(), ".local", "state");
+  if (process.env.XDG_STATE_HOME) return process.env.XDG_STATE_HOME;
+  if (process.platform === "win32") return windowsLocalAppData();
+  return join(homedir(), ".local", "state");
 }
 
 const DEFAULT_HARNESS_CHAIN = ["claude"] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,20 +27,26 @@
 import { runMain } from "citty";
 import { mainCommand } from "./cli/index.ts";
 import { loadConfig, personaDir } from "./config.ts";
+import { isReadOnlyInvocation } from "./lib/cliInvocation.ts";
 import { preloadEnvFiles } from "./lib/envBootstrap.ts";
 import { log } from "./lib/logger.ts";
 import { loadVaultIntoEnv } from "./lib/vault.ts";
 import { migratePlaintextToVault } from "./lib/vaultMigrate.ts";
 
-try {
-  const config = await loadConfig();
-  await migratePlaintextToVault(config);
-  const activePersona = process.env.PHANTOMBOT_PERSONA || config.defaultPersona;
-  await loadVaultIntoEnv(personaDir(config, activePersona));
-} catch (e) {
-  // Never let credential bootstrap wedge the CLI — log and carry on. The
-  // subcommand may still work (e.g. `phantombot persona` on a fresh box).
-  log.warn("startup: vault bootstrap failed", { error: (e as Error).message });
+// Skip the credential bootstrap entirely for read-only invocations
+// (--help/--version/bare) so they never mutate disk or provision a persona —
+// important for CI, which uses them as smoke tests. See cliInvocation.ts.
+if (!isReadOnlyInvocation(process.argv)) {
+  try {
+    const config = await loadConfig();
+    await migratePlaintextToVault(config);
+    const activePersona = process.env.PHANTOMBOT_PERSONA || config.defaultPersona;
+    await loadVaultIntoEnv(personaDir(config, activePersona));
+  } catch (e) {
+    // Never let credential bootstrap wedge the CLI — log and carry on. The
+    // subcommand may still work (e.g. `phantombot persona` on a fresh box).
+    log.warn("startup: vault bootstrap failed", { error: (e as Error).message });
+  }
+  await preloadEnvFiles();
 }
-await preloadEnvFiles();
 runMain(mainCommand);

--- a/src/lib/binaryUpdate.ts
+++ b/src/lib/binaryUpdate.ts
@@ -1,10 +1,22 @@
 /**
  * Download + SHA256-verify + atomically swap a phantombot binary.
  *
- * The actual filesystem swap relies on Linux semantics: rename(2) over
- * the currently-executing binary is safe. The kernel keeps the running
- * process backed by the original inode; the new file gets a fresh inode
- * at the same path. The next exec() of that path picks up the new file.
+ * The swap is platform-split because the OSes disagree on what you can do
+ * to a running executable:
+ *
+ *   - POSIX (linux/darwin): rename(2) OVER the currently-executing binary
+ *     is safe. The kernel keeps the running process backed by the original
+ *     inode; the new file gets a fresh inode at the same path, and the next
+ *     exec() of that path picks up the new file.
+ *
+ *   - Windows: the OS locks a running .exe against overwrite AND delete, so
+ *     rename-over is impossible. But it does NOT block RENAMING the running
+ *     image. So we rename the live `phantombot.exe` aside to
+ *     `phantombot.exe.old` (a directory-entry change, allowed while it runs),
+ *     then rename the verified new binary into the now-free path. The `.old`
+ *     stays locked until this process exits, so it can't be deleted here —
+ *     the freshly-relaunched process removes it on startup via
+ *     cleanupStaleUpdateArtifacts.
  *
  * SHA256 verification is mandatory — we refuse to swap if the downloaded
  * bytes don't match SHA256SUMS. A poisoned mirror or in-flight tamper
@@ -16,11 +28,13 @@ import { existsSync } from "node:fs";
 import {
   chmod,
   copyFile,
+  readdir,
   rename,
   rm,
   stat,
   writeFile,
 } from "node:fs/promises";
+import { basename, dirname } from "node:path";
 
 export interface DownloadAndVerifyOpts {
   /** URL of the binary asset (browser_download_url from the release). */
@@ -146,6 +160,12 @@ export interface ApplyUpdateOpts {
   tempPath: string;
   /** Path of the binary to replace (usually process.execPath). */
   targetPath: string;
+  /**
+   * Defaults to process.platform. On "win32" the swap renames the running
+   * .exe aside instead of renaming over it (which Windows forbids). Tests
+   * override to exercise the Windows path from a POSIX box.
+   */
+  procPlatform?: string;
 }
 
 export type ApplyResult =
@@ -184,6 +204,10 @@ export type ApplyResult =
 export async function applyUpdate(opts: ApplyUpdateOpts): Promise<ApplyResult> {
   if (!existsSync(opts.tempPath)) {
     return { ok: false, error: `temp file missing: ${opts.tempPath}` };
+  }
+  const procPlatform = opts.procPlatform ?? process.platform;
+  if (procPlatform === "win32") {
+    return applyUpdateWindows(opts.tempPath, opts.targetPath);
   }
   const backupPath = `${opts.targetPath}.bak`;
   try {
@@ -229,6 +253,101 @@ export async function applyUpdate(opts: ApplyUpdateOpts): Promise<ApplyResult> {
     /* best-effort cleanup; the next update will retry */
   }
   return { ok: true };
+}
+
+/**
+ * Windows binary swap. Windows locks a running .exe against overwrite/delete
+ * but permits RENAME, so:
+ *   1. Free up `${target}.old` (rm any stale one; if it's still locked by a
+ *      not-fully-exited prior process, fall back to a timestamped name so we
+ *      never fail on a lingering artifact).
+ *   2. rename(target → old)   — moves the live binary aside (allowed while it
+ *      runs; a directory-entry change, not a copy). Same volume by
+ *      construction (old sits next to target).
+ *   3. rename(temp → target)  — drops the verified new binary into the freed
+ *      path. On failure we rename `old` back so the path always has a valid
+ *      binary (rollback).
+ *
+ * We deliberately do NOT delete `old` here: it's still the running process's
+ * on-disk image and stays locked until this process exits. The relaunched
+ * (new) process removes it on startup — see cleanupStaleUpdateArtifacts.
+ */
+async function applyUpdateWindows(
+  tempPath: string,
+  targetPath: string,
+): Promise<ApplyResult> {
+  let oldPath = `${targetPath}.old`;
+  if (existsSync(oldPath)) {
+    await rm(oldPath, { force: true }).catch(() => {});
+    // Still there → it's locked by a prior process that hasn't fully exited.
+    // Use a unique name so this update isn't blocked; cleanup globs *.old.
+    if (existsSync(oldPath)) oldPath = `${targetPath}.${Date.now()}.old`;
+  }
+
+  try {
+    await rename(targetPath, oldPath);
+  } catch (e) {
+    return {
+      ok: false,
+      error: `failed to move running binary aside (${targetPath} → ${oldPath}): ${(e as Error).message}`,
+    };
+  }
+
+  try {
+    await rename(tempPath, targetPath);
+  } catch (e) {
+    // Roll back so the canonical path always holds a working binary.
+    try {
+      await rename(oldPath, targetPath);
+    } catch {
+      /* if restore fails too, `${target}.old` is the intact binary to
+         rename back by hand */
+    }
+    return {
+      ok: false,
+      error: `failed to install new binary (${tempPath} → ${targetPath}): ${(e as Error).message} (rolled back)`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Remove stale `${binary}.old` artifacts left behind by a Windows self-update.
+ * The Windows swap renames the previous binary aside because a running .exe
+ * can't be deleted; once the old process has exited the file is unlocked, so
+ * the freshly-relaunched process calls this at startup to tidy up. Matches
+ * both `${name}.old` and the timestamped `${name}.<n>.old` fallback.
+ *
+ * No-op on non-Windows (POSIX rename-over leaves nothing to clean). Returns
+ * the basenames actually removed. Never throws — a still-locked or
+ * unreadable dir is swallowed and retried on the next boot.
+ */
+export async function cleanupStaleUpdateArtifacts(
+  targetPath: string,
+  procPlatform: string = process.platform,
+): Promise<string[]> {
+  if (procPlatform !== "win32") return [];
+  const dir = dirname(targetPath);
+  const base = basename(targetPath);
+  const prefix = `${base}.`;
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const removed: string[] = [];
+  for (const name of entries) {
+    if (!name.startsWith(prefix) || !name.endsWith(".old")) continue;
+    try {
+      await rm(`${dir}/${name}`, { force: true });
+      removed.push(name);
+    } catch {
+      /* still locked (old process not fully gone) — leave for next boot */
+    }
+  }
+  return removed;
 }
 
 /**

--- a/src/lib/cliInvocation.ts
+++ b/src/lib/cliInvocation.ts
@@ -1,0 +1,30 @@
+/**
+ * Tiny, dependency-free helpers for reasoning about how the CLI was invoked,
+ * used by the entrypoint (src/index.ts) BEFORE the Citty dispatcher runs.
+ *
+ * Kept in its own module (rather than inline in index.ts) so it can be unit
+ * tested — importing index.ts would auto-run `runMain`, which we don't want in
+ * a test process.
+ */
+
+/**
+ * True when the invocation is a read-only one that must not touch disk or
+ * provision any state: `--help`/`-h`, `--version`/`-v`, the `help` subcommand,
+ * or a bare call with no subcommand (which just prints usage). CI uses
+ * `--help`/`--version` as "does the binary run?" smoke tests, so these must be
+ * pure — no vault migration, no persona creation.
+ *
+ * @param argv the full `process.argv` (element 0 = runtime, 1 = script).
+ */
+export function isReadOnlyInvocation(argv: string[]): boolean {
+  const args = argv.slice(2);
+  if (args.length === 0) return true; // bare `phantombot` → usage text
+  const first = args[0];
+  return (
+    first === "--help" ||
+    first === "-h" ||
+    first === "--version" ||
+    first === "-v" ||
+    first === "help"
+  );
+}

--- a/src/lib/filePermissions.ts
+++ b/src/lib/filePermissions.ts
@@ -31,7 +31,7 @@
  * "No mapping between account names and security IDs". The SID always maps and
  * is immune to renamed accounts and localized principal names.
  */
-function currentUserSid(): string {
+export function currentUserSid(): string {
   const res = Bun.spawnSync(["whoami", "/user", "/fo", "csv", "/nh"]);
   const out = new TextDecoder().decode(res.stdout).trim();
   // Output shape: "DOMAIN\user","S-1-5-21-…"

--- a/src/lib/filePermissions.ts
+++ b/src/lib/filePermissions.ts
@@ -1,0 +1,69 @@
+/**
+ * Cross-platform "lock this file down to just me" primitive.
+ *
+ * On POSIX the caller already writes sensitive files at mode 0o600, and the
+ * kernel enforces it — nothing to do here, so this is a no-op. On Windows the
+ * POSIX permission bits passed to writeFile are IGNORED: a freshly created file
+ * inherits its parent directory's ACL, which on a shared machine can grant read
+ * access to other principals (BUILTIN\Users, etc.). For the persona's crown
+ * jewel — identity.json, which holds the nsec every vault secret is encrypted
+ * under — that is not acceptable, so we apply an explicit restrictive ACL.
+ *
+ * The Windows lockdown does two things via `icacls`:
+ *   /inheritance:r   — remove all INHERITED ACEs (drops whatever the parent dir
+ *                      would have granted: Users, Authenticated Users, etc.)
+ *   /grant:r <me>:F  — replace any explicit grant for the current user with a
+ *                      single Full-control ACE.
+ * The net DACL is exactly one ACE: the current user, full control. Everyone
+ * else — including standard users on the same box — is denied by absence.
+ *
+ * Fails CLOSED: if the current account can't be resolved or icacls errors, this
+ * THROWS. Callers apply it to a tempfile BEFORE hard-linking it into place, so a
+ * throw means no identity.json is ever created — far better than silently
+ * persisting the nsec in a file other users could read.
+ */
+
+/**
+ * Resolve the current user's SID (e.g. `S-1-5-21-…-1001`) and grant by SID
+ * rather than by name. Account NAMES are ambiguous on Windows: on a workgroup
+ * (non-domain) machine `%USERDOMAIN%` is the workgroup name `WORKGROUP`, which
+ * is NOT a valid account authority, so `icacls /grant WORKGROUP\user` fails with
+ * "No mapping between account names and security IDs". The SID always maps and
+ * is immune to renamed accounts and localized principal names.
+ */
+function currentUserSid(): string {
+  const res = Bun.spawnSync(["whoami", "/user", "/fo", "csv", "/nh"]);
+  const out = new TextDecoder().decode(res.stdout).trim();
+  // Output shape: "DOMAIN\user","S-1-5-21-…"
+  const m = out.match(/(S-1-[0-9-]+)/);
+  if (!m) {
+    throw new Error(`could not resolve current user SID (whoami: ${out || "no output"})`);
+  }
+  return m[1]!;
+}
+
+/**
+ * Restrict `path` so ONLY the current user can access it. No-op on POSIX (the
+ * file's mode 0o600 already governs); applies an owner-only ACL on Windows.
+ * Throws on Windows if the lockdown cannot be verified to have succeeded.
+ */
+export function restrictFileToCurrentUser(path: string): void {
+  if (process.platform !== "win32") return;
+
+  // Grant by SID (`*S-1-…`) — see currentUserSid for why names are unsafe.
+  const sid = currentUserSid();
+  const res = Bun.spawnSync([
+    "icacls",
+    path,
+    "/inheritance:r",
+    "/grant:r",
+    `*${sid}:(F)`,
+  ]);
+  if (res.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(res.stderr).trim();
+    const stdout = new TextDecoder().decode(res.stdout).trim();
+    throw new Error(
+      `icacls lockdown failed for ${path}: ${stderr || stdout || `exit ${res.exitCode}`}`,
+    );
+  }
+}

--- a/src/lib/githubReleases.ts
+++ b/src/lib/githubReleases.ts
@@ -19,11 +19,28 @@ export type SupportedArch = "x64" | "arm64";
 
 /**
  * The full release-target tuple — phantombot ships one binary per
- * (platform, arch) pair, named `phantombot-${tag}-${target}`. Currently
- * built: linux-x64, linux-arm64, darwin-arm64. No darwin-x64 because no
- * deploy target uses Intel Mac.
+ * (platform, arch) pair, named `phantombot-${tag}-${target}` (Windows adds a
+ * `.exe` suffix — see releaseAssetName). Currently built: linux-x64,
+ * linux-arm64, darwin-arm64, windows-x64, windows-arm64. No darwin-x64
+ * because no deploy target uses Intel Mac.
  */
-export type SupportedTarget = "linux-x64" | "linux-arm64" | "darwin-arm64";
+export type SupportedTarget =
+  | "linux-x64"
+  | "linux-arm64"
+  | "darwin-arm64"
+  | "windows-x64"
+  | "windows-arm64";
+
+/**
+ * The release asset filename for a (tag, target). Windows binaries carry a
+ * `.exe` suffix (that's how the release workflow uploads them); every other
+ * platform is extensionless. Kept as a single helper so the updater's
+ * "what asset am I looking for" logic and any future callers agree.
+ */
+export function releaseAssetName(tag: string, target: SupportedTarget): string {
+  const base = `phantombot-${tag}-${target}`;
+  return target.startsWith("windows-") ? `${base}.exe` : base;
+}
 
 export interface ReleaseAsset {
   name: string;
@@ -140,7 +157,7 @@ export async function findLatestRelease(opts: {
 
   const tag = body.tag_name;
   const version = tag.startsWith("v") ? tag.slice(1) : tag;
-  const wantedBinaryName = `phantombot-${tag}-${opts.target}`;
+  const wantedBinaryName = releaseAssetName(tag, opts.target);
   const binary = body.assets.find((a) => a.name === wantedBinaryName);
   const checksums = body.assets.find((a) => a.name === "SHA256SUMS");
 
@@ -199,11 +216,12 @@ export function detectSupportedArch(
 /**
  * Map (process.platform, process.arch) to one of the release-target
  * tuples we actually ship. Returns undefined for combinations the
- * release workflow doesn't build (e.g. darwin-x64, linux-ia32, win32-*),
- * so `phantombot update` can refuse with a clear message instead of
+ * release workflow doesn't build (e.g. darwin-x64, linux-ia32), so
+ * `phantombot update` can refuse with a clear message instead of
  * 404-ing on a missing asset.
  *
- * Built targets: linux-x64, linux-arm64, darwin-arm64.
+ * Built targets: linux-x64, linux-arm64, darwin-arm64, windows-x64,
+ * windows-arm64.
  */
 export function detectSupportedTarget(
   procPlatform: string = process.platform,
@@ -213,6 +231,7 @@ export function detectSupportedTarget(
   if (!arch) return undefined;
   if (procPlatform === "linux") return `linux-${arch}` as SupportedTarget;
   if (procPlatform === "darwin" && arch === "arm64") return "darwin-arm64";
+  if (procPlatform === "win32") return `windows-${arch}` as SupportedTarget;
   return undefined;
 }
 

--- a/src/lib/personaIdentity.ts
+++ b/src/lib/personaIdentity.ts
@@ -3,8 +3,10 @@
  * long-lived secret key (`nsec`), used by BOTH the phantomchat channel and
  * the encrypted secrets vault (lib/vault.ts).
  *
- * Storage: `<personaDir>/identity.json` (mode 0600), shape:
+ * Storage: `<personaDir>/identity.json`, shape:
  *   { "nsec": "nsec1…" }
+ * Locked to the owner alone: mode 0600 on POSIX, an explicit owner-only ACL on
+ * Windows (where mode bits are ignored) — see lib/filePermissions.ts.
  *
  * Historically the nsec lived only inside `<personaDir>/phantomchat.json`
  * (see channels/phantomchat/personaStore.ts) — coupling the persona's crypto
@@ -26,6 +28,7 @@ import { dirname, join } from "node:path";
 
 import { generateSecretKey } from "nostr-tools/pure";
 
+import { restrictFileToCurrentUser } from "./filePermissions.ts";
 import {
   identityFromNsec,
   nsecEncode,
@@ -75,11 +78,13 @@ function uniqueTmpPath(path: string): string {
  * This is the single race-safe primitive for minting the shared identity; callers
  * must not do check-then-write (existsSync + unconditional rename) themselves.
  *
- * Mechanism: write a per-process-unique tempfile (mode 0600), then hard-LINK it
- * into place. `link()` is atomic and fails with EEXIST if the target already
- * exists, so exactly one racer wins; every loser reads the winner's nsec back
- * and adopts it. This closes the check-then-act race where two processes that
- * both saw "no identity.json" mint divergent nsecs — whichever wrote last would
+ * Mechanism: write a per-process-unique tempfile (mode 0600), lock it to the
+ * current user (owner-only ACL on Windows; the mode already suffices on POSIX),
+ * then hard-LINK it into place. `link()` is atomic and fails with EEXIST if the
+ * target already exists, so exactly one racer wins; every loser reads the
+ * winner's nsec back and adopts it. This closes the check-then-act race where
+ * two processes that both saw "no identity.json" mint divergent nsecs —
+ * whichever wrote last would
  * orphan everything the other had already encrypted under its key.
  *
  * Fails CLOSED: if identity.json already exists but its nsec can't be read back
@@ -101,6 +106,15 @@ export async function createPersonaIdentityIfAbsent(
       encoding: "utf8",
       mode: 0o600,
     });
+    // Lock the file down to the current user BEFORE linking it into place, so
+    // the canonical identity.json is restrictive from birth (never briefly
+    // readable by other principals). On POSIX the mode 0o600 above already does
+    // this and this is a no-op; on Windows the mode bits are ignored, so we
+    // apply an explicit owner-only ACL to the tmp file — the hard link below
+    // shares the same security descriptor, so identity.json inherits it. Fails
+    // CLOSED: a lockdown error throws here, before link(), so no world-readable
+    // identity.json is ever created (the finally block cleans up the tmp).
+    restrictFileToCurrentUser(tmp);
     try {
       await link(tmp, path);
       return nsec; // we won the race

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,10 +1,11 @@
 /**
  * Cross-platform service-manager router.
  *
- * Phantombot ships on Linux (systemd --user) and macOS (launchd, per-user
- * LaunchAgents). The two backends have different unit-file shapes,
- * different control verbs, and different log destinations — this module
- * is the single place where CLI code decides which one to talk to.
+ * Phantombot ships on Linux (systemd --user), macOS (launchd, per-user
+ * LaunchAgents) and Windows (Task Scheduler, per-user logon-triggered
+ * tasks). The backends have different unit-file shapes, different control
+ * verbs, and different log destinations — this module is the single place
+ * where CLI code decides which one to talk to.
  *
  * Public surface:
  *
@@ -30,6 +31,7 @@ import {
   defaultSystemdServiceControl,
   type ServiceControl,
 } from "./systemd.ts";
+import { defaultTaskSchedulerServiceControl } from "./taskScheduler.ts";
 
 export type { ServiceControl };
 
@@ -57,6 +59,8 @@ export function defaultServiceControl(): ServiceControl {
       return defaultSystemdServiceControl();
     case "darwin":
       return defaultLaunchdServiceControl();
+    case "windows":
+      return defaultTaskSchedulerServiceControl();
     default:
       return noopServiceControl();
   }
@@ -84,6 +88,8 @@ export function restartCommand(): string {
   switch (currentPlatform()) {
     case "darwin":
       return `launchctl kickstart -k gui/$(id -u)/dev.phantombot.phantombot`;
+    case "windows":
+      return `schtasks /End /TN "\\Phantombot\\phantombot" & schtasks /Run /TN "\\Phantombot\\phantombot"`;
     case "linux":
     default:
       return "systemctl --user restart phantombot";
@@ -95,6 +101,8 @@ export function statusCommand(): string {
   switch (currentPlatform()) {
     case "darwin":
       return `launchctl print gui/$(id -u)/dev.phantombot.phantombot`;
+    case "windows":
+      return `schtasks /Query /TN "\\Phantombot\\phantombot" /V /FO LIST`;
     case "linux":
     default:
       return "systemctl --user status phantombot";
@@ -106,6 +114,8 @@ export function logsCommand(): string {
   switch (currentPlatform()) {
     case "darwin":
       return `tail -f ~/Library/Logs/phantombot/dev.phantombot.phantombot.{out,err}.log`;
+    case "windows":
+      return `powershell -Command "Get-Content -Wait -Tail 50 \\"$env:LOCALAPPDATA\\phantombot\\logs\\phantombot.out.log\\""`;
     case "linux":
     default:
       return "journalctl --user -u phantombot -f";

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -33,11 +33,12 @@ import {
 
 export type { ServiceControl };
 
-export type Platform = "linux" | "darwin" | "unsupported";
+export type Platform = "linux" | "darwin" | "windows" | "unsupported";
 
 export function currentPlatform(): Platform {
   if (process.platform === "linux") return "linux";
   if (process.platform === "darwin") return "darwin";
+  if (process.platform === "win32") return "windows";
   return "unsupported";
 }
 

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -66,6 +66,56 @@ export function defaultServiceControl(): ServiceControl {
   }
 }
 
+export interface SelfRestartOpts {
+  /** The host's ServiceControl (POSIX path delegates to its restart()). */
+  serviceControl: ServiceControl;
+  /** Defaults to process.platform. Tests override. */
+  procPlatform?: string;
+  /**
+   * Test seam for the Windows graceful-exit trigger. Production emits
+   * SIGTERM so `phantombot run`'s existing shutdown handler drains cleanly.
+   */
+  triggerShutdown?: () => void;
+}
+
+/**
+ * Restart THE CURRENT phantombot process so it comes back running the
+ * freshly-swapped binary. This is the IN-PROCESS restart used by the
+ * `/update` and `/restart` slash-commands, where the caller is the running
+ * service itself — distinct from `defaultServiceControl().restart()`, which
+ * an EXTERNAL `phantombot update --restart` uses to bounce the service from a
+ * separate terminal.
+ *
+ * POSIX (linux/darwin): delegate to the supervisor's restart verb
+ * (`systemctl --user restart` / `launchctl kickstart`). Those SIGTERM us and
+ * the supervisor relaunches — safe to call from within the unit.
+ *
+ * Windows: we must NOT call `schtasks /End` + `/Run` from inside the task's
+ * own process tree — `/End` tears down that tree (including the child
+ * `schtasks.exe` we just spawned to issue `/Run`), so the relaunch can be
+ * dropped. Instead we exit cleanly (emit SIGTERM → the run loop's handler
+ * drains and returns), and the always-on task's 1-minute keep-alive
+ * TimeTrigger relaunches from the swapped binary within ≤60s. The relaunched
+ * process deletes the stale `.old` on startup. No console window, no watcher.
+ */
+export async function selfRestart(
+  opts: SelfRestartOpts,
+): Promise<{ ok: boolean; stderr?: string }> {
+  const platform = opts.procPlatform ?? process.platform;
+  if (platform === "win32") {
+    const trigger =
+      opts.triggerShutdown ??
+      (() => {
+        // Emit through the normal shutdown path so memory (SQLite/WAL) and the
+        // run-lock are released cleanly, exactly like a POSIX SIGTERM restart.
+        process.emit("SIGTERM" as NodeJS.Signals);
+      });
+    trigger();
+    return { ok: true };
+  }
+  return opts.serviceControl.restart();
+}
+
 function noopServiceControl(): ServiceControl {
   return {
     async isActive() {

--- a/src/lib/processGroup.ts
+++ b/src/lib/processGroup.ts
@@ -36,7 +36,8 @@
  * cmd in `setsid` and accept the spawn-time race.
  */
 
-import { dirname } from "node:path";
+import { execFileSync } from "node:child_process";
+import { delimiter, dirname, isAbsolute } from "node:path";
 import type { Subprocess, SpawnOptions } from "bun";
 import { log } from "./logger.ts";
 
@@ -76,14 +77,18 @@ export function withCommandDirOnPath(
   bin: string,
   env: Record<string, string | undefined>,
 ): Record<string, string | undefined> {
-  if (!bin.startsWith("/")) return env;
+  // Only act on an ABSOLUTE path — a bare command name is resolved via the
+  // existing PATH and `dirname("pi")` is "." which we must never inject.
+  // `isAbsolute` + the platform `delimiter` (":" on POSIX, ";" on Windows)
+  // keep this correct on both without changing POSIX behaviour.
+  if (!isAbsolute(bin)) return env;
   const binDir = dirname(bin);
   const currentPath = env.PATH ?? "";
-  const entries = currentPath.split(":");
+  const entries = currentPath.split(delimiter);
   if (entries.includes(binDir)) return env;
   return {
     ...env,
-    PATH: currentPath ? `${binDir}:${currentPath}` : binDir,
+    PATH: currentPath ? `${binDir}${delimiter}${currentPath}` : binDir,
   };
 }
 
@@ -116,9 +121,16 @@ export function spawnInNewSession<
   return Bun.spawn(cmd, {
     ...opts,
     env,
-    // Undocumented but stable Bun option (maps to POSIX_SPAWN_SETSID).
-    // See module docstring for why this beats a `setsid` wrapper.
-    detached: true,
+    // POSIX only: `detached` (undocumented but stable Bun option, maps to
+    // POSIX_SPAWN_SETSID) puts the child in its own session so pid==pgid and a
+    // single negative-pid signal reaches the whole descendant group. See the
+    // module docstring for why this beats a `setsid` wrapper.
+    //
+    // Windows has no POSIX process groups — we bring the tree down with
+    // `taskkill /T` by PID instead — and detaching there can prevent Bun from
+    // observing the child's exit, leaving `proc.exited` permanently unresolved
+    // (killProcessGroup would then hang). So we only detach on POSIX.
+    detached: process.platform !== "win32",
   } as typeof opts) as Subprocess<Stdin, Stdout, Stderr>;
 }
 
@@ -174,12 +186,14 @@ export async function killProcessGroup(
  * Returns true if the signal was delivered (or the kernel accepted it),
  * false if the group is already gone (ESRCH).
  *
- * Wraps `process.kill` with negative pid — the POSIX convention for
- * "this entire process group". Anything other than ESRCH is logged
- * and treated as a delivered signal (best-effort; the caller still
- * waits on proc.exited).
+ * On POSIX this wraps `process.kill` with a negative pid — the convention for
+ * "this entire process group". Windows has no process groups or signals in the
+ * POSIX sense, so there we shell out to `taskkill /T` (walk and terminate the
+ * child tree by PID). Anything other than "already gone" is logged and treated
+ * as a delivered signal (best-effort; the caller still waits on proc.exited).
  */
 function signalGroup(pid: number, signal: NodeJS.Signals): boolean {
+  if (process.platform === "win32") return windowsKillTree(pid);
   try {
     process.kill(-pid, signal);
     return true;
@@ -190,6 +204,51 @@ function signalGroup(pid: number, signal: NodeJS.Signals): boolean {
       pid,
       signal,
       code,
+      error: (e as Error).message,
+    });
+    return true;
+  }
+}
+
+/**
+ * Windows equivalent of a process-group kill: `taskkill /PID <pid> /T /F` walks
+ * the descendant tree and force-terminates it.
+ *
+ * Why always force (`/F`), ignoring the SIGTERM/SIGKILL distinction: a Windows
+ * console process tree (cmd + its children) does not honour the graceful
+ * WM_CLOSE that `taskkill` without `/F` sends, and — critically — `taskkill /T`
+ * WITHOUT `/F` returns exit 128 against a still-alive console tree, which is
+ * indistinguishable from "no such process". Treating that as "already gone"
+ * made killProcessGroup skip escalation and await a never-resolving exit. With
+ * `/F`, exit 128 reliably means the PID genuinely doesn't exist, so we can map
+ * it to the POSIX ESRCH branch. The grace window still applies: the caller
+ * races proc.exited against it, and a forced kill resolves proc.exited well
+ * inside a normal grace, so the escalation path simply never needs to fire.
+ *
+ * Returns false when the process is already gone (exit 128, mirroring the POSIX
+ * ESRCH branch) or when `taskkill` itself is missing (ENOENT) — in both cases no
+ * signal was delivered, so the caller must not treat the tree as reaped.
+ */
+function windowsKillTree(pid: number): boolean {
+  try {
+    execFileSync("taskkill", ["/PID", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch (e) {
+    // taskkill exits 128 ("process not found") when the tree is already gone.
+    const status = (e as { status?: number }).status;
+    if (status === 128) return false;
+    // taskkill missing from PATH: nothing was killed, so report failure rather
+    // than a misleading "signal delivered".
+    const code = (e as { code?: string }).code;
+    if (code === "ENOENT") {
+      log.warn("processGroup: taskkill not found on PATH", { pid });
+      return false;
+    }
+    log.warn("processGroup: taskkill failed", {
+      pid,
+      status,
       error: (e as Error).message,
     });
     return true;

--- a/src/lib/runLock.ts
+++ b/src/lib/runLock.ts
@@ -26,8 +26,11 @@
  * stranger inherited its PID" and reclaim the stale lock in the latter case.
  *
  * The token is best-effort and Linux-specific (/proc). On platforms where we
- * can't read it (macOS dev boxes), we degrade to the old PID-only liveness
- * check — no worse than before, and those aren't the always-on production host.
+ * can't read it (macOS and Windows), we degrade to the old PID-only liveness
+ * check — no worse than before. The only cost of the degraded path is that a
+ * crash-then-PID-recycle can make a stale lock look live until the lock file is
+ * removed; on Windows that file lives in per-user %TEMP% and is trivially
+ * cleared, matching the long-accepted macOS behaviour.
  */
 
 import {
@@ -39,6 +42,7 @@ import {
   writeSync,
   closeSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 export interface LockHandle {
@@ -58,6 +62,12 @@ export interface LockConflict {
 export function defaultLockPath(): string {
   const xdg = process.env.XDG_RUNTIME_DIR;
   if (xdg) return join(xdg, "phantombot.run.lock");
+  // Windows has no XDG_RUNTIME_DIR and no uid. `os.tmpdir()` resolves to the
+  // per-user %TEMP% (…\AppData\Local\Temp), which is already user-scoped, so a
+  // single filename there won't collide across accounts the way /tmp would.
+  if (process.platform === "win32") {
+    return join(tmpdir(), "phantombot.run.lock");
+  }
   const uid = process.getuid?.() ?? 0;
   return join("/tmp", `phantombot-${uid}.run.lock`);
 }

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -1,0 +1,576 @@
+/**
+ * Windows Task Scheduler backend — the `systemctl --user` / launchd analogue
+ * for phantombot on Windows.
+ *
+ * Mirrors the shape of `systemd.ts` and `launchd.ts` so the per-platform
+ * router in `platform.ts` can dispatch to it with the same surface area. A
+ * `SchtasksRunner` indirection keeps this testable: tests inject a fake
+ * runner instead of actually invoking `schtasks.exe`.
+ *
+ * Design constraints (from issue #201):
+ *   - NO admin. Registering a task in the CURRENT user's own tree via
+ *     `schtasks /Create` needs no elevation, unlike a true Windows Service
+ *     (SCM registration, which is what WinSW does). The trade-off is that a
+ *     user-scoped scheduled task with an InteractiveToken principal only runs
+ *     while that user is logged in — exactly the macOS/launchd model Andrew
+ *     accepted. Someone wanting true headless-without-login should install a
+ *     real service (e.g. WinSW); the README documents that.
+ *   - Runs as the current user, only when logged in:
+ *       <LogonType>InteractiveToken</LogonType> + <UserId> = current SID.
+ *     InteractiveToken means Task Scheduler needs no stored password.
+ *   - Grant/identify the principal by SID, never by name — a workgroup box has
+ *     %USERDOMAIN%=WORKGROUP which does not resolve (same lesson as the Phase 2
+ *     identity.json ACL). `currentUserSid()` is reused from filePermissions.ts.
+ *
+ * Task layout (all under a \Phantombot\ folder so they group in taskschd.msc):
+ *
+ *   \Phantombot\phantombot   — always-on `phantombot run`   (keep-alive)
+ *   \Phantombot\heartbeat    — `phantombot heartbeat`       (every 30 min)
+ *   \Phantombot\nightly      — `phantombot nightly`         (daily 02:00)
+ *   \Phantombot\tick         — `phantombot tick`            (every 60 s)
+ *
+ * Keep-alive without a supervisor: Task Scheduler has no true "restart on
+ * clean exit" like launchd's KeepAlive. We emulate it for the always-on task
+ * with a belt-and-braces pair: a LogonTrigger (start at logon) PLUS a
+ * TimeTrigger repeating every minute, combined with
+ * MultipleInstancesPolicy=IgnoreNew. If the agent is already running the
+ * minute-tick is ignored; if it died, the next tick restarts it. This gives
+ * effectively-infinite restart while logged in, admin-free.
+ *
+ * Logging (WinSW-inspired, minus the SCM): Task Scheduler does not capture a
+ * process's stdout/stderr, so the action is run through `cmd /c` with the
+ * streams redirected (append) to per-task .out.log / .err.log under
+ * %LOCALAPPDATA%\phantombot\logs — the same out/err split launchd writes to
+ * ~/Library/Logs. Log ROTATION is not yet handled here (documented limitation;
+ * WinSW is the upgrade path for rotation + richer supervision).
+ */
+
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+import { xdgDataHome } from "../config.ts";
+import { currentUserSid } from "./filePermissions.ts";
+import type { WriteSink } from "./io.ts";
+
+export const TASK_FOLDER = "\\Phantombot";
+export const PHANTOMBOT_TASK = "\\Phantombot\\phantombot";
+export const HEARTBEAT_TASK = "\\Phantombot\\heartbeat";
+export const NIGHTLY_TASK = "\\Phantombot\\nightly";
+export const TICK_TASK = "\\Phantombot\\tick";
+
+/** Short label used for the per-task log filenames. */
+type TaskLabel = "phantombot" | "heartbeat" | "nightly" | "tick";
+
+function logsDir(): string {
+  return join(xdgDataHome(), "phantombot", "logs");
+}
+
+/** Absolute path of a task's stdout / stderr log files. */
+export function taskLogPaths(label: TaskLabel): { out: string; err: string } {
+  const base = join(logsDir(), label);
+  return { out: `${base}.out.log`, err: `${base}.err.log` };
+}
+
+/**
+ * XML-escape a value for inclusion in Task Scheduler XML element text. Task
+ * XML is XML, so `&`, `<`, `>` need entities. Double quotes are legal in
+ * element text and stay intact (they matter for the cmd redirection string).
+ */
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Build the `cmd /c` argument string that runs the phantombot binary with its
+ * stdout/stderr appended to the task's log files. Task Scheduler executes the
+ * Command directly (no shell), so redirection operators are only honoured when
+ * we route through cmd.exe ourselves.
+ *
+ * Result (before XML-escaping), e.g.:
+ *   /c ""C:\...\phantombot.exe" run 1>>"C:\...\phantombot.out.log" 2>>"C:\...\phantombot.err.log""
+ *
+ * The doubled outer quotes are cmd's own rule: when the string after `/c`
+ * begins with a quote, cmd strips the first and last quote before parsing, so
+ * paths containing spaces survive intact.
+ */
+export function buildCmdArguments(
+  binPath: string,
+  args: readonly string[],
+  outLog: string,
+  errLog: string,
+): string {
+  const parts = [`"${binPath}"`, ...args].join(" ");
+  const inner = `${parts} 1>>"${outLog}" 2>>"${errLog}"`;
+  return `/c "${inner}"`;
+}
+
+interface TaskXmlOptions {
+  uri: string;
+  description: string;
+  /** Current user's SID — principal + logon-trigger UserId. */
+  sid: string;
+  label: TaskLabel;
+  binPath: string;
+  args: readonly string[];
+  /** Trigger XML block (already indented). */
+  triggersXml: string;
+  /** ISO 8601 duration; "PT0S" = unlimited (for the always-on daemon). */
+  executionTimeLimit: string;
+  /** Emit a <RestartOnFailure> safety net (the always-on task only). */
+  restartOnFailure?: boolean;
+}
+
+function generateTaskXml(opts: TaskXmlOptions): string {
+  const { out: outLog, err: errLog } = taskLogPaths(opts.label);
+  const cmdArgs = buildCmdArguments(opts.binPath, opts.args, outLog, errLog);
+  const workingDir = homedir();
+
+  const restart = opts.restartOnFailure
+    ? "    <RestartOnFailure>\n" +
+      "      <Interval>PT1M</Interval>\n" +
+      "      <Count>3</Count>\n" +
+      "    </RestartOnFailure>\n"
+    : "";
+
+  return (
+    '<?xml version="1.0" encoding="UTF-16"?>\n' +
+    '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n' +
+    "  <RegistrationInfo>\n" +
+    `    <Description>${xmlEscape(opts.description)}</Description>\n` +
+    `    <URI>${xmlEscape(opts.uri)}</URI>\n` +
+    "  </RegistrationInfo>\n" +
+    "  <Triggers>\n" +
+    opts.triggersXml +
+    "  </Triggers>\n" +
+    "  <Principals>\n" +
+    '    <Principal id="Author">\n' +
+    `      <UserId>${xmlEscape(opts.sid)}</UserId>\n` +
+    "      <LogonType>InteractiveToken</LogonType>\n" +
+    "      <RunLevel>LeastPrivilege</RunLevel>\n" +
+    "    </Principal>\n" +
+    "  </Principals>\n" +
+    "  <Settings>\n" +
+    "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n" +
+    "    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>\n" +
+    "    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n" +
+    "    <AllowHardTerminate>true</AllowHardTerminate>\n" +
+    "    <StartWhenAvailable>true</StartWhenAvailable>\n" +
+    "    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>\n" +
+    "    <IdleSettings>\n" +
+    "      <StopOnIdleEnd>false</StopOnIdleEnd>\n" +
+    "      <RestartOnIdle>false</RestartOnIdle>\n" +
+    "    </IdleSettings>\n" +
+    "    <AllowStartOnDemand>true</AllowStartOnDemand>\n" +
+    "    <Enabled>true</Enabled>\n" +
+    "    <Hidden>false</Hidden>\n" +
+    "    <RunOnlyIfIdle>false</RunOnlyIfIdle>\n" +
+    "    <WakeToRun>false</WakeToRun>\n" +
+    `    <ExecutionTimeLimit>${opts.executionTimeLimit}</ExecutionTimeLimit>\n` +
+    "    <Priority>7</Priority>\n" +
+    restart +
+    "  </Settings>\n" +
+    '  <Actions Context="Author">\n' +
+    "    <Exec>\n" +
+    "      <Command>cmd.exe</Command>\n" +
+    `      <Arguments>${xmlEscape(cmdArgs)}</Arguments>\n` +
+    `      <WorkingDirectory>${xmlEscape(workingDir)}</WorkingDirectory>\n` +
+    "    </Exec>\n" +
+    "  </Actions>\n" +
+    "</Task>\n"
+  );
+}
+
+/**
+ * A fixed past StartBoundary. Task Scheduler requires every TimeTrigger /
+ * CalendarTrigger to carry a StartBoundary; using a fixed past instant means
+ * "active immediately" and the repetition interval takes over from there.
+ */
+const START_BOUNDARY = "2020-01-01T00:00:00";
+const NIGHTLY_BOUNDARY = "2020-01-01T02:00:00";
+
+function repeatingTimeTrigger(interval: string): string {
+  return (
+    "    <TimeTrigger>\n" +
+    "      <Enabled>true</Enabled>\n" +
+    `      <StartBoundary>${START_BOUNDARY}</StartBoundary>\n` +
+    "      <Repetition>\n" +
+    `        <Interval>${interval}</Interval>\n` +
+    "        <StopAtDurationEnd>false</StopAtDurationEnd>\n" +
+    "      </Repetition>\n" +
+    "    </TimeTrigger>\n"
+  );
+}
+
+/** Generate the always-on phantombot agent task XML (keep-alive). */
+export function generatePhantombotTaskXml(sid: string, binPath: string): string {
+  // LogonTrigger starts it at logon; the 1-minute TimeTrigger + IgnoreNew
+  // restarts it if it ever dies. Together: keep-alive while logged in.
+  const triggers =
+    "    <LogonTrigger>\n" +
+    "      <Enabled>true</Enabled>\n" +
+    `      <UserId>${xmlEscape(sid)}</UserId>\n` +
+    "    </LogonTrigger>\n" +
+    repeatingTimeTrigger("PT1M");
+  return generateTaskXml({
+    uri: PHANTOMBOT_TASK,
+    description: "phantombot always-on agent (phantombot run)",
+    sid,
+    label: "phantombot",
+    binPath,
+    args: ["run"],
+    triggersXml: triggers,
+    executionTimeLimit: "PT0S", // unlimited — long-running daemon
+    restartOnFailure: true,
+  });
+}
+
+/** Generate the heartbeat task XML — fires every 30 minutes. */
+export function generateHeartbeatTaskXml(sid: string, binPath: string): string {
+  return generateTaskXml({
+    uri: HEARTBEAT_TASK,
+    description: "phantombot heartbeat (every 30 minutes)",
+    sid,
+    label: "heartbeat",
+    binPath,
+    args: ["heartbeat"],
+    triggersXml: repeatingTimeTrigger("PT30M"),
+    executionTimeLimit: "PT1H",
+  });
+}
+
+/** Generate the nightly task XML — fires daily at 02:00. */
+export function generateNightlyTaskXml(sid: string, binPath: string): string {
+  const triggers =
+    "    <CalendarTrigger>\n" +
+    "      <Enabled>true</Enabled>\n" +
+    `      <StartBoundary>${NIGHTLY_BOUNDARY}</StartBoundary>\n` +
+    "      <ScheduleByDay>\n" +
+    "        <DaysInterval>1</DaysInterval>\n" +
+    "      </ScheduleByDay>\n" +
+    "    </CalendarTrigger>\n";
+  return generateTaskXml({
+    uri: NIGHTLY_TASK,
+    description: "phantombot nightly (daily at 02:00)",
+    sid,
+    label: "nightly",
+    binPath,
+    args: ["nightly"],
+    triggersXml: triggers,
+    executionTimeLimit: "PT1H",
+  });
+}
+
+/** Generate the tick task XML — fires every 60 seconds. */
+export function generateTickTaskXml(sid: string, binPath: string): string {
+  return generateTaskXml({
+    uri: TICK_TASK,
+    description: "phantombot tick (every 60 seconds)",
+    sid,
+    label: "tick",
+    binPath,
+    args: ["tick"],
+    triggersXml: repeatingTimeTrigger("PT1M"),
+    executionTimeLimit: "PT1H",
+  });
+}
+
+export interface SchtasksResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface SchtasksRunner {
+  run(args: readonly string[]): Promise<SchtasksResult>;
+}
+
+export class BunSchtasksRunner implements SchtasksRunner {
+  async run(args: readonly string[]): Promise<SchtasksResult> {
+    const proc = Bun.spawn(["schtasks", ...args], {
+      env: { ...process.env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { exitCode, stdout, stderr };
+  }
+}
+
+/**
+ * Write a Task Scheduler XML file. schtasks /Create /XML is picky about
+ * encoding: the most broadly-compatible form is UTF-16LE with a BOM matching
+ * the `encoding="UTF-16"` declaration, so we encode explicitly rather than
+ * relying on writeFile's UTF-8 default.
+ */
+async function writeTaskXml(path: string, xml: string): Promise<void> {
+  const bom = Buffer.from([0xff, 0xfe]);
+  const body = Buffer.from(xml, "utf16le");
+  await writeFile(path, Buffer.concat([bom, body]));
+}
+
+interface TaskSpec {
+  name: string;
+  label: TaskLabel;
+  xml: string;
+}
+
+/**
+ * Write a task's XML to a transient file, import it with
+ * `schtasks /Create /XML … /F` (idempotent — /F overwrites an existing task
+ * of the same name), then delete the transient file. Shared by the full
+ * install and the heartbeat self-heal so both encode/quote identically.
+ */
+async function importTaskSpec(
+  spec: TaskSpec,
+  xmlDir: string,
+  schtasks: SchtasksRunner,
+): Promise<SchtasksResult> {
+  const xmlPath = join(xmlDir, `phantombot-task-${spec.label}.xml`);
+  await writeTaskXml(xmlPath, spec.xml);
+  const r = await schtasks.run([
+    "/Create",
+    "/TN",
+    spec.name,
+    "/XML",
+    xmlPath,
+    "/F",
+  ]);
+  // Best-effort cleanup of the transient import file.
+  await unlink(xmlPath).catch(() => {});
+  return r;
+}
+
+function allTaskSpecs(sid: string, binPath: string): TaskSpec[] {
+  return [
+    {
+      name: PHANTOMBOT_TASK,
+      label: "phantombot",
+      xml: generatePhantombotTaskXml(sid, binPath),
+    },
+    {
+      name: HEARTBEAT_TASK,
+      label: "heartbeat",
+      xml: generateHeartbeatTaskXml(sid, binPath),
+    },
+    {
+      name: NIGHTLY_TASK,
+      label: "nightly",
+      xml: generateNightlyTaskXml(sid, binPath),
+    },
+    { name: TICK_TASK, label: "tick", xml: generateTickTaskXml(sid, binPath) },
+  ];
+}
+
+export interface InstallTaskSchedulerOptions {
+  binPath: string;
+  /** Override the current user's SID (tests). Production resolves it live. */
+  sid?: string;
+  /** Directory for the transient XML import files (tests). Defaults to %TEMP%. */
+  xmlDir?: string;
+  schtasks: SchtasksRunner;
+  out: WriteSink;
+  err: WriteSink;
+}
+
+/**
+ * Register (or refresh) all four scheduled tasks. Writes each task's XML to a
+ * transient file, imports it with `schtasks /Create /XML … /F` (the /F makes
+ * the operation idempotent — it overwrites an existing task of the same name),
+ * then deletes the transient file.
+ */
+export async function installPhantombotTasks(
+  opts: InstallTaskSchedulerOptions,
+): Promise<{ installed: boolean }> {
+  const sid = opts.sid ?? currentUserSid();
+  const xmlDir = opts.xmlDir ?? tmpdir();
+
+  // Log dir must exist before the tasks first fire — cmd's `>>` redirection
+  // will fail to create a file inside a missing directory.
+  await mkdir(logsDir(), { recursive: true });
+  await mkdir(xmlDir, { recursive: true });
+
+  for (const spec of allTaskSpecs(sid, opts.binPath)) {
+    const r = await importTaskSpec(spec, xmlDir, opts.schtasks);
+    if (r.exitCode !== 0) {
+      opts.err.write(
+        `schtasks /Create ${spec.name} failed (${r.exitCode}): ${r.stderr.trim() || r.stdout.trim()}\n`,
+      );
+      return { installed: false };
+    }
+    opts.out.write(`registered scheduled task: ${spec.name}\n`);
+  }
+
+  opts.out.write(
+    `registered ${PHANTOMBOT_TASK} + heartbeat + nightly + tick\n`,
+  );
+  return { installed: true };
+}
+
+export interface UninstallTaskSchedulerOptions {
+  schtasks: SchtasksRunner;
+  out: WriteSink;
+  err: WriteSink;
+}
+
+/**
+ * Delete all four scheduled tasks (best-effort). A missing task returns
+ * non-zero from schtasks — logged and skipped, never fatal. The empty
+ * \Phantombot folder is harmless and left in place (schtasks has no reliable
+ * folder-delete verb across Windows versions).
+ */
+export async function uninstallPhantombotTasks(
+  opts: UninstallTaskSchedulerOptions,
+): Promise<{ removed: boolean }> {
+  const names = [TICK_TASK, NIGHTLY_TASK, HEARTBEAT_TASK, PHANTOMBOT_TASK];
+  for (const name of names) {
+    const r = await opts.schtasks.run(["/Delete", "/TN", name, "/F"]);
+    if (r.exitCode !== 0) {
+      opts.out.write(
+        `schtasks /Delete ${name} returned ${r.exitCode} (continuing)\n`,
+      );
+    } else {
+      opts.out.write(`removed scheduled task: ${name}\n`);
+    }
+  }
+  return { removed: true };
+}
+
+/**
+ * Windows paths are case-insensitive, and `schtasks /Query /XML` may echo the
+ * stored command line back with different casing than `process.execPath`
+ * reports. Compare case-folded so a mere case difference isn't mistaken for
+ * drift (which would trigger a needless — though harmless — re-import + log).
+ */
+function xmlReferencesBin(xml: string, binPath: string): boolean {
+  return xml.toLowerCase().includes(binPath.toLowerCase());
+}
+
+export interface EnsureTasksCurrentOptions {
+  binPath: string;
+  /** Override the current user's SID (tests). Production resolves it live. */
+  sid?: string;
+  /** Directory for the transient XML import files (tests). Defaults to %TEMP%. */
+  xmlDir?: string;
+  schtasks: SchtasksRunner;
+}
+
+export interface EnsureTasksCurrentResult {
+  /**
+   * Task names that were (re)registered because they were missing or still
+   * referenced a stale binary path. Empty = every task was already current.
+   */
+  rewrote: string[];
+}
+
+/**
+ * Self-heal the four scheduled tasks — the Windows analogue of systemd's
+ * `ensureSystemdUnitsCurrent`. For each task, query its registered XML; if the
+ * task is missing, or its command line no longer points at the current binary
+ * (the moved/updated-binary case), re-import it from the current template.
+ *
+ * Idempotent: a task that already references `binPath` is left untouched, so
+ * on a healthy box this is four cheap `/Query` calls and nothing else.
+ *
+ * Called on the heartbeat's regular cadence (see `defaultHealTaskScheduler` in
+ * cli/heartbeat.ts), so a long-running box that never restarts still re-checks
+ * every 30 minutes and repairs drift in place — matching the Linux experience
+ * where a moved binary would otherwise leave the tasks silently pointing at a
+ * path that no longer exists.
+ *
+ * Pure on its inputs (caller supplies the SID, temp dir and runner), so it
+ * unit-tests with a fake runner and no real schtasks.
+ */
+export async function ensureTasksCurrent(
+  opts: EnsureTasksCurrentOptions,
+): Promise<EnsureTasksCurrentResult> {
+  const sid = opts.sid ?? currentUserSid();
+  const xmlDir = opts.xmlDir ?? tmpdir();
+  const rewrote: string[] = [];
+  let ensuredDirs = false;
+
+  for (const spec of allTaskSpecs(sid, opts.binPath)) {
+    const q = await opts.schtasks.run(["/Query", "/TN", spec.name, "/XML"]);
+    const current =
+      q.exitCode === 0 && xmlReferencesBin(q.stdout, opts.binPath);
+    if (current) continue; // registered and already points at this binary
+
+    // Missing or drifted → re-import. Ensure the log + temp dirs exist first
+    // (a fresh box healing a never-installed task needs the logs dir before
+    // the task can first redirect into it), but only pay for it once.
+    if (!ensuredDirs) {
+      await mkdir(logsDir(), { recursive: true });
+      await mkdir(xmlDir, { recursive: true });
+      ensuredDirs = true;
+    }
+    const r = await importTaskSpec(spec, xmlDir, opts.schtasks);
+    if (r.exitCode === 0) rewrote.push(spec.name);
+  }
+
+  return { rewrote };
+}
+
+export interface TaskSchedulerServiceControl {
+  isActive(): Promise<boolean>;
+  restart(): Promise<{ ok: boolean; stderr?: string }>;
+  rerenderUnitIfStale(): Promise<{ rerendered: boolean; backupPath?: string }>;
+}
+
+/**
+ * Default TaskSchedulerServiceControl backed by real schtasks. Returns
+ * isActive=false on any error so callers can treat "task unknown" the same as
+ * "not running".
+ */
+export function defaultTaskSchedulerServiceControl(): TaskSchedulerServiceControl {
+  const runner = new BunSchtasksRunner();
+  return {
+    async isActive() {
+      // `schtasks /Query /TN <name>` exits 0 when the task is registered —
+      // the Task Scheduler analogue of a launchd unit being loaded.
+      const r = await runner.run(["/Query", "/TN", PHANTOMBOT_TASK]);
+      return r.exitCode === 0;
+    },
+    async restart() {
+      // End any running instance, then start a fresh one — the schtasks
+      // analogue of `systemctl restart`. /End on a stopped task is harmless.
+      await runner.run(["/End", "/TN", PHANTOMBOT_TASK]);
+      const r = await runner.run(["/Run", "/TN", PHANTOMBOT_TASK]);
+      return r.exitCode === 0
+        ? { ok: true }
+        : { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
+    },
+    async rerenderUnitIfStale() {
+      // Auto-heal a moved binary: if any registered task no longer references
+      // the current executable path, re-import them. Only meaningful when we
+      // ARE the compiled binary (dev `bun src/index.ts` shouldn't rewrite
+      // tasks), and only when an install already exists (don't provision tasks
+      // the user never asked for — mirrors the systemd `existsSync(unitPath)`
+      // guard).
+      const binPath = process.execPath;
+      if (!basename(binPath).startsWith("phantombot")) {
+        return { rerendered: false };
+      }
+      const installed = await runner.run(["/Query", "/TN", PHANTOMBOT_TASK]);
+      if (installed.exitCode !== 0) return { rerendered: false };
+      let sid: string;
+      try {
+        sid = currentUserSid();
+      } catch {
+        return { rerendered: false };
+      }
+      const r = await ensureTasksCurrent({ binPath, sid, schtasks: runner });
+      return { rerendered: r.rewrote.length > 0 };
+    },
+  };
+}
+
+/** Absolute path of the always-on task's stdout log (used for hint output). */
+export function taskSchedulerLogsHint(): string {
+  const { out } = taskLogPaths("phantombot");
+  return out;
+}

--- a/src/lib/updateNotify.ts
+++ b/src/lib/updateNotify.ts
@@ -46,6 +46,7 @@ import {
 import { log } from "./logger.ts";
 import {
   defaultServiceControl,
+  selfRestart,
   type ServiceControl,
 } from "./platform.ts";
 
@@ -321,7 +322,7 @@ export async function runUpdateFlow(
     return {
       reply:
         `can't self-update on this host: phantombot only ships binaries ` +
-        `for linux-x64, linux-arm64, and darwin-arm64 ` +
+        `for linux-x64, linux-arm64, darwin-arm64, windows-x64, and windows-arm64 ` +
         `(this machine reports platform=${procPlatform} arch=${procArch})`,
     };
   }
@@ -398,7 +399,11 @@ export async function runUpdateFlow(
   //    the flow used (matters for tests that inject a stub).
   const svc = input.serviceControl ?? defaultServiceControl();
   const restart = async (): Promise<void> => {
-    const r = await svc.restart();
+    // In-process restart: POSIX delegates to the supervisor; Windows exits
+    // cleanly and lets the keep-alive task relaunch from the swapped binary
+    // (see selfRestart — calling schtasks End/Run from our own task tree
+    // would race the relaunch).
+    const r = await selfRestart({ serviceControl: svc, procPlatform });
     if (!r.ok) {
       log.error("updateNotify: restart failed after binary swap", {
         stderr: r.stderr,

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -442,9 +442,10 @@ describe("/update", () => {
     // dispatcher doesn't accept seams. Instead, swap process.platform
     // briefly so the flow exits early at the platform check — far before
     // any network call. (Bun preserves the property descriptor; restore
-    // in finally.)
+    // in finally.) Use freebsd: win32 is a supported release target now,
+    // so it would proceed to a real network fetch instead of short-circuiting.
     const origPlatform = process.platform;
-    Object.defineProperty(process, "platform", { value: "win32" });
+    Object.defineProperty(process, "platform", { value: "freebsd" });
     try {
       const r = await handleSlashCommand(
         "/update",
@@ -452,7 +453,7 @@ describe("/update", () => {
       );
       expect(r).not.toBeNull();
       expect(r!.reply).toContain("can't self-update");
-      expect(r!.reply).toContain("platform=win32");
+      expect(r!.reply).toContain("platform=freebsd");
       // No restart callback when the flow short-circuits at the platform
       // check (nothing was installed, nothing to restart).
       expect(r!.afterSend).toBeUndefined();

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { rmrf } from "./fixtures/rmrf.ts";
 import { runHeartbeatCli } from "../src/cli/heartbeat.ts";
 import type { Config } from "../src/config.ts";
 import { heartbeatMarkerPath } from "../src/lib/timerHealth.ts";
@@ -52,7 +53,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await rm(workdir, { recursive: true, force: true });
+  await rmrf(workdir);
 });
 
 describe("runHeartbeatCli", () => {

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -15,6 +15,10 @@ import type {
   LaunchctlRunner,
 } from "../src/lib/launchd.ts";
 import type {
+  SchtasksResult,
+  SchtasksRunner,
+} from "../src/lib/taskScheduler.ts";
+import type {
   SystemctlResult,
   SystemctlRunner,
   UserSystemdEnv,
@@ -33,6 +37,15 @@ class FakeLaunchctl implements LaunchctlRunner {
   async run(args: readonly string[]): Promise<LaunchctlResult> {
     this.calls.push([...args]);
     return { exitCode: 0, stdout: "", stderr: "" };
+  }
+}
+
+class FakeSchtasks implements SchtasksRunner {
+  calls: string[][] = [];
+  responses: SchtasksResult[] = [];
+  async run(args: readonly string[]): Promise<SchtasksResult> {
+    this.calls.push([...args]);
+    return this.responses.shift() ?? { exitCode: 0, stdout: "", stderr: "" };
   }
 }
 
@@ -262,6 +275,103 @@ describe("runInstall (darwin/launchd)", () => {
     expect(code).toBe(2);
     expect(err.text).toContain("compiled binary");
     expect(lc.calls).toEqual([]);
+  });
+});
+
+describe("runInstall (windows/schtasks)", () => {
+  const WIN_BIN =
+    "C:\\Users\\andrew\\AppData\\Local\\phantombot\\bin\\phantombot.exe";
+
+  test("accepts the .exe binary and imports all four tasks", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const st = new FakeSchtasks();
+    const code = await runInstall({
+      binPath: WIN_BIN,
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err,
+      platform: "windows",
+    });
+    expect(code).toBe(0);
+    // Four /Create imports, one per task.
+    const creates = st.calls.filter((c) => c[0] === "/Create");
+    expect(creates.length).toBe(4);
+    expect(out.text).toContain("registered");
+    // The logged-in-only caveat is surfaced to the user.
+    expect(out.text).toContain("logged in");
+  });
+
+  test("doesn't fall through to systemctl or launchctl on windows", async () => {
+    const sys = new FakeSystemctl();
+    const lc = new FakeLaunchctl();
+    const st = new FakeSchtasks();
+    const code = await runInstall({
+      binPath: WIN_BIN,
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      systemctl: sys,
+      launchctl: lc,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      platform: "windows",
+    });
+    expect(code).toBe(0);
+    expect(sys.calls).toEqual([]);
+    expect(lc.calls).toEqual([]);
+  });
+
+  test("propagates a schtasks import failure as a non-zero exit", async () => {
+    const err = new CaptureStream();
+    const st = new FakeSchtasks();
+    st.responses = [{ exitCode: 1, stdout: "", stderr: "Access is denied" }];
+    const code = await runInstall({
+      binPath: WIN_BIN,
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err,
+      platform: "windows",
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("schtasks /Create");
+  });
+
+  test("rejects a non-phantombot binary on windows too", async () => {
+    const err = new CaptureStream();
+    const st = new FakeSchtasks();
+    const code = await runInstall({
+      binPath: "C:\\Program Files\\bun\\bun.exe",
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err,
+      platform: "windows",
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("compiled binary");
+    expect(st.calls).toEqual([]);
+  });
+});
+
+describe("runUninstall (windows/schtasks)", () => {
+  test("deletes all four tasks and reports complete", async () => {
+    const out = new CaptureStream();
+    const st = new FakeSchtasks();
+    const code = await runUninstall({
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+      platform: "windows",
+    });
+    expect(code).toBe(0);
+    const deletes = st.calls.filter((c) => c[0] === "/Delete");
+    expect(deletes.length).toBe(4);
+    expect(out.text).toContain("uninstall complete");
   });
 });
 

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -5,9 +5,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { rmrf } from "./fixtures/rmrf.ts";
 import { runInstall } from "../src/cli/install.ts";
 import { runUninstall } from "../src/cli/uninstall.ts";
 import type {
@@ -87,7 +88,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await rm(workdir, { recursive: true, force: true });
+  await rmrf(workdir);
 });
 
 const sysEnvReady = (): UserSystemdEnv => ({

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -345,6 +345,78 @@ describe("runUpdate on darwin-arm64", () => {
   });
 });
 
+describe("runUpdate on windows-x64", () => {
+  // On Windows the asset name carries a `.exe` suffix and the swap renames
+  // the running binary aside to `.exe.old` (rename-over is forbidden for a
+  // live .exe). Verify the right asset is fetched, `phantombot.exe` is
+  // accepted as a valid binary, and the rename-aside swap lands correctly.
+  const WIN_ASSET = "phantombot-v1.0.99-windows-x64.exe";
+  const WIN_BYTES = Buffer.from("WINDOWS_BINARY_VERIFIED");
+  const WIN_SHA = createHash("sha256").update(WIN_BYTES).digest("hex");
+
+  function windowsFetch(): typeof fetch {
+    const releaseBody = {
+      tag_name: "v1.0.99",
+      body: "test release",
+      assets: [
+        {
+          name: WIN_ASSET,
+          browser_download_url: "https://example/" + WIN_ASSET,
+          size: WIN_BYTES.byteLength,
+        },
+        {
+          name: "phantombot-v1.0.99-linux-x64",
+          browser_download_url: "https://example/linux-x64",
+          size: WIN_BYTES.byteLength,
+        },
+        {
+          name: "SHA256SUMS",
+          browser_download_url: "https://example/SHA256SUMS",
+          size: 256,
+        },
+      ],
+    };
+    return (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (isGitHubApiUrl(u)) {
+        return new Response(JSON.stringify(releaseBody), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (u.includes("SHA256SUMS")) {
+        return new Response(`${WIN_SHA}  ${WIN_ASSET}\n`, { status: 200 });
+      }
+      return new Response(WIN_BYTES, { status: 200 });
+    }) as unknown as typeof fetch;
+  }
+
+  test("accepts phantombot.exe, picks the .exe asset, renames the old binary aside", async () => {
+    const winBin = join(workdir, "phantombot.exe");
+    await writeFile(winBin, "OLD_BINARY", { mode: 0o755 });
+    const out = new CaptureStream();
+    const code = await runUpdate({
+      binPath: winBin,
+      procPlatform: "win32",
+      procArch: "x64",
+      currentVersion: "1.0.42",
+      fetchImpl: windowsFetch(),
+      out,
+      err: new CaptureStream(),
+      force: true,
+      healSystemdUnits: false,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("phantombot-v1.0.99-windows-x64.exe");
+    // New binary in place; previous one preserved as .old for startup cleanup.
+    expect((await readFile(winBin)).equals(WIN_BYTES)).toBe(true);
+    expect(await readFile(`${winBin}.old`, "utf8")).toBe("OLD_BINARY");
+    // No POSIX .bak left behind.
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(`${winBin}.bak`)).toBe(false);
+  });
+});
+
 describe("runUpdate happy path with --force --restart", () => {
   test("downloads, verifies, swaps, restarts — the full cron contract", async () => {
     const out = new CaptureStream();

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,9 +6,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { rmrf } from "./fixtures/rmrf.ts";
 import {
   DEFAULT_GRAPH_EXPANSION,
   DEFAULT_RETRIEVAL,
@@ -89,7 +90,7 @@ afterEach(async () => {
     if (SAVED_ENV[k] === undefined) delete process.env[k];
     else process.env[k] = SAVED_ENV[k];
   }
-  await rm(workdir, { recursive: true, force: true });
+  await rmrf(workdir);
 });
 
 describe("loadConfig — defaults (no file)", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -428,7 +428,9 @@ describe("personaDir", () => {
   test("joins personasDir + name", async () => {
     process.env.PHANTOMBOT_PERSONAS_DIR = "/tmp/personas";
     const c = await loadConfig();
-    expect(personaDir(c, "robbie")).toBe("/tmp/personas/robbie");
+    // Build the expectation with the host path.join so the separator is right
+    // on Windows (backslash) as well as POSIX.
+    expect(personaDir(c, "robbie")).toBe(join("/tmp/personas", "robbie"));
   });
 });
 

--- a/tests/fixtures/rmrf.ts
+++ b/tests/fixtures/rmrf.ts
@@ -16,8 +16,13 @@ import { rm } from "node:fs/promises";
  */
 export async function rmrf(
   path: string,
-  attempts = 20,
-  delayMs = 50,
+  // Generous headroom: a suite that fans a migration into several personas
+  // leaves multiple bun:sqlite Database objects awaiting finalization, and a
+  // single gc()+retry occasionally isn't enough to release every handle. The
+  // fast path (POSIX, or a dir with no lingering handle) still returns on the
+  // first attempt, so the ceiling only costs time in the rare busy case.
+  attempts = 50,
+  delayMs = 100,
 ): Promise<void> {
   const gc = (globalThis as { Bun?: { gc?: (sync: boolean) => void } }).Bun?.gc;
   for (let i = 0; ; i++) {

--- a/tests/fixtures/rmrf.ts
+++ b/tests/fixtures/rmrf.ts
@@ -1,0 +1,37 @@
+import { rm } from "node:fs/promises";
+
+/**
+ * Recursively remove a directory, retrying on Windows EBUSY/EPERM/ENOTEMPTY.
+ *
+ * Three facts force this helper's shape:
+ *   1. On Windows, bun:sqlite releases the vault.sqlite file handle only when
+ *      the Database object is FINALIZED by the GC — not synchronously on
+ *      close(). Until then an rm of the enclosing temp dir throws EBUSY.
+ *   2. That finalizer won't run on its own during a tight retry loop, so we
+ *      force it with Bun.gc(true) before each attempt (empirically this drops
+ *      the release latency from ~100ms of hoping-for-a-GC to 0ms).
+ *   3. Bun's fs.rm IGNORES Node's maxRetries/retryDelay options, so we retry by
+ *      hand rather than leaning on them.
+ * On POSIX the first attempt succeeds and the gc()/retry machinery is inert.
+ */
+export async function rmrf(
+  path: string,
+  attempts = 20,
+  delayMs = 50,
+): Promise<void> {
+  const gc = (globalThis as { Bun?: { gc?: (sync: boolean) => void } }).Bun?.gc;
+  for (let i = 0; ; i++) {
+    try {
+      // Run finalizers so any just-closed bun:sqlite handle is released.
+      gc?.(true);
+      await rm(path, { recursive: true, force: true });
+      return;
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      const retryable =
+        code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY";
+      if (!retryable || i >= attempts - 1) throw e;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+}

--- a/tests/lib-binaryUpdate.test.ts
+++ b/tests/lib-binaryUpdate.test.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import {
   applyUpdate,
   checkWritable,
+  cleanupStaleUpdateArtifacts,
   downloadAndVerify,
   parseSha256SumsLine,
 } from "../src/lib/binaryUpdate.ts";
@@ -217,5 +218,102 @@ describe("checkWritable", () => {
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.reason).toContain("doesn't exist");
+  });
+});
+
+describe("applyUpdate on Windows (rename-aside swap)", () => {
+  test("moves the running binary to .old and installs the new one", async () => {
+    const target = join(workdir, "phantombot.exe");
+    const tmp = join(workdir, "phantombot.exe.update.tmp");
+    await writeFile(target, "OLD", { mode: 0o755 });
+    await writeFile(tmp, "NEW", { mode: 0o755 });
+
+    const r = await applyUpdate({
+      tempPath: tmp,
+      targetPath: target,
+      procPlatform: "win32",
+    });
+    expect(r.ok).toBe(true);
+    // New binary is in place…
+    expect(await readFile(target, "utf8")).toBe("NEW");
+    // …and the previous one is preserved as .old (Windows can't delete a
+    // running .exe; startup cleanup removes it after the process exits).
+    expect(await readFile(`${target}.old`, "utf8")).toBe("OLD");
+    // The temp file was consumed by the rename.
+    expect(existsSync(tmp)).toBe(false);
+  });
+
+  test("does not use the POSIX .bak path on win32", async () => {
+    const target = join(workdir, "phantombot.exe");
+    const tmp = join(workdir, "phantombot.exe.update.tmp");
+    await writeFile(target, "OLD", { mode: 0o755 });
+    await writeFile(tmp, "NEW", { mode: 0o755 });
+    await applyUpdate({ tempPath: tmp, targetPath: target, procPlatform: "win32" });
+    expect(existsSync(`${target}.bak`)).toBe(false);
+  });
+
+  test("falls back to a timestamped .old when a stale .old is present", async () => {
+    const target = join(workdir, "phantombot.exe");
+    const tmp = join(workdir, "phantombot.exe.update.tmp");
+    await writeFile(target, "OLD", { mode: 0o755 });
+    await writeFile(tmp, "NEW", { mode: 0o755 });
+    // A stale .old from a prior update (in reality it would be removable;
+    // here we just confirm the swap still succeeds and the new binary lands).
+    await writeFile(`${target}.old`, "STALE", { mode: 0o755 });
+
+    const r = await applyUpdate({
+      tempPath: tmp,
+      targetPath: target,
+      procPlatform: "win32",
+    });
+    expect(r.ok).toBe(true);
+    expect(await readFile(target, "utf8")).toBe("NEW");
+  });
+
+  test("errors (does not touch target) when temp file is missing", async () => {
+    const target = join(workdir, "phantombot.exe");
+    await writeFile(target, "OLD", { mode: 0o755 });
+    const r = await applyUpdate({
+      tempPath: join(workdir, "phantombot.exe.update.tmp"),
+      targetPath: target,
+      procPlatform: "win32",
+    });
+    expect(r.ok).toBe(false);
+    // The live binary is untouched — no half-applied swap.
+    expect(await readFile(target, "utf8")).toBe("OLD");
+    expect(existsSync(`${target}.old`)).toBe(false);
+  });
+});
+
+describe("cleanupStaleUpdateArtifacts", () => {
+  test("removes .old and timestamped .old next to the binary (win32)", async () => {
+    const target = join(workdir, "phantombot.exe");
+    await writeFile(target, "LIVE", { mode: 0o755 });
+    await writeFile(`${target}.old`, "x");
+    await writeFile(`${target}.1720000000000.old`, "x");
+    // Unrelated files must survive.
+    await writeFile(join(workdir, "phantombot.exe.update.tmp"), "x");
+    await writeFile(join(workdir, "notes.old"), "x");
+
+    const removed = await cleanupStaleUpdateArtifacts(target, "win32");
+    expect(removed.sort()).toEqual(
+      ["phantombot.exe.1720000000000.old", "phantombot.exe.old"].sort(),
+    );
+    expect(existsSync(`${target}.old`)).toBe(false);
+    expect(existsSync(`${target}.1720000000000.old`)).toBe(false);
+    // The live binary and unrelated files are left alone.
+    expect(existsSync(target)).toBe(true);
+    expect(existsSync(join(workdir, "phantombot.exe.update.tmp"))).toBe(true);
+    expect(existsSync(join(workdir, "notes.old"))).toBe(true);
+  });
+
+  test("is a no-op on POSIX platforms", async () => {
+    const target = join(workdir, "phantombot");
+    await writeFile(target, "LIVE", { mode: 0o755 });
+    await writeFile(`${target}.old`, "x");
+    const removed = await cleanupStaleUpdateArtifacts(target, "linux");
+    expect(removed).toEqual([]);
+    // Nothing deleted on POSIX (rename-over leaves no .old to clean).
+    expect(existsSync(`${target}.old`)).toBe(true);
   });
 });

--- a/tests/lib-githubReleases.test.ts
+++ b/tests/lib-githubReleases.test.ts
@@ -6,7 +6,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   detectSupportedArch,
+  detectSupportedTarget,
   findLatestRelease,
+  releaseAssetName,
 } from "../src/lib/githubReleases.ts";
 
 const SAVED_ENV = {
@@ -99,6 +101,44 @@ describe("detectSupportedArch", () => {
   });
 });
 
+describe("detectSupportedTarget", () => {
+  test("linux x64/arm64", () => {
+    expect(detectSupportedTarget("linux", "x64")).toBe("linux-x64");
+    expect(detectSupportedTarget("linux", "arm64")).toBe("linux-arm64");
+  });
+  test("darwin arm64 only (no intel mac build)", () => {
+    expect(detectSupportedTarget("darwin", "arm64")).toBe("darwin-arm64");
+    expect(detectSupportedTarget("darwin", "x64")).toBeUndefined();
+  });
+  test("windows x64/arm64", () => {
+    expect(detectSupportedTarget("win32", "x64")).toBe("windows-x64");
+    expect(detectSupportedTarget("win32", "arm64")).toBe("windows-arm64");
+  });
+  test("unsupported platform/arch → undefined", () => {
+    expect(detectSupportedTarget("freebsd", "x64")).toBeUndefined();
+    expect(detectSupportedTarget("win32", "ia32")).toBeUndefined();
+  });
+});
+
+describe("releaseAssetName", () => {
+  test("POSIX targets are extensionless", () => {
+    expect(releaseAssetName("v1.2.3", "linux-x64")).toBe(
+      "phantombot-v1.2.3-linux-x64",
+    );
+    expect(releaseAssetName("v1.2.3", "darwin-arm64")).toBe(
+      "phantombot-v1.2.3-darwin-arm64",
+    );
+  });
+  test("windows targets carry the .exe suffix", () => {
+    expect(releaseAssetName("v1.2.3", "windows-x64")).toBe(
+      "phantombot-v1.2.3-windows-x64.exe",
+    );
+    expect(releaseAssetName("v1.2.3", "windows-arm64")).toBe(
+      "phantombot-v1.2.3-windows-arm64.exe",
+    );
+  });
+});
+
 describe("findLatestRelease", () => {
   test("picks the x64 binary + SHA256SUMS, strips leading v from version", async () => {
     const r = await findLatestRelease({
@@ -125,6 +165,31 @@ describe("findLatestRelease", () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.release.binary.name).toBe("phantombot-v1.0.43-linux-arm64");
+  });
+
+  test("resolves the .exe asset for a windows target", async () => {
+    const withWindows = {
+      ...SAMPLE_RELEASE,
+      assets: [
+        ...SAMPLE_RELEASE.assets,
+        {
+          name: "phantombot-v1.0.43-windows-x64.exe",
+          browser_download_url:
+            "https://example/phantombot-v1.0.43-windows-x64.exe",
+          size: 90_000_000,
+        },
+      ],
+    };
+    const r = await findLatestRelease({
+      target: "windows-x64",
+      fetchImpl: fakeFetch(200, withWindows),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.release.binary.name).toBe("phantombot-v1.0.43-windows-x64.exe");
+    expect(r.release.binary.url).toBe(
+      "https://example/phantombot-v1.0.43-windows-x64.exe",
+    );
   });
 
   test("errors when the right-arch asset is absent", async () => {

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -390,9 +390,14 @@ describe("runHeartbeat update check hook", () => {
       lastNotifiedPath: join(workdir, "last-notified"),
     });
     // The heartbeat itself succeeded — promotions/staleness/index work
-    // happened. The update-check result records the failure but doesn't
-    // bubble it up.
-    expect(r.updateCheck?.status).toBe("release_check_failed");
+    // happened. The update-check result records the outcome but never bubbles
+    // it up. On Linux/macOS a published release target exists, so the failing
+    // fetch surfaces as release_check_failed. On Windows there is no release
+    // target yet, so the check no-targets *before* it ever calls fetch — a
+    // different status, but the same invariant: the heartbeat did not fail.
+    const expectedStatus =
+      process.platform === "win32" ? "no_target" : "release_check_failed";
+    expect(r.updateCheck?.status).toBe(expectedStatus);
     expect(r.ranAt).toBeDefined();
   });
 });

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -391,13 +391,10 @@ describe("runHeartbeat update check hook", () => {
     });
     // The heartbeat itself succeeded — promotions/staleness/index work
     // happened. The update-check result records the outcome but never bubbles
-    // it up. On Linux/macOS a published release target exists, so the failing
-    // fetch surfaces as release_check_failed. On Windows there is no release
-    // target yet, so the check no-targets *before* it ever calls fetch — a
-    // different status, but the same invariant: the heartbeat did not fail.
-    const expectedStatus =
-      process.platform === "win32" ? "no_target" : "release_check_failed";
-    expect(r.updateCheck?.status).toBe(expectedStatus);
+    // it up. Every shipped platform (linux/darwin/windows) now has a published
+    // release target, so the failing fetch surfaces as release_check_failed on
+    // all of them — the invariant is that the heartbeat itself did not fail.
+    expect(r.updateCheck?.status).toBe("release_check_failed");
     expect(r.ranAt).toBeDefined();
   });
 });

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -3,9 +3,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { rmrf } from "./fixtures/rmrf.ts";
 import {
   checkStaleness,
   extractRecentSection,
@@ -25,7 +26,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await rm(workdir, { recursive: true, force: true });
+  await rmrf(workdir);
 });
 
 async function file(rel: string, content: string) {

--- a/tests/lib-platform.test.ts
+++ b/tests/lib-platform.test.ts
@@ -13,7 +13,9 @@ import {
   defaultServiceControl,
   logsCommand,
   restartCommand,
+  selfRestart,
   statusCommand,
+  type ServiceControl,
 } from "../src/lib/platform.ts";
 
 describe("currentPlatform", () => {
@@ -67,5 +69,54 @@ describe("defaultServiceControl", () => {
     // We don't care what it returns; we care that it doesn't blow up
     // when no service-manager bus is available (e.g. CI containers).
     await expect(svc.isActive()).resolves.toBeDefined();
+  });
+});
+
+describe("selfRestart", () => {
+  function trackingSvc(result: { ok: boolean; stderr?: string } = { ok: true }) {
+    const calls: number[] = [];
+    const svc: ServiceControl = {
+      async isActive() {
+        return true;
+      },
+      async restart() {
+        calls.push(1);
+        return result;
+      },
+      async rerenderUnitIfStale() {
+        return { rerendered: false };
+      },
+    };
+    return { svc, calls };
+  }
+
+  test("POSIX: delegates to the supervisor's restart()", async () => {
+    const { svc, calls } = trackingSvc({ ok: true });
+    const r = await selfRestart({ serviceControl: svc, procPlatform: "linux" });
+    expect(r.ok).toBe(true);
+    expect(calls.length).toBe(1);
+  });
+
+  test("POSIX: surfaces a failed supervisor restart", async () => {
+    const { svc } = trackingSvc({ ok: false, stderr: "boom" });
+    const r = await selfRestart({ serviceControl: svc, procPlatform: "darwin" });
+    expect(r.ok).toBe(false);
+    expect(r.stderr).toBe("boom");
+  });
+
+  test("Windows: triggers a clean exit and never calls schtasks restart()", async () => {
+    const { svc, calls } = trackingSvc({ ok: true });
+    let shutdowns = 0;
+    const r = await selfRestart({
+      serviceControl: svc,
+      procPlatform: "win32",
+      triggerShutdown: () => {
+        shutdowns++;
+      },
+    });
+    expect(r.ok).toBe(true);
+    // The keep-alive relaunches us; we must NOT End/Run our own task tree.
+    expect(calls.length).toBe(0);
+    expect(shutdowns).toBe(1);
   });
 });

--- a/tests/lib-platform.test.ts
+++ b/tests/lib-platform.test.ts
@@ -17,14 +17,15 @@ import {
 } from "../src/lib/platform.ts";
 
 describe("currentPlatform", () => {
-  test("returns linux/darwin/unsupported only", () => {
+  test("returns linux/darwin/windows/unsupported only", () => {
     const p = currentPlatform();
-    expect(["linux", "darwin", "unsupported"]).toContain(p);
+    expect(["linux", "darwin", "windows", "unsupported"]).toContain(p);
   });
 
-  test("matches process.platform when it's one of the supported pair", () => {
+  test("matches process.platform for each supported platform", () => {
     if (process.platform === "linux") expect(currentPlatform()).toBe("linux");
     if (process.platform === "darwin") expect(currentPlatform()).toBe("darwin");
+    if (process.platform === "win32") expect(currentPlatform()).toBe("windows");
   });
 });
 

--- a/tests/lib-platform.test.ts
+++ b/tests/lib-platform.test.ts
@@ -44,6 +44,14 @@ describe("hint commands shape per platform", () => {
     expect(statusCommand()).toContain("launchctl print");
     expect(logsCommand()).toContain("Library/Logs/phantombot");
   });
+
+  test("on windows: schtasks strings", () => {
+    if (process.platform !== "win32") return;
+    expect(restartCommand()).toContain("schtasks /Run /TN");
+    expect(restartCommand()).toContain("\\Phantombot\\phantombot");
+    expect(statusCommand()).toContain("schtasks /Query /TN");
+    expect(logsCommand()).toContain("phantombot\\logs\\phantombot.out.log");
+  });
 });
 
 describe("defaultServiceControl", () => {

--- a/tests/lib-processGroup.test.ts
+++ b/tests/lib-processGroup.test.ts
@@ -13,11 +13,21 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
+import { delimiter, dirname } from "node:path";
 import {
   killProcessGroup,
   spawnInNewSession,
   withCommandDirOnPath,
 } from "../src/lib/processGroup.ts";
+
+// The spawn/kill tests below drive real POSIX subprocesses (`sleep`, `sh -c`,
+// `#!/usr/bin/env node` shebangs) and the negative-pid group signal — none of
+// which exist on Windows, where the equivalent path is taskkill /T (covered by
+// its own Windows-only test at the bottom). Skip the POSIX-model suites on
+// Windows rather than assert against a process model that isn't there.
+const isWin = process.platform === "win32";
+const describePosix = isWin ? describe.skip : describe;
+const describeWin = isWin ? describe : describe.skip;
 
 function isAlive(pid: number): boolean {
   try {
@@ -86,7 +96,7 @@ afterEach(() => {
   trackedPids.length = 0;
 });
 
-describe("spawnInNewSession", () => {
+describePosix("spawnInNewSession", () => {
   test("starts the binary with the same pid==pgid (the kill-the-group precondition)", async () => {
     // We can't observe pgid directly without /proc, but we CAN verify
     // that the process started and is reachable via its own pid.
@@ -106,7 +116,7 @@ describe("spawnInNewSession", () => {
   });
 });
 
-describe("killProcessGroup — orphan grandchild fix", () => {
+describePosix("killProcessGroup — orphan grandchild fix", () => {
   test("SIGTERM to the group reaps both parent AND grandchild", async () => {
     // Shell spawns a backgrounded sleep, prints its pid, then waits.
     // Without process-group kill, killing the shell would leave the
@@ -139,7 +149,7 @@ describe("killProcessGroup — orphan grandchild fix", () => {
   });
 });
 
-describe("killProcessGroup — SIGTERM→SIGKILL escalation", () => {
+describePosix("killProcessGroup — SIGTERM→SIGKILL escalation", () => {
   test("escalates to SIGKILL when SIGTERM is trapped/ignored", async () => {
     // Use a Bun process that registers a no-op SIGTERM handler so the
     // signal is delivered but the process keeps running. Only SIGKILL
@@ -194,20 +204,26 @@ describe("killProcessGroup — SIGTERM→SIGKILL escalation", () => {
   });
 });
 
+// These are pure string tests with no subprocess, so they run on every
+// platform. We build expected PATHs from the host's `path.delimiter`
+// (":" on POSIX, ";" on Windows) and `path.dirname` — the same primitives
+// withCommandDirOnPath uses — so the assertions hold on both without
+// hardcoding a POSIX separator.
 describe("withCommandDirOnPath — shebang interpreter resolution", () => {
   test("prepends an absolute binary's own dir to PATH", () => {
-    const out = withCommandDirOnPath("/opt/nvm/versions/node/v24/bin/pi", {
-      PATH: "/usr/bin:/bin",
-    });
-    expect(out.PATH).toBe("/opt/nvm/versions/node/v24/bin:/usr/bin:/bin");
+    const bin = "/opt/nvm/versions/node/v24/bin/pi";
+    const before = ["/usr/bin", "/bin"].join(delimiter);
+    const out = withCommandDirOnPath(bin, { PATH: before });
+    expect(out.PATH).toBe([dirname(bin), before].join(delimiter));
   });
 
   test("is a no-op when the dir is already on PATH", () => {
-    const env = { PATH: "/opt/nvm/versions/node/v24/bin:/usr/bin" };
-    const out = withCommandDirOnPath("/opt/nvm/versions/node/v24/bin/pi", env);
+    const bin = "/opt/nvm/versions/node/v24/bin/pi";
+    const env = { PATH: [dirname(bin), "/usr/bin"].join(delimiter) };
+    const out = withCommandDirOnPath(bin, env);
     // Same object reference back — nothing to change, no needless clone churn.
     expect(out).toBe(env);
-    expect(out.PATH).toBe("/opt/nvm/versions/node/v24/bin:/usr/bin");
+    expect(out.PATH).toBe([dirname(bin), "/usr/bin"].join(delimiter));
   });
 
   test("handles an empty/absent PATH by seeding it with the bin dir", () => {
@@ -236,7 +252,33 @@ describe("withCommandDirOnPath — shebang interpreter resolution", () => {
   });
 });
 
-describe("spawnInNewSession — shebang interpreter on a narrow PATH", () => {
+describeWin("killProcessGroup — Windows taskkill tree", () => {
+  test("force-terminates a spawned console process tree via taskkill /T /F", async () => {
+    // Windows analog of the orphan-grandchild test: `cmd /c ping -n 60` spawns
+    // a child ping and blocks for ~60s. killProcessGroup must bring the whole
+    // tree down with `taskkill /T /F` and resolve. Regression guard for the
+    // exit-128 bug: `taskkill /T` WITHOUT /F returns 128 on a live console
+    // tree, which we previously misread as "already gone" and then hung on
+    // proc.exited. This must complete promptly, not sit out the grace window.
+    const proc = spawnInNewSession(
+      ["cmd", "/c", "ping -n 60 127.0.0.1 >NUL"],
+      { stdin: "ignore", stdout: "ignore", stderr: "ignore" },
+    );
+    trackedPids.push(proc.pid!);
+    expect(isAlive(proc.pid!)).toBe(true);
+
+    const start = Date.now();
+    await killProcessGroup(proc, 2000);
+    const elapsedMs = Date.now() - start;
+
+    // A forced kill resolves proc.exited well inside the grace window, so this
+    // returns fast rather than waiting out the full 2s.
+    expect(elapsedMs).toBeLessThan(2000);
+    expect(isAlive(proc.pid!)).toBe(false);
+  }, 15000);
+});
+
+describePosix("spawnInNewSession — shebang interpreter on a narrow PATH", () => {
   test("a #!/usr/bin/env node script beside its interpreter runs with a stripped PATH", async () => {
     // Reproduce the systemd exit-127 bug in miniature: put a Node-shebang
     // script in the SAME dir as a `node` symlink, then spawn it with a PATH
@@ -269,7 +311,7 @@ describe("spawnInNewSession — shebang interpreter on a narrow PATH", () => {
   });
 });
 
-describe("killProcessGroup — already-dead handling", () => {
+describePosix("killProcessGroup — already-dead handling", () => {
   test("safe to call after the process has already exited", async () => {
     const proc = spawnInNewSession(["true"], {
       stdin: "ignore",

--- a/tests/lib-runLock.test.ts
+++ b/tests/lib-runLock.test.ts
@@ -121,19 +121,26 @@ describe("defaultLockPath", () => {
     const saved = process.env.XDG_RUNTIME_DIR;
     process.env.XDG_RUNTIME_DIR = "/run/user/1003";
     try {
-      expect(defaultLockPath()).toBe("/run/user/1003/phantombot.run.lock");
+      // Build the expectation with the host's path.join so the separator is
+      // correct on Windows too (XDG_RUNTIME_DIR still wins if it's set there).
+      expect(defaultLockPath()).toBe(join("/run/user/1003", "phantombot.run.lock"));
     } finally {
       if (saved === undefined) delete process.env.XDG_RUNTIME_DIR;
       else process.env.XDG_RUNTIME_DIR = saved;
     }
   });
 
-  test("falls back to /tmp/phantombot-<uid>.run.lock when XDG_RUNTIME_DIR is unset", () => {
+  test("falls back to a per-user temp path when XDG_RUNTIME_DIR is unset", () => {
     const saved = process.env.XDG_RUNTIME_DIR;
     delete process.env.XDG_RUNTIME_DIR;
     try {
-      const uid = process.getuid?.() ?? 0;
-      expect(defaultLockPath()).toBe(`/tmp/phantombot-${uid}.run.lock`);
+      if (process.platform === "win32") {
+        // Windows has no uid and no /tmp — the lock lives in per-user %TEMP%.
+        expect(defaultLockPath()).toBe(join(tmpdir(), "phantombot.run.lock"));
+      } else {
+        const uid = process.getuid?.() ?? 0;
+        expect(defaultLockPath()).toBe(`/tmp/phantombot-${uid}.run.lock`);
+      }
     } finally {
       if (saved !== undefined) process.env.XDG_RUNTIME_DIR = saved;
     }

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -7,9 +7,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { rmrf } from "./fixtures/rmrf.ts";
 
 import {
   buildCmdArguments,
@@ -58,7 +59,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await rm(workdir, { recursive: true, force: true });
+  await rmrf(workdir);
 });
 
 describe("buildCmdArguments", () => {

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for Windows Task Scheduler XML generation + install/uninstall logic.
+ * Uses a fake SchtasksRunner that records every invocation, so we don't need
+ * actual schtasks.exe on the test host (and so these tests pass on Linux CI).
+ * The XML is generated as a plain string regardless of platform, so all of
+ * these run everywhere.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildCmdArguments,
+  ensureTasksCurrent,
+  generateHeartbeatTaskXml,
+  generateNightlyTaskXml,
+  generatePhantombotTaskXml,
+  generateTickTaskXml,
+  installPhantombotTasks,
+  type SchtasksResult,
+  type SchtasksRunner,
+  uninstallPhantombotTasks,
+  HEARTBEAT_TASK,
+  NIGHTLY_TASK,
+  PHANTOMBOT_TASK,
+  TICK_TASK,
+} from "../src/lib/taskScheduler.ts";
+
+const SID = "S-1-5-21-1111111111-2222222222-3333333333-1001";
+const BIN = "C:\\Users\\andrew\\AppData\\Local\\phantombot\\bin\\phantombot.exe";
+
+class FakeSchtasks implements SchtasksRunner {
+  calls: string[][] = [];
+  responses: SchtasksResult[] = [];
+  async run(args: readonly string[]): Promise<SchtasksResult> {
+    this.calls.push([...args]);
+    return this.responses.shift() ?? { exitCode: 0, stdout: "", stderr: "" };
+  }
+}
+
+class CaptureStream {
+  chunks: string[] = [];
+  write(s: string | Uint8Array): boolean {
+    this.chunks.push(typeof s === "string" ? s : new TextDecoder().decode(s));
+    return true;
+  }
+  get text(): string {
+    return this.chunks.join("");
+  }
+}
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-schtasks-"));
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("buildCmdArguments", () => {
+  test("wraps the binary + redirects both streams, doubling the outer quotes", () => {
+    const args = buildCmdArguments(
+      BIN,
+      ["run"],
+      "C:\\logs\\phantombot.out.log",
+      "C:\\logs\\phantombot.err.log",
+    );
+    // cmd's rule: the whole payload after /c is wrapped in one more quote pair.
+    expect(args).toBe(
+      `/c ""${BIN}" run 1>>"C:\\logs\\phantombot.out.log" 2>>"C:\\logs\\phantombot.err.log""`,
+    );
+  });
+});
+
+describe("generatePhantombotTaskXml", () => {
+  const xml = generatePhantombotTaskXml(SID, BIN);
+
+  test("is a Task Scheduler 1.2 document with the right URI", () => {
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-16"?>');
+    expect(xml).toContain(
+      '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">',
+    );
+    expect(xml).toContain(`<URI>${PHANTOMBOT_TASK}</URI>`);
+  });
+
+  test("runs as the current user by SID, only while logged in, no elevation", () => {
+    expect(xml).toContain(`<UserId>${SID}</UserId>`);
+    expect(xml).toContain("<LogonType>InteractiveToken</LogonType>");
+    expect(xml).toContain("<RunLevel>LeastPrivilege</RunLevel>");
+  });
+
+  test("keep-alive: logon trigger + 1-minute repeat + IgnoreNew, unlimited runtime", () => {
+    expect(xml).toContain("<LogonTrigger>");
+    expect(xml).toContain("<Interval>PT1M</Interval>");
+    expect(xml).toContain(
+      "<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>",
+    );
+    expect(xml).toContain("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>");
+    expect(xml).toContain("<RestartOnFailure>");
+  });
+
+  test("action routes through cmd.exe so stdout/stderr are logged", () => {
+    expect(xml).toContain("<Command>cmd.exe</Command>");
+    expect(xml).toContain("phantombot.out.log");
+    expect(xml).toContain("phantombot.err.log");
+    // The `>` of the redirection must be XML-escaped inside <Arguments>.
+    expect(xml).toContain("1&gt;&gt;");
+    expect(xml).toContain("2&gt;&gt;");
+    // ...and the raw unescaped operator must NOT appear.
+    expect(xml).not.toContain("1>>");
+  });
+});
+
+describe("companion task schedules", () => {
+  test("heartbeat repeats every 30 minutes", () => {
+    const xml = generateHeartbeatTaskXml(SID, BIN);
+    expect(xml).toContain(`<URI>${HEARTBEAT_TASK}</URI>`);
+    expect(xml).toContain("<Interval>PT30M</Interval>");
+    expect(xml).toContain("heartbeat.out.log");
+    expect(xml).not.toContain("<RestartOnFailure>");
+  });
+
+  test("nightly fires daily at 02:00 (calendar trigger)", () => {
+    const xml = generateNightlyTaskXml(SID, BIN);
+    expect(xml).toContain(`<URI>${NIGHTLY_TASK}</URI>`);
+    expect(xml).toContain("<CalendarTrigger>");
+    expect(xml).toContain("<ScheduleByDay>");
+    expect(xml).toContain("<DaysInterval>1</DaysInterval>");
+    expect(xml).toContain("2020-01-01T02:00:00");
+  });
+
+  test("tick repeats every minute", () => {
+    const xml = generateTickTaskXml(SID, BIN);
+    expect(xml).toContain(`<URI>${TICK_TASK}</URI>`);
+    expect(xml).toContain("<Interval>PT1M</Interval>");
+    expect(xml).toContain("tick.out.log");
+  });
+});
+
+describe("XML escaping", () => {
+  test("ampersands and angle brackets in the bin path become entities", () => {
+    const xml = generatePhantombotTaskXml(SID, "C:\\odd&path\\<bot>.exe");
+    expect(xml).toContain("C:\\odd&amp;path\\&lt;bot&gt;.exe");
+  });
+});
+
+describe("installPhantombotTasks", () => {
+  test("imports all four tasks with /F, in main→companions order", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const st = new FakeSchtasks();
+    const result = await installPhantombotTasks({
+      binPath: BIN,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err,
+    });
+    expect(result.installed).toBe(true);
+
+    const seq = st.calls.map((c) => c.join(" "));
+    expect(seq).toEqual([
+      `/Create /TN ${PHANTOMBOT_TASK} /XML ${join(workdir, "phantombot-task-phantombot.xml")} /F`,
+      `/Create /TN ${HEARTBEAT_TASK} /XML ${join(workdir, "phantombot-task-heartbeat.xml")} /F`,
+      `/Create /TN ${NIGHTLY_TASK} /XML ${join(workdir, "phantombot-task-nightly.xml")} /F`,
+      `/Create /TN ${TICK_TASK} /XML ${join(workdir, "phantombot-task-tick.xml")} /F`,
+    ]);
+    expect(out.text).toContain("registered");
+  });
+
+  test("transient XML import files are cleaned up after import", async () => {
+    const { existsSync } = await import("node:fs");
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const st = new FakeSchtasks();
+    await installPhantombotTasks({
+      binPath: BIN,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err,
+    });
+    expect(existsSync(join(workdir, "phantombot-task-phantombot.xml"))).toBe(
+      false,
+    );
+    expect(existsSync(join(workdir, "phantombot-task-tick.xml"))).toBe(false);
+  });
+
+  test("XML is written as UTF-16LE with a BOM (schtasks import requirement)", async () => {
+    const { readFileSync } = await import("node:fs");
+    // The runner sees the file at import time — exactly when schtasks.exe
+    // would — before install cleans up the transient. Capture its first bytes.
+    let firstBytes: Buffer | undefined;
+    const st: SchtasksRunner = {
+      async run(args: readonly string[]): Promise<SchtasksResult> {
+        const i = args.indexOf("/XML");
+        if (i >= 0 && firstBytes === undefined) {
+          firstBytes = readFileSync(args[i + 1]!);
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    };
+    await installPhantombotTasks({
+      binPath: BIN,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(firstBytes?.[0]).toBe(0xff);
+    expect(firstBytes?.[1]).toBe(0xfe);
+  });
+
+  test("fails install (and reports) when a /Create returns non-zero", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const st = new FakeSchtasks();
+    st.responses = [{ exitCode: 1, stdout: "", stderr: "Access is denied" }];
+    const result = await installPhantombotTasks({
+      binPath: BIN,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err,
+    });
+    expect(result.installed).toBe(false);
+    expect(err.text).toContain("schtasks /Create");
+    expect(err.text).toContain("Access is denied");
+    // Bailed after the first failure — no companion imports attempted.
+    expect(st.calls.length).toBe(1);
+  });
+});
+
+describe("uninstallPhantombotTasks", () => {
+  test("deletes each task with /F in reverse (companions→main) order", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const st = new FakeSchtasks();
+    const result = await uninstallPhantombotTasks({ schtasks: st, out, err });
+    expect(result.removed).toBe(true);
+    expect(st.calls.map((c) => c.join(" "))).toEqual([
+      `/Delete /TN ${TICK_TASK} /F`,
+      `/Delete /TN ${NIGHTLY_TASK} /F`,
+      `/Delete /TN ${HEARTBEAT_TASK} /F`,
+      `/Delete /TN ${PHANTOMBOT_TASK} /F`,
+    ]);
+    expect(out.text).toContain("removed scheduled task");
+  });
+
+  test("a missing task (non-zero delete) is logged, not fatal", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const st = new FakeSchtasks();
+    st.responses = [
+      { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
+      { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
+      { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
+      { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
+    ];
+    const result = await uninstallPhantombotTasks({ schtasks: st, out, err });
+    expect(result.removed).toBe(true);
+    expect(out.text).toContain("returned 1 (continuing)");
+  });
+});
+
+describe("ensureTasksCurrent (heartbeat self-heal)", () => {
+  const OLD_BIN =
+    "C:\\Users\\andrew\\AppData\\Local\\phantombot\\old\\phantombot.exe";
+
+  /** The registered XML each task's `/Query /XML` should return, keyed by name. */
+  function registeredXml(bin: string): Record<string, string> {
+    return {
+      [PHANTOMBOT_TASK]: generatePhantombotTaskXml(SID, bin),
+      [HEARTBEAT_TASK]: generateHeartbeatTaskXml(SID, bin),
+      [NIGHTLY_TASK]: generateNightlyTaskXml(SID, bin),
+      [TICK_TASK]: generateTickTaskXml(SID, bin),
+    };
+  }
+
+  /**
+   * A schtasks fake whose `/Query /XML` answers come from a per-task map
+   * (undefined => task not installed, exit 1) and whose `/Create` always
+   * succeeds. Records every call so tests can assert which tasks were
+   * re-imported.
+   */
+  class HealFake implements SchtasksRunner {
+    calls: string[][] = [];
+    constructor(private queryXml: Record<string, string | undefined>) {}
+    async run(args: readonly string[]): Promise<SchtasksResult> {
+      this.calls.push([...args]);
+      if (args[0] === "/Query") {
+        const tn = args[args.indexOf("/TN") + 1]!;
+        const xml = this.queryXml[tn];
+        if (xml === undefined) {
+          return { exitCode: 1, stdout: "", stderr: "cannot find" };
+        }
+        return { exitCode: 0, stdout: xml, stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    created(): string[] {
+      return this.calls
+        .filter((c) => c[0] === "/Create")
+        .map((c) => c[c.indexOf("/TN") + 1]!);
+    }
+  }
+
+  test("healthy box: every task already points at the binary → no re-import", async () => {
+    const st = new HealFake(registeredXml(BIN));
+    const r = await ensureTasksCurrent({
+      binPath: BIN,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+    });
+    expect(r.rewrote).toEqual([]);
+    expect(st.created()).toEqual([]);
+    // Four cheap queries and nothing else.
+    expect(st.calls.every((c) => c[0] === "/Query")).toBe(true);
+    expect(st.calls.length).toBe(4);
+  });
+
+  test("moved binary: all four tasks drifted → all re-registered", async () => {
+    const st = new HealFake(registeredXml(OLD_BIN));
+    const r = await ensureTasksCurrent({
+      binPath: BIN,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+    });
+    expect(r.rewrote).toEqual([
+      PHANTOMBOT_TASK,
+      HEARTBEAT_TASK,
+      NIGHTLY_TASK,
+      TICK_TASK,
+    ]);
+    expect(st.created()).toEqual([
+      PHANTOMBOT_TASK,
+      HEARTBEAT_TASK,
+      NIGHTLY_TASK,
+      TICK_TASK,
+    ]);
+  });
+
+  test("a single missing task is re-registered; the current ones are left alone", async () => {
+    const xml = registeredXml(BIN);
+    xml[TICK_TASK] = undefined as unknown as string; // tick was deleted
+    const st = new HealFake(xml);
+    const r = await ensureTasksCurrent({
+      binPath: BIN,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+    });
+    expect(r.rewrote).toEqual([TICK_TASK]);
+    expect(st.created()).toEqual([TICK_TASK]);
+  });
+
+  test("path casing differences alone are not treated as drift", async () => {
+    // schtasks may echo the command line back with different casing; a mere
+    // case difference must not trigger a needless re-import.
+    const st = new HealFake(registeredXml(BIN.toUpperCase()));
+    const r = await ensureTasksCurrent({
+      binPath: BIN.toLowerCase(),
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+    });
+    expect(r.rewrote).toEqual([]);
+    expect(st.created()).toEqual([]);
+  });
+});

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -415,13 +415,67 @@ describe("runUpdateFlow", () => {
       },
       pendingPath,
       lastNotifiedPath: lastNotifiedPathLocal,
-      procPlatform: "win32",
+      // freebsd is genuinely unreleased (win32 IS supported since the
+      // Windows self-update work — see the win32 case below).
+      procPlatform: "freebsd",
       procArch: "x64",
     });
     expect(r.reply).toContain("can't self-update");
-    expect(r.reply).toContain("platform=win32");
+    expect(r.reply).toContain("platform=freebsd");
     expect(r.restart).toBeUndefined();
     expect(runUpdateCalled).toBe(false);
+  });
+
+  test("win32 → supported: swaps and returns a restart() callback", async () => {
+    const { svc } = fakeSvc();
+    let runUpdateCalledWith: unknown;
+    // The release must carry the `.exe` asset for a windows target, so
+    // findLatestRelease (which runUpdateFlow calls before the swap) resolves.
+    const winReleaseBody = {
+      tag_name: "v1.0.99",
+      published_at: "2026-05-01T00:00:00Z",
+      body: "test release",
+      assets: [
+        {
+          name: "phantombot-v1.0.99-windows-x64.exe",
+          browser_download_url:
+            "https://example/phantombot-v1.0.99-windows-x64.exe",
+          size: 123,
+        },
+        {
+          name: "SHA256SUMS",
+          browser_download_url: "https://example/SHA256SUMS",
+          size: 256,
+        },
+      ],
+    };
+    const r = await runUpdateFlow({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      chatId: 42,
+      fetchImpl: fakeReleaseFetch({ releaseBody: winReleaseBody }),
+      serviceControl: svc,
+      runUpdateImpl: async (opts) => {
+        runUpdateCalledWith = opts;
+        return 0;
+      },
+      pendingPath,
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "win32",
+      procArch: "x64",
+    });
+    // Windows is a real release target now — the flow proceeds to a swap.
+    expect(r.reply).toContain("installed");
+    expect(r.restart).toBeDefined();
+    // runUpdate saw win32 so it takes the rename-aside swap path.
+    expect((runUpdateCalledWith as { procPlatform: string }).procPlatform).toBe(
+      "win32",
+    );
+    // NB: we deliberately don't invoke r.restart() here. On win32 selfRestart's
+    // default shutdown trigger is process.emit("SIGTERM"), which would signal
+    // the test runner. The "Windows exits cleanly, never calls schtasks
+    // restart()" behaviour is asserted in lib-platform.test.ts with an injected
+    // trigger.
   });
 });
 
@@ -628,7 +682,8 @@ describe("checkAndNotifyOnce", () => {
       fetchImpl: fakeReleaseFetch(),
       transport: new FakeTransport(),
       lastNotifiedPath: lastNotifiedPathLocal,
-      procPlatform: "win32",
+      // freebsd has no release target (win32 is supported now).
+      procPlatform: "freebsd",
       procArch: "x64",
     });
     expect(r.status).toBe("no_target");

--- a/tests/persona-identity.test.ts
+++ b/tests/persona-identity.test.ts
@@ -23,6 +23,36 @@ import {
   readPersonaIdentityNsec,
 } from "../src/lib/personaIdentity.ts";
 
+const isWindows = process.platform === "win32";
+
+/** Dump a file's ACL via icacls (Windows only). */
+function aclDump(path: string): string {
+  const res = Bun.spawnSync(["icacls", path]);
+  return new TextDecoder().decode(res.stdout);
+}
+
+/**
+ * Assert `path` is locked to the current user alone:
+ *   - POSIX: mode is exactly 0600.
+ *   - Windows: the DACL grants the current user and NO one else — no inherited
+ *     ACEs and none of the broad principals a parent dir would otherwise leak.
+ */
+async function expectOwnerOnly(path: string): Promise<void> {
+  if (!isWindows) {
+    const st = await stat(path);
+    expect(st.mode & 0o777).toBe(0o600);
+    return;
+  }
+  const out = aclDump(path);
+  const user = process.env.USERNAME ?? "";
+  expect(user).not.toBe("");
+  expect(out).toContain(user); // the owner has an ACE
+  expect(out).not.toMatch(/\(I\)/); // no inherited ACEs (inheritance removed)
+  expect(out).not.toMatch(/BUILTIN\\Users/i);
+  expect(out).not.toMatch(/\bEveryone\b/i);
+  expect(out).not.toMatch(/Authenticated Users/i);
+}
+
 let workdir: string;
 
 beforeEach(async () => {
@@ -34,7 +64,7 @@ afterEach(async () => {
 });
 
 describe("getOrCreatePersonaIdentity", () => {
-  test("generates, persists identity.json at mode 0600, returns a valid identity", async () => {
+  test("generates, persists identity.json locked to the owner, returns a valid identity", async () => {
     const dir = join(workdir, "p");
     const identity = await getOrCreatePersonaIdentity(dir);
 
@@ -42,8 +72,7 @@ describe("getOrCreatePersonaIdentity", () => {
     expect(identity.npub).toMatch(/^npub1/);
     expect(identity.secretKey.length).toBe(32);
 
-    const st = await stat(personaIdentityPath(dir));
-    expect(st.mode & 0o777).toBe(0o600);
+    await expectOwnerOnly(personaIdentityPath(dir));
     expect(readPersonaIdentityNsec(dir)).toBe(identity.nsec);
   });
 
@@ -104,11 +133,10 @@ describe("createPersonaIdentityIfAbsent", () => {
     expect(readPersonaIdentityNsec(dir)).toBe(id.nsec);
   });
 
-  test("persists at mode 0600", async () => {
+  test("persists locked to the owner alone (mode 0600 / owner-only ACL)", async () => {
     const dir = join(workdir, "p");
     await createPersonaIdentityIfAbsent(dir, generateIdentity().nsec);
-    const st = await stat(personaIdentityPath(dir));
-    expect(st.mode & 0o777).toBe(0o600);
+    await expectOwnerOnly(personaIdentityPath(dir));
   });
 
   test("never overwrites an existing identity — returns the incumbent nsec", async () => {

--- a/tests/persona-identity.test.ts
+++ b/tests/persona-identity.test.ts
@@ -11,9 +11,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm, stat, writeFile, mkdir } from "node:fs/promises";
+import { mkdtemp, stat, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { rmrf } from "./fixtures/rmrf.ts";
 
 import { generateIdentity } from "../src/lib/nostrIdentity.ts";
 import {
@@ -60,7 +61,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await rm(workdir, { recursive: true, force: true });
+  await rmrf(workdir);
 });
 
 describe("getOrCreatePersonaIdentity", () => {

--- a/tests/vault-migrate.test.ts
+++ b/tests/vault-migrate.test.ts
@@ -14,10 +14,11 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { rmrf } from "./fixtures/rmrf.ts";
 import type { Config } from "../src/config.ts";
 import { personaDir } from "../src/config.ts";
 import { saveEnvFile } from "../src/lib/envFile.ts";
@@ -64,7 +65,9 @@ afterEach(async () => {
   else process.env.PHANTOMBOT_USER_ENV_FILE = savedUserEnvVar;
   if (savedCentralEnvVar === undefined) delete process.env.PHANTOMBOT_ENV_FILE;
   else process.env.PHANTOMBOT_ENV_FILE = savedCentralEnvVar;
-  await rm(workdir, { recursive: true, force: true });
+  // rmrf retries on Windows EBUSY (bun:sqlite handles linger briefly after
+  // close()). No-op-fast on POSIX. See fixtures/rmrf.
+  await rmrf(workdir);
 });
 
 describe("migratePlaintextToVault", () => {

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -15,13 +15,15 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { generateSecretKey } from "nostr-tools/pure";
 
 import { Database } from "bun:sqlite";
+
+import { rmrf } from "./fixtures/rmrf.ts";
 
 import {
   _resetVaultTrackingForTesting,
@@ -42,7 +44,9 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await rm(workdir, { recursive: true, force: true });
+  // rmrf retries on Windows EBUSY: a bun:sqlite handle can linger a few ms after
+  // close(), racing the recursive delete. No-op-fast on POSIX. See fixtures/rmrf.
+  await rmrf(workdir);
 });
 
 describe("vault crypto round-trip", () => {

--- a/tests/windows-port.test.ts
+++ b/tests/windows-port.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Windows-port shim tests (issue #201, feature/windows-port).
+ *
+ * These verify the platform-conditional behaviour of the Phase 1 shims:
+ * path resolution, the run-lock path, the platform enum, and the read-only
+ * invocation guard. Where a shim branches on `process.platform`, we stub it
+ * with a save/restore wrapper so the Windows branch is exercised even though
+ * CI runs on Linux — the assertions are pure path/string logic with no OS
+ * calls, so this is safe and deterministic.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { xdgConfigHome, xdgDataHome, xdgStateHome } from "../src/config.ts";
+import { currentPlatform } from "../src/lib/platform.ts";
+import { defaultLockPath } from "../src/lib/runLock.ts";
+import { isReadOnlyInvocation } from "../src/lib/cliInvocation.ts";
+
+/** Temporarily override process.platform for one synchronous assertion. */
+function withPlatform(value: NodeJS.Platform, fn: () => void): void {
+  const saved = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value, configurable: true });
+  try {
+    fn();
+  } finally {
+    if (saved) Object.defineProperty(process, "platform", saved);
+  }
+}
+
+/** Temporarily set/unset env vars around a callback, restoring after. */
+function withEnv(vars: Record<string, string | undefined>, fn: () => void): void {
+  const saved: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(vars)) {
+    saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    fn();
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe("currentPlatform (windows)", () => {
+  test("maps win32 → windows", () => {
+    withPlatform("win32", () => {
+      expect(currentPlatform()).toBe("windows");
+    });
+  });
+});
+
+describe("xdg* path resolvers on Windows", () => {
+  const XDG = {
+    XDG_CONFIG_HOME: undefined,
+    XDG_DATA_HOME: undefined,
+    XDG_STATE_HOME: undefined,
+    LOCALAPPDATA: "C:\\Users\\megan\\AppData\\Local",
+  };
+
+  test("config, data AND state all collapse under %LOCALAPPDATA% (single root)", () => {
+    withEnv(XDG, () => {
+      withPlatform("win32", () => {
+        const root = "C:\\Users\\megan\\AppData\\Local";
+        expect(xdgConfigHome()).toBe(root);
+        expect(xdgDataHome()).toBe(root);
+        expect(xdgStateHome()).toBe(root);
+      });
+    });
+  });
+
+  test("explicit XDG_* env still wins on Windows (test/override escape hatch)", () => {
+    withEnv({ ...XDG, XDG_DATA_HOME: "D:\\override\\data" }, () => {
+      withPlatform("win32", () => {
+        expect(xdgDataHome()).toBe("D:\\override\\data");
+      });
+    });
+  });
+
+  test("does NOT affect POSIX resolution", () => {
+    withEnv(
+      { XDG_CONFIG_HOME: undefined, XDG_DATA_HOME: undefined, XDG_STATE_HOME: undefined },
+      () => {
+        withPlatform("linux", () => {
+          expect(xdgConfigHome()).toContain(".config");
+          expect(xdgDataHome()).toContain(join(".local", "share"));
+          expect(xdgStateHome()).toContain(join(".local", "state"));
+        });
+      },
+    );
+  });
+});
+
+describe("defaultLockPath on Windows", () => {
+  test("falls back to per-user %TEMP% when XDG_RUNTIME_DIR is unset", () => {
+    withEnv({ XDG_RUNTIME_DIR: undefined }, () => {
+      withPlatform("win32", () => {
+        expect(defaultLockPath()).toBe(join(tmpdir(), "phantombot.run.lock"));
+      });
+    });
+  });
+
+  test("XDG_RUNTIME_DIR still wins if somehow set", () => {
+    withEnv({ XDG_RUNTIME_DIR: "R:\\run" }, () => {
+      withPlatform("win32", () => {
+        expect(defaultLockPath()).toBe(join("R:\\run", "phantombot.run.lock"));
+      });
+    });
+  });
+});
+
+describe("isReadOnlyInvocation", () => {
+  const argv = (...rest: string[]) => ["bun", "phantombot", ...rest];
+
+  test("bare invocation (no subcommand) is read-only", () => {
+    expect(isReadOnlyInvocation(argv())).toBe(true);
+  });
+
+  test.each([["--help"], ["-h"], ["--version"], ["-v"], ["help"]])(
+    "%s is read-only",
+    (flag) => {
+      expect(isReadOnlyInvocation(argv(flag))).toBe(true);
+    },
+  );
+
+  test.each([["run"], ["ask"], ["vault"], ["persona"], ["tick"], ["nightly"]])(
+    "%s subcommand is NOT read-only (bootstrap must run)",
+    (sub) => {
+      expect(isReadOnlyInvocation(argv(sub))).toBe(false);
+    },
+  );
+
+  test("a --help AFTER a real subcommand is not treated as top-level read-only", () => {
+    // `phantombot vault --help` still runs bootstrap; only the top-level
+    // help/version fast-path is guarded. This is intentional and documented.
+    expect(isReadOnlyInvocation(argv("vault", "--help"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Windows Port (#201)

Native Windows build of phantombot: a single compiled Bun `.exe`, user-scoped
background service (no admin), with full CLI parity. This is the umbrella branch
for the full port - **one branch, one commit per phase, merged only when the
whole port is proven**. Kept as a **draft** so it tracks the work without merge
risk.

Closes #201 when complete.

### Approach
- Build and test on a real Windows VM, not just CI.
- Single-root data layout: config, data and state all under
  `%LOCALAPPDATA%\phantombot` (no roaming).
- Logon-triggered Task Scheduler for the `systemctl --user` / macOS-style
  "runs while logged in" model (no admin). True headless-without-login is
  out of scope; README will point at WinSW for anyone who needs it.

### Phase status
- [x] **Phase 1 - Core POSIX->Windows shims** (`4acb29d`)
  - Paths: config/data/state resolve to a single `%LOCALAPPDATA%\phantombot`
    root (verified live on the VM).
  - Run-lock: Windows falls back to per-user `%TEMP%`.
  - Tree-kill: replaced POSIX negative-pid group signal with `taskkill /T /F`.
    (Fixed a real bug: `taskkill /T` without `/F` returns exit 128 on a live
    console tree, which read as "already dead" and hung the kill. Now always
    force-kills.)
  - `platform` enum gains `windows`; startup credential bootstrap now skipped
    on `--help`/`--version` so read-only commands don't mutate state or
    provision a stray persona.
  - New `tests/windows-port.test.ts` + Windows-aware fixes to existing suites.
  - Verified: typecheck clean; full Linux suite green (1883 pass); affected
    suites on Windows 82 pass / 6 skip (POSIX-only) / 0 fail.
- [x] **Phase 2 - Vault clean-create + owner-only `identity.json` ACL** (`e34306e`)
  - `lib/filePermissions.ts`: `restrictFileToCurrentUser()` applies an
    owner-only ACL via `icacls` (`/inheritance:r` + `/grant:r *<SID>:F`) on
    Windows, no-op on POSIX. Fails closed. Applied to the tmp file before the
    atomic hard-link, so `identity.json` is restrictive from birth.
  - Grant by **SID**, not name: on a workgroup box `%USERDOMAIN%` is
    `WORKGROUP`, not a valid authority, so `icacls` by name fails.
  - Vault clean-create verified on the VM (`bun:sqlite` read/write).
  - Perms tests made platform-aware; added `tests/fixtures/rmrf.ts` (Bun.gc
    before rm to dodge Windows EBUSY from bun:sqlite's GC-deferred handle
    release; test-only).
  - Verified: typecheck clean both OSes; identity+vault suites 35 pass / 0 fail
    on Linux AND the Windows VM.
- [x] **Phase 3 - User-scoped service (Task Scheduler logon trigger)** (`c75a314`)
  - New `lib/taskScheduler.ts`: generates Task Scheduler 1.2 XML for four
    per-user tasks under `\Phantombot\` (`run`, `heartbeat`, `nightly`,
    `tick`), registered via `schtasks /Create /XML /F`. Principal is the
    current user by **SID** with `LogonType=InteractiveToken` - no admin, no
    stored password, runs only while logged in (the macOS model).
  - Keep-alive without a supervisor: `LogonTrigger` + a 1-minute repeating
    `TimeTrigger` + `MultipleInstancesPolicy=IgnoreNew` restarts the agent if
    it dies, admin-free.
  - Logging: actions route through `cmd /c` with stdout/stderr appended to
    per-task `.out.log`/`.err.log` under `%LOCALAPPDATA%\phantombot\logs`
    (Task Scheduler doesn't capture stdout). Log **rotation** is a documented
    limitation - WinSW is the upgrade path.
  - XML written UTF-16LE + BOM (schtasks import requirement); bin-name check
    made separator-agnostic and accepts `phantombot.exe`.
  - Wired `windows` into `platform.ts` (service control + restart/status/logs
    hints), `install.ts`, `uninstall.ts`. Reuses `currentUserSid()` from
    Phase 2.
  - Verified end-to-end on the VM: `install` registers all four tasks with no
    password prompt; XML carries `InteractiveToken` + the real exe path;
    running the `tick` task creates its redirected log files; `uninstall`
    removes all four and a follow-up query returns "not found". Unit suites
    (`lib-taskScheduler`, `lib-platform`, `cli-install`) 37 pass / 0 fail on
    Linux AND the Windows VM; typecheck clean both OSes; full Linux suite
    green (1904 pass).
- [x] **Phase 4** - CI (`windows-latest`) + coverage baseline + README Windows docs (`4af8842`)

### Notes for reviewers
- The full `bun test` suite is not yet green on Windows - other suites across
  the repo still assume POSIX. Scoping which tests run on `windows-latest` is
  Phase 4 work.
- No migration path is exercised on Windows (no legacy installs exist); the
  clean-create path is what matters.