### PR TITLE
fix(windows): detect harnesses on PATH and stop conjuring a default persona

### DIFF
--- a/src/lib/harnessAvailability.ts
+++ b/src/lib/harnessAvailability.ts
@@ -1,6 +1,6 @@
 import { access, constants, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { delimiter, isAbsolute, join } from "node:path";
 import type { Config } from "../config.ts";
 import { log } from "./logger.ts";
 import { saveHarnessBins } from "../state.ts";
@@ -43,32 +43,69 @@ export function expandSystemdPath(path: string, home = homedir()): string {
     .join(":");
 }
 
-export async function whichBinary(
-  bin: string,
-  pathEnv = process.env.PATH ?? "",
-): Promise<string | undefined> {
-  if (bin.startsWith("/")) {
-    return (await executableFile(bin)) ? bin : undefined;
-  }
-  for (const dir of pathEnv.split(":")) {
-    if (!dir) continue;
-    const candidate = join(dir, bin);
-    if (await executableFile(candidate)) {
-      return candidate;
-    }
+const isWindows = process.platform === "win32";
+
+/**
+ * Extensions to try when resolving a bare command name against a directory.
+ *
+ * POSIX executables have no extension, so the only candidate is the name as
+ * given (""). On Windows the shipped harness CLIs are `claude.cmd`, `pi.cmd`,
+ * `gemini.cmd`, `codex.exe` etc., and which suffixes count as "runnable" is
+ * defined by PATHEXT. We try "" first so an already-qualified name (bin =
+ * "claude.cmd", or an absolute path) resolves directly, then every PATHEXT
+ * suffix for the bare-name case.
+ */
+export function executableExtensions(
+  platform: NodeJS.Platform = process.platform,
+  pathext: string | undefined = process.env.PATHEXT,
+): string[] {
+  if (platform !== "win32") return [""];
+  const raw = pathext ?? ".COM;.EXE;.BAT;.CMD";
+  const exts = raw
+    .split(";")
+    .map((e) => e.trim())
+    .filter((e) => e.length > 0);
+  return ["", ...exts];
+}
+
+/**
+ * Resolve a base path to a runnable file, trying platform executable
+ * extensions. Returns the matched path (with extension, if one was appended).
+ */
+async function resolveExecutable(basePath: string): Promise<string | undefined> {
+  for (const ext of executableExtensions()) {
+    const candidate = basePath + ext;
+    if (await executableFile(candidate)) return candidate;
   }
   return undefined;
 }
 
-async function executable(path: string): Promise<boolean> {
-  return executableFile(path);
+export async function whichBinary(
+  bin: string,
+  pathEnv = process.env.PATH ?? "",
+): Promise<string | undefined> {
+  if (isAbsolute(bin)) {
+    return await resolveExecutable(bin);
+  }
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    const found = await resolveExecutable(join(dir, bin));
+    if (found) return found;
+  }
+  return undefined;
 }
 
 async function executableFile(path: string): Promise<boolean> {
   try {
     const info = await stat(path);
     if (!info.isFile()) return false;
-    await access(path, constants.X_OK);
+    // The Unix execute bit isn't modeled on Windows: access(X_OK) there can
+    // spuriously fail (or pass) and would wrongly reject a real `.cmd`/`.exe`.
+    // A regular file with a PATHEXT-recognised extension is runnable, so on
+    // win32 the isFile() check above is the gate.
+    if (!isWindows) {
+      await access(path, constants.X_OK);
+    }
     return true;
   } catch {
     return false;
@@ -88,7 +125,7 @@ async function existingChildDirs(parent: string): Promise<string[]> {
 
 export async function harnessSearchPath(home = homedir()): Promise<string[]> {
   const dirs = new Set<string>();
-  for (const dir of (process.env.PATH ?? "").split(":")) {
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
     if (dir) dirs.add(dir);
   }
 
@@ -103,6 +140,14 @@ export async function harnessSearchPath(home = homedir()): Promise<string[]> {
     join(home, ".local", "share", "pi-node", "current", "bin"),
   ];
   for (const dir of staticDirs) dirs.add(dir);
+
+  if (isWindows) {
+    // Windows global-install locations the POSIX home subdirs don't cover:
+    // npm global shims land in %APPDATA%\npm, and bun's global bin in
+    // %USERPROFILE%\.bun\bin (already added above) - add the npm one here.
+    const appData = process.env.APPDATA;
+    if (appData) dirs.add(join(appData, "npm"));
+  }
 
   for (const nodeDir of await existingChildDirs(join(home, ".nvm", "versions", "node"))) {
     dirs.add(join(nodeDir, "bin"));
@@ -125,18 +170,17 @@ export async function resolveHarnessBinary(
   bin: string,
   pathEnv = process.env.PATH ?? "",
 ): Promise<ResolvedHarnessBinary> {
-  if (bin.startsWith("/")) {
-    return (await executable(bin))
-      ? { path: bin, source: "configured" }
-      : {};
+  if (isAbsolute(bin)) {
+    const resolved = await resolveExecutable(bin);
+    return resolved ? { path: resolved, source: "configured" } : {};
   }
 
   const fromPath = await whichBinary(bin, pathEnv);
   if (fromPath) return { path: fromPath, source: "path" };
 
   for (const dir of await harnessSearchPath()) {
-    const candidate = join(dir, bin);
-    if (await executable(candidate)) {
+    const candidate = await resolveExecutable(join(dir, bin));
+    if (candidate) {
       return { path: candidate, source: "search" };
     }
   }
@@ -155,7 +199,7 @@ export async function checkConfiguredHarnesses(
     const bin = harnessBin(config, id);
     if (!bin) continue;
     let resolved = await resolveHarnessBinary(bin, pathEnv);
-    if (!resolved.path && bin.startsWith("/")) {
+    if (!resolved.path && isAbsolute(bin)) {
       const fallbackBin = defaultHarnessBin(id);
       if (fallbackBin) {
         resolved = await resolveHarnessBinary(fallbackBin, pathEnv);

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -24,7 +24,7 @@
 
 import { Database } from "bun:sqlite";
 import { createCipheriv, createDecipheriv } from "node:crypto";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { hkdf } from "@noble/hashes/hkdf.js";
@@ -233,6 +233,16 @@ export async function openPersonaVault(personaDir: string): Promise<Vault> {
 async function readAllVaultValues(
   personaDirPath: string,
 ): Promise<{ values: Map<string, string>; badKeys: string[] } | null> {
+  // Open-existing-only: this is a pure READ path (env loading), so it must never
+  // provision a persona as a side effect. openPersonaVault -> getOrCreatePersonaIdentity
+  // + openVaultWithSecret both mkdir/create on demand, so calling them for a
+  // never-provisioned persona (e.g. the built-in "phantom" default during the
+  // startup bootstrap) would conjure a stray persona dir + identity.json + vault
+  // the user never asked for. Guard on the persona dir already existing; if it
+  // doesn't, treat it as "no vault" (null) exactly like an unopenable one.
+  if (!existsSync(personaDirPath)) {
+    return null;
+  }
   let vault: Vault;
   try {
     vault = await openPersonaVault(personaDirPath);

--- a/tests/lib-harnessAvailability.test.ts
+++ b/tests/lib-harnessAvailability.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  executableExtensions,
   expandSystemdPath,
   whichBinary,
   checkConfiguredHarnesses,
@@ -22,6 +23,37 @@ describe("expandSystemdPath", () => {
     const home = "/home/test";
     const path = "%h/bin:%h/.local/bin";
     expect(expandSystemdPath(path, home)).toBe("/home/test/bin:/home/test/.local/bin");
+  });
+});
+
+describe("executableExtensions", () => {
+  test("POSIX resolves the bare name only", () => {
+    expect(executableExtensions("linux")).toEqual([""]);
+    expect(executableExtensions("darwin")).toEqual([""]);
+  });
+
+  test("Windows tries the bare name first, then each PATHEXT suffix", () => {
+    expect(executableExtensions("win32", ".COM;.EXE;.BAT;.CMD")).toEqual([
+      "",
+      ".COM",
+      ".EXE",
+      ".BAT",
+      ".CMD",
+    ]);
+  });
+
+  test("Windows falls back to a sane PATHEXT default when unset", () => {
+    // Without this, a bare `claude` never matches the shipped `claude.cmd`.
+    expect(executableExtensions("win32", undefined)).toContain(".CMD");
+    expect(executableExtensions("win32", undefined)).toContain(".EXE");
+  });
+
+  test("Windows tolerates whitespace and blank PATHEXT entries", () => {
+    expect(executableExtensions("win32", " .EXE ; ; .CMD ")).toEqual([
+      "",
+      ".EXE",
+      ".CMD",
+    ]);
   });
 });
 
@@ -48,6 +80,21 @@ describe("whichBinary", () => {
   test("resolves bare names from pathEnv", async () => {
     const pathEnv = "/bin:/usr/bin";
     expect(await whichBinary("sh", pathEnv)).toBe("/bin/sh");
+  });
+
+  // Windows-only: runs on the test-windows CI runner. Proves the bare harness
+  // name `claude` resolves to the shipped `claude.cmd` via PATHEXT, and that the
+  // PATH is split on `;` (not `:`, which would shred `C:\...` entries).
+  const winTest = process.platform === "win32" ? test : test.skip;
+  winTest("resolves a bare name to its .cmd via PATHEXT across a ';'-joined PATH", async () => {
+    const dirA = await mkdtemp(join(tmpdir(), "phantombot-win-a-"));
+    const dirB = await mkdtemp(join(tmpdir(), "phantombot-win-b-"));
+    const cmd = join(dirB, "claude.cmd");
+    await writeFile(cmd, "@echo off\r\nexit /b 0\r\n", "utf8");
+
+    // dirA first (no match), dirB second - a ';'-joined, drive-letter PATH.
+    const pathEnv = `${dirA};${dirB}`;
+    expect(await whichBinary("claude", pathEnv)).toBe(cmd);
   });
 });
 

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -217,6 +217,23 @@ describe("loadVaultIntoEnv reconcile", () => {
     expect(tracked.has("BAR")).toBe(true);
   });
 
+  test("open-existing-only: a never-provisioned persona dir is NOT created on load", async () => {
+    // Regression: the startup bootstrap loads the default persona's vault to
+    // populate env. That load must never conjure the persona on disk - otherwise
+    // `persona new test` on a fresh box also silently creates a stray `phantom`.
+    const dir = join(workdir, "never-provisioned");
+    expect(existsSync(dir)).toBe(false);
+
+    const env: NodeJS.ProcessEnv = {};
+    const tracked = new Set<string>();
+    const { updated, removed } = await loadVaultIntoEnv(dir, env, tracked);
+
+    // No dir, no identity.json, no vault.sqlite materialized.
+    expect(existsSync(dir)).toBe(false);
+    expect(updated).toEqual([]);
+    expect(removed).toEqual([]);
+  });
+
   test("existing env value is sticky — vault never overwrites it", async () => {
     const dir = join(workdir, "p");
     const v = await openPersonaVault(dir);


### PR DESCRIPTION
Two Windows-install correctness bugs found while testing the fresh install on the VM.

## 1. Harnesses show `[NOT FOUND]` in the TUI (and doctor)

`src/lib/harnessAvailability.ts` was POSIX-only, so on Windows every harness came back unresolved:

- split `PATH` on `:` - Windows uses `;`, and drive letters like `C:\` contain `:`, so the whole PATH gets shredded
- appended no executable extension - the shipped CLIs are `claude.cmd` / `pi.cmd` / `codex.exe`, never a bare `claude`
- gated on the Unix execute bit (`X_OK`) - not modeled on Windows, can spuriously reject a real `.cmd`
- treated only `/`-prefixed paths as absolute - Windows absolute paths start with a drive letter

**Fix:** split on `path.delimiter`, iterate `PATHEXT` (bare name first, then each suffix), use `path.isAbsolute`, and skip the `X_OK` check on win32. Also add `%APPDATA%\npm` to the search path. This mirrors the win32 handling already present in `installVscode.ts`. POSIX behaviour is unchanged.

## 2. A stray `phantom` persona is created every time

`persona new test` on a fresh box left you with both `phantom` and `test`. The startup vault bootstrap (`src/index.ts`) loads the default persona's vault into env, and that read path (`openPersonaVault` -> `getOrCreatePersonaIdentity` + `openVaultWithSecret`) provisioned the persona dir, `identity.json` and `vault.sqlite` as a **side effect of a read**. With `defaultPersona` falling back to the literal `"phantom"`, any non-read-only command conjured it.

**Fix (open-existing-only):** `readAllVaultValues` now returns `null` (treated as "no vault") when the persona dir doesn't already exist, so a pure env-load never provisions. Real vault reads/writes and `persona new` are untouched.

## Tests

- `executableExtensions` unit coverage (PATHEXT parsing, defaults, whitespace) - runs on Linux CI
- Windows-gated end-to-end `whichBinary` test: bare `claude` resolves to `claude.cmd` across a `;`-joined, drive-letter PATH - runs on the test-windows runner
- Regression test: loading a never-provisioned persona creates nothing on disk

Full suite green (1935 pass), typecheck clean. Windows-only behaviour; Linux/macOS untouched.