### PR TITLE
fix(windows): pass harness prompts via temp files to beat the argv length limit

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -58,6 +58,11 @@ import {
 } from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
 import { spawnInNewSession } from "../lib/processGroup.ts";
+import {
+  argvNeedsTempFiles,
+  createHarnessTempDir,
+  type HarnessTempDir,
+} from "../lib/harnessArgvFiles.ts";
 
 export interface ClaudeHarnessConfig {
   /** Path to the `claude` CLI binary. Default: "claude" (looked up in PATH). */
@@ -71,7 +76,13 @@ export interface ClaudeHarnessConfig {
 export class ClaudeHarness implements Harness {
   readonly id = "claude";
 
-  constructor(private readonly config: ClaudeHarnessConfig) {}
+  constructor(
+    private readonly config: ClaudeHarnessConfig,
+    // Injectable so the Windows argv-length branch below is testable on a
+    // POSIX CI runner. Prod callers pass only the config and get the real
+    // platform.
+    private readonly platform: NodeJS.Platform = process.platform,
+  ) {}
 
   async available(): Promise<boolean> {
     try {
@@ -87,10 +98,27 @@ export class ClaudeHarness implements Harness {
   }
 
   async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
-    const args = this.buildArgs(req.systemPrompt, req.toolsMode);
+    // Windows argv-length workaround. Claude's conversation payload already
+    // travels on stdin, but the persona/memory system prompt still rides on
+    // argv via `--system-prompt <text>` - and megan's BOOT.md alone can blow
+    // Windows' ~8,191-char command-line limit, so the child fails to spawn
+    // with "The command line is too long." Spill the system prompt to a temp
+    // file and pass `--system-prompt-file <file>` instead. POSIX keeps the
+    // inline `--system-prompt <text>` path unchanged. See harnessArgvFiles.
+    const useTempFiles = argvNeedsTempFiles(this.platform);
+    let temp: HarnessTempDir | undefined;
+    let systemPromptFile: string | undefined;
+    if (useTempFiles) {
+      temp = await createHarnessTempDir();
+      systemPromptFile = await temp.file("system-prompt.md", req.systemPrompt);
+    }
+    try {
+
+    const args = this.buildArgs(req.systemPrompt, req.toolsMode, systemPromptFile);
     log.debug("claude.invoke spawning", {
       bin: this.config.bin,
       argCount: args.length,
+      tempFiles: useTempFiles,
     });
 
     // Re-source ~/.env / ~/.config/phantombot/.env so secrets the agent
@@ -137,11 +165,21 @@ export class ClaudeHarness implements Harness {
         model: this.config.model,
       }),
     });
+
+    } finally {
+      // Remove the temp system-prompt file once the child has exited (or the
+      // consumer stopped iterating early). No-op on POSIX.
+      await temp?.cleanup();
+    }
   }
 
   private buildArgs(
     systemPrompt: string,
     toolsMode?: "none",
+    // When set (Windows), the persona system prompt is passed by FILE
+    // (`--system-prompt-file`) instead of inline (`--system-prompt <text>`)
+    // to stay under the command-line length limit.
+    systemPromptFile?: string,
   ): string[] {
     const args = [
       "--print",
@@ -189,7 +227,13 @@ export class ClaudeHarness implements Harness {
     // running `claude` directly on this host (e.g. for emergency repairs) is
     // unaffected. See PHANTOMBOT_INJECTED_CLAUDE_SETTINGS for the policy.
     args.push("--settings", JSON.stringify(PHANTOMBOT_INJECTED_CLAUDE_SETTINGS));
-    args.push("--system-prompt", systemPrompt);
+    if (systemPromptFile) {
+      // Windows: read the persona system prompt from a file to keep it off the
+      // length-limited command line. Verified against Claude Code.
+      args.push("--system-prompt-file", systemPromptFile);
+    } else {
+      args.push("--system-prompt", systemPrompt);
+    }
     return args;
   }
 }

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -44,6 +44,11 @@ import {
 } from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
 import { spawnInNewSession } from "../lib/processGroup.ts";
+import {
+  argvNeedsTempFiles,
+  createHarnessTempDir,
+  type HarnessTempDir,
+} from "../lib/harnessArgvFiles.ts";
 
 export interface PiHarnessConfig {
   /** Path to the `pi` CLI binary. Default: "pi" (looked up in PATH). */
@@ -69,7 +74,13 @@ export interface PiHarnessConfig {
 export class PiHarness implements Harness {
   readonly id = "pi";
 
-  constructor(private readonly config: PiHarnessConfig) {}
+  constructor(
+    private readonly config: PiHarnessConfig,
+    // Injectable so the Windows argv-length branch below is testable on a
+    // POSIX CI runner. Prod callers pass only the config and get the real
+    // platform.
+    private readonly platform: NodeJS.Platform = process.platform,
+  ) {}
 
   get maxPayloadBytes(): number {
     return this.config.maxPayloadBytes;
@@ -100,10 +111,29 @@ export class PiHarness implements Harness {
       return;
     }
 
+    // Windows argv-length workaround. On Windows the whole command line is
+    // capped at ~8,191 chars, and pi carries BOTH the system prompt (a flag
+    // value) AND the full rendered payload (the positional) on argv - a real
+    // persona turn is tens of KB, so the child fails to spawn with "The
+    // command line is too long." and the bot replies with nothing. Spill both
+    // to temp files: pi reads `--system-prompt <file>` as the system prompt
+    // and includes an `@<file>` positional's contents in the message. POSIX
+    // (ARG_MAX ~2 MB) keeps the raw argv path unchanged. See harnessArgvFiles.
+    const useTempFiles = argvNeedsTempFiles(this.platform);
+    let temp: HarnessTempDir | undefined;
+    let systemPromptArg = req.systemPrompt;
+    let payloadArg = payload;
+    if (useTempFiles) {
+      temp = await createHarnessTempDir();
+      systemPromptArg = await temp.file("system-prompt.md", req.systemPrompt);
+      payloadArg = `@${await temp.file("payload.md", payload)}`;
+    }
+    try {
+
     const args = [
       "--print",
       "--mode", "json",
-      "--system-prompt", req.systemPrompt,
+      "--system-prompt", systemPromptArg,
       // Pre-prompting trim:
       //   --offline   Disables Pi's STARTUP network operations (telemetry,
       //               update checks) only — NOT the model API call. The
@@ -207,10 +237,13 @@ export class PiHarness implements Harness {
     }
 
     // Payload is the LAST positional arg (pi reads it from argv, not stdin).
-    args.push(payload);
+    // On Windows this is `@<tempfile>` so pi loads the payload from disk
+    // instead of the length-limited command line; on POSIX it's the raw text.
+    args.push(payloadArg);
     log.debug("pi.invoke spawning", {
       bin: this.config.bin,
       payloadBytes: totalBytes,
+      tempFiles: useTempFiles,
     });
 
     // Relay THIS harness's provider + api-key into the child env so the bundled
@@ -249,6 +282,12 @@ export class PiHarness implements Harness {
       activity: piActivity,
       buildDoneMeta: () => ({ harnessId: this.id, payloadBytes: totalBytes }),
     });
+
+    } finally {
+      // Remove the temp payload/system-prompt files once the child has exited
+      // (or the consumer stopped iterating early). No-op on POSIX.
+      await temp?.cleanup();
+    }
   }
 }
 

--- a/src/lib/harnessArgvFiles.ts
+++ b/src/lib/harnessArgvFiles.ts
@@ -1,0 +1,70 @@
+/**
+ * Windows argv-length workaround for harnesses that carry large prompt data
+ * on the command line.
+ *
+ * POSIX ARG_MAX is ~2 MB, so phantombot's rendered payloads (persona + memory
+ * + conversation history - routinely tens of KB) pass fine as argv. Windows
+ * caps a whole process command line at ~8,191 characters (the CreateProcess
+ * lpCommandLine limit), so the same payload makes the child fail to spawn with
+ * "The command line is too long." - the harness then exits 1 and the bot
+ * replies with nothing.
+ *
+ * The fix is to spill the two oversized argv payloads - the system prompt and
+ * the rendered conversation - into temp files and hand the child a short file
+ * reference instead:
+ *
+ *   - pi:     `--system-prompt <file>` (pi reads a path's contents as the
+ *             system prompt) and the positional `@<file>` (pi includes an
+ *             `@file`'s contents in the initial message).
+ *   - claude: `--system-prompt-file <file>` (the conversation already travels
+ *             on stdin, so only the system prompt needs spilling).
+ *
+ * Both mechanisms were verified empirically against pi 0.80.3 and Claude Code
+ * before this was written. POSIX keeps the existing argv path byte-for-byte
+ * unchanged - the temp-file path is gated to Windows only.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * True when the platform's command line is short enough that large prompt
+ * payloads must be spilled to temp files rather than passed as argv. Only
+ * Windows today (~8,191-char limit). The `platform` arg is injectable so the
+ * branch is unit-testable on a POSIX CI runner.
+ */
+export function argvNeedsTempFiles(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === "win32";
+}
+
+export interface HarnessTempDir {
+  /** Absolute path of the private temp directory. */
+  readonly dir: string;
+  /** Write `content` to `<dir>/<name>`; resolves to the absolute path. */
+  file(name: string, content: string): Promise<string>;
+  /** Remove the temp dir and everything in it. Never throws. */
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Create a private temp directory for a single harness invocation. The caller
+ * MUST call `cleanup()` in a `finally` once the child process has exited, so a
+ * thrown error or an early generator return still removes the files.
+ */
+export async function createHarnessTempDir(): Promise<HarnessTempDir> {
+  const dir = await mkdtemp(join(tmpdir(), "phantombot-harness-"));
+  return {
+    dir,
+    async file(name: string, content: string): Promise<string> {
+      const path = join(dir, name);
+      await writeFile(path, content, "utf8");
+      return path;
+    },
+    async cleanup(): Promise<void> {
+      await rm(dir, { recursive: true, force: true }).catch(() => {});
+    },
+  };
+}

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   ClaudeHarness,
@@ -432,6 +433,69 @@ describe("ClaudeHarness subprocess invocation passes injected settings", () => {
     expect(texts).toContain("--disable-slash-commands");
     // Per-machine dynamic sections dropped.
     expect(texts).toContain("--exclude-dynamic-system-prompt-sections");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Windows argv-length workaround. Claude's conversation payload already goes
+// via stdin, but the persona system prompt still rides on argv via
+// `--system-prompt <text>` - and a large BOOT.md can exceed Windows' ~8,191
+// char command-line limit. On Windows the harness spills the system prompt to
+// a temp file and passes `--system-prompt-file <file>` instead. Platform is
+// injected so this runs on the Linux CI runner.
+// ---------------------------------------------------------------------------
+
+describe("ClaudeHarness Windows argv-length workaround", () => {
+  const argvOf = (chunks: HarnessChunk[]): string =>
+    chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+
+  test("win32: system prompt goes to a file, not raw argv", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness(
+      { bin: FAKE_CLAUDE, model: "test", fallbackModel: "" },
+      "win32",
+    );
+    const chunks = await collect(
+      h.invoke(newRequest({ systemPrompt: "SECRET-CLAUDE-PERSONA" })),
+    );
+    const argv = argvOf(chunks);
+    // File flag present with a temp path; inline flag + raw text absent.
+    expect(argv).toContain("--system-prompt-file");
+    expect(argv).toContain("system-prompt.md");
+    expect(argv).not.toContain("SECRET-CLAUDE-PERSONA");
+  });
+
+  test("win32: temp system-prompt file is cleaned up after the run", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness(
+      { bin: FAKE_CLAUDE, model: "test", fallbackModel: "" },
+      "win32",
+    );
+    const chunks = await collect(h.invoke(newRequest()));
+    const argv = argvOf(chunks);
+    const match = argv.match(/(\S*system-prompt\.md)/);
+    const systemPromptFile = match?.[1];
+    expect(systemPromptFile).toBeTruthy();
+    expect(existsSync(systemPromptFile!)).toBe(false);
+  });
+
+  test("POSIX: system prompt stays inline via --system-prompt", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    // Force the POSIX branch so this holds on the Windows CI runner too.
+    const h = new ClaudeHarness(
+      { bin: FAKE_CLAUDE, model: "test", fallbackModel: "" },
+      "linux",
+    );
+    const chunks = await collect(
+      h.invoke(newRequest({ systemPrompt: "INLINE-CLAUDE-PERSONA" })),
+    );
+    const argv = argvOf(chunks);
+    expect(argv).toContain("--system-prompt");
+    expect(argv).toContain("INLINE-CLAUDE-PERSONA");
+    expect(argv).not.toContain("--system-prompt-file");
   });
 });
 

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   PiHarness,
@@ -418,6 +419,69 @@ describe("PiHarness.invoke (subprocess)", () => {
       recoverable: true,
       error: expect.stringContaining("timed out"),
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Windows argv-length workaround. On Windows the whole command line is capped
+// at ~8,191 chars; pi carries both the system prompt (a flag) and the full
+// payload (the positional) on argv, so a real persona turn fails to spawn.
+// The harness spills both to temp files and passes `--system-prompt <file>`
+// plus an `@<file>` positional. The platform is injected so this runs on the
+// Linux CI runner. FAKE_PI 'argv' mode echoes argv so we can inspect it.
+// ---------------------------------------------------------------------------
+
+describe("PiHarness.invoke Windows argv-length workaround", () => {
+  const argvOf = (chunks: HarnessChunk[]): string =>
+    chunks
+      .filter((c) => c.type === "text")
+      .map((c) => (c as { text: string }).text)
+      .join("");
+
+  test("win32: system prompt + payload go to temp files, not raw argv", async () => {
+    process.env.FAKE_PI_MODE = "argv";
+    const harness = new PiHarness({ bin: FAKE_PI, maxPayloadBytes: 1_500_000 }, "win32");
+    const chunks = await collect(
+      harness.invoke(
+        newRequest({ systemPrompt: "SECRET-PERSONA-PROMPT", userMessage: "SECRET-USER-MSG" }),
+      ),
+    );
+    const argv = argvOf(chunks);
+
+    // The raw system prompt and payload text must NOT appear on the command
+    // line - they live in the temp files instead.
+    expect(argv).not.toContain("SECRET-PERSONA-PROMPT");
+    expect(argv).not.toContain("SECRET-USER-MSG");
+    // The system prompt is passed as a file path, the payload as an @file.
+    expect(argv).toContain("system-prompt.md");
+    expect(argv).toMatch(/@\S*payload\.md/);
+  });
+
+  test("win32: temp dir is cleaned up after the run", async () => {
+    process.env.FAKE_PI_MODE = "argv";
+    const harness = new PiHarness({ bin: FAKE_PI, maxPayloadBytes: 1_500_000 }, "win32");
+    const chunks = await collect(harness.invoke(newRequest()));
+    const argv = argvOf(chunks);
+    const match = argv.match(/@(\S*payload\.md)/);
+    const payloadFile = match?.[1];
+    expect(payloadFile).toBeTruthy();
+    // The temp payload file referenced on argv is gone once invoke() completed.
+    expect(existsSync(payloadFile!)).toBe(false);
+  });
+
+  test("POSIX: system prompt + payload stay inline on argv", async () => {
+    process.env.FAKE_PI_MODE = "argv";
+    // Force the POSIX branch so this holds on the Windows CI runner too.
+    const harness = new PiHarness({ bin: FAKE_PI, maxPayloadBytes: 1_500_000 }, "linux");
+    const chunks = await collect(
+      harness.invoke(
+        newRequest({ systemPrompt: "INLINE-PERSONA", userMessage: "INLINE-MSG" }),
+      ),
+    );
+    const argv = argvOf(chunks);
+    expect(argv).toContain("INLINE-PERSONA");
+    expect(argv).toContain("INLINE-MSG");
+    expect(argv).not.toContain("payload.md");
   });
 });
 

--- a/tests/lib-harnessArgvFiles.test.ts
+++ b/tests/lib-harnessArgvFiles.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the Windows argv-length workaround helper.
+ *
+ *   - argvNeedsTempFiles() gates ONLY on win32 (so POSIX behavior is
+ *     untouched and the branch is testable on a Linux CI runner).
+ *   - createHarnessTempDir() writes files and cleanup() removes the dir.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import {
+  argvNeedsTempFiles,
+  createHarnessTempDir,
+} from "../src/lib/harnessArgvFiles.ts";
+
+describe("argvNeedsTempFiles", () => {
+  test("true only on win32", () => {
+    expect(argvNeedsTempFiles("win32")).toBe(true);
+    expect(argvNeedsTempFiles("linux")).toBe(false);
+    expect(argvNeedsTempFiles("darwin")).toBe(false);
+    expect(argvNeedsTempFiles("freebsd")).toBe(false);
+  });
+});
+
+describe("createHarnessTempDir", () => {
+  test("writes file contents and returns an absolute path inside the dir", async () => {
+    const temp = await createHarnessTempDir();
+    try {
+      const p = await temp.file("payload.md", "hello payload");
+      expect(p.startsWith(temp.dir)).toBe(true);
+      expect(existsSync(p)).toBe(true);
+      expect(await readFile(p, "utf8")).toBe("hello payload");
+    } finally {
+      await temp.cleanup();
+    }
+  });
+
+  test("cleanup removes the whole dir and its files", async () => {
+    const temp = await createHarnessTempDir();
+    const p = await temp.file("system-prompt.md", "persona");
+    expect(existsSync(temp.dir)).toBe(true);
+    await temp.cleanup();
+    expect(existsSync(temp.dir)).toBe(false);
+    expect(existsSync(p)).toBe(false);
+  });
+
+  test("cleanup is idempotent and never throws", async () => {
+    const temp = await createHarnessTempDir();
+    await temp.cleanup();
+    // Second cleanup on an already-removed dir must resolve, not reject.
+    await expect(temp.cleanup()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Draft for review

Opened as a **draft** at Andrew's request. Not to be merged until it has been reviewed and verified on a fresh test persona on the Windows VM (avoiding a collision with the live megan persona there).

## Problem

On Windows the entire child command line is capped at ~8,191 characters (CreateProcess `lpCommandLine`). On a real persona turn both harnesses overflow it, fail to spawn with `The command line is too long.`, and exit 1 with no reply. Symptom: the bot shows a typing indicator, then goes silent.

Root cause differs per harness:

- **pi** carries BOTH the system prompt (`--system-prompt <text>`) and the full rendered payload (the positional argument) on argv. On the reporter's box the payload was ~18 KB.
- **claude** already streams the conversation via stdin, but still passes the whole persona/memory system prompt on argv via `--system-prompt`. A large `BOOT.md` alone overflows the limit, which is why claude failed the same way.

## Fix (Windows only)

Spill the oversized argv payloads to temp files and hand the child a short file reference instead. POSIX (`ARG_MAX` ~2 MB) keeps the existing inline argv path byte for byte.

- **pi:** write the system prompt and the payload to temp files; pass `--system-prompt <file>` and the positional `@<file>`.
- **claude:** write the system prompt to a temp file; pass `--system-prompt-file <file>`.

Temp files are created per invocation in a private temp dir and removed in a `finally`.

## Why not stdin (xiaomi-mimo's Option A)

pi ignores stdin in `--print` mode (confirmed by its own `--help` and our harness code), so piping the payload would have failed silently. The temp-file approach is harness-native for both.

## Empirically verified before writing the code

Against pi 0.80.3 and Claude Code on a real box:

- pi `--system-prompt <path>` reads the file contents as the system prompt (pirate-rule test obeyed).
- pi `@<path>` positional presents the file contents as the message (`@file` containing "17 plus 25" answered `42`).
- claude `--system-prompt-file <path>` applies the file as the system prompt (pirate-rule test obeyed).

## The one thing to eyeball on the VM

Confirm pi's `@file` presents the payload as a clean user message (no attachment wrapper that shifts model behaviour). It behaved correctly in local testing; worth a direct look on the target box with a fresh persona.

## Tests

- New `tests/lib-harnessArgvFiles.test.ts`: the win32-only decision gate and the temp-dir write/cleanup/idempotency helper.
- pi and claude harness tests with an injected `platform`: Windows spills prompts to files and cleans them up; POSIX keeps prompts inline. These run on the Linux CI runner (no Windows-gating needed) via the fixtures' argv-echo mode.

Full suite green (1945 pass, 3 skip, 0 fail), typecheck clean.

## Note for the reviewer

The `invoke()` bodies are wrapped in `try { ... } finally { temp?.cleanup() }` but the inner code keeps its original indentation, so the diff stays focused on the real change rather than a whitespace reflow. Happy to re-indent if preferred.