### PR TITLE
feat(p2p): enable relay-free P2P transport by default

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -323,9 +323,10 @@ export interface Config {
   /**
    * Relay-free P2P transport (phantombot#258): a local ws bridge for the
    * same-machine PhantomChat PWA plus werift WebRTC + Nostr-signalled channels
-   * to peer nodes. DISABLED BY DEFAULT — an unconfigured or existing install
-   * runs exactly as before (no bridge port opened, no capability advertised, no
-   * signaling subscription). See P2PSettings and buildP2PConfig.
+   * to peer nodes. ENABLED BY DEFAULT — a fresh install opens the loopback
+   * bridge, advertises P2P capability and subscribes to signaling so the
+   * same-machine PWA lights up P2P with no config. Set `enabled = false`
+   * (or PHANTOMBOT_P2P_ENABLED=0) to opt out. See P2PSettings and buildP2PConfig.
    *
    * Optional on the type (so partial test configs need not spell it out), but
    * `loadConfig` always populates it; consumers treat absence as `DEFAULT_P2P`.
@@ -335,7 +336,7 @@ export interface Config {
 
 /** Settings for the relay-free P2P transport node (phantombot#258). */
 export interface P2PSettings {
-  /** Master switch. Default false — the whole subsystem is dormant when off. */
+  /** Master switch. Default true — set false to keep the subsystem dormant. */
   enabled: boolean;
   /**
    * Loopback port for the PWA ws bridge. MUST match the PWA's
@@ -362,7 +363,7 @@ export interface P2PSettings {
 }
 
 export const DEFAULT_P2P: P2PSettings = {
-  enabled: false,
+  enabled: true,
   port: 47100,
   // Google's public STUN — reflexive-only, no relaying, no infra of ours.
   stunServers: ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -710,10 +710,10 @@ flush_after_hours = 6
 });
 
 describe("loadConfig — p2p (phantombot#258)", () => {
-  test("defaults to disabled on port 47100 with public STUN", async () => {
+  test("defaults to enabled on port 47100 with public STUN", async () => {
     const c = await loadConfig();
     expect(c.p2p).toEqual({
-      enabled: false,
+      enabled: true,
       port: 47100,
       stunServers: ["stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"],
       allowedOrigins: ["https://chat.phantomyard.ai"],


### PR DESCRIPTION
## Why

The P2P transport node (#258) shipped **disabled by default**, gated behind a `[p2p] enabled = true` section in `config.toml`. That meant even on localhost — phantombot and the PhantomChat PWA on the same machine — the P2P badge stayed **grey** and the loopback bridge (port 47100) never opened, because nothing published the capability advert the PWA ingests.

Zero-config P2P is the whole point. This flips it on by default.

## What

- `DEFAULT_P2P.enabled`: `false` → `true`.
- A fresh/unconfigured install now opens the loopback bridge, advertises P2P capability (kind-30078) and subscribes to signaling automatically. The same-machine PWA ingests the advert and the badge goes **green**.
- Doc comments updated to match.

## Safety / opt-out

- Override precedence is **unchanged**: `PHANTOMBOT_P2P_ENABLED` (env) > `[p2p] enabled` (toml) > default. Opt out any time with `enabled = false` or `PHANTOMBOT_P2P_ENABLED=0`.
- Bridge still binds **127.0.0.1 only** (off the LAN) and gates browser `Origin` exactly as before — no-Origin/localhost allowed, otherwise must be in `allowedOrigins` (defaults to the prod PhantomChat origin).
- STUN remains reflexive-only public STUN — no infra of ours, no media relaying.

## Tests

- Updated the config defaults test to expect `enabled: true`.
- `config` + all `p2p-*` suites green; full suite green apart from 2 pre-existing `harnesses-pi` subprocess failures that also fail on unmodified main.
- `tsc --noEmit` clean.