### PR TITLE
fix(windows): make the memory index portable by storing posix paths

### DIFF
--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -1054,7 +1054,18 @@ function walk(
     if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
     const st = statSync(full);
     out.push({
-      path: relative(dir.startsWith(root) ? dirname(root) : root, full),
+      // Store paths posix-style (forward slashes) on every OS. relative()
+      // emits the platform separator, so Windows would record backslash
+      // paths. That makes the index non-portable: move a persona's memory
+      // between Linux and Windows and the first walk finds zero matching
+      // rows, so every note is deleted and re-embedded (or, if the source
+      // files are missing, the whole index is wiped). Normalising here keys
+      // the index the same way everywhere. Downstream reads use join(), and
+      // resolveMdLink/buildNameIndex already normalise, so this is safe.
+      path: relative(dir.startsWith(root) ? dirname(root) : root, full).replace(
+        /\\/g,
+        "/",
+      ),
       scope,
       mtimeMs: Math.floor(st.mtimeMs),
       size: st.size,

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -1053,19 +1053,22 @@ function walk(
     }
     if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
     const st = statSync(full);
+    // Store paths posix-style (forward slashes) on every OS. relative()
+    // emits the platform separator, so Windows would record backslash
+    // paths. That makes the index non-portable: move a persona's memory
+    // between Linux and Windows and the first walk finds zero matching
+    // rows, so every note is deleted and re-embedded (or, if the source
+    // files are missing, the whole index is wiped). Normalising here keys
+    // the index the same way everywhere. Downstream reads use join(), and
+    // resolveMdLink/buildNameIndex already normalise, so this is safe.
+    //
+    // The replace is gated to Windows only: on POSIX a backslash is a legal
+    // filename character, so rewriting it there could corrupt a path for a
+    // note literally named with a backslash. Windows separators are always
+    // backslashes, so the guard is safe and leaves Linux/Mac paths untouched.
+    const rel = relative(dir.startsWith(root) ? dirname(root) : root, full);
     out.push({
-      // Store paths posix-style (forward slashes) on every OS. relative()
-      // emits the platform separator, so Windows would record backslash
-      // paths. That makes the index non-portable: move a persona's memory
-      // between Linux and Windows and the first walk finds zero matching
-      // rows, so every note is deleted and re-embedded (or, if the source
-      // files are missing, the whole index is wiped). Normalising here keys
-      // the index the same way everywhere. Downstream reads use join(), and
-      // resolveMdLink/buildNameIndex already normalise, so this is safe.
-      path: relative(dir.startsWith(root) ? dirname(root) : root, full).replace(
-        /\\/g,
-        "/",
-      ),
+      path: process.platform === "win32" ? rel.replace(/\\/g, "/") : rel,
       scope,
       mtimeMs: Math.floor(st.mtimeMs),
       size: st.size,

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -95,6 +95,18 @@ describe("walkMarkdown", () => {
       "kb/concepts/Foo.md",
     ].sort());
   });
+
+  test("records nested paths posix-style, never with backslashes", async () => {
+    await note("kb/concepts/Foo.md", "foo");
+    const paths = walkMarkdown(personaDir).map((f) => f.path);
+    // Portability invariant: the index keys files the same way on every OS,
+    // so a persona's memory can move between Linux and Windows without the
+    // first walk missing every row (which deletes and re-embeds, or wipes,
+    // the index). On the Windows CI runner this catches relative() emitting
+    // backslash separators.
+    expect(paths).toContain("kb/concepts/Foo.md");
+    for (const p of paths) expect(p).not.toContain("\\");
+  });
 });
 
 describe("MemoryIndex.refreshStale", () => {


### PR DESCRIPTION
## Problem

Copying a persona's `memory/`+`kb/` from Linux to a Windows install, then reusing an existing memory-index, results in the persona coming up with **no memory**.

Root cause: `walkMarkdown` in `src/lib/memoryIndex.ts` records each file's path with `relative()`, which emits the **platform** separator. So the index is keyed with backslashes on Windows and forward slashes on Linux. When the walk paths and the recorded paths use different separators, the refresh sees **zero** matching rows and:

- deletes every recorded row and re-embeds from scratch (losing vector embeddings), or
- if the source files aren't where it looks, deletes every row and leaves the index empty (the observed 'no memory' outcome).

The derived index is therefore **not portable** across OSes, even though the source `.md` files are.

## Fix

Normalise the stored path to posix (forward slashes) at the single source, `walk()`. Now the index keys files identically on every OS, so a persona's memory survives a Linux to/from Windows move without churn.

This is contained because downstream consumers already tolerate forward slashes:
- reads use `path.join(personaDir, f.path)` which accepts `/` on Windows;
- `resolveMdLink` and `buildNameIndex` already normalise separators.

## Tests

- New `walkMarkdown` test asserts nested paths are recorded posix-style and never contain a backslash. Trivially true on Linux CI; on the Windows CI runner it fails pre-fix and passes post-fix.
- Full suite green locally (1946 pass, 0 fail); typecheck clean.

## Migration note for existing installs

The recommended cutover is unchanged and still the right advice: copy the persona's source (`memory/`, `kb/`), **do not** copy the derived `memory-index/`, and rebuild it natively with `phantombot memory index --rebuild`. This PR additionally makes an already-built index **portable**, so a copied index no longer self-wipes on the first search.

## Not deployed

Review-only draft, as agreed. No VM touched.