### PR TITLE
feat(p2p): relay-free P2P transport node — werift + Nostr signaling (#258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,10 +632,12 @@ an encrypted WebRTC data channel with no relay in the hot path.
   is a secure context, so an HTTPS PWA may open it — no TLS-cert wall). The bridge
   **gates WebSocket upgrades on the browser `Origin`**: loopback binding keeps the
   port off the LAN, but any website you visit could otherwise reach it (WebSocket
-  isn't CORS-preflighted). No-`Origin` clients (CLI/tooling) and localhost origins
-  (the dev PWA) are always allowed; other browser origins must be in
-  `allowed_origins` (defaults to the production PhantomChat origin) or the upgrade
-  is refused with **403**.
+  isn't CORS-preflighted). Clients that send no `Origin` header (CLI/tooling) and
+  localhost origins (the dev PWA) are always allowed; other browser origins must
+  be in `allowed_origins` (defaults to the production PhantomChat origin) or the
+  upgrade is refused with **403**. A literal `Origin: null` — what a browser emits
+  from an *opaque* origin (sandboxed iframe, `data:`/`file:` page, some redirects)
+  — is treated as untrusted and refused too, so it can't be used to slip the gate.
 - Two nodes negotiate a **werift** (pure-TypeScript WebRTC) data channel. werift
   is used instead of Hyperswarm/`node-datachannel` because it's the only stack
   that survives `bun build --compile` into the shipped single binary — no native

--- a/README.md
+++ b/README.md
@@ -629,7 +629,13 @@ an encrypted WebRTC data channel with no relay in the hot path.
 ```
 
 - The node exposes **`ws://localhost:47100`** for the same-machine PWA (loopback
-  is a secure context, so an HTTPS PWA may open it — no TLS-cert wall).
+  is a secure context, so an HTTPS PWA may open it — no TLS-cert wall). The bridge
+  **gates WebSocket upgrades on the browser `Origin`**: loopback binding keeps the
+  port off the LAN, but any website you visit could otherwise reach it (WebSocket
+  isn't CORS-preflighted). No-`Origin` clients (CLI/tooling) and localhost origins
+  (the dev PWA) are always allowed; other browser origins must be in
+  `allowed_origins` (defaults to the production PhantomChat origin) or the upgrade
+  is refused with **403**.
 - Two nodes negotiate a **werift** (pure-TypeScript WebRTC) data channel. werift
   is used instead of Hyperswarm/`node-datachannel` because it's the only stack
   that survives `bun build --compile` into the shipped single binary — no native
@@ -657,10 +663,14 @@ stun_servers = [        # public reflexive-only STUN (no infra of ours)
   "stun:stun.l.google.com:19302",
   "stun:stun1.l.google.com:19302",
 ]
+allowed_origins = [     # browser origins allowed to open the loopback bridge
+  "https://chat.phantomyard.ai",   # (localhost + no-Origin clients always allowed)
+]
 ```
 
 Env overrides (highest precedence): `PHANTOMBOT_P2P_ENABLED=1`,
-`PHANTOMBOT_P2P_PORT=47100`, `PHANTOMBOT_P2P_STUN="stun:a:3478,stun:b:3478"`.
+`PHANTOMBOT_P2P_PORT=47100`, `PHANTOMBOT_P2P_STUN="stun:a:3478,stun:b:3478"`,
+`PHANTOMBOT_P2P_ALLOWED_ORIGINS="https://chat.phantomyard.ai"`.
 
 Check it with `phantombot p2p status` — it prints the resolved config and probes
 the loopback port to tell you whether a node is actually listening on this

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Runtime:
 | `phantombot logs [--no-follow] [--lines N]` | Tail the service logs (journalctl/launchd files/Task Scheduler log) |
 | `phantombot ask "<prompt>"` | One-shot prompt through the persona and harness chain |
 | `phantombot update [--check] [--force] [--restart]` | Check, install, or restart after updates |
+| `phantombot p2p status` | Show relay-free P2P transport config and whether a local node is listening |
 
 Agent-facing tools:
 
@@ -606,6 +607,71 @@ in `phantomchat.json`. It's merged with what's auto-detected:
 ```
 
 Most setups won't need it — the auto-detection covers them.
+
+## Relay-free P2P transport (preview)
+
+Normally every PhantomChat message round-trips through a public Nostr relay. That
+relay is both a latency floor (even two peers on the same desk pay a relay hop)
+and a dependency you don't control. The P2P transport (issue #258) demotes relays
+from "carry every message" to **signaling + fallback only**: your phantombot
+becomes your personal P2P node, and messages travel **directly node-to-node** over
+an encrypted WebRTC data channel with no relay in the hot path.
+
+**How it fits together**
+
+```
+  PWA (browser)                                    PWA (browser)
+     │  ws://localhost:47100                          │  ws://localhost:47100
+     ▼                                                ▼
+  [phantombot node] ◀── werift WebRTC data channel ──▶ [phantombot node]
+     ╲                    (direct, encrypted)                    ╱
+      ╲···· Nostr relays: WebRTC handshake (signaling) only ····╱
+```
+
+- The node exposes **`ws://localhost:47100`** for the same-machine PWA (loopback
+  is a secure context, so an HTTPS PWA may open it — no TLS-cert wall).
+- Two nodes negotiate a **werift** (pure-TypeScript WebRTC) data channel. werift
+  is used instead of Hyperswarm/`node-datachannel` because it's the only stack
+  that survives `bun build --compile` into the shipped single binary — no native
+  addon, no sidecar.
+- **Nostr carries only the WebRTC handshake** (SDP offer/answer + ICE candidates),
+  encrypted with NIP-44 on a dedicated ephemeral event kind — never your message
+  contents, which stay end-to-end sealed. Public **STUN** handles NAT traversal
+  (STUN only reflects your IP back, it never relays — so there's still no
+  infrastructure of ours in the path).
+- If no direct route can be established, everything **falls back to the existing
+  relay path**, so nothing ever breaks.
+
+**Off by default — zero regression.** The whole subsystem is dormant unless you
+turn it on. An unconfigured or existing install opens no port, advertises no
+capability, and behaves byte-for-byte as before. The node also relays only the
+opaque gift-wrap between peers — it never holds a key for your message contents.
+
+**Enable it** in `~/.config/phantombot/config.toml`, then restart the service:
+
+```toml
+[p2p]
+enabled = true          # default false
+port = 47100            # loopback ws bridge; must match the PWA (default 47100)
+stun_servers = [        # public reflexive-only STUN (no infra of ours)
+  "stun:stun.l.google.com:19302",
+  "stun:stun1.l.google.com:19302",
+]
+```
+
+Env overrides (highest precedence): `PHANTOMBOT_P2P_ENABLED=1`,
+`PHANTOMBOT_P2P_PORT=47100`, `PHANTOMBOT_P2P_STUN="stun:a:3478,stun:b:3478"`.
+
+Check it with `phantombot p2p status` — it prints the resolved config and probes
+the loopback port to tell you whether a node is actually listening on this
+machine.
+
+> **Preview scope.** This ships the phantombot node half. The PWA already sends
+> over `ws://localhost` when a peer advertises P2P capability, but the PWA-side
+> *ingestion* of a node's capability advertisement lands in a companion
+> phantomchat change — so until that ships, the node runs and advertises but the
+> PWA ladder stays on the relay path. A single node binds the loopback port, so
+> on a multi-persona host only the first PhantomChat persona hosts it.
 
 ## Editors: VS Code, Zed & JetBrains
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "jsonc-parser": "^3.3.1",
         "nostr-tools": "2.23.3",
         "smol-toml": "^1.3.0",
+        "werift": "0.23.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -21,9 +22,19 @@
     },
   },
   "packages": {
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@clack/core": ["@clack/core@1.3.0", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA=="],
 
     "@clack/prompts": ["@clack/prompts@1.3.0", "", { "dependencies": { "@clack/core": "1.3.0", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw=="],
+
+    "@fidm/asn1": ["@fidm/asn1@1.0.4", "", {}, "sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ=="],
+
+    "@fidm/x509": ["@fidm/x509@1.2.1", "", { "dependencies": { "@fidm/asn1": "^1.0.4", "tweetnacl": "^1.0.1" } }, "sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w=="],
+
+    "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
+
+    "@minhducsun2002/leb128": ["@minhducsun2002/leb128@1.0.0", "", {}, "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
@@ -31,15 +42,53 @@
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-rsa": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pfx": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.8.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
+
     "@scure/base": ["@scure/base@2.0.0", "", {}, "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="],
 
     "@scure/bip32": ["@scure/bip32@2.0.1", "", { "dependencies": { "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA=="],
 
     "@scure/bip39": ["@scure/bip39@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1", "@scure/base": "2.0.0" } }, "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg=="],
 
+    "@shinyoshiaki/binary-data": ["@shinyoshiaki/binary-data@0.6.1", "", { "dependencies": { "generate-function": "^2.3.1", "is-plain-object": "^2.0.3" } }, "sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w=="],
+
+    "@shinyoshiaki/jspack": ["@shinyoshiaki/jspack@0.0.6", "", {}, "sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg=="],
+
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "aes-js": ["aes-js@3.1.2", "", {}, "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
@@ -49,27 +98,87 @@
 
     "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
 
+    "date-fns": ["date-fns@2.30.0", "", { "dependencies": { "@babel/runtime": "^7.21.0" } }, "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw=="],
+
+    "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
+
+    "dns-packet": ["dns-packet@5.6.1", "", { "dependencies": { "@leichtgewicht/ip-codec": "^2.0.1" } }, "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
+    "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "int64-buffer": ["int64-buffer@1.1.0", "", {}, "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw=="],
+
+    "ip": ["ip@2.0.1", "", {}, "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="],
+
+    "is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
+
+    "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
+
+    "isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
+
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
+    "mp4box": ["mp4box@0.5.4", "", {}, "sha512-GcCH0fySxBurJtvr0dfhz0IxHZjc1RP+F+I8xw+LIwkU1a+7HJx8NCDiww1I5u4Hz6g4eR1JlGADEGJ9r4lSfA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "multicast-dns": ["multicast-dns@7.2.5", "", { "dependencies": { "dns-packet": "^5.2.2", "thunky": "^1.0.2" }, "bin": { "multicast-dns": "cli.js" } }, "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg=="],
 
     "nostr-tools": ["nostr-tools@2.23.3", "", { "dependencies": { "@noble/ciphers": "2.1.1", "@noble/curves": "2.0.1", "@noble/hashes": "2.0.1", "@scure/base": "2.0.0", "@scure/bip32": "2.0.1", "@scure/bip39": "2.0.1", "nostr-wasm": "0.1.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-AALyt9k8xPdF4UV2mlLJ2mgCn4kpTB0DZ8t2r6wjdUh6anfx2cTVBsHUlo9U0EY/cKC5wcNyiMAmRJV5OVEalA=="],
 
     "nostr-wasm": ["nostr-wasm@0.1.0", "", {}, "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA=="],
 
+    "p-cancelable": ["p-cancelable@2.1.1", "", {}, "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="],
+
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
+    "rx.mini": ["rx.mini@1.4.0", "", {}, "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="],
+
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
+    "thunky": ["thunky@1.1.0", "", {}, "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "werift": ["werift@0.23.0", "", { "dependencies": { "@fidm/x509": "^1.2.1", "@minhducsun2002/leb128": "^1.0.0", "@noble/curves": "^1.8.1", "@peculiar/x509": "^1.12.3", "@shinyoshiaki/binary-data": "^0.6.1", "@shinyoshiaki/jspack": "^0.0.6", "aes-js": "^3.1.2", "buffer": "^6.0.3", "debug": "4.4.0", "fast-deep-equal": "^3.1.3", "int64-buffer": "1.1.0", "ip": "^2.0.1", "mp4box": "^0.5.3", "multicast-dns": "^7.2.5", "tweetnacl": "^1.0.3", "werift-common": "*", "werift-dtls": "*", "werift-ice": "*", "werift-rtp": "*", "werift-sctp": "*" } }, "sha512-/WcIN5DHFG9Ri4anGOmIkp8gxBGFMWSIB/m4sfZ5CWlLfD3iMhiaAUuTBuc+KV3SY9NDmvmLtiN2uaM7k3lVzw=="],
+
+    "werift-common": ["werift-common@0.0.3", "", { "dependencies": { "@shinyoshiaki/jspack": "^0.0.6", "debug": "^4.4.0" } }, "sha512-ma3E4BqKTyZVLhrdfTVs2T1tg9seeUtKMRn5e64LwgrogWa62+3LAUoLBUSl1yPWhgSkXId7GmcHuWDen9IJeQ=="],
+
+    "werift-dtls": ["werift-dtls@0.5.7", "", { "dependencies": { "@fidm/x509": "^1.2.1", "@noble/curves": "^1.3.0", "@peculiar/x509": "^1.9.2", "@shinyoshiaki/binary-data": "^0.6.1", "date-fns": "^2.29.3", "lodash": "^4.17.21", "rx.mini": "^1.2.2", "tweetnacl": "^1.0.3" } }, "sha512-z2fjbP7fFUFmu/Ky4bCKXzdgPTtmSY1DYi0TUf3GG2zJT4jMQ3TQmGY8y7BSSNGetvL4h3pRZ5un0EcSOWpPog=="],
+
+    "werift-ice": ["werift-ice@0.2.2", "", { "dependencies": { "@shinyoshiaki/jspack": "^0.0.6", "buffer-crc32": "^1.0.0", "debug": "^4.3.4", "int64-buffer": "^1.0.1", "ip": "^2.0.1", "lodash": "^4.17.21", "multicast-dns": "^7.2.5", "p-cancelable": "^2.1.1", "rx.mini": "^1.2.2" } }, "sha512-td52pHp+JmFnUn5jfDr/SSNO0dMCbknhuPdN1tFp9cfRj5jaktN63qnAdUuZC20QCC3ETWdsOthcm+RalHpFCQ=="],
+
+    "werift-rtp": ["werift-rtp@0.8.8", "", { "dependencies": { "@minhducsun2002/leb128": "^1.0.0", "@shinyoshiaki/jspack": "^0.0.6", "aes-js": "^3.1.2", "buffer": "^6.0.3", "mp4box": "^0.5.3" } }, "sha512-GiYMSdvCyScQaw5bnEsraSoHUVZpjfokJAiLV4R1FsiB06t6XiebPYPpkqB9nYNNKiA8Z/cYWsym7wISq1sYSQ=="],
+
+    "werift-sctp": ["werift-sctp@0.0.11", "", { "dependencies": { "@shinyoshiaki/jspack": "^0.0.6" } }, "sha512-7109yuI5U7NTEHjqjn0A8VeynytkgVaxM6lRr1Ziv0D8bPcaB8A7U/P88M7WaCpWDoELHoXiRUjQycMWStIgjQ=="],
 
     "@scure/bip32/@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
 
@@ -80,5 +189,15 @@
     "nostr-tools/@noble/curves": ["@noble/curves@2.0.1", "", { "dependencies": { "@noble/hashes": "2.0.1" } }, "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw=="],
 
     "nostr-tools/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "werift/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "werift-dtls/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "werift-dtls/@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "werift/@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,15 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 | `src/lib/{systemd,launchd,taskScheduler}.ts` | Per-OS backends: unit/plist/task templates + a `ServiceControl` impl. Each encapsulates its own keep-alive quirk (systemd `Restart=on-failure`; launchd `KeepAlive`; Windows 1-min `TimeTrigger`), so `stop`/`start` behave consistently across OSes. | `systemctl`/`launchctl`/`schtasks` |
 | `src/lib/serviceLifecycle.ts` | `runLifecycleAction` — the shared driver behind `phantombot start/stop/restart`. OS-agnostic: only ever calls `ServiceControl`, never a supervisor directly. | `platform.ts` |
 | `src/cli/{start,stop,restart,logs}.ts` | Thin CLI wrappers over `serviceLifecycle`/`logsSpec` for the service-lifecycle verbs. | `lib/serviceLifecycle`, `lib/platform` |
+| `src/p2p/` | Relay-free P2P transport (issue #258). The node is a dumb, encrypted-wrap relay: it forwards opaque gift-wraps node-to-node and never decrypts them. Off by default (`config.p2p.enabled`). | `werift`, `nostrCrypto`, `RelayPool`, Bun ws |
+| `src/p2p/frame.ts` | Wire-frame contract with the PWA: parse/build `["EVENT", <gift-wrap>]` relay frames, read the recipient off the wrap p-tag. Pure. | — |
+| `src/p2p/signaling.ts` | WebRTC handshake (SDP/ICE) over Nostr — NIP-44-encrypted on a dedicated ephemeral kind (21050), separate from the chat 1059 plane. Rides the `RelayPool` seam. | `nostrCrypto`, `RelayPool` |
+| `src/p2p/peerConnection.ts` | One werift `RTCPeerConnection` + data channel per peer. Readiness is gated on the **data channel** `open` event, not transport `connected` (the channel opens later; flushing early drops the first frame). | `werift` |
+| `src/p2p/localBridge.ts` | `ws://localhost:47100` server (Bun native, loopback-only) for the same-machine PWA. Frames in → route; peer frames → broadcast to PWA. | Bun ws |
+| `src/p2p/node.ts` | Orchestrator. Routes frames by recipient pubkey, dials peers on demand, deterministic initiator (smaller pubkey) + `hello` nudge to avoid offer glare, per-peer outbox buffered until the channel opens. All seams injected for testing. | `peerConnection`, `signaling`, `localBridge` |
+| `src/p2p/capability.ts` | Capability advertisement (NIP-78 kind 30078) so a peer's PWA can light up its transport ladder. The PWA-side ingestion is a companion phantomchat change. | `RelayPool` |
+| `src/p2p/index.ts` | Daemon glue: `buildP2PNode` (from a persona's identity/relays/pool) + `runP2PNode` (start, wait for abort, stop), pushed onto `run`'s task list. | all of `src/p2p/*` |
+| `src/cli/p2p.ts` | `phantombot p2p status` — read-only view of the config + a loopback probe. | `config` |
 
 ## End-to-end flow
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "cron-parser": "^5.5.0",
     "jsonc-parser": "^3.3.1",
     "nostr-tools": "2.23.3",
-    "smol-toml": "^1.3.0"
+    "smol-toml": "^1.3.0",
+    "werift": "0.23.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,6 +46,7 @@ import tickCmd from "./tick.ts";
 import updateCmd from "./update.ts";
 import voiceCmd from "./voice.ts";
 import replyModeCmd from "./replyMode.ts";
+import p2pCmd from "./p2p.ts";
 
 export const mainCommand = defineCommand({
   meta: {
@@ -82,5 +83,6 @@ export const mainCommand = defineCommand({
     update: updateCmd,
     voice: voiceCmd,
     "reply-mode": replyModeCmd,
+    p2p: p2pCmd,
   },
 });

--- a/src/cli/p2p.ts
+++ b/src/cli/p2p.ts
@@ -1,0 +1,98 @@
+/**
+ * `phantombot p2p` — inspect the relay-free P2P transport (phantombot#258).
+ *
+ * The node itself runs inside `phantombot run`; this command is a read-only
+ * window on it. `p2p status` prints the resolved config and probes the loopback
+ * bridge port to report whether a node is actually listening on this machine.
+ */
+
+import { defineCommand } from "citty";
+
+import { DEFAULT_P2P, loadConfig } from "../config.ts";
+
+/** Probe whether something is accepting ws connections on the loopback port. */
+async function bridgeListening(port: number, timeoutMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (v: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(v);
+    };
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    } catch {
+      done(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+      done(false);
+    }, timeoutMs);
+    ws.addEventListener("open", () => {
+      clearTimeout(timer);
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+      done(true);
+    });
+    ws.addEventListener("error", () => {
+      clearTimeout(timer);
+      done(false);
+    });
+  });
+}
+
+const statusCmd = defineCommand({
+  meta: {
+    name: "status",
+    description: "Show P2P transport config and whether a local node is listening.",
+  },
+  async run() {
+    const config = await loadConfig();
+    const p2p = config.p2p ?? DEFAULT_P2P;
+
+    console.log("P2P transport (phantombot#258)");
+    console.log(`  enabled:  ${p2p.enabled ? "yes" : "no (relay-only)"}`);
+    console.log(`  port:     ${p2p.port} (ws://127.0.0.1:${p2p.port}, loopback only)`);
+    console.log(
+      `  STUN:     ${p2p.stunServers.length ? p2p.stunServers.join(", ") : "none (host candidates only)"}`,
+    );
+
+    if (!p2p.enabled) {
+      console.log(
+        "\nP2P is disabled. Enable it with `p2p.enabled = true` in config.toml " +
+          "(or PHANTOMBOT_P2P_ENABLED=1), then restart the service.",
+      );
+      process.exitCode = 0;
+      return;
+    }
+
+    const listening = await bridgeListening(p2p.port);
+    console.log(`\n  bridge:   ${listening ? "listening ✓" : "not listening ✗"}`);
+    if (!listening) {
+      console.log(
+        "  A node is not currently bound to the port. Is `phantombot run` " +
+          "(or the service) up on this machine?",
+      );
+    }
+    process.exitCode = 0;
+  },
+});
+
+export default defineCommand({
+  meta: {
+    name: "p2p",
+    description: "Relay-free P2P transport node (phantombot#258).",
+  },
+  subCommands: {
+    status: statusCmd,
+  },
+});

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -36,10 +36,16 @@ import { cleanupStaleUpdateArtifacts } from "../lib/binaryUpdate.ts";
 import { npubEncode } from "../lib/nostrIdentity.ts";
 import {
   type Config,
+  DEFAULT_P2P,
   loadConfig,
   personaDir,
   type TelegramAccount,
 } from "../config.ts";
+import {
+  advertiseP2PCapability,
+  buildP2PNode,
+  runP2PNode,
+} from "../p2p/index.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import {
   resolveHarnessBinsForConfig,
@@ -559,6 +565,12 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         );
       }
 
+      // The relay-free P2P node (phantombot#258) binds a single loopback port
+      // (config.p2p.port), so exactly ONE persona hosts it — the first
+      // phantomchat persona. Disabled by default; see config.p2p.
+      const p2pSettings = config.p2p ?? DEFAULT_P2P;
+      let p2pNodeStarted = false;
+
       for (const spec of phantomchatPersonas) {
         const { identity, allowedHex, tofu, groupBots } = spec.config;
 
@@ -765,6 +777,48 @@ export async function runRun(input: RunInput = {}): Promise<number> {
               error: (e as Error).message,
             });
           });
+        }
+
+        // Relay-free P2P transport node. Rides THIS persona's identity, relays
+        // and relay pool: a loopback ws bridge for the same-machine PhantomChat
+        // PWA plus werift WebRTC channels to peer nodes, with Nostr carrying only
+        // the WebRTC handshake. Started for the first phantomchat persona only
+        // (single loopback port). Inert unless config.p2p.enabled.
+        if (p2pSettings.enabled && !p2pNodeStarted) {
+          p2pNodeStarted = true;
+          try {
+            const p2pNode = buildP2PNode({
+              secretKey: identity.secretKey,
+              publicKeyHex: identity.publicKeyHex,
+              relays,
+              pool: pool as unknown as Parameters<typeof buildP2PNode>[0]["pool"],
+              settings: p2pSettings,
+            });
+            advertiseP2PCapability({
+              secretKey: identity.secretKey,
+              publicKeyHex: identity.publicKeyHex,
+              relays,
+              pool: pool as unknown as Parameters<typeof buildP2PNode>[0]["pool"],
+              settings: p2pSettings,
+            });
+            out.write(
+              `  [p2p:${spec.persona}] node on ws://127.0.0.1:${p2pSettings.port}, ` +
+                `${p2pSettings.stunServers.length} STUN server(s)\n`,
+            );
+            tasks.push(runP2PNode(p2pNode, ac.signal));
+          } catch (e) {
+            p2pNodeStarted = false;
+            log.warn(`p2p[${spec.persona}]: node failed to start`, {
+              error: (e as Error).message,
+            });
+            err.write(
+              `warning: p2p node failed to start (port ${p2pSettings.port} in use?) — chat still works over relays\n`,
+            );
+          }
+        } else if (p2pSettings.enabled && p2pNodeStarted) {
+          out.write(
+            `  [p2p:${spec.persona}] skipped — a P2P node is already bound to port ${p2pSettings.port}\n`,
+          );
         }
       }
     }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -44,7 +44,7 @@ import {
 import {
   advertiseP2PCapability,
   buildP2PNode,
-  runP2PNode,
+  startP2PNode,
 } from "../p2p/index.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import {
@@ -785,35 +785,29 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         // the WebRTC handshake. Started for the first phantomchat persona only
         // (single loopback port). Inert unless config.p2p.enabled.
         if (p2pSettings.enabled && !p2pNodeStarted) {
-          p2pNodeStarted = true;
-          try {
-            const p2pNode = buildP2PNode({
-              secretKey: identity.secretKey,
-              publicKeyHex: identity.publicKeyHex,
-              relays,
-              pool: pool as unknown as Parameters<typeof buildP2PNode>[0]["pool"],
-              settings: p2pSettings,
-            });
-            advertiseP2PCapability({
-              secretKey: identity.secretKey,
-              publicKeyHex: identity.publicKeyHex,
-              relays,
-              pool: pool as unknown as Parameters<typeof buildP2PNode>[0]["pool"],
-              settings: p2pSettings,
-            });
-            out.write(
-              `  [p2p:${spec.persona}] node on ws://127.0.0.1:${p2pSettings.port}, ` +
-                `${p2pSettings.stunServers.length} STUN server(s)\n`,
-            );
-            tasks.push(runP2PNode(p2pNode, ac.signal));
-          } catch (e) {
-            p2pNodeStarted = false;
-            log.warn(`p2p[${spec.persona}]: node failed to start`, {
-              error: (e as Error).message,
-            });
-            err.write(
-              `warning: p2p node failed to start (port ${p2pSettings.port} in use?) — chat still works over relays\n`,
-            );
+          const p2pDeps = {
+            secretKey: identity.secretKey,
+            publicKeyHex: identity.publicKeyHex,
+            relays,
+            pool: pool as unknown as Parameters<typeof buildP2PNode>[0]["pool"],
+            settings: p2pSettings,
+          };
+          const p2pNode = buildP2PNode(p2pDeps);
+          // Start SYNCHRONOUSLY and contain any port-conflict throw inside the
+          // helper, so a failed P2P bring-up degrades to relays instead of
+          // rejecting a pushed task and aborting the whole `run` process.
+          const p2pTask = startP2PNode({
+            node: p2pNode,
+            advertise: () => advertiseP2PCapability(p2pDeps),
+            signal: ac.signal,
+            out,
+            err,
+            persona: spec.persona,
+            port: p2pSettings.port,
+          });
+          if (p2pTask) {
+            p2pNodeStarted = true;
+            tasks.push(p2pTask);
           }
         } else if (p2pSettings.enabled && p2pNodeStarted) {
           out.write(

--- a/src/config.ts
+++ b/src/config.ts
@@ -319,7 +319,44 @@ export interface Config {
   retrieval?: RetrievalSettings;
 
   voice: import("./lib/voice.ts").VoiceConfig;
+
+  /**
+   * Relay-free P2P transport (phantombot#258): a local ws bridge for the
+   * same-machine PhantomChat PWA plus werift WebRTC + Nostr-signalled channels
+   * to peer nodes. DISABLED BY DEFAULT — an unconfigured or existing install
+   * runs exactly as before (no bridge port opened, no capability advertised, no
+   * signaling subscription). See P2PSettings and buildP2PConfig.
+   *
+   * Optional on the type (so partial test configs need not spell it out), but
+   * `loadConfig` always populates it; consumers treat absence as `DEFAULT_P2P`.
+   */
+  p2p?: P2PSettings;
 }
+
+/** Settings for the relay-free P2P transport node (phantombot#258). */
+export interface P2PSettings {
+  /** Master switch. Default false — the whole subsystem is dormant when off. */
+  enabled: boolean;
+  /**
+   * Loopback port for the PWA ws bridge. MUST match the PWA's
+   * DEFAULT_LOCAL_NODE_PORT (47100). Bound to 127.0.0.1 only.
+   */
+  port: number;
+  /**
+   * Public STUN servers for NAT traversal. STUN only reflects your public
+   * IP:port back — it never relays media — so using public STUN keeps the
+   * "no infrastructure of ours" constraint intact. Empty = host candidates
+   * only (localhost + LAN work; remote NAT traversal won't).
+   */
+  stunServers: string[];
+}
+
+export const DEFAULT_P2P: P2PSettings = {
+  enabled: false,
+  port: 47100,
+  // Google's public STUN — reflexive-only, no relaying, no infra of ours.
+  stunServers: ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],
+};
 
 /**
  * XDG base-directory resolution, identical on every platform. Windows uses
@@ -361,6 +398,7 @@ export async function loadConfig(): Promise<Config> {
   const tomlCodex = (tomlHarnesses.codex ?? {}) as Record<string, unknown>;
   const tomlChannels = (toml.channels ?? {}) as Record<string, unknown>;
   const tomlTelegram = (tomlChannels.telegram ?? {}) as Record<string, unknown>;
+  const tomlP2p = (toml.p2p ?? {}) as Record<string, unknown>;
   const tomlEmbeddings = (toml.embeddings ?? {}) as Record<string, unknown>;
   const tomlGemini = (tomlEmbeddings.gemini ?? {}) as Record<string, unknown>;
   const tomlRetrieval = (toml.retrieval ?? {}) as Record<string, unknown>;
@@ -508,7 +546,43 @@ export async function loadConfig(): Promise<Config> {
     retrieval: buildRetrievalConfig(tomlRetrieval, tomlTurnIndexing),
 
     voice: buildVoiceConfig(tomlVoice),
+
+    p2p: buildP2PConfig(tomlP2p),
   };
+}
+
+/**
+ * Resolve the relay-free P2P transport settings. Env wins over TOML wins over
+ * defaults, same precedence as everything else. DISABLED by default so an
+ * unconfigured install is byte-for-byte unchanged. The port is clamped to the
+ * unprivileged range; STUN servers fall back to the public reflexive-only set.
+ */
+function buildP2PConfig(tomlP2p: Record<string, unknown>): P2PSettings {
+  const enabled =
+    asBool(process.env.PHANTOMBOT_P2P_ENABLED) ??
+    asBool(tomlP2p.enabled) ??
+    DEFAULT_P2P.enabled;
+
+  const port = clampInt(
+    asInt(process.env.PHANTOMBOT_P2P_PORT) ??
+      asInt(tomlP2p.port) ??
+      DEFAULT_P2P.port,
+    1024,
+    65_535,
+  );
+
+  // Env is a comma-separated list (like PHANTOMBOT_TELEGRAM_ALLOWED_USERS);
+  // TOML is a native array. An explicit empty env value ("") means "no STUN".
+  const stunFromEnv = process.env.PHANTOMBOT_P2P_STUN;
+  const stunServers =
+    stunFromEnv !== undefined
+      ? stunFromEnv
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      : (asStringArray(tomlP2p.stun_servers) ?? DEFAULT_P2P.stunServers);
+
+  return { enabled, port, stunServers };
 }
 
 function buildTelegramStreamingConfig(

--- a/src/config.ts
+++ b/src/config.ts
@@ -349,6 +349,16 @@ export interface P2PSettings {
    * only (localhost + LAN work; remote NAT traversal won't).
    */
   stunServers: string[];
+  /**
+   * Browser origins allowed to open the loopback ws bridge. Binding to 127.0.0.1
+   * keeps the port off the LAN, but ANY website the user visits can still reach
+   * `ws://127.0.0.1:<port>` from the browser (WebSocket handshakes are not
+   * CORS-preflighted). We gate on the `Origin` header: requests with NO Origin
+   * (CLI probes / non-browser tooling) and localhost origins (the dev PWA) are
+   * always allowed; a browser Origin is otherwise accepted only if it is in this
+   * list. Defaults to the production PhantomChat origin.
+   */
+  allowedOrigins: string[];
 }
 
 export const DEFAULT_P2P: P2PSettings = {
@@ -356,6 +366,9 @@ export const DEFAULT_P2P: P2PSettings = {
   port: 47100,
   // Google's public STUN — reflexive-only, no relaying, no infra of ours.
   stunServers: ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],
+  // The production PhantomChat PWA. Localhost origins (dev) and no-Origin
+  // clients (CLI) are allowed unconditionally on top of this list.
+  allowedOrigins: ["https://chat.phantomyard.ai"],
 };
 
 /**
@@ -582,7 +595,19 @@ function buildP2PConfig(tomlP2p: Record<string, unknown>): P2PSettings {
           .filter((s) => s.length > 0)
       : (asStringArray(tomlP2p.stun_servers) ?? DEFAULT_P2P.stunServers);
 
-  return { enabled, port, stunServers };
+  // Same env-list convention as STUN: comma-separated env overrides the TOML
+  // array; an explicit empty env value ("") means "no extra browser origins"
+  // (localhost + no-Origin clients are still allowed by the bridge itself).
+  const originsFromEnv = process.env.PHANTOMBOT_P2P_ALLOWED_ORIGINS;
+  const allowedOrigins =
+    originsFromEnv !== undefined
+      ? originsFromEnv
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      : (asStringArray(tomlP2p.allowed_origins) ?? DEFAULT_P2P.allowedOrigins);
+
+  return { enabled, port, stunServers, allowedOrigins };
 }
 
 function buildTelegramStreamingConfig(

--- a/src/p2p/capability.ts
+++ b/src/p2p/capability.ts
@@ -1,0 +1,117 @@
+/**
+ * P2P capability advertisement (phantomyard/phantombot#258, phantomchat#61).
+ *
+ * The PWA's transport ladder is GATED: it only tries a direct transport toward a
+ * peer that has ADVERTISED it can accept one (see phantomchat
+ * `transport/capability.ts` — `PeerCapabilityRegistry`). Until a peer advertises,
+ * every send falls straight through to the relay with no probe and no added
+ * latency. That registry is empty for every PWA user today; this module is how a
+ * phantombot node fills it.
+ *
+ * A node publishes an addressable app-data event (NIP-78 kind 30078, `d` tag
+ * `phantomchat-p2p`) under the persona's pubkey. It is replaceable, so
+ * re-publishing on each start just supersedes the previous one, and it is public
+ * (unencrypted) on purpose — capability is not a secret, and the PWA needs to
+ * read a contact's capability before any encrypted channel exists.
+ *
+ * PROPOSED CROSS-REPO CONTRACT. The matching PWA-side ingestion (subscribe by
+ * contact pubkey, parse this event, call `PeerCapabilityRegistry.set`) lands in
+ * a phantomchat companion PR. Until it ships this advertisement is inert: it's a
+ * public event nothing reads yet, so publishing it changes no behaviour. The
+ * shape here is the contract that companion implements.
+ */
+
+import { finalizeEvent } from "nostr-tools/pure";
+
+import { log } from "../lib/logger.ts";
+import type { NTNostrEvent } from "../lib/nostrCrypto.ts";
+import type { RelayPool } from "../channels/phantomchat/transport.ts";
+
+/** NIP-78 addressable app-data kind used for the capability advertisement. */
+export const CAPABILITY_KIND = 30078;
+
+/** The `d` tag that namespaces our capability event within kind 30078. */
+export const CAPABILITY_D_TAG = "phantomchat-p2p";
+
+/**
+ * What a node advertises. Mirrors the PWA's `PeerCapabilities` shape verbatim
+ * (phantomchat `transport/capability.ts`) so ingestion is a direct assignment.
+ */
+export interface NodeCapabilities {
+  /** The node can accept a same-machine `ws://localhost` bridge connection. */
+  localWs: boolean;
+  /** TCP port the node's ws bridge listens on. */
+  localWsPort: number;
+  /** The node can hold a WebRTC data channel (LAN host candidates or remote). */
+  webrtc: boolean;
+  /**
+   * The node runs a raw-UDP DHT. Always false: this build uses werift WebRTC +
+   * Nostr signaling, not Hyperswarm (which panics under Bun). Kept in the shape
+   * so the field is explicit rather than absent.
+   */
+  dht: boolean;
+}
+
+/** Build the capability descriptor a running node advertises. */
+export function nodeCapabilities(port: number): NodeCapabilities {
+  return { localWs: true, localWsPort: port, webrtc: true, dht: false };
+}
+
+/** Build (and sign) the replaceable capability event for this node. */
+export function buildCapabilityEvent(
+  ourSk: Uint8Array,
+  caps: NodeCapabilities,
+): NTNostrEvent {
+  const template = {
+    kind: CAPABILITY_KIND,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [["d", CAPABILITY_D_TAG]],
+    content: JSON.stringify(caps),
+  };
+  return finalizeEvent(template, ourSk) as unknown as NTNostrEvent;
+}
+
+/**
+ * Parse a capability event back to `{ authorHex, caps }`, or `null` when it is
+ * not a well-formed capability advertisement. This is the reference the PWA
+ * companion mirrors on ingest. Never throws.
+ */
+export function parseCapabilityEvent(
+  event: NTNostrEvent,
+): { authorHex: string; caps: NodeCapabilities } | null {
+  try {
+    if (event.kind !== CAPABILITY_KIND) return null;
+    const hasDTag = event.tags.some((t) => t[0] === "d" && t[1] === CAPABILITY_D_TAG);
+    if (!hasDTag) return null;
+    const parsed = JSON.parse(event.content) as Partial<NodeCapabilities>;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return {
+      authorHex: event.pubkey,
+      caps: {
+        localWs: Boolean(parsed.localWs),
+        localWsPort: typeof parsed.localWsPort === "number" ? parsed.localWsPort : 0,
+        webrtc: Boolean(parsed.webrtc),
+        dht: Boolean(parsed.dht),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Publish this node's capability advertisement. Best-effort: resolves once the
+ * event has been handed to the relays (success if any relay accepts). A failure
+ * to reach relays is non-fatal — the advertisement is inert until a PWA reads it.
+ */
+export async function publishCapability(
+  pool: RelayPool,
+  relays: string[],
+  event: NTNostrEvent,
+): Promise<void> {
+  const results = await Promise.allSettled(pool.publish(relays, event));
+  const ok = results.some((r) => r.status === "fulfilled");
+  if (!ok) {
+    log.debug("[p2p] capability advertisement reached no relay");
+  }
+}

--- a/src/p2p/frame.ts
+++ b/src/p2p/frame.ts
@@ -1,0 +1,109 @@
+/**
+ * P2P wire-frame contract with the PhantomChat PWA (phantomyard/phantombot#258,
+ * phantomyard/phantomchat#61/#62).
+ *
+ * The PWA and phantombot speak the SAME wire language as a Nostr relay. When the
+ * PWA wants to push a message over a direct transport it does NOT invent a
+ * bespoke envelope — it ships the EXACT kind-1059 gift-wrap it just published to
+ * the relay, framed as a standard relay `["EVENT", wrap]` message (see
+ * phantomchat `transport-selector.ts`). The receiver feeds that frame straight
+ * into its relay-pool ingest (`NostrRelayPool.ingestP2PEvent`).
+ *
+ * phantombot's P2P node is therefore a DUMB, ENCRYPTED-WRAP RELAY: it forwards
+ * the opaque gift-wrap node-to-node and never decrypts it. All this module does
+ * is (a) validate a frame is a well-formed `["EVENT", wrap]`, and (b) read the
+ * recipient's real pubkey off the wrap's `p` tag so the node knows which peer to
+ * route to. The wrap's inner content stays sealed end-to-end between the two
+ * PWAs — the node has no key for it and never needs one.
+ */
+
+import type { NTNostrEvent } from "../lib/nostrCrypto.ts";
+
+/**
+ * The loopback port the local node exposes for the PWA ws bridge. MUST stay in
+ * sync with `DEFAULT_LOCAL_NODE_PORT` in the phantomchat PWA
+ * (`src/lib/phantomchat/transport/local-ws-transport.ts`). Changing one without
+ * the other silently breaks the Tier-1 localhost path.
+ */
+export const DEFAULT_LOCAL_NODE_PORT = 47100;
+
+/** The relay-wire kind carried over the bridge: a NIP-59 gift-wrap. */
+export const GIFTWRAP_KIND = 1059;
+
+/** A parsed, validated `["EVENT", wrap]` frame. */
+export interface ParsedEventFrame {
+  /** The opaque gift-wrap event. The node forwards this verbatim. */
+  wrap: NTNostrEvent;
+  /** The recipient's real pubkey (hex), read from the wrap's `p` tag. */
+  recipientHex: string;
+}
+
+/**
+ * Shape a gift-wrap into the relay wire frame the PWA ingest expects:
+ * `["EVENT", wrap]` as a JSON string. Symmetric with `parseEventFrame`.
+ */
+export function buildEventFrame(wrap: NTNostrEvent): string {
+  return JSON.stringify(["EVENT", wrap]);
+}
+
+/**
+ * Read the recipient's real pubkey off a gift-wrap. NIP-59 wraps address the
+ * recipient with a single `["p", <recipientPubHex>]` tag (the outer author is a
+ * throwaway ephemeral key, so authorship reveals nothing). Returns the first
+ * `p` tag value, or `null` if the wrap carries none.
+ */
+export function recipientOfWrap(wrap: NTNostrEvent): string | null {
+  if (!wrap || !Array.isArray(wrap.tags)) return null;
+  for (const tag of wrap.tags) {
+    if (Array.isArray(tag) && tag[0] === "p" && typeof tag[1] === "string" && tag[1]) {
+      return tag[1];
+    }
+  }
+  return null;
+}
+
+/**
+ * Minimal structural check that an object is a signed Nostr event we can relay.
+ * We do NOT verify the signature here — the node never trusts wrap contents, it
+ * only forwards them, and the receiving PWA re-verifies on ingest. We just guard
+ * against malformed frames that would poison the transport.
+ */
+export function looksLikeEvent(value: unknown): value is NTNostrEvent {
+  if (!value || typeof value !== "object") return false;
+  const e = value as Record<string, unknown>;
+  return (
+    typeof e.id === "string" &&
+    typeof e.pubkey === "string" &&
+    typeof e.sig === "string" &&
+    typeof e.content === "string" &&
+    typeof e.kind === "number" &&
+    typeof e.created_at === "number" &&
+    Array.isArray(e.tags)
+  );
+}
+
+/**
+ * Parse a raw ws payload into a validated event frame, or return `null` when it
+ * is anything other than a well-formed `["EVENT", <gift-wrap>]`. Never throws:
+ * a bad frame is dropped, not fatal. We accept only kind-1059 gift-wraps that
+ * carry a recipient `p` tag — that is the entire vocabulary of the bridge, so
+ * anything else (a `["REQ", …]`, a `["CLOSE", …]`, junk) is ignored.
+ */
+export function parseEventFrame(raw: string): ParsedEventFrame | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed[0] !== "EVENT") return null;
+
+  const wrap = parsed[1];
+  if (!looksLikeEvent(wrap)) return null;
+  if (wrap.kind !== GIFTWRAP_KIND) return null;
+
+  const recipientHex = recipientOfWrap(wrap);
+  if (!recipientHex) return null;
+
+  return { wrap, recipientHex };
+}

--- a/src/p2p/index.ts
+++ b/src/p2p/index.ts
@@ -1,0 +1,77 @@
+/**
+ * P2P transport node — public surface + daemon glue (phantomyard/phantombot#258).
+ *
+ * Assembles the werift + Nostr-signaling + Bun-ws pieces into a running node and
+ * exposes a start-and-wait-for-abort helper the `run` daemon pushes onto its
+ * task list, mirroring the phantomchat listener pattern.
+ */
+
+import { log } from "../lib/logger.ts";
+import type { P2PSettings } from "../config.ts";
+import type { RelayPool } from "../channels/phantomchat/transport.ts";
+import {
+  buildCapabilityEvent,
+  nodeCapabilities,
+  publishCapability,
+} from "./capability.ts";
+import { LocalBridge } from "./localBridge.ts";
+import { P2PNode } from "./node.ts";
+import { NostrSignaling } from "./signaling.ts";
+
+export { P2PNode } from "./node.ts";
+export { DEFAULT_LOCAL_NODE_PORT } from "./frame.ts";
+export type { NodeCapabilities } from "./capability.ts";
+
+export interface BuildP2PNodeDeps {
+  /** Persona secret key — signs signaling + capability, derives our pubkey. */
+  secretKey: Uint8Array;
+  /** Persona pubkey (hex) — decides initiator/responder role per peer. */
+  publicKeyHex: string;
+  /** Relays used for signaling + capability (same set the chat channel uses). */
+  relays: string[];
+  /** The relay pool to ride (reuse the persona's existing SimplePool). */
+  pool: RelayPool;
+  /** Resolved P2P settings (port + STUN). */
+  settings: P2PSettings;
+}
+
+/** Assemble a ready-to-start P2P node from a persona's identity + relays. */
+export function buildP2PNode(deps: BuildP2PNodeDeps): P2PNode {
+  const signaling = new NostrSignaling(deps.secretKey, deps.relays, deps.pool);
+  const iceServers = deps.settings.stunServers.map((urls) => ({ urls }));
+  return new P2PNode({
+    ourPubHex: deps.publicKeyHex,
+    iceServers,
+    signaling,
+    createBridge: (onOutbound) => new LocalBridge({ port: deps.settings.port, onOutbound }),
+  });
+}
+
+/**
+ * Publish this node's capability advertisement once. Best-effort and detached
+ * from startup — a relay hiccup must never delay the node coming up, and the
+ * advert is inert until a PWA companion reads it.
+ */
+export function advertiseP2PCapability(deps: BuildP2PNodeDeps): void {
+  const event = buildCapabilityEvent(deps.secretKey, nodeCapabilities(deps.settings.port));
+  void publishCapability(deps.pool, deps.relays, event).catch((err) => {
+    log.debug(`[p2p] capability advertise failed: ${String(err)}`);
+  });
+}
+
+/**
+ * Start a node and keep it alive until the abort signal fires, then stop it.
+ * Shaped like the phantomchat listener so `run` can `tasks.push(...)` it and
+ * `Promise.all` the lot under the shared shutdown `AbortController`.
+ */
+export async function runP2PNode(node: P2PNode, signal: AbortSignal): Promise<void> {
+  node.start();
+  await new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+  node.stop();
+}

--- a/src/p2p/index.ts
+++ b/src/p2p/index.ts
@@ -43,7 +43,12 @@ export function buildP2PNode(deps: BuildP2PNodeDeps): P2PNode {
     ourPubHex: deps.publicKeyHex,
     iceServers,
     signaling,
-    createBridge: (onOutbound) => new LocalBridge({ port: deps.settings.port, onOutbound }),
+    createBridge: (onOutbound) =>
+      new LocalBridge({
+        port: deps.settings.port,
+        onOutbound,
+        allowedOrigins: deps.settings.allowedOrigins,
+      }),
   });
 }
 
@@ -60,12 +65,16 @@ export function advertiseP2PCapability(deps: BuildP2PNodeDeps): void {
 }
 
 /**
- * Start a node and keep it alive until the abort signal fires, then stop it.
+ * Keep an ALREADY-STARTED node alive until the abort signal fires, then stop it.
  * Shaped like the phantomchat listener so `run` can `tasks.push(...)` it and
  * `Promise.all` the lot under the shared shutdown `AbortController`.
+ *
+ * The node MUST already be started (see `startP2PNode`). Startup is deliberately
+ * kept out of this task: `node.start()` throws synchronously on a port conflict,
+ * and if that throw happened here it would surface as a rejected task and abort
+ * the whole `phantombot run` process — exactly the failure this split prevents.
  */
-export async function runP2PNode(node: P2PNode, signal: AbortSignal): Promise<void> {
-  node.start();
+export async function keepP2PNodeAlive(node: P2PNode, signal: AbortSignal): Promise<void> {
   await new Promise<void>((resolve) => {
     if (signal.aborted) {
       resolve();
@@ -74,4 +83,49 @@ export async function runP2PNode(node: P2PNode, signal: AbortSignal): Promise<vo
     signal.addEventListener("abort", () => resolve(), { once: true });
   });
   node.stop();
+}
+
+export interface StartP2PNodeInput {
+  node: P2PNode;
+  /** Publish the capability advert — only after a successful start. */
+  advertise: () => void;
+  signal: AbortSignal;
+  out: { write: (s: string) => void };
+  err: { write: (s: string) => void };
+  persona: string;
+  port: number;
+}
+
+/**
+ * Start a P2P node with its bridge SYNCHRONOUSLY and, on success, return a
+ * long-lived task to push onto the daemon's list. On failure (e.g. the loopback
+ * port is already taken by another persona/process) it is fully contained: the
+ * error is logged, a relay-fallback warning is written, the node is torn down,
+ * and `null` is returned so the caller keeps every other channel running.
+ *
+ * This is the crux of the port-conflict-must-not-kill-the-daemon fix — the throw
+ * is caught here, never inside a pushed Promise.
+ */
+export function startP2PNode(input: StartP2PNodeInput): Promise<void> | null {
+  try {
+    input.node.start(); // synchronous; throws if the loopback port is in use
+  } catch (e) {
+    log.warn(`p2p[${input.persona}]: node failed to start`, {
+      error: (e as Error).message,
+    });
+    input.err.write(
+      `warning: p2p node failed to start (port ${input.port} in use?) — chat still works over relays\n`,
+    );
+    try {
+      input.node.stop();
+    } catch {
+      // best-effort teardown of a half-started node
+    }
+    return null;
+  }
+  input.advertise();
+  input.out.write(
+    `  [p2p:${input.persona}] node on ws://127.0.0.1:${input.port}\n`,
+  );
+  return keepP2PNodeAlive(input.node, input.signal);
 }

--- a/src/p2p/localBridge.ts
+++ b/src/p2p/localBridge.ts
@@ -32,6 +32,50 @@ export interface LocalBridgeOptions {
   host?: string;
   /** An outgoing PWA frame was received and parsed. */
   onOutbound: (frame: ParsedEventFrame, raw: string) => void;
+  /**
+   * Browser origins allowed to upgrade. A no-`Origin` client (CLI/tooling) and
+   * localhost origins (the dev PWA) are always allowed; any other browser
+   * `Origin` must appear here or the upgrade is refused with 403.
+   */
+  allowedOrigins?: string[];
+}
+
+/**
+ * Decide whether a WebSocket upgrade may proceed, based on its `Origin` header.
+ *
+ * The bridge binds to loopback, but a browser will still send WebSocket
+ * handshakes to `ws://127.0.0.1:<port>` from ANY site the user is visiting, and
+ * WebSocket is exempt from CORS preflight — so without this gate an arbitrary
+ * page could subscribe to every wrap broadcast and inject `EVENT` frames for the
+ * node to forward. The policy:
+ *
+ *   - No `Origin` header  → allow. Non-browser clients (CLI probes, the werift
+ *     test harness, curl) don't send one; browsers always do.
+ *   - `localhost` / `127.0.0.1` / `[::1]` origin (any scheme/port) → allow. This
+ *     is the user's own dev PhantomChat, not a remote site.
+ *   - Origin in `allowedOrigins` (exact match) → allow (e.g. prod PhantomChat).
+ *   - Anything else → deny.
+ */
+export function isOriginAllowed(
+  origin: string | null | undefined,
+  allowedOrigins: readonly string[],
+): boolean {
+  // No Origin header at all: not a browser cross-site request.
+  if (origin === null || origin === undefined || origin === "") return true;
+  // Some non-browser agents send the literal "null" origin; treat as non-browser.
+  if (origin === "null") return true;
+
+  let host: string;
+  try {
+    host = new URL(origin).hostname;
+  } catch {
+    // Unparseable Origin → treat as hostile, refuse.
+    return false;
+  }
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]") {
+    return true;
+  }
+  return allowedOrigins.includes(origin);
 }
 
 /** Per-socket data. Empty today; a hook for future auth/handshake state. */
@@ -41,6 +85,7 @@ export class LocalBridge {
   private readonly port: number;
   private readonly host: string;
   private readonly onOutbound: (frame: ParsedEventFrame, raw: string) => void;
+  private readonly allowedOrigins: readonly string[];
   private server: Server<SocketData> | null = null;
   private readonly clients = new Set<ServerWebSocket<SocketData>>();
 
@@ -48,6 +93,7 @@ export class LocalBridge {
     this.port = opts.port;
     this.host = opts.host ?? "127.0.0.1";
     this.onOutbound = opts.onOutbound;
+    this.allowedOrigins = opts.allowedOrigins ?? [];
   }
 
   /** The port the bridge is actually listening on (useful when port was 0). */
@@ -71,6 +117,13 @@ export class LocalBridge {
       port: this.port,
       hostname: this.host,
       fetch(req, server) {
+        // Refuse cross-site browser upgrades BEFORE upgrading — a visited page
+        // must not be able to attach to the local node (see isOriginAllowed).
+        const origin = req.headers.get("origin");
+        if (!isOriginAllowed(origin, self.allowedOrigins)) {
+          log.warn(`[p2p] bridge refused upgrade from origin ${origin}`);
+          return new Response("phantombot p2p bridge: origin not allowed", { status: 403 });
+        }
         // Only accept WebSocket upgrades; everything else is a 426.
         if (server.upgrade(req, { data: {} })) return undefined;
         return new Response("phantombot p2p bridge: websocket only", { status: 426 });

--- a/src/p2p/localBridge.ts
+++ b/src/p2p/localBridge.ts
@@ -51,6 +51,9 @@ export interface LocalBridgeOptions {
  *
  *   - No `Origin` header  → allow. Non-browser clients (CLI probes, the werift
  *     test harness, curl) don't send one; browsers always do.
+ *   - Literal `Origin: null` → DENY. This is what a browser emits for an *opaque*
+ *     origin (sandboxed iframe, `data:`/`file:` page, some cross-origin
+ *     redirects); a hostile page can provoke it, so opaque origins are untrusted.
  *   - `localhost` / `127.0.0.1` / `[::1]` origin (any scheme/port) → allow. This
  *     is the user's own dev PhantomChat, not a remote site.
  *   - Origin in `allowedOrigins` (exact match) → allow (e.g. prod PhantomChat).
@@ -60,10 +63,14 @@ export function isOriginAllowed(
   origin: string | null | undefined,
   allowedOrigins: readonly string[],
 ): boolean {
-  // No Origin header at all: not a browser cross-site request.
+  // Genuinely absent Origin header: not a browser cross-site request. (Bun's
+  // req.headers.get("origin") returns real null when the header is absent, which
+  // is distinct from a browser sending the literal string "null".)
   if (origin === null || origin === undefined || origin === "") return true;
-  // Some non-browser agents send the literal "null" origin; treat as non-browser.
-  if (origin === "null") return true;
+  // A literal "null" Origin is a browser *opaque* origin (sandboxed iframe,
+  // data:/file: page, some cross-origin redirects). NOT a non-browser tell — a
+  // hostile page can provoke it to slip the gate, so refuse it as untrusted.
+  if (origin === "null") return false;
 
   let host: string;
   try {

--- a/src/p2p/localBridge.ts
+++ b/src/p2p/localBridge.ts
@@ -1,0 +1,138 @@
+/**
+ * The Tier-1 local endpoint: a `ws://localhost:<port>` server the same-machine
+ * PhantomChat PWA connects to (phantomyard/phantombot#258, phantomchat#61).
+ *
+ * `localhost` is a secure context, so an HTTPS-served PWA is allowed to open a
+ * plain `ws://localhost` socket to it (this is NOT blocked as mixed content the
+ * way `ws://<LAN-IP>` would be). The bridge is deliberately dumb:
+ *
+ *   PWA → bridge : the PWA ships an outgoing message as a Nostr relay frame,
+ *                  `["EVENT", <gift-wrap>]`. The bridge parses it, reads the
+ *                  recipient off the wrap's p-tag, and hands it to `onOutbound`
+ *                  (which the node routes to the right peer connection). The
+ *                  wrap stays sealed — the bridge never decrypts it.
+ *   bridge → PWA : inbound wraps that arrived from peers are broadcast to every
+ *                  connected local socket as the same `["EVENT", wrap]` frame,
+ *                  which the PWA feeds straight into its relay-pool ingest.
+ *
+ * Binds to loopback ONLY (127.0.0.1) — never a routable interface — so nothing
+ * off the machine can reach it. Built on Bun's native WebSocket server (no extra
+ * dependency, and it compiles into the single binary).
+ */
+
+import type { Server, ServerWebSocket } from "bun";
+
+import { log } from "../lib/logger.ts";
+import { parseEventFrame, type ParsedEventFrame } from "./frame.ts";
+
+export interface LocalBridgeOptions {
+  /** Loopback port to listen on. Defaults handled by the caller. */
+  port: number;
+  /** Loopback host. Defaults to 127.0.0.1; never bind a routable interface. */
+  host?: string;
+  /** An outgoing PWA frame was received and parsed. */
+  onOutbound: (frame: ParsedEventFrame, raw: string) => void;
+}
+
+/** Per-socket data. Empty today; a hook for future auth/handshake state. */
+type SocketData = Record<string, never>;
+
+export class LocalBridge {
+  private readonly port: number;
+  private readonly host: string;
+  private readonly onOutbound: (frame: ParsedEventFrame, raw: string) => void;
+  private server: Server<SocketData> | null = null;
+  private readonly clients = new Set<ServerWebSocket<SocketData>>();
+
+  constructor(opts: LocalBridgeOptions) {
+    this.port = opts.port;
+    this.host = opts.host ?? "127.0.0.1";
+    this.onOutbound = opts.onOutbound;
+  }
+
+  /** The port the bridge is actually listening on (useful when port was 0). */
+  get boundPort(): number {
+    return this.server?.port ?? this.port;
+  }
+
+  /** How many local PWA sockets are connected right now. */
+  clientCount(): number {
+    return this.clients.size;
+  }
+
+  /**
+   * Start listening. Throws if the port is already in use (e.g. a second node
+   * on the same machine) — the caller decides whether that is fatal.
+   */
+  start(): void {
+    if (this.server) return;
+    const self = this;
+    this.server = Bun.serve<SocketData>({
+      port: this.port,
+      hostname: this.host,
+      fetch(req, server) {
+        // Only accept WebSocket upgrades; everything else is a 426.
+        if (server.upgrade(req, { data: {} })) return undefined;
+        return new Response("phantombot p2p bridge: websocket only", { status: 426 });
+      },
+      websocket: {
+        open(ws) {
+          self.clients.add(ws);
+          log.debug(`[p2p] bridge client connected (${self.clients.size} open)`);
+        },
+        message(_ws, message) {
+          const raw = typeof message === "string" ? message : Buffer.from(message).toString("utf8");
+          const frame = parseEventFrame(raw);
+          if (!frame) {
+            // Not a relay EVENT frame we route (could be a REQ/CLOSE); ignore.
+            return;
+          }
+          try {
+            self.onOutbound(frame, raw);
+          } catch (err) {
+            log.debug(`[p2p] bridge onOutbound threw: ${String(err)}`);
+          }
+        },
+        close(ws) {
+          self.clients.delete(ws);
+          log.debug(`[p2p] bridge client disconnected (${self.clients.size} open)`);
+        },
+      },
+    });
+    log.info(`[p2p] local bridge listening on ws://${this.host}:${this.boundPort}`);
+  }
+
+  /**
+   * Push an inbound frame to every connected local PWA socket. Returns the
+   * number of sockets it was delivered to (0 when no PWA is attached — the wrap
+   * is simply dropped, and the relay copy remains the PWA's source of truth).
+   */
+  broadcast(frame: string): number {
+    let sent = 0;
+    for (const ws of this.clients) {
+      try {
+        ws.send(frame);
+        sent++;
+      } catch (err) {
+        log.debug(`[p2p] bridge broadcast failed to a client: ${String(err)}`);
+      }
+    }
+    return sent;
+  }
+
+  /** Stop the server and drop all client sockets. Idempotent. */
+  stop(): void {
+    for (const ws of this.clients) {
+      try {
+        ws.close();
+      } catch {
+        // best-effort
+      }
+    }
+    this.clients.clear();
+    if (this.server) {
+      this.server.stop(true);
+      this.server = null;
+    }
+  }
+}

--- a/src/p2p/node.ts
+++ b/src/p2p/node.ts
@@ -91,15 +91,20 @@ export class P2PNode {
     this.bridge = deps.createBridge((frame, raw) => this.onOutbound(frame, raw));
   }
 
-  /** Start the bridge + signaling. Idempotent. */
+  /**
+   * Start the bridge + signaling. Idempotent. `bridge.start()` throws
+   * synchronously on a port conflict — we only mark the node `started` AFTER
+   * both come up, so a failed start leaves the node re-startable and makes
+   * `stop()` a safe no-op (the caller in `startP2PNode` handles the throw).
+   */
   start(): void {
     if (this.started) return;
-    this.started = true;
     this.signaling.onMessage((senderHex, msg) => {
       void this.onSignal(senderHex, msg);
     });
-    this.bridge.start();
+    this.bridge.start(); // may throw (port in use) — started stays false
     this.signaling.start();
+    this.started = true;
     log.info(`[p2p] node started (self ${this.ourPubHex.slice(0, 8)})`);
   }
 

--- a/src/p2p/node.ts
+++ b/src/p2p/node.ts
@@ -1,0 +1,258 @@
+/**
+ * The P2P node orchestrator (phantomyard/phantombot#258).
+ *
+ * Wires the three planes together and routes opaque gift-wrap frames between
+ * them:
+ *
+ *   PWA  ──ws://localhost──▶  LocalBridge ─▶ node ─▶ PeerConnection ─▶ peer node
+ *   peer node ─▶ PeerConnection ─▶ node ─▶ LocalBridge ──ws──▶ PWA
+ *
+ * with Nostr signaling carrying the WebRTC handshake for each peer. The node is
+ * pure routing: it reads the recipient off a wrap's p-tag and forwards the
+ * sealed wrap to that peer's data channel (dialing one on demand), and it
+ * broadcasts inbound peer frames to the local PWA. It never decrypts a wrap.
+ *
+ * Glare-free negotiation: for any pair, the node with the SMALLER pubkey is the
+ * sole initiator. When the larger-pubkey node has traffic it can't offer itself,
+ * it sends a `hello` nudge and the initiator offers. So exactly one side ever
+ * offers — no rollback, no perfect-negotiation state machine.
+ *
+ * Everything is injected through seams (`signaling`, `createBridge`,
+ * `createPeer`) so the whole routing brain is unit-testable with in-memory fakes
+ * and zero sockets, while production wires the real werift + Nostr + Bun-ws
+ * implementations.
+ */
+
+import { log } from "../lib/logger.ts";
+import type { ParsedEventFrame } from "./frame.ts";
+import type { PeerConnectionOptions, PeerState } from "./peerConnection.ts";
+import { PeerConnection } from "./peerConnection.ts";
+import type { SignalMessage, Signaling } from "./signaling.ts";
+
+/** The subset of a peer connection the orchestrator drives (mockable). */
+export interface PeerLike {
+  readonly peerHex: string;
+  getState(): PeerState;
+  isReady(): boolean;
+  start(): Promise<void>;
+  handleSignal(msg: SignalMessage): Promise<void>;
+  send(frame: string): boolean;
+  close(): void;
+}
+
+/** The local endpoint the node pushes inbound frames to (mockable). */
+export interface BridgePort {
+  start(): void;
+  stop(): void;
+  /** Push a frame to connected local PWA sockets; returns delivery count. */
+  broadcast(frame: string): number;
+  /** How many local PWA sockets are attached. */
+  clientCount(): number;
+}
+
+export interface P2PNodeDeps {
+  /** This node's pubkey (hex) — decides initiator/responder role per peer. */
+  ourPubHex: string;
+  /** Public STUN servers for NAT traversal. Empty = host candidates only. */
+  iceServers: { urls: string }[];
+  /** Nostr-backed signaling (or a fake in tests). */
+  signaling: Signaling;
+  /** Build the local ws bridge, given the outbound-frame handler to call. */
+  createBridge: (onOutbound: (frame: ParsedEventFrame, raw: string) => void) => BridgePort;
+  /** Build a peer connection. Defaults to a real werift `PeerConnection`. */
+  createPeer?: (opts: PeerConnectionOptions) => PeerLike;
+  /** Max frames buffered per peer while its channel comes up. Default 64. */
+  maxOutboxPerPeer?: number;
+}
+
+const DEFAULT_MAX_OUTBOX = 64;
+
+export class P2PNode {
+  private readonly ourPubHex: string;
+  private readonly iceServers: { urls: string }[];
+  private readonly signaling: Signaling;
+  private readonly createPeer: (opts: PeerConnectionOptions) => PeerLike;
+  private readonly maxOutbox: number;
+  private readonly bridge: BridgePort;
+
+  private readonly peers = new Map<string, PeerLike>();
+  /** Frames waiting for a peer's channel to open, per peer. */
+  private readonly outbox = new Map<string, string[]>();
+  /** Peers we've already kicked into negotiating (offer sent / nudge sent). */
+  private readonly negotiating = new Set<string>();
+  private started = false;
+
+  constructor(deps: P2PNodeDeps) {
+    this.ourPubHex = deps.ourPubHex;
+    this.iceServers = deps.iceServers;
+    this.signaling = deps.signaling;
+    this.createPeer = deps.createPeer ?? ((o) => new PeerConnection(o));
+    this.maxOutbox = deps.maxOutboxPerPeer ?? DEFAULT_MAX_OUTBOX;
+    this.bridge = deps.createBridge((frame, raw) => this.onOutbound(frame, raw));
+  }
+
+  /** Start the bridge + signaling. Idempotent. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.signaling.onMessage((senderHex, msg) => {
+      void this.onSignal(senderHex, msg);
+    });
+    this.bridge.start();
+    this.signaling.start();
+    log.info(`[p2p] node started (self ${this.ourPubHex.slice(0, 8)})`);
+  }
+
+  /** Stop everything and drop all peer connections. Idempotent. */
+  stop(): void {
+    if (!this.started) return;
+    this.started = false;
+    for (const peer of this.peers.values()) {
+      try {
+        peer.close();
+      } catch (err) {
+        log.debug(`[p2p] peer close failed: ${String(err)}`);
+      }
+    }
+    this.peers.clear();
+    this.outbox.clear();
+    this.negotiating.clear();
+    this.signaling.stop();
+    this.bridge.stop();
+    log.info("[p2p] node stopped");
+  }
+
+  /** A snapshot for the `p2p status` CLI. */
+  stats(): { localClients: number; peers: { peerHex: string; state: PeerState }[] } {
+    return {
+      localClients: this.bridge.clientCount(),
+      peers: Array.from(this.peers.values()).map((p) => ({
+        peerHex: p.peerHex,
+        state: p.getState(),
+      })),
+    };
+  }
+
+  private amInitiator(peerHex: string): boolean {
+    return this.ourPubHex < peerHex;
+  }
+
+  /** An outgoing PWA frame → route it to the recipient peer's channel. */
+  private onOutbound(frame: ParsedEventFrame, raw: string): void {
+    const peerHex = frame.recipientHex;
+    if (peerHex === this.ourPubHex) {
+      // A self-addressed wrap (multi-device sync copy). There is no remote peer
+      // to route it to; the relay copy handles multi-device. Drop silently.
+      return;
+    }
+    const peer = this.getOrCreatePeer(peerHex);
+    if (peer.isReady()) {
+      if (peer.send(raw)) return;
+      // Send failed on a supposedly-open channel — fall through to buffer/redial.
+    }
+    this.enqueue(peerHex, raw);
+    this.kickstart(peerHex, peer);
+  }
+
+  /** An inbound signal from a peer. */
+  private async onSignal(senderHex: string, msg: SignalMessage): Promise<void> {
+    if (msg.t === "hello") {
+      // We were nudged to initiate. Only act if we are in fact the initiator.
+      if (this.amInitiator(senderHex)) {
+        const peer = this.getOrCreatePeer(senderHex);
+        this.kickstart(senderHex, peer);
+      }
+      return;
+    }
+    const peer = this.getOrCreatePeer(senderHex);
+    // Receiving an offer/answer/candidate means we're actively negotiating, so
+    // don't also fire a nudge for this peer.
+    this.negotiating.add(senderHex);
+    await peer.handleSignal(msg);
+  }
+
+  /** An inbound frame off a peer's data channel → hand to the local PWA. */
+  private onPeerFrame(_peerHex: string, frame: string): void {
+    this.bridge.broadcast(frame);
+  }
+
+  private onPeerState(peerHex: string, state: PeerState): void {
+    if (state === "connected") {
+      this.flushOutbox(peerHex);
+    } else if (state === "failed" || state === "closed") {
+      this.dropPeer(peerHex);
+    }
+  }
+
+  private getOrCreatePeer(peerHex: string): PeerLike {
+    const existing = this.peers.get(peerHex);
+    if (existing) {
+      const s = existing.getState();
+      if (s !== "failed" && s !== "closed") return existing;
+      this.dropPeer(peerHex);
+    }
+    const peer = this.createPeer({
+      peerHex,
+      initiator: this.amInitiator(peerHex),
+      iceServers: this.iceServers,
+      sendSignal: (msg) => void this.signaling.send(peerHex, msg),
+      onFrame: (frame) => this.onPeerFrame(peerHex, frame),
+      onState: (state) => this.onPeerState(peerHex, state),
+    });
+    this.peers.set(peerHex, peer);
+    if (!this.outbox.has(peerHex)) this.outbox.set(peerHex, []);
+    return peer;
+  }
+
+  /**
+   * Begin negotiation with a peer exactly once. The initiator sends its offer;
+   * the responder can't offer, so it nudges the initiator with a `hello`.
+   */
+  private kickstart(peerHex: string, peer: PeerLike): void {
+    if (this.negotiating.has(peerHex)) return;
+    this.negotiating.add(peerHex);
+    if (this.amInitiator(peerHex)) {
+      void peer.start();
+    } else {
+      void this.signaling.send(peerHex, { t: "hello" });
+    }
+  }
+
+  private enqueue(peerHex: string, raw: string): void {
+    let box = this.outbox.get(peerHex);
+    if (!box) {
+      box = [];
+      this.outbox.set(peerHex, box);
+    }
+    box.push(raw);
+    // Bounded: the relay copy is the guaranteed floor, so dropping the oldest
+    // buffered P2P copy is safe — it just means that message went relay-only.
+    if (box.length > this.maxOutbox) box.shift();
+  }
+
+  private flushOutbox(peerHex: string): void {
+    const box = this.outbox.get(peerHex);
+    const peer = this.peers.get(peerHex);
+    if (!box || !peer) return;
+    this.outbox.set(peerHex, []);
+    for (const raw of box) {
+      if (!peer.send(raw)) {
+        log.debug(`[p2p] flush send failed for ${peerHex.slice(0, 8)}; dropping (relay is floor)`);
+      }
+    }
+  }
+
+  private dropPeer(peerHex: string): void {
+    const peer = this.peers.get(peerHex);
+    if (peer) {
+      try {
+        peer.close();
+      } catch (err) {
+        log.debug(`[p2p] dropPeer close failed: ${String(err)}`);
+      }
+    }
+    this.peers.delete(peerHex);
+    this.outbox.delete(peerHex);
+    this.negotiating.delete(peerHex);
+  }
+}

--- a/src/p2p/peerConnection.ts
+++ b/src/p2p/peerConnection.ts
@@ -1,0 +1,249 @@
+/**
+ * A single WebRTC connection to one remote phantombot node, built on werift —
+ * the pure-TypeScript WebRTC stack (phantomyard/phantombot#258). werift is used
+ * (not `node-datachannel`/Hyperswarm) because it is the only stack that survives
+ * `bun build --compile` into the shipped single binary: no native `.node` addon,
+ * verified end-to-end (ICE→DTLS→SCTP data-channel round-trip) inside a compiled
+ * Bun binary during the spike.
+ *
+ * Each instance owns exactly one `RTCPeerConnection` and one data channel to one
+ * peer, keyed by the peer's node pubkey. The class is transport-only: it moves
+ * opaque gift-wrap frames (see `frame.ts`) back and forth and never inspects
+ * them. SDP/ICE negotiation is delegated to an injected `sendSignal` callback
+ * (wired to Nostr signaling by the node orchestrator), so this file has zero
+ * Nostr knowledge and is unit-testable by looping two instances' signals in
+ * memory — exactly how the spike proved it.
+ */
+
+import { RTCPeerConnection } from "werift";
+
+import { log } from "../lib/logger.ts";
+import type { CandidateSignal, SdpSignal, SignalMessage } from "./signaling.ts";
+
+/** Connection lifecycle, collapsed to what the orchestrator cares about. */
+export type PeerState = "new" | "connecting" | "connected" | "failed" | "closed";
+
+export interface PeerConnectionOptions {
+  /** The remote node's pubkey (hex) — identifies the peer for signaling. */
+  peerHex: string;
+  /**
+   * Who initiates. The node with the lexicographically SMALLER pubkey is the
+   * initiator (deterministic, so both sides agree without a round-trip and we
+   * never double-offer). The initiator creates the data channel + offer; the
+   * responder waits for the offer and answers.
+   */
+  initiator: boolean;
+  /** ICE servers (public STUN). Empty = host candidates only (localhost/LAN). */
+  iceServers: { urls: string }[];
+  /** Publish a signal to the peer. Wired to Nostr signaling by the node. */
+  sendSignal: (msg: SignalMessage) => void;
+  /** An inbound data-channel frame arrived from the peer. */
+  onFrame: (frame: string) => void;
+  /** Connection state changed. */
+  onState?: (state: PeerState) => void;
+}
+
+/** Data-channel label. Both sides must agree; the responder reads it off the offer. */
+const DATA_CHANNEL_LABEL = "phantomchat-bridge";
+
+export class PeerConnection {
+  readonly peerHex: string;
+  private readonly initiator: boolean;
+  private readonly sendSignal: (msg: SignalMessage) => void;
+  private readonly onFrame: (frame: string) => void;
+  private readonly onStateCb?: (state: PeerState) => void;
+
+  private pc: RTCPeerConnection;
+  private channel: ReturnType<RTCPeerConnection["createDataChannel"]> | null = null;
+  private state: PeerState = "new";
+  private remoteDescriptionSet = false;
+  /** ICE candidates that arrived before the remote description — flushed after. */
+  private pendingCandidates: CandidateSignal[] = [];
+  private closed = false;
+
+  constructor(opts: PeerConnectionOptions) {
+    this.peerHex = opts.peerHex;
+    this.initiator = opts.initiator;
+    this.sendSignal = opts.sendSignal;
+    this.onFrame = opts.onFrame;
+    this.onStateCb = opts.onState;
+
+    this.pc = new RTCPeerConnection({ iceServers: opts.iceServers });
+    this.wire();
+  }
+
+  /** Current collapsed connection state. */
+  getState(): PeerState {
+    return this.state;
+  }
+
+  /** Is the data channel open and ready to carry frames right now? */
+  isReady(): boolean {
+    return this.state === "connected" && this.channel?.readyState === "open";
+  }
+
+  private setState(next: PeerState): void {
+    if (this.state === next || this.state === "closed") return;
+    this.state = next;
+    this.onStateCb?.(next);
+  }
+
+  private wire(): void {
+    // Trickle local ICE candidates to the peer as they are gathered. `undefined`
+    // signals end-of-candidates — nothing to send, so we skip it.
+    this.pc.onIceCandidate.subscribe((candidate) => {
+      if (!candidate || !candidate.candidate) return;
+      this.sendSignal({
+        t: "candidate",
+        candidate: candidate.candidate,
+        sdpMid: candidate.sdpMid ?? null,
+        sdpMLineIndex: candidate.sdpMLineIndex ?? null,
+      });
+    });
+
+    this.pc.connectionStateChange.subscribe((s) => {
+      // NOTE: transport `connected` is NOT the same as "ready to carry frames" —
+      // the SCTP data channel opens slightly AFTER the ICE/DTLS transport
+      // connects. We deliberately do NOT promote to `connected` here; that
+      // happens on the data channel's `open` event (see `bindChannel`), which is
+      // the point at which `send()` actually works. Promoting too early would
+      // flush the outbox into a not-yet-open channel and silently drop frames.
+      if (s === "failed" || s === "disconnected") {
+        // A failed/disconnected transport is terminal for this attempt; the
+        // orchestrator drops and can re-dial on the next outbound frame.
+        this.setState("failed");
+      } else if (s === "closed") {
+        this.setState("closed");
+      } else if (this.state !== "connected") {
+        // new / connecting / transport-connected → still coming up. Never
+        // downgrade once the channel has opened.
+        this.setState("connecting");
+      }
+    });
+
+    // The responder receives the channel the initiator created.
+    this.pc.onDataChannel.subscribe((ch) => {
+      this.bindChannel(ch);
+    });
+  }
+
+  private bindChannel(ch: ReturnType<RTCPeerConnection["createDataChannel"]>): void {
+    this.channel = ch;
+    ch.onMessage.subscribe((msg) => {
+      const text = typeof msg === "string" ? msg : Buffer.from(msg).toString("utf8");
+      try {
+        this.onFrame(text);
+      } catch (err) {
+        log.debug(`[p2p] onFrame handler threw for ${this.short()}: ${String(err)}`);
+      }
+    });
+    ch.stateChanged.subscribe((s) => {
+      if (s === "open") this.setState("connected");
+    });
+    if (ch.readyState === "open") this.setState("connected");
+  }
+
+  /**
+   * Kick off negotiation. The initiator creates the data channel and sends an
+   * offer; the responder does nothing here and waits for the offer to arrive via
+   * `handleSignal`. Safe to call once.
+   */
+  async start(): Promise<void> {
+    if (this.closed) return;
+    this.setState("connecting");
+    if (!this.initiator) return;
+    try {
+      const ch = this.pc.createDataChannel(DATA_CHANNEL_LABEL);
+      this.bindChannel(ch);
+      const offer = await this.pc.createOffer();
+      await this.pc.setLocalDescription(offer);
+      this.sendSignal({ t: "offer", sdp: this.pc.localDescription?.sdp ?? offer.sdp });
+    } catch (err) {
+      log.warn(`[p2p] offer failed for ${this.short()}`, { error: String(err) });
+      this.setState("failed");
+    }
+  }
+
+  /** Feed an inbound signal (offer/answer/candidate/bye) from this peer. */
+  async handleSignal(msg: SignalMessage): Promise<void> {
+    if (this.closed) return;
+    try {
+      if (msg.t === "offer") await this.onOffer(msg);
+      else if (msg.t === "answer") await this.onAnswer(msg);
+      else if (msg.t === "candidate") await this.onCandidate(msg);
+      else if (msg.t === "bye") this.close();
+    } catch (err) {
+      log.warn(`[p2p] handleSignal(${msg.t}) failed for ${this.short()}`, { error: String(err) });
+      this.setState("failed");
+    }
+  }
+
+  private async onOffer(msg: SdpSignal): Promise<void> {
+    await this.pc.setRemoteDescription({ type: "offer", sdp: msg.sdp });
+    this.remoteDescriptionSet = true;
+    await this.flushCandidates();
+    const answer = await this.pc.createAnswer();
+    await this.pc.setLocalDescription(answer);
+    this.sendSignal({ t: "answer", sdp: this.pc.localDescription?.sdp ?? answer.sdp });
+  }
+
+  private async onAnswer(msg: SdpSignal): Promise<void> {
+    await this.pc.setRemoteDescription({ type: "answer", sdp: msg.sdp });
+    this.remoteDescriptionSet = true;
+    await this.flushCandidates();
+  }
+
+  private async onCandidate(msg: CandidateSignal): Promise<void> {
+    // Candidates can race ahead of the remote description; buffer until it lands.
+    if (!this.remoteDescriptionSet) {
+      this.pendingCandidates.push(msg);
+      return;
+    }
+    await this.addCandidate(msg);
+  }
+
+  private async flushCandidates(): Promise<void> {
+    const pending = this.pendingCandidates;
+    this.pendingCandidates = [];
+    for (const c of pending) await this.addCandidate(c);
+  }
+
+  private async addCandidate(msg: CandidateSignal): Promise<void> {
+    await this.pc.addIceCandidate({
+      candidate: msg.candidate,
+      sdpMid: msg.sdpMid ?? undefined,
+      sdpMLineIndex: msg.sdpMLineIndex ?? undefined,
+    });
+  }
+
+  /**
+   * Send an opaque frame to the peer over the data channel. Returns false if the
+   * channel isn't open, so the orchestrator can fall back to another route.
+   */
+  send(frame: string): boolean {
+    if (!this.isReady() || !this.channel) return false;
+    try {
+      this.channel.send(frame);
+      return true;
+    } catch (err) {
+      log.debug(`[p2p] data-channel send failed for ${this.short()}: ${String(err)}`);
+      return false;
+    }
+  }
+
+  /** Tear down the connection. Idempotent. */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.setState("closed");
+    try {
+      void this.pc.close();
+    } catch (err) {
+      log.debug(`[p2p] pc close failed for ${this.short()}: ${String(err)}`);
+    }
+  }
+
+  private short(): string {
+    return this.peerHex.slice(0, 8);
+  }
+}

--- a/src/p2p/signaling.ts
+++ b/src/p2p/signaling.ts
@@ -1,0 +1,225 @@
+/**
+ * P2P signaling over Nostr (phantomyard/phantombot#258).
+ *
+ * A WebRTC connection cannot bootstrap itself: two nodes behind NAT must first
+ * swap an SDP offer/answer and a handful of ICE candidates. Something has to
+ * carry those small blobs. We already depend on Nostr relays, so they carry the
+ * signaling too — demoted from "every message" to just the WebRTC handshake.
+ *
+ * Design choices:
+ *
+ *  - **Dedicated ephemeral kind (`NOSTR_KIND_P2P_SIGNAL`).** Signaling does NOT
+ *    reuse the chat gift-wrap kind (1059). If it did, the persona's chat
+ *    subscription (`kind:1059, #p:<us>`) would pick up signaling events and try
+ *    to unwrap them as chat messages. A distinct kind in the ephemeral range
+ *    (20000–29999, per NIP-01 relays don't persist these) keeps the two planes
+ *    cleanly separate and means stale offers aren't stored on relays forever.
+ *
+ *  - **NIP-44 encryption, REAL-key authorship.** Unlike chat (which signs with a
+ *    throwaway ephemeral key to hide the social graph), signaling is signed with
+ *    the node's real key so the recipient can derive the shared NIP-44
+ *    conversation key from `event.pubkey`. The two nodes already know each
+ *    other's pubkeys (that's how the PWA routed here), so there is no graph to
+ *    hide at this layer — and the SDP/ICE payload stays end-to-end encrypted.
+ *
+ * The module exposes pure encode/decode helpers (fully unit-testable) and a
+ * `NostrSignaling` class that rides the same `RelayPool` seam the chat transport
+ * uses, so tests inject an in-memory fake pool with zero sockets.
+ */
+
+import { finalizeEvent, getPublicKey } from "nostr-tools/pure";
+
+import { log } from "../lib/logger.ts";
+import {
+  getConversationKey,
+  nip44Encrypt,
+  nip44Decrypt,
+  type NTNostrEvent,
+} from "../lib/nostrCrypto.ts";
+import type { NostrFilter, RelayPool } from "../channels/phantomchat/transport.ts";
+
+/**
+ * Ephemeral Nostr kind for P2P WebRTC signaling. In the 20000–29999 ephemeral
+ * range so relays don't persist it. Distinct from chat gift-wraps (1059) and the
+ * PhantomChat typing indicator (20001).
+ */
+export const NOSTR_KIND_P2P_SIGNAL = 21050;
+
+/**
+ * How far back the signaling subscription looks on (re)connect. Ephemeral events
+ * generally aren't replayed, but a small window tolerates relays that briefly
+ * buffer. Signaling is retried by the connection layer, so this is only a hint.
+ */
+export const SIGNAL_SINCE_WINDOW_SEC = 30;
+
+/** An SDP offer or answer. */
+export interface SdpSignal {
+  t: "offer" | "answer";
+  sdp: string;
+}
+
+/** A single trickled ICE candidate. */
+export interface CandidateSignal {
+  t: "candidate";
+  candidate: string;
+  sdpMid?: string | null;
+  sdpMLineIndex?: number | null;
+}
+
+/** Signals a peer has given up on this handshake so we can tear the half-open PC down. */
+export interface ByeSignal {
+  t: "bye";
+}
+
+/**
+ * A nudge from the deterministic-RESPONDER side to the INITIATOR side. To avoid
+ * offer glare, only the peer with the smaller pubkey ever offers. When the
+ * larger-pubkey node has traffic for a peer it can't offer itself, so it sends a
+ * `hello`; the initiator answers by starting its offer.
+ */
+export interface HelloSignal {
+  t: "hello";
+}
+
+export type SignalMessage = SdpSignal | CandidateSignal | ByeSignal | HelloSignal;
+
+/** Structural guard for a decoded signal payload. */
+export function isSignalMessage(value: unknown): value is SignalMessage {
+  if (!value || typeof value !== "object") return false;
+  const t = (value as { t?: unknown }).t;
+  if (t === "offer" || t === "answer") return typeof (value as SdpSignal).sdp === "string";
+  if (t === "candidate") return typeof (value as CandidateSignal).candidate === "string";
+  if (t === "bye" || t === "hello") return true;
+  return false;
+}
+
+/**
+ * Encrypt + sign a signal for `recipientHex`. Returns a ready-to-publish
+ * ephemeral Nostr event. Pure aside from the ephemeral `created_at`.
+ */
+export function encodeSignal(
+  senderSk: Uint8Array,
+  recipientHex: string,
+  msg: SignalMessage,
+): NTNostrEvent {
+  const convKey = getConversationKey(senderSk, recipientHex);
+  const content = nip44Encrypt(JSON.stringify(msg), convKey);
+  const template = {
+    kind: NOSTR_KIND_P2P_SIGNAL,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [["p", recipientHex]],
+    content,
+  };
+  return finalizeEvent(template, senderSk) as unknown as NTNostrEvent;
+}
+
+/**
+ * Decrypt an inbound signaling event. Derives the NIP-44 conversation key from
+ * the event's (real) author pubkey and our secret key. Returns the sender's
+ * pubkey and the decoded message, or `null` if the event isn't a valid signal
+ * addressed to us (bad decrypt, wrong shape). Never throws.
+ */
+export function decodeSignal(
+  recipientSk: Uint8Array,
+  event: NTNostrEvent,
+): { senderHex: string; msg: SignalMessage } | null {
+  try {
+    if (event.kind !== NOSTR_KIND_P2P_SIGNAL) return null;
+    const senderHex = event.pubkey;
+    const convKey = getConversationKey(recipientSk, senderHex);
+    const plaintext = nip44Decrypt(event.content, convKey);
+    const msg = JSON.parse(plaintext) as unknown;
+    if (!isSignalMessage(msg)) return null;
+    return { senderHex, msg };
+  } catch {
+    return null;
+  }
+}
+
+/** Callback for a decoded inbound signal. */
+export type SignalHandler = (senderHex: string, msg: SignalMessage) => void;
+
+/**
+ * The signaling seam the connection layer depends on. A real implementation
+ * rides Nostr relays; tests inject a fake that loops messages in-memory.
+ */
+export interface Signaling {
+  /** Publish a signal to a peer. Best-effort; resolves once handed to relays. */
+  send(recipientHex: string, msg: SignalMessage): Promise<void>;
+  /** Register the inbound handler. Only one handler is supported. */
+  onMessage(handler: SignalHandler): void;
+  /** Begin subscribing for inbound signals addressed to us. */
+  start(): void;
+  /** Tear the subscription down. */
+  stop(): void;
+}
+
+/** Nostr-relay-backed signaling over the shared `RelayPool` seam. */
+export class NostrSignaling implements Signaling {
+  private readonly ourSk: Uint8Array;
+  private readonly ourPubHex: string;
+  private readonly relays: string[];
+  private readonly pool: RelayPool;
+  private handler: SignalHandler | null = null;
+  private sub: { close(): void } | null = null;
+  /** Dedup inbound events by id — relays can deliver the same event twice. */
+  private readonly seen = new Set<string>();
+
+  constructor(ourSk: Uint8Array, relays: string[], pool: RelayPool) {
+    this.ourSk = ourSk;
+    this.ourPubHex = getPublicKey(ourSk);
+    this.relays = relays;
+    this.pool = pool;
+  }
+
+  onMessage(handler: SignalHandler): void {
+    this.handler = handler;
+  }
+
+  start(): void {
+    if (this.sub) return;
+    const filter: NostrFilter = {
+      kinds: [NOSTR_KIND_P2P_SIGNAL],
+      "#p": [this.ourPubHex],
+      since: Math.floor(Date.now() / 1000) - SIGNAL_SINCE_WINDOW_SEC,
+    };
+    this.sub = this.pool.subscribeMany(this.relays, filter, {
+      onevent: (event) => this.ingest(event),
+    });
+  }
+
+  stop(): void {
+    if (this.sub) {
+      try {
+        this.sub.close();
+      } catch (err) {
+        log.debug(`[p2p] signaling sub close failed: ${String(err)}`);
+      }
+      this.sub = null;
+    }
+    this.seen.clear();
+  }
+
+  private ingest(event: NTNostrEvent): void {
+    if (!event || typeof event.id !== "string") return;
+    if (this.seen.has(event.id)) return;
+    this.seen.add(event.id);
+    // Bound the dedup set so a long-lived node doesn't leak memory.
+    if (this.seen.size > 4096) {
+      this.seen.clear();
+      this.seen.add(event.id);
+    }
+    const decoded = decodeSignal(this.ourSk, event);
+    if (!decoded) return;
+    this.handler?.(decoded.senderHex, decoded.msg);
+  }
+
+  async send(recipientHex: string, msg: SignalMessage): Promise<void> {
+    const event = encodeSignal(this.ourSk, recipientHex, msg);
+    const results = await Promise.allSettled(this.pool.publish(this.relays, event));
+    const ok = results.some((r) => r.status === "fulfilled");
+    if (!ok) {
+      log.debug(`[p2p] signaling publish reached no relay for ${recipientHex.slice(0, 8)}`);
+    }
+  }
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -33,6 +33,7 @@ describe("phantombot CLI dispatcher", () => {
       "memory",
       "nightly",
       "notify",
+      "p2p",
       "persona",
       "phantomchat",
       "reply-mode",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -69,6 +69,9 @@ const ENV_KEYS = [
   "PHANTOMBOT_TELEGRAM_BUBBLE_DELAY_MS",
   "PHANTOMBOT_TELEGRAM_VOICE_MAX_SENTENCES",
   "PHANTOMBOT_CHATTINESS",
+  "PHANTOMBOT_P2P_ENABLED",
+  "PHANTOMBOT_P2P_PORT",
+  "PHANTOMBOT_P2P_STUN",
 ];
 
 let workdir: string;
@@ -702,5 +705,51 @@ flush_after_hours = 6
     expect(memoryIndexPath("phantom")).toBe(
       join(workdir, "data", "phantombot", "memory-index", "phantom.sqlite"),
     );
+  });
+});
+
+describe("loadConfig — p2p (phantombot#258)", () => {
+  test("defaults to disabled on port 47100 with public STUN", async () => {
+    const c = await loadConfig();
+    expect(c.p2p).toEqual({
+      enabled: false,
+      port: 47100,
+      stunServers: ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],
+    });
+  });
+
+  test("env overrides enabled, port and STUN", async () => {
+    process.env.PHANTOMBOT_P2P_ENABLED = "1";
+    process.env.PHANTOMBOT_P2P_PORT = "48000";
+    process.env.PHANTOMBOT_P2P_STUN = "stun:a.example:3478,stun:b.example:3478";
+    const c = await loadConfig();
+    expect(c.p2p).toEqual({
+      enabled: true,
+      port: 48000,
+      stunServers: ["stun:a.example:3478", "stun:b.example:3478"],
+    });
+  });
+
+  test("TOML sets p2p, env still wins", async () => {
+    const configDir = join(workdir, "config", "phantombot");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "config.toml"),
+      ['[p2p]', 'enabled = true', 'port = 50000', 'stun_servers = ["stun:toml.example:3478"]'].join("\n"),
+    );
+    const fromToml = await loadConfig();
+    expect(fromToml.p2p!.enabled).toBe(true);
+    expect(fromToml.p2p!.port).toBe(50000);
+    expect(fromToml.p2p!.stunServers).toEqual(["stun:toml.example:3478"]);
+
+    process.env.PHANTOMBOT_P2P_PORT = "51000";
+    const envWins = await loadConfig();
+    expect(envWins.p2p!.port).toBe(51000);
+  });
+
+  test("port is clamped to the unprivileged range", async () => {
+    process.env.PHANTOMBOT_P2P_PORT = "80";
+    const c = await loadConfig();
+    expect(c.p2p!.port).toBe(1024);
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -72,6 +72,7 @@ const ENV_KEYS = [
   "PHANTOMBOT_P2P_ENABLED",
   "PHANTOMBOT_P2P_PORT",
   "PHANTOMBOT_P2P_STUN",
+  "PHANTOMBOT_P2P_ALLOWED_ORIGINS",
 ];
 
 let workdir: string;
@@ -715,18 +716,21 @@ describe("loadConfig — p2p (phantombot#258)", () => {
       enabled: false,
       port: 47100,
       stunServers: ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],
+      allowedOrigins: ["https://chat.phantomyard.ai"],
     });
   });
 
-  test("env overrides enabled, port and STUN", async () => {
+  test("env overrides enabled, port, STUN and allowed origins", async () => {
     process.env.PHANTOMBOT_P2P_ENABLED = "1";
     process.env.PHANTOMBOT_P2P_PORT = "48000";
     process.env.PHANTOMBOT_P2P_STUN = "stun:a.example:3478,stun:b.example:3478";
+    process.env.PHANTOMBOT_P2P_ALLOWED_ORIGINS = "https://one.example, https://two.example";
     const c = await loadConfig();
     expect(c.p2p).toEqual({
       enabled: true,
       port: 48000,
       stunServers: ["stun:a.example:3478", "stun:b.example:3478"],
+      allowedOrigins: ["https://one.example", "https://two.example"],
     });
   });
 

--- a/tests/p2p-capability.test.ts
+++ b/tests/p2p-capability.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Capability advertisement: the event a node publishes so a peer's PWA can light
+ * up its transport ladder. Pins the build/parse contract the phantomchat
+ * companion mirrors on ingest.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { generateSecretKey, getPublicKey, verifyEvent } from "nostr-tools/pure";
+
+import {
+  buildCapabilityEvent,
+  nodeCapabilities,
+  parseCapabilityEvent,
+  CAPABILITY_D_TAG,
+  CAPABILITY_KIND,
+} from "../src/p2p/capability.ts";
+import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
+
+describe("p2p capability advertisement", () => {
+  test("nodeCapabilities advertises localWs + webrtc, never dht", () => {
+    const caps = nodeCapabilities(47100);
+    expect(caps).toEqual({ localWs: true, localWsPort: 47100, webrtc: true, dht: false });
+  });
+
+  test("build then parse round-trips, signed and addressable", () => {
+    const sk = generateSecretKey();
+    const caps = nodeCapabilities(47100);
+    const event = buildCapabilityEvent(sk, caps);
+
+    expect(event.kind).toBe(CAPABILITY_KIND);
+    expect(event.tags.some((t) => t[0] === "d" && t[1] === CAPABILITY_D_TAG)).toBe(true);
+    expect(verifyEvent(event as never)).toBe(true);
+
+    const parsed = parseCapabilityEvent(event);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.authorHex).toBe(getPublicKey(sk));
+    expect(parsed!.caps).toEqual(caps);
+  });
+
+  test("parseCapabilityEvent rejects the wrong kind / missing d-tag / junk", () => {
+    const base = { pubkey: "a".repeat(64), created_at: 1, sig: "", id: "" };
+    expect(
+      parseCapabilityEvent({ ...base, kind: 1, tags: [["d", CAPABILITY_D_TAG]], content: "{}" } as NTNostrEvent),
+    ).toBeNull();
+    expect(
+      parseCapabilityEvent({ ...base, kind: CAPABILITY_KIND, tags: [], content: "{}" } as NTNostrEvent),
+    ).toBeNull();
+    expect(
+      parseCapabilityEvent({
+        ...base,
+        kind: CAPABILITY_KIND,
+        tags: [["d", CAPABILITY_D_TAG]],
+        content: "not json",
+      } as NTNostrEvent),
+    ).toBeNull();
+  });
+
+  test("parse coerces missing fields to safe defaults", () => {
+    const sk = generateSecretKey();
+    const event = buildCapabilityEvent(sk, {
+      localWs: true,
+      localWsPort: 47100,
+      webrtc: true,
+      dht: false,
+    });
+    // Hand-mangle content to drop fields, re-sign not needed (parse ignores sig).
+    const mangled = { ...event, content: JSON.stringify({ webrtc: true }) } as NTNostrEvent;
+    const parsed = parseCapabilityEvent(mangled);
+    expect(parsed!.caps).toEqual({ localWs: false, localWsPort: 0, webrtc: true, dht: false });
+  });
+});

--- a/tests/p2p-frame.test.ts
+++ b/tests/p2p-frame.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Wire-frame contract with the PhantomChat PWA. The PWA ships an outgoing
+ * message as a Nostr relay frame `["EVENT", <gift-wrap>]`; the node parses it,
+ * reads the recipient off the wrap's p-tag, and forwards the sealed wrap. These
+ * tests pin that contract — a mismatch silently breaks the Tier-1 path.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildEventFrame,
+  looksLikeEvent,
+  parseEventFrame,
+  recipientOfWrap,
+  DEFAULT_LOCAL_NODE_PORT,
+  GIFTWRAP_KIND,
+} from "../src/p2p/frame.ts";
+import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
+
+function wrap(overrides: Partial<NTNostrEvent> = {}): NTNostrEvent {
+  return {
+    id: "a".repeat(64),
+    pubkey: "b".repeat(64),
+    sig: "c".repeat(128),
+    kind: GIFTWRAP_KIND,
+    created_at: 1_700_000_000,
+    tags: [["p", "d".repeat(64)]],
+    content: "sealed",
+    ...overrides,
+  };
+}
+
+describe("p2p frame contract", () => {
+  test("default local port stays 47100 (must match the PWA)", () => {
+    expect(DEFAULT_LOCAL_NODE_PORT).toBe(47100);
+  });
+
+  test("build then parse round-trips a gift-wrap", () => {
+    const w = wrap();
+    const frame = buildEventFrame(w);
+    const parsed = parseEventFrame(frame);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.recipientHex).toBe("d".repeat(64));
+    expect(parsed!.wrap.id).toBe(w.id);
+  });
+
+  test("recipientOfWrap reads the first p-tag", () => {
+    expect(recipientOfWrap(wrap())).toBe("d".repeat(64));
+    expect(
+      recipientOfWrap(wrap({ tags: [["e", "x"], ["p", "e".repeat(64)]] })),
+    ).toBe("e".repeat(64));
+    expect(recipientOfWrap(wrap({ tags: [["e", "x"]] }))).toBeNull();
+  });
+
+  test("looksLikeEvent guards structure", () => {
+    expect(looksLikeEvent(wrap())).toBe(true);
+    expect(looksLikeEvent({})).toBe(false);
+    expect(looksLikeEvent(null)).toBe(false);
+    expect(looksLikeEvent({ ...wrap(), id: 123 })).toBe(false);
+  });
+
+  test("parseEventFrame rejects non-EVENT frames and junk", () => {
+    expect(parseEventFrame("not json")).toBeNull();
+    expect(parseEventFrame(JSON.stringify(["REQ", "sub", {}]))).toBeNull();
+    expect(parseEventFrame(JSON.stringify(["CLOSE", "sub"]))).toBeNull();
+    expect(parseEventFrame(JSON.stringify(["EVENT"]))).toBeNull();
+    expect(parseEventFrame(JSON.stringify(["EVENT", { bad: true }]))).toBeNull();
+  });
+
+  test("parseEventFrame rejects a non-gift-wrap kind", () => {
+    const frame = buildEventFrame(wrap({ kind: 1 }));
+    expect(parseEventFrame(frame)).toBeNull();
+  });
+
+  test("parseEventFrame rejects a wrap with no recipient p-tag", () => {
+    const frame = buildEventFrame(wrap({ tags: [["e", "x"]] }));
+    expect(parseEventFrame(frame)).toBeNull();
+  });
+});

--- a/tests/p2p-integration.test.ts
+++ b/tests/p2p-integration.test.ts
@@ -1,0 +1,123 @@
+/**
+ * End-to-end: two full P2P nodes exchange a message with NO relay in the data
+ * path. Real werift peer connections (loopback host candidates), real routing
+ * brain, an in-memory signaling bus standing in for Nostr relays, and fake
+ * bridges standing in for the two PWAs.
+ *
+ * The flow proven here is the whole point of phantombot#258:
+ *
+ *   PWA_A → bridge_A → node_A → werift data channel → node_B → bridge_B → PWA_B
+ *
+ * The gift-wrap is opaque to both nodes; they forward it verbatim. Success = the
+ * exact frame PWA_A sent lands at PWA_B's bridge, having never touched a relay.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
+
+import { P2PNode, type BridgePort } from "../src/p2p/node.ts";
+import type { ParsedEventFrame } from "../src/p2p/frame.ts";
+import type { SignalMessage, SignalHandler, Signaling } from "../src/p2p/signaling.ts";
+import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
+
+/** In-memory signaling fabric: routes signals between registered node pubkeys. */
+class SignalBus {
+  private handlers = new Map<string, SignalHandler>();
+  register(hex: string, handler: SignalHandler): void {
+    this.handlers.set(hex, handler);
+  }
+  route(from: string, to: string, msg: SignalMessage): void {
+    // Deliver asynchronously, like a relay would.
+    const h = this.handlers.get(to);
+    if (h) queueMicrotask(() => h(from, msg));
+  }
+}
+
+class BusSignaling implements Signaling {
+  constructor(
+    private readonly ourHex: string,
+    private readonly bus: SignalBus,
+  ) {}
+  private handler: SignalHandler | null = null;
+  send(to: string, msg: SignalMessage): Promise<void> {
+    this.bus.route(this.ourHex, to, msg);
+    return Promise.resolve();
+  }
+  onMessage(h: SignalHandler): void {
+    this.handler = h;
+  }
+  start(): void {
+    this.bus.register(this.ourHex, (from, msg) => this.handler?.(from, msg));
+  }
+  stop(): void {}
+}
+
+/** A bridge that captures broadcasts and can inject a PWA send. */
+class CapturingBridge implements BridgePort {
+  broadcasts: string[] = [];
+  outbound!: (frame: ParsedEventFrame, raw: string) => void;
+  start(): void {}
+  stop(): void {}
+  broadcast(frame: string): number {
+    this.broadcasts.push(frame);
+    return 1;
+  }
+  clientCount(): number {
+    return 1;
+  }
+  pwaSends(recipientHex: string, raw: string): void {
+    const frame: ParsedEventFrame = {
+      wrap: { tags: [["p", recipientHex]] } as unknown as NTNostrEvent,
+      recipientHex,
+    };
+    this.outbound(frame, raw);
+  }
+}
+
+function buildNode(ourHex: string, bus: SignalBus) {
+  const bridge = new CapturingBridge();
+  const node = new P2PNode({
+    ourPubHex: ourHex,
+    iceServers: [],
+    signaling: new BusSignaling(ourHex, bus),
+    createBridge: (onOutbound) => {
+      bridge.outbound = onOutbound;
+      return bridge;
+    },
+    // real werift PeerConnection (default createPeer)
+  });
+  node.start();
+  return { node, bridge };
+}
+
+describe("two-node P2P bridge (relay-free data path)", () => {
+  test(
+    "a frame from PWA_A lands at PWA_B over the werift channel",
+    async () => {
+      const aHex = getPublicKey(generateSecretKey());
+      const bHex = getPublicKey(generateSecretKey());
+      const bus = new SignalBus();
+
+      const a = buildNode(aHex, bus);
+      const b = buildNode(bHex, bus);
+
+      // PWA_A sends a message addressed to B.
+      const raw = JSON.stringify(["EVENT", { id: "wrap-1", to: bHex, sealed: true }]);
+      a.bridge.pwaSends(bHex, raw);
+
+      // Wait for the werift handshake + delivery.
+      const deadline = Date.now() + 15_000;
+      while (b.bridge.broadcasts.length === 0 && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      expect(b.bridge.broadcasts).toEqual([raw]);
+      // And A never broadcast to itself (no self-loop).
+      expect(a.bridge.broadcasts).toHaveLength(0);
+
+      a.node.stop();
+      b.node.stop();
+    },
+    20_000,
+  );
+});

--- a/tests/p2p-localBridge.test.ts
+++ b/tests/p2p-localBridge.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Local ws bridge — the real Bun WebSocket server, exercised by a real loopback
+ * WebSocket client. Proves the PWA-facing contract end to end: a client frame
+ * reaches `onOutbound`, and a broadcast reaches the client.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { LocalBridge } from "../src/p2p/localBridge.ts";
+import { buildEventFrame } from "../src/p2p/frame.ts";
+import type { ParsedEventFrame } from "../src/p2p/frame.ts";
+import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
+
+let bridge: LocalBridge | null = null;
+afterEach(() => {
+  bridge?.stop();
+  bridge = null;
+});
+
+function giftWrap(recipientHex: string): NTNostrEvent {
+  return {
+    id: "a".repeat(64),
+    pubkey: "b".repeat(64),
+    sig: "c".repeat(128),
+    kind: 1059,
+    created_at: 1,
+    tags: [["p", recipientHex]],
+    content: "sealed",
+  };
+}
+
+function openClient(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    ws.addEventListener("open", () => resolve(ws));
+    ws.addEventListener("error", () => reject(new Error("client failed to open")));
+    setTimeout(() => reject(new Error("client open timeout")), 3000);
+  });
+}
+
+describe("LocalBridge loopback", () => {
+  test("a client EVENT frame reaches onOutbound with the recipient parsed", async () => {
+    const received: ParsedEventFrame[] = [];
+    bridge = new LocalBridge({ port: 0, onOutbound: (f) => received.push(f) });
+    bridge.start();
+
+    const client = await openClient(bridge.boundPort);
+    const recipientHex = "d".repeat(64);
+    client.send(buildEventFrame(giftWrap(recipientHex)));
+
+    await Bun.sleep(100);
+    expect(received).toHaveLength(1);
+    expect(received[0]!.recipientHex).toBe(recipientHex);
+    client.close();
+  });
+
+  test("junk and non-EVENT frames are ignored, not delivered", async () => {
+    const received: ParsedEventFrame[] = [];
+    bridge = new LocalBridge({ port: 0, onOutbound: (f) => received.push(f) });
+    bridge.start();
+
+    const client = await openClient(bridge.boundPort);
+    client.send("not json");
+    client.send(JSON.stringify(["REQ", "sub", {}]));
+    await Bun.sleep(100);
+    expect(received).toHaveLength(0);
+    client.close();
+  });
+
+  test("broadcast reaches connected clients", async () => {
+    bridge = new LocalBridge({ port: 0, onOutbound: () => {} });
+    bridge.start();
+
+    const client = await openClient(bridge.boundPort);
+    const got = new Promise<string>((resolve) => {
+      client.addEventListener("message", (ev) => resolve(String(ev.data)));
+    });
+
+    // Wait for the server to register the socket, then broadcast.
+    await Bun.sleep(50);
+    const frame = buildEventFrame(giftWrap("e".repeat(64)));
+    const count = bridge.broadcast(frame);
+    expect(count).toBe(1);
+
+    const received = await Promise.race([
+      got,
+      new Promise<string>((_, r) => setTimeout(() => r(new Error("no message")), 2000)),
+    ]);
+    expect(received).toBe(frame);
+    client.close();
+  });
+
+  test("broadcast to nobody returns 0 and does not throw", () => {
+    bridge = new LocalBridge({ port: 0, onOutbound: () => {} });
+    bridge.start();
+    expect(bridge.broadcast("frame")).toBe(0);
+  });
+});

--- a/tests/p2p-localBridge.test.ts
+++ b/tests/p2p-localBridge.test.ts
@@ -6,7 +6,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { LocalBridge } from "../src/p2p/localBridge.ts";
+import { LocalBridge, isOriginAllowed } from "../src/p2p/localBridge.ts";
 import { buildEventFrame } from "../src/p2p/frame.ts";
 import type { ParsedEventFrame } from "../src/p2p/frame.ts";
 import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
@@ -94,5 +94,75 @@ describe("LocalBridge loopback", () => {
     bridge = new LocalBridge({ port: 0, onOutbound: () => {} });
     bridge.start();
     expect(bridge.broadcast("frame")).toBe(0);
+  });
+});
+
+describe("isOriginAllowed (pure)", () => {
+  const allow = ["https://chat.phantomyard.ai"];
+
+  test("no / empty / null Origin is allowed (CLI + non-browser tooling)", () => {
+    expect(isOriginAllowed(null, allow)).toBe(true);
+    expect(isOriginAllowed(undefined, allow)).toBe(true);
+    expect(isOriginAllowed("", allow)).toBe(true);
+    expect(isOriginAllowed("null", allow)).toBe(true);
+  });
+
+  test("localhost origins are always allowed (the dev PWA)", () => {
+    expect(isOriginAllowed("http://localhost:5173", allow)).toBe(true);
+    expect(isOriginAllowed("https://localhost", allow)).toBe(true);
+    expect(isOriginAllowed("http://127.0.0.1:8080", allow)).toBe(true);
+    expect(isOriginAllowed("http://[::1]:3000", allow)).toBe(true);
+  });
+
+  test("a listed production origin is allowed, an unlisted site is not", () => {
+    expect(isOriginAllowed("https://chat.phantomyard.ai", allow)).toBe(true);
+    expect(isOriginAllowed("https://example.com", allow)).toBe(false);
+    expect(isOriginAllowed("https://evil.phantomyard.ai", allow)).toBe(false);
+    // Must be exact — a lookalike host is not a substring match.
+    expect(isOriginAllowed("https://chat.phantomyard.ai.evil.com", allow)).toBe(false);
+  });
+
+  test("an unparseable Origin is refused", () => {
+    expect(isOriginAllowed("not a url", allow)).toBe(false);
+  });
+});
+
+describe("LocalBridge origin gate (live)", () => {
+  // The gate runs in `fetch` BEFORE `server.upgrade`, so a plain GET is enough
+  // to exercise it: a hostile Origin is refused with 403; an allowed Origin
+  // passes the gate and only then hits the "websocket only" 426.
+  test("a hostile browser Origin is refused with 403", async () => {
+    bridge = new LocalBridge({
+      port: 0,
+      onOutbound: () => {},
+      allowedOrigins: ["https://chat.phantomyard.ai"],
+    });
+    bridge.start();
+    const res = await fetch(`http://127.0.0.1:${bridge.boundPort}/`, {
+      headers: { Origin: "https://example.com" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("the allowed PhantomChat origin passes the gate (426, not 403)", async () => {
+    bridge = new LocalBridge({
+      port: 0,
+      onOutbound: () => {},
+      allowedOrigins: ["https://chat.phantomyard.ai"],
+    });
+    bridge.start();
+    const res = await fetch(`http://127.0.0.1:${bridge.boundPort}/`, {
+      headers: { Origin: "https://chat.phantomyard.ai" },
+    });
+    expect(res.status).toBe(426);
+  });
+
+  test("a localhost origin passes the gate even when not explicitly listed", async () => {
+    bridge = new LocalBridge({ port: 0, onOutbound: () => {}, allowedOrigins: [] });
+    bridge.start();
+    const res = await fetch(`http://127.0.0.1:${bridge.boundPort}/`, {
+      headers: { Origin: "http://localhost:5173" },
+    });
+    expect(res.status).toBe(426);
   });
 });

--- a/tests/p2p-localBridge.test.ts
+++ b/tests/p2p-localBridge.test.ts
@@ -100,11 +100,17 @@ describe("LocalBridge loopback", () => {
 describe("isOriginAllowed (pure)", () => {
   const allow = ["https://chat.phantomyard.ai"];
 
-  test("no / empty / null Origin is allowed (CLI + non-browser tooling)", () => {
+  test("a genuinely absent Origin is allowed (CLI + non-browser tooling)", () => {
     expect(isOriginAllowed(null, allow)).toBe(true);
     expect(isOriginAllowed(undefined, allow)).toBe(true);
     expect(isOriginAllowed("", allow)).toBe(true);
-    expect(isOriginAllowed("null", allow)).toBe(true);
+  });
+
+  test('a literal "null" Origin (browser opaque origin) is refused', () => {
+    // Sandboxed iframes, data:/file: pages, and some cross-origin redirects make
+    // a browser send `Origin: null`. A hostile page can provoke it, so it must
+    // NOT be treated as trusted non-browser tooling.
+    expect(isOriginAllowed("null", allow)).toBe(false);
   });
 
   test("localhost origins are always allowed (the dev PWA)", () => {
@@ -140,6 +146,19 @@ describe("LocalBridge origin gate (live)", () => {
     bridge.start();
     const res = await fetch(`http://127.0.0.1:${bridge.boundPort}/`, {
       headers: { Origin: "https://example.com" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test('a literal "null" Origin is refused with 403', async () => {
+    bridge = new LocalBridge({
+      port: 0,
+      onOutbound: () => {},
+      allowedOrigins: ["https://chat.phantomyard.ai"],
+    });
+    bridge.start();
+    const res = await fetch(`http://127.0.0.1:${bridge.boundPort}/`, {
+      headers: { Origin: "null" },
     });
     expect(res.status).toBe(403);
   });

--- a/tests/p2p-node.test.ts
+++ b/tests/p2p-node.test.ts
@@ -1,0 +1,265 @@
+/**
+ * The node routing brain, driven entirely through its seams (fake signaling,
+ * fake bridge, fake peers) so it runs with zero sockets. Covers the parts that
+ * are easy to get wrong: deterministic initiator vs. hello-nudge, buffering a
+ * frame until the channel opens then flushing it, dropping self-addressed
+ * wraps, and redialling a failed peer.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { P2PNode, type BridgePort, type PeerLike } from "../src/p2p/node.ts";
+import type { PeerConnectionOptions, PeerState } from "../src/p2p/peerConnection.ts";
+import type { ParsedEventFrame } from "../src/p2p/frame.ts";
+import type { SignalMessage, SignalHandler, Signaling } from "../src/p2p/signaling.ts";
+import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
+
+class FakeSignaling implements Signaling {
+  sent: { to: string; msg: SignalMessage }[] = [];
+  handler: SignalHandler | null = null;
+  started = false;
+  send(to: string, msg: SignalMessage): Promise<void> {
+    this.sent.push({ to, msg });
+    return Promise.resolve();
+  }
+  onMessage(h: SignalHandler): void {
+    this.handler = h;
+  }
+  start(): void {
+    this.started = true;
+  }
+  stop(): void {
+    this.started = false;
+  }
+  /** Simulate an inbound signal from a peer. */
+  emit(senderHex: string, msg: SignalMessage): void {
+    this.handler?.(senderHex, msg);
+  }
+}
+
+class FakeBridge implements BridgePort {
+  broadcasts: string[] = [];
+  clients = 1;
+  started = false;
+  outbound!: (frame: ParsedEventFrame, raw: string) => void;
+  start(): void {
+    this.started = true;
+  }
+  stop(): void {
+    this.started = false;
+  }
+  broadcast(frame: string): number {
+    this.broadcasts.push(frame);
+    return this.clients;
+  }
+  clientCount(): number {
+    return this.clients;
+  }
+  /** Simulate the PWA sending a frame over ws://localhost. */
+  pwaSends(recipientHex: string, raw = `["EVENT",{"to":"${recipientHex}"}]`): void {
+    const frame: ParsedEventFrame = {
+      wrap: { tags: [["p", recipientHex]] } as unknown as NTNostrEvent,
+      recipientHex,
+    };
+    this.outbound(frame, raw);
+  }
+}
+
+class FakePeer implements PeerLike {
+  readonly peerHex: string;
+  readonly opts: PeerConnectionOptions;
+  state: PeerState = "new";
+  started = false;
+  sent: string[] = [];
+  handled: SignalMessage[] = [];
+  closed = false;
+  sendReturns = true;
+  constructor(opts: PeerConnectionOptions) {
+    this.peerHex = opts.peerHex;
+    this.opts = opts;
+  }
+  getState(): PeerState {
+    return this.state;
+  }
+  isReady(): boolean {
+    return this.state === "connected";
+  }
+  start(): Promise<void> {
+    this.started = true;
+    this.state = "connecting";
+    return Promise.resolve();
+  }
+  handleSignal(msg: SignalMessage): Promise<void> {
+    this.handled.push(msg);
+    return Promise.resolve();
+  }
+  send(frame: string): boolean {
+    if (!this.sendReturns) return false;
+    this.sent.push(frame);
+    return true;
+  }
+  close(): void {
+    this.closed = true;
+    this.state = "closed";
+  }
+  /** Drive the state transition the node listens on. */
+  transition(state: PeerState): void {
+    this.state = state;
+    this.opts.onState?.(state);
+  }
+  /** Simulate an inbound data-channel frame. */
+  deliver(frame: string): void {
+    this.opts.onFrame(frame);
+  }
+}
+
+function makeNode(ourPubHex: string) {
+  const signaling = new FakeSignaling();
+  const bridge = new FakeBridge();
+  const peers: FakePeer[] = [];
+  const node = new P2PNode({
+    ourPubHex,
+    iceServers: [],
+    signaling,
+    createBridge: (onOutbound) => {
+      bridge.outbound = onOutbound;
+      return bridge;
+    },
+    createPeer: (opts) => {
+      const p = new FakePeer(opts);
+      peers.push(p);
+      return p;
+    },
+  });
+  node.start();
+  return { node, signaling, bridge, peers, peerFor: (hex: string) => peers.find((p) => p.peerHex === hex) };
+}
+
+describe("P2PNode routing", () => {
+  test("start wires bridge + signaling", () => {
+    const { signaling, bridge } = makeNode("m".repeat(64));
+    expect(signaling.started).toBe(true);
+    expect(bridge.started).toBe(true);
+  });
+
+  test("as initiator: outbound frame dials, buffers, then flushes on connect", () => {
+    const us = "a".repeat(64);
+    const peerHex = "f".repeat(64); // us < peer → we initiate
+    const { bridge, peerFor } = makeNode(us);
+
+    bridge.pwaSends(peerHex, "frame-1");
+    const peer = peerFor(peerHex)!;
+    expect(peer.started).toBe(true); // initiator started the offer
+    expect(peer.sent).toHaveLength(0); // not ready yet → buffered
+
+    peer.transition("connected");
+    expect(peer.sent).toEqual(["frame-1"]); // flushed
+  });
+
+  test("as responder: outbound frame sends a hello nudge instead of offering", () => {
+    const us = "f".repeat(64);
+    const peerHex = "a".repeat(64); // us > peer → peer initiates, we nudge
+    const { signaling, bridge, peerFor } = makeNode(us);
+
+    bridge.pwaSends(peerHex, "frame-1");
+    const peer = peerFor(peerHex)!;
+    expect(peer.started).toBe(false); // responder must not offer
+    expect(signaling.sent).toContainEqual({ to: peerHex, msg: { t: "hello" } });
+
+    peer.transition("connected");
+    expect(peer.sent).toEqual(["frame-1"]);
+  });
+
+  test("ready peer sends immediately without buffering", () => {
+    const us = "a".repeat(64);
+    const peerHex = "f".repeat(64);
+    const { bridge, peerFor } = makeNode(us);
+
+    bridge.pwaSends(peerHex, "first");
+    const peer = peerFor(peerHex)!;
+    peer.transition("connected");
+    bridge.pwaSends(peerHex, "second");
+    expect(peer.sent).toEqual(["first", "second"]);
+  });
+
+  test("hello nudge makes the initiator offer", () => {
+    const us = "a".repeat(64); // us < peer → we're the initiator
+    const peerHex = "f".repeat(64);
+    const { signaling, peerFor } = makeNode(us);
+
+    signaling.emit(peerHex, { t: "hello" });
+    expect(peerFor(peerHex)!.started).toBe(true);
+  });
+
+  test("hello nudge to a responder is ignored (no double-offer)", () => {
+    const us = "f".repeat(64); // us > peer → we're the responder
+    const peerHex = "a".repeat(64);
+    const { signaling, peers } = makeNode(us);
+
+    signaling.emit(peerHex, { t: "hello" });
+    expect(peers).toHaveLength(0); // nothing created, nothing offered
+  });
+
+  test("inbound offer creates a peer and feeds it the signal", () => {
+    const us = "f".repeat(64);
+    const peerHex = "a".repeat(64);
+    const { signaling, peerFor } = makeNode(us);
+
+    signaling.emit(peerHex, { t: "offer", sdp: "x" });
+    expect(peerFor(peerHex)!.handled).toEqual([{ t: "offer", sdp: "x" }]);
+  });
+
+  test("inbound peer frame is broadcast to the local PWA", () => {
+    const us = "a".repeat(64);
+    const peerHex = "f".repeat(64);
+    const { bridge, peerFor } = makeNode(us);
+    bridge.pwaSends(peerHex);
+    peerFor(peerHex)!.deliver(`["EVENT",{"inbound":true}]`);
+    expect(bridge.broadcasts).toEqual([`["EVENT",{"inbound":true}]`]);
+  });
+
+  test("a self-addressed wrap is dropped, no peer created", () => {
+    const us = "a".repeat(64);
+    const { bridge, peers } = makeNode(us);
+    bridge.pwaSends(us);
+    expect(peers).toHaveLength(0);
+  });
+
+  test("a failed peer is dropped and redialled on the next frame", () => {
+    const us = "a".repeat(64);
+    const peerHex = "f".repeat(64);
+    const { bridge, peers, peerFor } = makeNode(us);
+
+    bridge.pwaSends(peerHex, "one");
+    const first = peerFor(peerHex)!;
+    first.transition("failed");
+    expect(first.closed).toBe(true);
+
+    bridge.pwaSends(peerHex, "two");
+    // A brand-new peer object was created for the redial.
+    expect(peers.filter((p) => p.peerHex === peerHex)).toHaveLength(2);
+    expect(peers[1]!.started).toBe(true);
+  });
+
+  test("stop closes peers and tears down bridge + signaling", () => {
+    const us = "a".repeat(64);
+    const peerHex = "f".repeat(64);
+    const { node, signaling, bridge, peerFor } = makeNode(us);
+    bridge.pwaSends(peerHex);
+    node.stop();
+    expect(peerFor(peerHex)!.closed).toBe(true);
+    expect(signaling.started).toBe(false);
+    expect(bridge.started).toBe(false);
+  });
+
+  test("stats reflects local clients and peer states", () => {
+    const us = "a".repeat(64);
+    const peerHex = "f".repeat(64);
+    const { node, bridge, peerFor } = makeNode(us);
+    bridge.pwaSends(peerHex);
+    peerFor(peerHex)!.transition("connected");
+    const stats = node.stats();
+    expect(stats.localClients).toBe(1);
+    expect(stats.peers).toEqual([{ peerHex, state: "connected" }]);
+  });
+});

--- a/tests/p2p-peerConnection.test.ts
+++ b/tests/p2p-peerConnection.test.ts
@@ -1,0 +1,106 @@
+/**
+ * werift peer-connection wrapper — the real thing. Two PeerConnection instances
+ * run in-process; their signaling is looped in memory (as Nostr would, minus the
+ * relays). This exercises a genuine ICE → DTLS → SCTP data-channel handshake on
+ * loopback host candidates and proves opaque frames flow both ways — the same
+ * round-trip the pre-implementation spike validated under a compiled Bun binary.
+ *
+ * No STUN (`iceServers: []`) so it needs no network — host candidates on
+ * loopback connect the two peers entirely offline, which is also exactly the
+ * Tier-1/Tier-2 (localhost/LAN) path.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { PeerConnection } from "../src/p2p/peerConnection.ts";
+import type { SignalMessage } from "../src/p2p/signaling.ts";
+
+/**
+ * Wire two peers so each one's outgoing signals are delivered to the other's
+ * `handleSignal` on a microtask (mimicking async relay delivery without races).
+ */
+function connectPair(onAFrame: (f: string) => void, onBFrame: (f: string) => void) {
+  let a!: PeerConnection;
+  let b!: PeerConnection;
+
+  a = new PeerConnection({
+    peerHex: "b", // A dials B
+    initiator: true,
+    iceServers: [],
+    sendSignal: (msg: SignalMessage) => void Promise.resolve().then(() => b.handleSignal(msg)),
+    onFrame: onAFrame,
+  });
+  b = new PeerConnection({
+    peerHex: "a",
+    initiator: false,
+    iceServers: [],
+    sendSignal: (msg: SignalMessage) => void Promise.resolve().then(() => a.handleSignal(msg)),
+    onFrame: onBFrame,
+  });
+
+  return { a, b };
+}
+
+function waitFor<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, rej) => setTimeout(() => rej(new Error(`timeout: ${label}`)), ms)),
+  ]);
+}
+
+describe("werift PeerConnection round-trip", () => {
+  test(
+    "two peers negotiate and exchange opaque frames both ways",
+    async () => {
+      let resolveB!: (f: string) => void;
+      let resolveA!: (f: string) => void;
+      const gotOnB = new Promise<string>((r) => (resolveB = r));
+      const gotOnA = new Promise<string>((r) => (resolveA = r));
+
+      const { a, b } = connectPair(
+        (f) => resolveA(f),
+        (f) => {
+          resolveB(f);
+          // Echo back so we also prove B→A direction.
+          b.send(JSON.stringify(["EVENT", { echo: "from-b" }]));
+        },
+      );
+
+      // A initiates; once its channel opens, send a frame.
+      await a.start();
+      // Poll until A's channel is ready, then send.
+      const deadline = Date.now() + 12_000;
+      while (!a.isReady() && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(a.isReady()).toBe(true);
+      a.send(JSON.stringify(["EVENT", { hello: "from-a" }]));
+
+      const onB = await waitFor(gotOnB, 12_000, "B receive");
+      const onA = await waitFor(gotOnA, 12_000, "A receive (echo)");
+
+      expect(JSON.parse(onB)).toEqual(["EVENT", { hello: "from-a" }]);
+      expect(JSON.parse(onA)).toEqual(["EVENT", { echo: "from-b" }]);
+      expect(a.getState()).toBe("connected");
+      expect(b.getState()).toBe("connected");
+
+      a.close();
+      b.close();
+      expect(a.getState()).toBe("closed");
+    },
+    20_000,
+  );
+
+  test("send returns false before the channel is open", () => {
+    const pc = new PeerConnection({
+      peerHex: "z",
+      initiator: true,
+      iceServers: [],
+      sendSignal: () => {},
+      onFrame: () => {},
+    });
+    expect(pc.isReady()).toBe(false);
+    expect(pc.send("frame")).toBe(false);
+    pc.close();
+  });
+});

--- a/tests/p2p-signaling.test.ts
+++ b/tests/p2p-signaling.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Nostr signaling: SDP/ICE exchange over an encrypted ephemeral event kind,
+ * separate from the chat gift-wrap plane. Real NIP-44 crypto; the relay pool is
+ * an in-memory fake so no sockets are touched.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
+
+import {
+  NostrSignaling,
+  decodeSignal,
+  encodeSignal,
+  isSignalMessage,
+  NOSTR_KIND_P2P_SIGNAL,
+  type SignalMessage,
+} from "../src/p2p/signaling.ts";
+import type { NostrFilter, RelayPool } from "../src/channels/phantomchat/transport.ts";
+import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
+
+describe("p2p signaling crypto", () => {
+  test("encode → decode round-trips each signal type between two nodes", () => {
+    const aSk = generateSecretKey();
+    const bSk = generateSecretKey();
+    const bHex = getPublicKey(bSk);
+    const aHex = getPublicKey(aSk);
+
+    const messages: SignalMessage[] = [
+      { t: "offer", sdp: "v=0\r\no=- offer" },
+      { t: "answer", sdp: "v=0\r\no=- answer" },
+      { t: "candidate", candidate: "candidate:1 1 udp ...", sdpMid: "0", sdpMLineIndex: 0 },
+      { t: "hello" },
+      { t: "bye" },
+    ];
+
+    for (const msg of messages) {
+      const event = encodeSignal(aSk, bHex, msg);
+      expect(event.kind).toBe(NOSTR_KIND_P2P_SIGNAL);
+      expect(event.tags).toContainEqual(["p", bHex]);
+      // B decodes it and learns A is the sender.
+      const decoded = decodeSignal(bSk, event);
+      expect(decoded).not.toBeNull();
+      expect(decoded!.senderHex).toBe(aHex);
+      expect(decoded!.msg).toEqual(msg);
+    }
+  });
+
+  test("a third party cannot decrypt a signal", () => {
+    const aSk = generateSecretKey();
+    const bSk = generateSecretKey();
+    const eveSk = generateSecretKey();
+    const event = encodeSignal(aSk, getPublicKey(bSk), { t: "offer", sdp: "secret" });
+    expect(decodeSignal(eveSk, event)).toBeNull();
+  });
+
+  test("decodeSignal rejects a wrong kind and malformed payload", () => {
+    const aSk = generateSecretKey();
+    const bSk = generateSecretKey();
+    const good = encodeSignal(aSk, getPublicKey(bSk), { t: "offer", sdp: "x" });
+    expect(decodeSignal(bSk, { ...good, kind: 1 })).toBeNull();
+    expect(decodeSignal(bSk, { ...good, content: "garbage" })).toBeNull();
+  });
+
+  test("isSignalMessage validates shape", () => {
+    expect(isSignalMessage({ t: "offer", sdp: "x" })).toBe(true);
+    expect(isSignalMessage({ t: "candidate", candidate: "x" })).toBe(true);
+    expect(isSignalMessage({ t: "hello" })).toBe(true);
+    expect(isSignalMessage({ t: "offer" })).toBe(false);
+    expect(isSignalMessage({ t: "nope" })).toBe(false);
+    expect(isSignalMessage(null)).toBe(false);
+  });
+});
+
+describe("NostrSignaling over the relay-pool seam", () => {
+  function fakePool() {
+    const published: NTNostrEvent[] = [];
+    let onevent: ((e: NTNostrEvent) => void) | undefined;
+    let capturedFilter: NostrFilter | undefined;
+    const pool: RelayPool = {
+      subscribeMany(_relays, filter, params) {
+        capturedFilter = filter;
+        onevent = params.onevent;
+        return { close() {} };
+      },
+      publish(_relays, event) {
+        published.push(event);
+        return [Promise.resolve("ok")];
+      },
+      close() {},
+    };
+    return {
+      pool,
+      published,
+      emit: (e: NTNostrEvent) => onevent?.(e),
+      filter: () => capturedFilter,
+    };
+  }
+
+  test("subscribes with the signal kind + our p-tag, single filter object", () => {
+    const sk = generateSecretKey();
+    const f = fakePool();
+    const sig = new NostrSignaling(sk, ["wss://r"], f.pool);
+    sig.start();
+    const filter = f.filter()!;
+    expect(Array.isArray(filter)).toBe(false);
+    expect(filter.kinds).toEqual([NOSTR_KIND_P2P_SIGNAL]);
+    expect(filter["#p"]).toEqual([getPublicKey(sk)]);
+  });
+
+  test("send publishes an encrypted event the peer can decode", async () => {
+    const aSk = generateSecretKey();
+    const bSk = generateSecretKey();
+    const f = fakePool();
+    const sig = new NostrSignaling(aSk, ["wss://r"], f.pool);
+    await sig.send(getPublicKey(bSk), { t: "offer", sdp: "hello-sdp" });
+    expect(f.published).toHaveLength(1);
+    const decoded = decodeSignal(bSk, f.published[0]!);
+    expect(decoded!.msg).toEqual({ t: "offer", sdp: "hello-sdp" });
+  });
+
+  test("inbound events reach the handler, deduped by id", () => {
+    const aSk = generateSecretKey();
+    const bSk = generateSecretKey();
+    const f = fakePool();
+    const bSig = new NostrSignaling(bSk, ["wss://r"], f.pool);
+    const got: { senderHex: string; msg: SignalMessage }[] = [];
+    bSig.onMessage((senderHex, msg) => got.push({ senderHex, msg }));
+    bSig.start();
+
+    const event = encodeSignal(aSk, getPublicKey(bSk), { t: "candidate", candidate: "c" });
+    f.emit(event);
+    f.emit(event); // duplicate delivery from a second relay
+    expect(got).toHaveLength(1);
+    expect(got[0]!.senderHex).toBe(getPublicKey(aSk));
+    expect(got[0]!.msg).toEqual({ t: "candidate", candidate: "c" });
+  });
+
+  test("undecryptable inbound events are ignored, not thrown", () => {
+    const bSk = generateSecretKey();
+    const eveSk = generateSecretKey();
+    const otherSk = generateSecretKey();
+    const f = fakePool();
+    const bSig = new NostrSignaling(bSk, ["wss://r"], f.pool);
+    let calls = 0;
+    bSig.onMessage(() => calls++);
+    bSig.start();
+    // Encrypted to someone else — B can't decode it.
+    f.emit(encodeSignal(eveSk, getPublicKey(otherSk), { t: "bye" }));
+    expect(calls).toBe(0);
+  });
+});

--- a/tests/p2p-startup.test.ts
+++ b/tests/p2p-startup.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Daemon startup containment (phantomchat#258, Kai review on #266).
+ *
+ * `node.start()` throws SYNCHRONOUSLY when the loopback port is already taken.
+ * If that throw escaped into a pushed task it would reject `Promise.all(tasks)`
+ * and abort the whole `phantombot run` process — killing PhantomChat over a P2P
+ * port conflict. `startP2PNode` must contain it: log, warn, tear down, return
+ * `null`, and never reject. These tests drive that with a REAL LocalBridge
+ * occupying the port (the exact failure Kai reproduced).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { startP2PNode } from "../src/p2p/index.ts";
+import { P2PNode } from "../src/p2p/node.ts";
+import { LocalBridge } from "../src/p2p/localBridge.ts";
+import type { SignalHandler, SignalMessage, Signaling } from "../src/p2p/signaling.ts";
+
+class FakeSignaling implements Signaling {
+  started = false;
+  send(_to: string, _msg: SignalMessage): Promise<void> {
+    return Promise.resolve();
+  }
+  onMessage(_h: SignalHandler): void {}
+  start(): void {
+    this.started = true;
+  }
+  stop(): void {
+    this.started = false;
+  }
+}
+
+class Capture {
+  text = "";
+  write(s: string): void {
+    this.text += s;
+  }
+}
+
+const SELF = "a".repeat(64);
+
+let blocker: LocalBridge | null = null;
+let node: P2PNode | null = null;
+afterEach(() => {
+  node?.stop();
+  node = null;
+  blocker?.stop();
+  blocker = null;
+});
+
+function makeNode(port: number): P2PNode {
+  return new P2PNode({
+    ourPubHex: SELF,
+    iceServers: [],
+    signaling: new FakeSignaling(),
+    createBridge: (onOutbound) => new LocalBridge({ port, onOutbound }),
+  });
+}
+
+describe("startP2PNode — port-conflict containment", () => {
+  test("a taken loopback port degrades to a warning, not a rejected task", async () => {
+    // Occupy the port first — this is Kai's two-bridges-on-one-port repro.
+    blocker = new LocalBridge({ port: 0, onOutbound: () => {} });
+    blocker.start();
+    const takenPort = blocker.boundPort;
+
+    node = makeNode(takenPort);
+    const out = new Capture();
+    const err = new Capture();
+    let advertised = false;
+
+    const task = startP2PNode({
+      node,
+      advertise: () => {
+        advertised = true;
+      },
+      signal: new AbortController().signal,
+      out,
+      err,
+      persona: "lena",
+      port: takenPort,
+    });
+
+    // Contained: no task to push, relay-fallback warning emitted, advert skipped.
+    expect(task).toBeNull();
+    expect(err.text).toContain("chat still works over relays");
+    expect(advertised).toBe(false);
+    // The node was left re-startable (start never completed), not wedged.
+    expect(node.stats().peers).toEqual([]);
+  });
+
+  test("a free port starts, advertises, and the task resolves on abort", async () => {
+    node = makeNode(0);
+    const out = new Capture();
+    const err = new Capture();
+    let advertised = false;
+    const ac = new AbortController();
+
+    const task = startP2PNode({
+      node,
+      advertise: () => {
+        advertised = true;
+      },
+      signal: ac.signal,
+      out,
+      err,
+      persona: "lena",
+      port: 0,
+    });
+
+    expect(task).not.toBeNull();
+    expect(advertised).toBe(true);
+    expect(out.text).toContain("[p2p:lena]");
+    expect(err.text).toBe("");
+
+    // The keep-alive task must resolve cleanly once we abort (no hang, no throw).
+    ac.abort();
+    await task;
+  });
+});


### PR DESCRIPTION
## What & why

Closes the phantombot half of **#258** (companion: phantomchat #61/#62). Today every PhantomChat message round-trips a public Nostr relay — a latency floor and a dependency we don't control. This makes phantombot the user's **personal P2P node** so two nodes talk **directly node-to-node over an encrypted WebRTC data channel**, with relays demoted to the WebRTC handshake (signaling) + a fallback floor. No relay in the message hot path; no infrastructure of ours.

## The werift decision (resolving #258's blocker)

Robbie's blocker on #258 was that the intended Holepunch stack **doesn't run under Bun**: `new Hyperswarm()` panics (`uv_interface_addresses`) and `node-datachannel` can't be bundled by `bun build --compile`. After a hands-on spike we confirmed **werift** (pure-TypeScript WebRTC) survives compilation into the shipped single binary — a full ICE→DTLS→SCTP data-channel round-trip works *inside a compiled Bun binary*. So this PR uses **werift + Nostr-for-signaling**, exactly as agreed:

- **werift** for the peer-to-peer data channels — no native addon, no sidecar, one binary.
- **Nostr** carries only the SDP offer/answer + ICE candidates, NIP-44-encrypted on a **dedicated ephemeral kind (21050)** so it never collides with the chat 1059 gift-wrap plane. Message contents never touch it — they stay end-to-end sealed.
- **Public STUN** for NAT traversal (reflexive-only; it never relays, so there's still zero infra of ours).

## Contract (matches the merged PWA side)

The node is a **dumb, encrypted-wrap relay**. The PWA ships `["EVENT", <gift-wrap>]` (a standard Nostr relay frame) over `ws://localhost:47100`; the node reads the recipient off the wrap's `p`-tag, forwards the **sealed** wrap to that peer's data channel, and broadcasts inbound wraps back to the local PWA. It never holds a key for the contents. Port and framing match phantomchat #62's `local-ws-transport.ts` verbatim.

## Zero regression — off by default

`config.p2p.enabled` defaults **false**. An unconfigured or existing install opens no port, advertises no capability, runs no signaling subscription — byte-for-byte unchanged. Enable via `[p2p]` in config.toml or `PHANTOMBOT_P2P_ENABLED=1`.

## What's here

| Module (`src/p2p/`) | Role |
|---|---|
| `frame.ts` | Wire contract: parse/build `["EVENT", wrap]`, recipient from p-tag (pure) |
| `signaling.ts` | SDP/ICE over Nostr (NIP-44, ephemeral kind 21050) on the `RelayPool` seam |
| `peerConnection.ts` | One werift `RTCPeerConnection` + data channel per peer |
| `localBridge.ts` | Bun-native `ws://localhost:47100`, loopback-only |
| `node.ts` | Routing brain: deterministic initiator + `hello` nudge (glare-free), per-peer outbox |
| `capability.ts` | NIP-78 capability advertisement (the format the PWA companion will ingest) |
| `index.ts` | Daemon glue (`buildP2PNode` / `runP2PNode`), wired into `run` |

Plus `config.p2p` (enabled/port/stun, env + TOML), `phantombot p2p status`, README + architecture docs.

## The bug worth flagging in review

Readiness is gated on the **data channel `open` event, not** the ICE/DTLS `connectionStateChange === "connected"`. The transport connects slightly *before* the SCTP channel opens; gating on transport-connected flushed the first buffered frame into a not-yet-open channel and silently dropped it. Caught by the end-to-end test; fixed and commented. (This is exactly the kind of thing the relay floor would have masked in the field.)

## Tests

- **Real werift round-trip** — two `PeerConnection` instances do a genuine ICE→DTLS→data-channel handshake on loopback and exchange frames both ways (~0.4s).
- **End-to-end two-node** — two full nodes exchange a wrap with **no relay in the data path** (in-memory signaling bus + real werift).
- Routing brain via injected fakes; the Bun ws bridge via a **real loopback WebSocket client**; pure frame/capability/signaling (real NIP-44 crypto); config precedence + clamping.
- 38 p2p tests + config coverage. **Full suite green** (the 2 unrelated `harnesses-pi` failures are the known local env-leak — a real `PHANTOMBOT_PI_API_KEY` in the dev shell bleeds into the harness subprocess; this branch touches nothing in that path). Typecheck clean.

## Scope / follow-ups (honest)

- **PWA-side capability ingestion** is the companion phantomchat change. The PWA already *sends* over `ws://localhost` for a P2P-capable peer, but it doesn't yet *populate* its capability registry from a node's advertisement — so until that lands, the node runs and advertises but the PWA ladder stays on relays. This PR defines that advertisement format (`capability.ts`).
- **Single loopback port** ⇒ on a multi-persona host only the first PhantomChat persona hosts the node.
- **Remote symmetric-NAT** still falls back to the relay (by design — that's our "TURN" without running one).