### PR TITLE
p2p: plaintext loopback port discovery (revert self-encryption)

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,9 +631,13 @@ an encrypted WebRTC data channel with no relay in the hot path.
 - **No hardcoded port — the PWA discovers it.** Each node binds an **OS-ephemeral
   loopback port** (`port = 0`), so any number of personas can host a node on one
   machine with **zero port collisions**. The node publishes its real bound port in
-  its capability advert, but **self-encrypted** (NIP-44, to its own key) — so your
-  IP and port never hit a relay in the clear. The PWA reads its *own* npub's
-  self-advert, decrypts the port, and dials `ws://localhost:<that port>`.
+  its capability advert, in **plaintext** — a loopback port bound to `127.0.0.1` is
+  reachable only from this machine, so it's not a secret, and any same-machine PWA
+  (a *different* Nostr identity than the node) reads the port and dials
+  `ws://localhost:<that port>`. (An earlier design self-encrypted the port to the
+  node's own key; that was wrong — the PWA is a different identity and could never
+  decrypt it. LAN IPs aren't advertised at all: ICE discovers LAN host candidates
+  live on the node↔node WebRTC path.)
 - The node exposes that loopback bridge for the same-machine PWA (loopback
   is a secure context, so an HTTPS PWA may open it — no TLS-cert wall). The bridge
   **gates WebSocket upgrades on the browser `Origin`**: loopback binding keeps the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 | `src/p2p/peerConnection.ts` | One werift `RTCPeerConnection` + data channel per peer. Readiness is gated on the **data channel** `open` event, not transport `connected` (the channel opens later; flushing early drops the first frame). | `werift` |
 | `src/p2p/localBridge.ts` | `ws://localhost:<ephemeral>` server (Bun native, loopback-only) for the same-machine PWA; `boundPort` reads back the OS-assigned port. Frames in → route; peer frames → broadcast to PWA. | Bun ws |
 | `src/p2p/node.ts` | Orchestrator. Routes frames by recipient pubkey, dials peers on demand, deterministic initiator (smaller pubkey) + `hello` nudge to avoid offer glare, per-peer outbox buffered until the channel opens. All seams injected for testing. | `peerConnection`, `signaling`, `localBridge` |
-| `src/p2p/capability.ts` | Capability advertisement (NIP-78 kind 30078): public capability booleans + a **self-encrypted** reachability blob (bound port + LAN IPs, NIP-44 to own key) so only the owner's PWA learns the local port. | `nostrCrypto`, `RelayPool` |
+| `src/p2p/capability.ts` | Capability advertisement (NIP-78 kind 30078): **plaintext** capability booleans + the actual bound loopback port. The port is a `127.0.0.1`-only ephemeral port (not a secret), so any same-machine PWA reads it and dials `ws://localhost`. | `RelayPool` |
 | `src/p2p/index.ts` | Daemon glue: `buildP2PNode` (from a persona's identity/relays/pool) + `runP2PNode` (start, wait for abort, stop), pushed onto `run`'s task list. | all of `src/p2p/*` |
 | `src/cli/p2p.ts` | `phantombot p2p status` — read-only view of the config + a loopback probe. | `config` |
 

--- a/src/p2p/capability.ts
+++ b/src/p2p/capability.ts
@@ -9,36 +9,32 @@
  *
  * A node publishes an addressable app-data event (NIP-78 kind 30078, `d` tag
  * `phantomchat-p2p`) under the persona's pubkey. It is replaceable, so
- * re-publishing on each start supersedes the previous one.
+ * re-publishing on each start supersedes the previous one, and its content is
+ * PLAINTEXT on purpose:
  *
- * TWO-PART CONTENT — public booleans + a self-encrypted reachability blob:
+ *   { "localWs": true, "localWsPort": 33297, "webrtc": true, "dht": false }
  *
- *   {
- *     "localWs": true, "webrtc": true, "dht": false,   // PUBLIC — any contact reads
- *     "enc": "<NIP-44 self-encrypted { localWsPort, lanIps }>"  // OWNER-ONLY
- *   }
- *
- * The capability BOOLEANS must stay public: a contact has to read whether we can
- * accept a direct transport BEFORE any encrypted channel exists, and they don't
- * hold our key. But the concrete REACHABILITY — which loopback port our bridge
- * bound (now OS-ephemeral, not a fixed 47100) and our LAN IPs — is nobody's
- * business but our own. Only the persona's own PWA, holding the same nsec, can
- * decrypt the `enc` blob (NIP-44 conversation key from our key to our own
- * pubkey). So the port/IP never touch a relay in the clear, while the gate still
- * works. The PWA discovers its LOCAL node's port by reading its OWN self-advert.
+ * WHY PLAINTEXT (and why the earlier self-encrypted-port design was wrong).
+ * Nothing here is a secret:
+ *   - The capability BOOLEANS must be public — a contact has to read whether we
+ *     can accept a direct transport BEFORE any encrypted channel exists, and
+ *     they don't hold our key.
+ *   - `localWsPort` is an OS-ephemeral loopback port bound to 127.0.0.1. It is
+ *     reachable ONLY from this machine; a remote party who learns "33297" still
+ *     cannot dial our localhost. So it is not sensitive — and encrypting it broke
+ *     the actual use case: the PWA is a DIFFERENT identity than the node, so it
+ *     could never decrypt a self-keyed blob to learn the port. Plaintext, any
+ *     same-machine PWA reads the port and dials `ws://localhost:PORT`.
+ *   - LAN IPs are gone entirely: a browser PWA cannot dial a bare LAN IP over
+ *     `ws://` (mixed-content + no TLS), and the node↔node WebRTC path discovers
+ *     LAN host candidates live via ICE at connection time. A frozen LAN IP in an
+ *     advert was a stale duplicate nobody consumed. Deleted.
  */
-
-import { networkInterfaces } from "node:os";
 
 import { finalizeEvent } from "nostr-tools/pure";
 
 import { log } from "../lib/logger.ts";
-import {
-  getConversationKey,
-  nip44Decrypt,
-  nip44Encrypt,
-  type NTNostrEvent,
-} from "../lib/nostrCrypto.ts";
+import type { NTNostrEvent } from "../lib/nostrCrypto.ts";
 import type { RelayPool } from "../channels/phantomchat/transport.ts";
 
 /** NIP-78 addressable app-data kind used for the capability advertisement. */
@@ -48,139 +44,79 @@ export const CAPABILITY_KIND = 30078;
 export const CAPABILITY_D_TAG = "phantomchat-p2p";
 
 /**
- * The PUBLIC capability booleans — plaintext, readable by any contact. Mirrors
- * the boolean half of the PWA's `PeerCapabilities` shape.
+ * What a node advertises — PLAINTEXT. Mirrors the PWA's `PeerCapabilities` shape
+ * verbatim (phantomchat `transport/capability.ts`) so ingestion is a direct
+ * assignment.
  */
 export interface NodeCapabilities {
   /** The node can accept a same-machine `ws://localhost` bridge connection. */
   localWs: boolean;
+  /**
+   * The OS-ephemeral loopback TCP port the ws bridge is ACTUALLY listening on
+   * (not a fixed 47100). A same-machine PWA reads this to dial `ws://localhost`.
+   */
+  localWsPort: number;
   /** The node can hold a WebRTC data channel (LAN host candidates or remote). */
   webrtc: boolean;
   /**
    * The node runs a raw-UDP DHT. Always false: this build uses werift WebRTC +
-   * Nostr signaling, not Hyperswarm (which panics under Bun).
+   * Nostr signaling, not Hyperswarm (which panics under Bun). Kept in the shape
+   * so the field is explicit rather than absent.
    */
   dht: boolean;
 }
 
 /**
- * OWNER-PRIVATE reachability — carried self-encrypted in the `enc` field, so
- * only the persona's own nsec can read it. Never leaves a relay in the clear.
+ * Build the capability descriptor a running node advertises.
+ *
+ * @param boundPort the ACTUAL bound loopback port (e.g. `bridge.boundPort`).
  */
-export interface NodeReachability {
-  /**
-   * The loopback TCP port the ws bridge is ACTUALLY listening on. With
-   * OS-ephemeral binding (`port: 0`) this is the real bound port, discovered at
-   * runtime — the PWA reads it here rather than assuming a fixed 47100.
-   */
-  localWsPort: number;
-  /**
-   * Non-internal IPv4 LAN addresses of this host. Informational: a browser PWA
-   * cannot dial a bare LAN IP over `ws://` (mixed-content + no TLS), so the LAN
-   * hop is served by ICE host candidates on the node↔node WebRTC path, not by
-   * the browser. Advertised so a peer knows "everything about" us for future use.
-   */
-  lanIps: string[];
-}
-
-/** Build the PUBLIC capability booleans a running node advertises. */
-export function nodeCapabilities(): NodeCapabilities {
-  return { localWs: true, webrtc: true, dht: false };
-}
-
-/**
- * Enumerate this host's non-internal IPv4 addresses (its LAN IPs). Never throws;
- * returns `[]` if enumeration fails. `family` is compared against both the
- * string `"IPv4"` (Node/Bun) and the numeric `4` some runtimes report.
- */
-export function localLanIps(): string[] {
-  try {
-    const out: string[] = [];
-    for (const addrs of Object.values(networkInterfaces())) {
-      if (!addrs) continue;
-      for (const a of addrs) {
-        const isV4 = a.family === "IPv4" || (a.family as unknown) === 4;
-        if (isV4 && !a.internal && a.address) out.push(a.address);
-      }
-    }
-    return out;
-  } catch {
-    return [];
-  }
+export function nodeCapabilities(boundPort: number): NodeCapabilities {
+  return { localWs: true, localWsPort: boundPort, webrtc: true, dht: false };
 }
 
 /**
  * Build (and sign) the replaceable capability event for this node.
  *
- * @param ourSk       persona secret key (signs the event + derives the self key)
- * @param ourPubHex   persona pubkey (hex) — the self-encryption recipient
- * @param boundPort   the ACTUAL bound loopback port (e.g. `bridge.boundPort`)
- * @param reachability override the reachability blob (LAN IPs default to
- *                      `localLanIps()`); primarily a test seam.
+ * @param ourSk     persona secret key (signs the event)
+ * @param boundPort the ACTUAL bound loopback port (e.g. `bridge.boundPort`)
  */
 export function buildCapabilityEvent(
   ourSk: Uint8Array,
-  ourPubHex: string,
   boundPort: number,
-  reachability?: Partial<NodeReachability>,
 ): NTNostrEvent {
-  const reach: NodeReachability = {
-    localWsPort: boundPort,
-    lanIps: reachability?.lanIps ?? localLanIps(),
-    ...reachability,
-  };
-  const selfKey = getConversationKey(ourSk, ourPubHex);
-  const enc = nip44Encrypt(JSON.stringify(reach), selfKey);
-  const content = JSON.stringify({ ...nodeCapabilities(), enc });
   const template = {
     kind: CAPABILITY_KIND,
     created_at: Math.floor(Date.now() / 1000),
     tags: [["d", CAPABILITY_D_TAG]],
-    content,
+    content: JSON.stringify(nodeCapabilities(boundPort)),
   };
   return finalizeEvent(template, ourSk) as unknown as NTNostrEvent;
 }
 
 /**
- * Parse a capability event back to its public caps (and, when `ourSk` is given
- * and this is our OWN advert, the decrypted reachability). Returns `null` when
- * the event is not a well-formed capability advertisement. Never throws.
- *
- * `reachability` is only populated for a SELF advert — decryption uses the self
- * conversation key `(ourSk → event.pubkey)`, which succeeds only when
- * `event.pubkey` is our own pubkey. A contact's advert yields `caps` with no
- * `reachability`, which is correct: a contact's port/IP are none of our business.
+ * Parse a capability event back to `{ authorHex, caps }`, or `null` when it is
+ * not a well-formed capability advertisement. This is the reference the PWA
+ * companion mirrors on ingest. Never throws.
  */
 export function parseCapabilityEvent(
   event: NTNostrEvent,
-  ourSk?: Uint8Array,
-): { authorHex: string; caps: NodeCapabilities; reachability?: NodeReachability } | null {
+): { authorHex: string; caps: NodeCapabilities } | null {
   try {
     if (event.kind !== CAPABILITY_KIND) return null;
     const hasDTag = event.tags.some((t) => t[0] === "d" && t[1] === CAPABILITY_D_TAG);
     if (!hasDTag) return null;
-    const parsed = JSON.parse(event.content) as Record<string, unknown>;
+    const parsed = JSON.parse(event.content) as Partial<NodeCapabilities>;
     if (typeof parsed !== "object" || parsed === null) return null;
-    const caps: NodeCapabilities = {
-      localWs: Boolean(parsed.localWs),
-      webrtc: Boolean(parsed.webrtc),
-      dht: Boolean(parsed.dht),
+    return {
+      authorHex: event.pubkey,
+      caps: {
+        localWs: Boolean(parsed.localWs),
+        localWsPort: typeof parsed.localWsPort === "number" ? parsed.localWsPort : 0,
+        webrtc: Boolean(parsed.webrtc),
+        dht: Boolean(parsed.dht),
+      },
     };
-    let reachability: NodeReachability | undefined;
-    if (ourSk && typeof parsed.enc === "string") {
-      try {
-        const selfKey = getConversationKey(ourSk, event.pubkey);
-        const reach = JSON.parse(nip44Decrypt(parsed.enc, selfKey)) as Partial<NodeReachability>;
-        reachability = {
-          localWsPort: typeof reach.localWsPort === "number" ? reach.localWsPort : 0,
-          lanIps: Array.isArray(reach.lanIps) ? reach.lanIps.filter((x) => typeof x === "string") : [],
-        };
-      } catch {
-        // Not our advert (can't derive the matching key) or corrupt blob — the
-        // public caps are still valid; just no reachability.
-      }
-    }
-    return { authorHex: event.pubkey, caps, reachability };
   } catch {
     return null;
   }

--- a/src/p2p/iceErrorGuard.ts
+++ b/src/p2p/iceErrorGuard.ts
@@ -1,0 +1,90 @@
+/**
+ * ICE UDP-socket error guard (phantomyard/phantombot#274).
+ *
+ * werift's ICE agent opens *connected* UDP (`dgram`) sockets for each candidate
+ * pair. On Linux, when a datagram is sent to a host/port with nothing listening,
+ * the kernel delivers an ICMP port/host-unreachable back on that connected
+ * socket, which Node surfaces as an asynchronous `error` event on the socket
+ * (`ECONNREFUSED` / `EHOSTUNREACH` / `ENETUNREACH`, syscall `recv`/`send`).
+ *
+ * werift does not attach an `error` listener to these sockets, so the event
+ * propagates as an **uncaught exception** and kills the whole process. In
+ * practice this fires constantly during normal ICE — every dead/stale candidate
+ * (a moved LAN IP, a firewalled srflx probe) triggers one — so a single WebRTC
+ * handshake reliably crash-loops the daemon: the peer connects, an ICE probe
+ * bounces, the process exits 1, systemd respawns, repeat. That is exactly why a
+ * P2P peer would connect and then never reply.
+ *
+ * These errors are *benign* — that candidate pair is simply unreachable and ICE
+ * moves on to the next. The correct behaviour is to swallow them (debug-log) and
+ * keep running. We scope the guard as tightly as possible: only errors that look
+ * like a dgram send/recv syscall failure with a known unreachable code are
+ * absorbed. Anything else re-throws, preserving the original crash-on-real-bug
+ * semantics (a throw inside an `uncaughtException` handler is fatal to the
+ * process, with the original stack).
+ */
+
+import { log } from "../lib/logger.ts";
+
+/** dgram syscalls the ICE agent uses; a benign error must originate from one. */
+const ICE_SYSCALLS = new Set(["recv", "send", "recvmsg", "sendmsg"]);
+
+/**
+ * Unreachable/transient codes the kernel raises for a connected UDP socket whose
+ * peer isn't listening or isn't routable. All benign for ICE candidate probing.
+ */
+const ICE_BENIGN_CODES = new Set([
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ECONNRESET",
+  "EPERM", // some firewalls surface blocked sends as EPERM
+]);
+
+interface NodeSystemError extends Error {
+  code?: string;
+  syscall?: string;
+}
+
+/** True only for the narrow class of benign ICE UDP socket errors. */
+export function isBenignIceSocketError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as NodeSystemError;
+  return (
+    typeof e.syscall === "string" &&
+    ICE_SYSCALLS.has(e.syscall) &&
+    typeof e.code === "string" &&
+    ICE_BENIGN_CODES.has(e.code)
+  );
+}
+
+let installed = false;
+
+/**
+ * Install the process-level guard exactly once. Idempotent across personas.
+ * Benign ICE socket errors are logged at debug and swallowed; everything else
+ * re-throws so a genuine bug still crashes loudly.
+ */
+export function installIceErrorGuard(): void {
+  if (installed) return;
+  installed = true;
+
+  process.on("uncaughtException", (err) => {
+    if (isBenignIceSocketError(err)) {
+      const e = err as NodeSystemError;
+      log.debug(`[p2p] ignoring benign ICE socket error: ${e.code} (${e.syscall})`);
+      return;
+    }
+    // Not ours — restore default fatal behaviour with the original error/stack.
+    throw err;
+  });
+
+  process.on("unhandledRejection", (reason) => {
+    if (isBenignIceSocketError(reason)) {
+      const e = reason as NodeSystemError;
+      log.debug(`[p2p] ignoring benign ICE socket rejection: ${e.code} (${e.syscall})`);
+      return;
+    }
+    throw reason;
+  });
+}

--- a/src/p2p/index.ts
+++ b/src/p2p/index.ts
@@ -10,6 +10,7 @@ import { log } from "../lib/logger.ts";
 import type { P2PSettings } from "../config.ts";
 import type { RelayPool } from "../channels/phantomchat/transport.ts";
 import { buildCapabilityEvent, publishCapability } from "./capability.ts";
+import { installIceErrorGuard } from "./iceErrorGuard.ts";
 import { LocalBridge } from "./localBridge.ts";
 import { P2PNode } from "./node.ts";
 import { NostrSignaling } from "./signaling.ts";
@@ -108,6 +109,10 @@ export interface StartP2PNodeInput {
  * is caught here, never inside a pushed Promise.
  */
 export function startP2PNode(input: StartP2PNodeInput): Promise<void> | null {
+  // werift's ICE UDP sockets throw benign uncaught ECONNREFUSED/EHOSTUNREACH on
+  // dead candidate probes, which would crash-loop the daemon mid-handshake.
+  // Install the scoped guard before any peer connection can open a socket.
+  installIceErrorGuard();
   try {
     input.node.start(); // synchronous; throws if a fixed loopback port is in use
   } catch (e) {

--- a/src/p2p/index.ts
+++ b/src/p2p/index.ts
@@ -53,11 +53,11 @@ export function buildP2PNode(deps: BuildP2PNodeDeps): P2PNode {
  * from startup — a relay hiccup must never delay the node coming up.
  *
  * `boundPort` is the node's ACTUAL bound loopback port (`node.boundPort`), read
- * AFTER `start()` so an OS-ephemeral bind (`port: 0`) advertises the real port,
- * self-encrypted, rather than the configured request.
+ * AFTER `start()` so an OS-ephemeral bind (`port: 0`) advertises the real bound
+ * port (plaintext) rather than the configured request.
  */
 export function advertiseP2PCapability(deps: BuildP2PNodeDeps, boundPort: number): void {
-  const event = buildCapabilityEvent(deps.secretKey, deps.publicKeyHex, boundPort);
+  const event = buildCapabilityEvent(deps.secretKey, boundPort);
   void publishCapability(deps.pool, deps.relays, event).catch((err) => {
     log.debug(`[p2p] capability advertise failed: ${String(err)}`);
   });

--- a/src/p2p/node.ts
+++ b/src/p2p/node.ts
@@ -86,6 +86,13 @@ export class P2PNode {
   private readonly outbox = new Map<string, string[]>();
   /** Peers we've already kicked into negotiating (offer sent / nudge sent). */
   private readonly negotiating = new Set<string>();
+  /**
+   * The SDP of the last offer we accepted per peer. An inbound offer starts a
+   * NEW WebRTC session, so a peer that already exists must be rebuilt (its old
+   * transport belongs to a dead session). We dedup by SDP so a relay re-delivery
+   * of the SAME offer doesn't tear down a connection we just built from it.
+   */
+  private readonly lastOfferSdp = new Map<string, string>();
   private started = false;
 
   constructor(deps: P2PNodeDeps) {
@@ -184,6 +191,28 @@ export class P2PNode {
         this.kickstart(senderHex, peer);
       }
       return;
+    }
+    if (msg.t === "offer") {
+      const prevSdp = this.lastOfferSdp.get(senderHex);
+      if (prevSdp === msg.sdp) {
+        // Exact-duplicate offer (relay re-delivery) — don't churn the connection
+        // we already built from it.
+        log.info(`[p2p] duplicate offer from ${senderHex.slice(0, 8)} — ignoring`);
+        return;
+      }
+      // A DIFFERENT offer after a previous one = the peer restarted its WebRTC
+      // session with brand-new ICE/DTLS credentials. Any peer we still hold
+      // belongs to the dead session; feeding this offer into it can't revive the
+      // transport — it stalls. Rebuild on a clean connection. (On the FIRST offer
+      // — prevSdp undefined — we do NOT rebuild: an existing peer here was just
+      // created to buffer early-arriving candidates, and tearing it down would
+      // drop those candidates. Feed the offer straight into it instead.)
+      const isNewSession = prevSdp !== undefined;
+      this.lastOfferSdp.set(senderHex, msg.sdp);
+      if (isNewSession && this.peers.has(senderHex)) {
+        log.info(`[p2p] new offer from ${senderHex.slice(0, 8)} — rebuilding peer`);
+        this.dropPeer(senderHex);
+      }
     }
     const peer = this.getOrCreatePeer(senderHex);
     // Receiving an offer/answer/candidate means we're actively negotiating, so

--- a/src/p2p/node.ts
+++ b/src/p2p/node.ts
@@ -176,6 +176,7 @@ export class P2PNode {
 
   /** An inbound signal from a peer. */
   private async onSignal(senderHex: string, msg: SignalMessage): Promise<void> {
+    log.info(`[p2p] signal in: ${msg.t} from ${senderHex.slice(0, 8)}`);
     if (msg.t === "hello") {
       // We were nudged to initiate. Only act if we are in fact the initiator.
       if (this.amInitiator(senderHex)) {
@@ -197,6 +198,7 @@ export class P2PNode {
   }
 
   private onPeerState(peerHex: string, state: PeerState): void {
+    log.info(`[p2p] peer ${peerHex.slice(0, 8)} → ${state}`);
     if (state === "connected") {
       this.flushOutbox(peerHex);
     } else if (state === "failed" || state === "closed") {
@@ -232,8 +234,10 @@ export class P2PNode {
     if (this.negotiating.has(peerHex)) return;
     this.negotiating.add(peerHex);
     if (this.amInitiator(peerHex)) {
+      log.info(`[p2p] kickstart ${peerHex.slice(0, 8)}: sending offer (initiator)`);
       void peer.start();
     } else {
+      log.info(`[p2p] kickstart ${peerHex.slice(0, 8)}: sending hello (responder)`);
       void this.signaling.send(peerHex, { t: "hello" });
     }
   }

--- a/src/p2p/peerConnection.ts
+++ b/src/p2p/peerConnection.ts
@@ -131,6 +131,22 @@ export class PeerConnection {
     this.channel = ch;
     ch.onMessage.subscribe((msg) => {
       const text = typeof msg === "string" ? msg : Buffer.from(msg).toString("utf8");
+      // Mesh keepalive control frames. The PWA's mesh-manager sends `PING` every
+      // 30s and tears the channel down if no `PONG` returns within 90s. These are
+      // NOT gift-wrap frames — answer `PING` on this same channel and never
+      // surface a control frame to the bridge (broadcasting it would both leak a
+      // bogus "message" to local PWAs AND leave the ping unanswered → the peer
+      // kills a perfectly healthy channel on the 90s clock). Swallow stray `PONG`
+      // too (we don't send `PING`, but a duplicate must not be parsed as a frame).
+      if (text === "PING") {
+        try {
+          ch.send("PONG");
+        } catch (err) {
+          log.debug(`[p2p] PONG reply failed for ${this.short()}: ${String(err)}`);
+        }
+        return;
+      }
+      if (text === "PONG") return;
       try {
         this.onFrame(text);
       } catch (err) {

--- a/src/p2p/signaling.ts
+++ b/src/p2p/signaling.ts
@@ -186,6 +186,9 @@ export class NostrSignaling implements Signaling {
     this.sub = this.pool.subscribeMany(this.relays, filter, {
       onevent: (event) => this.ingest(event),
     });
+    log.info(
+      `[p2p] signaling subscribed (kind ${NOSTR_KIND_P2P_SIGNAL}, self ${this.ourPubHex.slice(0, 8)}, ${this.relays.length} relays)`,
+    );
   }
 
   stop(): void {

--- a/tests/p2p-capability.test.ts
+++ b/tests/p2p-capability.test.ts
@@ -3,10 +3,12 @@
  * up its transport ladder. Pins the build/parse contract the phantomchat
  * companion mirrors on ingest.
  *
- * The advert is TWO-PART: public capability booleans (any contact reads) plus a
- * self-encrypted reachability blob (only the owner's nsec decrypts). These tests
- * pin both halves — that a contact sees the booleans but NOT the port/IP, and
- * that the owner recovers the real bound port.
+ * The advert is PLAINTEXT: capability booleans + the ACTUAL bound loopback port.
+ * A loopback port bound to 127.0.0.1 is reachable only from this machine, so it
+ * is not a secret; publishing it plaintext is what lets a same-machine PWA (a
+ * DIFFERENT identity than the node) discover the port and dial `ws://localhost`.
+ * LAN IPs are intentionally not advertised — ICE discovers LAN host candidates
+ * live on the node↔node WebRTC path.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -14,7 +16,6 @@ import { generateSecretKey, getPublicKey, verifyEvent } from "nostr-tools/pure";
 
 import {
   buildCapabilityEvent,
-  localLanIps,
   nodeCapabilities,
   parseCapabilityEvent,
   CAPABILITY_D_TAG,
@@ -23,13 +24,18 @@ import {
 import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
 
 describe("p2p capability advertisement", () => {
-  test("nodeCapabilities advertises localWs + webrtc, never dht (booleans only)", () => {
-    expect(nodeCapabilities()).toEqual({ localWs: true, webrtc: true, dht: false });
+  test("nodeCapabilities advertises localWs + bound port + webrtc, never dht", () => {
+    expect(nodeCapabilities(33297)).toEqual({
+      localWs: true,
+      localWsPort: 33297,
+      webrtc: true,
+      dht: false,
+    });
   });
 
-  test("build then parse round-trips public caps, signed and addressable", () => {
+  test("build then parse round-trips caps + port, signed and addressable", () => {
     const sk = generateSecretKey();
-    const event = buildCapabilityEvent(sk, getPublicKey(sk), 54321);
+    const event = buildCapabilityEvent(sk, 54321);
 
     expect(event.kind).toBe(CAPABILITY_KIND);
     expect(event.tags.some((t) => t[0] === "d" && t[1] === CAPABILITY_D_TAG)).toBe(true);
@@ -38,43 +44,29 @@ describe("p2p capability advertisement", () => {
     const parsed = parseCapabilityEvent(event);
     expect(parsed).not.toBeNull();
     expect(parsed!.authorHex).toBe(getPublicKey(sk));
-    expect(parsed!.caps).toEqual({ localWs: true, webrtc: true, dht: false });
-  });
-
-  test("port and LAN IPs are NOT in plaintext — only in the encrypted blob", () => {
-    const sk = generateSecretKey();
-    const event = buildCapabilityEvent(sk, getPublicKey(sk), 54321, {
-      lanIps: ["192.168.1.42"],
+    expect(parsed!.caps).toEqual({
+      localWs: true,
+      localWsPort: 54321,
+      webrtc: true,
+      dht: false,
     });
-    // The wire content must not leak the port or IP in the clear.
-    expect(event.content).not.toContain("54321");
-    expect(event.content).not.toContain("192.168.1.42");
-    // Plaintext holds only the booleans + the opaque `enc` field.
-    const plain = JSON.parse(event.content) as Record<string, unknown>;
-    expect(plain.localWsPort).toBeUndefined();
-    expect(typeof plain.enc).toBe("string");
   });
 
-  test("the OWNER decrypts the reachability blob (its own bound port + LAN IPs)", () => {
-    const sk = generateSecretKey();
-    const event = buildCapabilityEvent(sk, getPublicKey(sk), 54321, {
-      lanIps: ["192.168.1.42"],
-    });
-    // Owner passes its own sk → the self conversation key decrypts `enc`.
-    const parsed = parseCapabilityEvent(event, sk);
-    expect(parsed!.reachability).toEqual({ localWsPort: 54321, lanIps: ["192.168.1.42"] });
-  });
-
-  test("a CONTACT (different key) reads booleans but never the reachability", () => {
+  test("the bound port is PLAINTEXT on the wire (no encryption) — a contact reads it", () => {
     const sk = generateSecretKey();
     const contactSk = generateSecretKey();
-    const event = buildCapabilityEvent(sk, getPublicKey(sk), 54321, {
-      lanIps: ["192.168.1.42"],
-    });
-    // A contact's key can't derive the self key → no reachability, caps still read.
-    const parsed = parseCapabilityEvent(event, contactSk);
-    expect(parsed!.caps).toEqual({ localWs: true, webrtc: true, dht: false });
-    expect(parsed!.reachability).toBeUndefined();
+    const event = buildCapabilityEvent(sk, 54321);
+
+    // The port is public — it's a loopback port, not a secret. No `enc` blob.
+    expect(event.content).toContain("54321");
+    const plain = JSON.parse(event.content) as Record<string, unknown>;
+    expect(plain.localWsPort).toBe(54321);
+    expect(plain.enc).toBeUndefined();
+
+    // A different key parses the port just fine — no key material needed.
+    const parsed = parseCapabilityEvent(event);
+    expect(parsed!.caps.localWsPort).toBe(54321);
+    void contactSk;
   });
 
   test("parseCapabilityEvent rejects the wrong kind / missing d-tag / junk", () => {
@@ -95,18 +87,17 @@ describe("p2p capability advertisement", () => {
     ).toBeNull();
   });
 
-  test("parse coerces missing booleans to safe defaults", () => {
+  test("parse coerces missing fields to safe defaults", () => {
     const sk = generateSecretKey();
-    const event = buildCapabilityEvent(sk, getPublicKey(sk), 47100);
+    const event = buildCapabilityEvent(sk, 47100);
     // Hand-mangle content to drop fields (parse ignores sig).
     const mangled = { ...event, content: JSON.stringify({ webrtc: true }) } as NTNostrEvent;
     const parsed = parseCapabilityEvent(mangled);
-    expect(parsed!.caps).toEqual({ localWs: false, webrtc: true, dht: false });
-  });
-
-  test("localLanIps returns strings and never throws", () => {
-    const ips = localLanIps();
-    expect(Array.isArray(ips)).toBe(true);
-    for (const ip of ips) expect(typeof ip).toBe("string");
+    expect(parsed!.caps).toEqual({
+      localWs: false,
+      localWsPort: 0,
+      webrtc: true,
+      dht: false,
+    });
   });
 });

--- a/tests/p2p-iceErrorGuard.test.ts
+++ b/tests/p2p-iceErrorGuard.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { isBenignIceSocketError } from "../src/p2p/iceErrorGuard.ts";
+
+/** Build a Node-style system error the way dgram surfaces one. */
+function sysError(code: string, syscall: string): Error {
+  const e = new Error(`${code}: ${syscall} failed`) as Error & {
+    code?: string;
+    syscall?: string;
+  };
+  e.code = code;
+  e.syscall = syscall;
+  return e;
+}
+
+describe("isBenignIceSocketError", () => {
+  it("absorbs the observed crash: ECONNREFUSED on recv", () => {
+    // The exact shape that was crash-looping Lena mid-handshake.
+    expect(isBenignIceSocketError(sysError("ECONNREFUSED", "recv"))).toBe(true);
+  });
+
+  it("absorbs the family of unreachable UDP codes on send/recv", () => {
+    for (const code of ["ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH", "ECONNRESET", "EPERM"]) {
+      for (const syscall of ["recv", "send", "recvmsg", "sendmsg"]) {
+        expect(isBenignIceSocketError(sysError(code, syscall))).toBe(true);
+      }
+    }
+  });
+
+  it("does NOT absorb a real application error", () => {
+    expect(isBenignIceSocketError(new Error("something broke"))).toBe(false);
+  });
+
+  it("does NOT absorb an unreachable code from a non-dgram syscall", () => {
+    // ECONNREFUSED from a TCP connect() is a real failure we must not swallow.
+    expect(isBenignIceSocketError(sysError("ECONNREFUSED", "connect"))).toBe(false);
+  });
+
+  it("does NOT absorb an unrelated code on a dgram syscall", () => {
+    expect(isBenignIceSocketError(sysError("EACCES", "recv"))).toBe(false);
+  });
+
+  it("is null/undefined/primitive safe", () => {
+    expect(isBenignIceSocketError(null)).toBe(false);
+    expect(isBenignIceSocketError(undefined)).toBe(false);
+    expect(isBenignIceSocketError("ECONNREFUSED")).toBe(false);
+  });
+});

--- a/tests/p2p-node.test.ts
+++ b/tests/p2p-node.test.ts
@@ -210,6 +210,57 @@ describe("P2PNode routing", () => {
     expect(peerFor(peerHex)!.handled).toEqual([{ t: "offer", sdp: "x" }]);
   });
 
+  test("a re-offer (new session) rebuilds the peer on a clean connection", () => {
+    const us = "f".repeat(64);
+    const peerHex = "a".repeat(64);
+    const { signaling, peers, peerFor } = makeNode(us);
+
+    // First session: offer establishes a peer.
+    signaling.emit(peerHex, { t: "offer", sdp: "session-1" });
+    const first = peerFor(peerHex)!;
+    first.transition("connected");
+    expect(peers.filter((p) => p.peerHex === peerHex)).toHaveLength(1);
+
+    // The peer reconnects with a brand-new offer while the old (zombie) peer is
+    // still "connected" — werift never fired a failure. Must rebuild, not feed
+    // the new-session offer into the dead transport.
+    signaling.emit(peerHex, { t: "offer", sdp: "session-2" });
+    expect(first.closed).toBe(true);
+    const both = peers.filter((p) => p.peerHex === peerHex);
+    expect(both).toHaveLength(2);
+    expect(both[1]!.handled).toEqual([{ t: "offer", sdp: "session-2" }]);
+  });
+
+  test("a duplicate offer (same SDP) is ignored, not rebuilt", () => {
+    const us = "f".repeat(64);
+    const peerHex = "a".repeat(64);
+    const { signaling, peers, peerFor } = makeNode(us);
+
+    signaling.emit(peerHex, { t: "offer", sdp: "same" });
+    const first = peerFor(peerHex)!;
+    signaling.emit(peerHex, { t: "offer", sdp: "same" });
+    // No teardown, no second peer, offer handled exactly once.
+    expect(first.closed).toBe(false);
+    expect(peers.filter((p) => p.peerHex === peerHex)).toHaveLength(1);
+    expect(first.handled).toEqual([{ t: "offer", sdp: "same" }]);
+  });
+
+  test("a candidate arriving before the first offer is not torn down by that offer", () => {
+    const us = "f".repeat(64);
+    const peerHex = "a".repeat(64);
+    const { signaling, peers, peerFor } = makeNode(us);
+
+    // Relay reordering: candidate lands first, creating a buffering peer.
+    signaling.emit(peerHex, { t: "candidate", candidate: "cand", sdpMid: null, sdpMLineIndex: null });
+    const peer = peerFor(peerHex)!;
+    // The FIRST offer must feed this same peer (preserving buffered candidates),
+    // NOT rebuild it.
+    signaling.emit(peerHex, { t: "offer", sdp: "session-1" });
+    expect(peer.closed).toBe(false);
+    expect(peers.filter((p) => p.peerHex === peerHex)).toHaveLength(1);
+    expect(peer.handled.map((m) => m.t)).toEqual(["candidate", "offer"]);
+  });
+
   test("inbound peer frame is broadcast to the local PWA", () => {
     const us = "a".repeat(64);
     const peerHex = "f".repeat(64);

--- a/tests/p2p-peerConnection.test.ts
+++ b/tests/p2p-peerConnection.test.ts
@@ -91,6 +91,44 @@ describe("werift PeerConnection round-trip", () => {
     20_000,
   );
 
+  test(
+    "PING/PONG keepalive control frames are never surfaced as messages",
+    async () => {
+      const bFrames: string[] = [];
+      const aFrames: string[] = [];
+      const { a, b } = connectPair(
+        (f) => aFrames.push(f),
+        (f) => bFrames.push(f),
+      );
+
+      await a.start();
+      const deadline = Date.now() + 12_000;
+      while (!a.isReady() && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(a.isReady()).toBe(true);
+
+      // The PWA's mesh keepalive: PING must be intercepted + answered, never
+      // handed to the bridge as a bogus "message". PONG likewise swallowed.
+      a.send("PING");
+      a.send("PONG");
+      // A real gift-wrap frame after the control frames must still arrive.
+      a.send(JSON.stringify(["EVENT", { real: true }]));
+
+      const start = Date.now();
+      while (bFrames.length === 0 && Date.now() - start < 5_000) {
+        await new Promise((r) => setTimeout(r, 25));
+      }
+      // Exactly the real frame reached B — no PING, no PONG.
+      expect(bFrames).toEqual([JSON.stringify(["EVENT", { real: true }])]);
+      expect(aFrames).toEqual([]); // B's PONG reply was swallowed on A too
+
+      a.close();
+      b.close();
+    },
+    20_000,
+  );
+
   test("send returns false before the channel is open", () => {
     const pc = new PeerConnection({
       peerHex: "z",


### PR DESCRIPTION
## Why

The same-PC P2P path never engaged: the PWA fell back to relay on every send to a co-located node (e.g. Andrew's PWA → local `max` node). Digging into *why P2P never engaged at all* then surfaced three further node-side bugs that were silently keeping every peer on relay. This PR fixes all of them; the node side of P2P is now **reliable and proven live on Lena**.

## 1. Plaintext loopback port (original fix)

Root cause was #268's design: the node's bound loopback port was **self-encrypted** (NIP-44, to the node's own key) in the capability advert, on the theory the PWA would read its *own* self-advert to learn the port. But **the PWA is a different Nostr identity than the node** — it can never derive the self conversation key, so it could never decrypt the blob. The localhost tier never learned the port → every same-PC send dropped to relay.

A loopback port bound to `127.0.0.1` is reachable **only from that machine** — it's not a secret. So publish it plaintext in the capability booleans and any same-machine PWA dials `ws://localhost:<port>`.

- `capability.ts`: `NodeCapabilities` regains `localWsPort`; `NodeReachability`, `localLanIps()`, and the entire NIP-44 self-encrypt/decrypt path removed.
- `index.ts`: `advertiseP2PCapability` no longer threads the pubkey into `buildCapabilityEvent`.
- **Kept from #268**: OS-ephemeral binding (`port: 0`), `boundPort` plumbing, removed single-persona gate.
- **`lanIps` dropped** — a browser can't dial a bare LAN IP, and ICE discovers LAN host candidates live at connection time. The frozen advert value was a stale duplicate nobody consumed.

## 2. Signaling lifecycle observability (`2014dea`)

The node logged **nothing** on inbound signals or channel-open — only on failure — so "zero signaling in the journal" couldn't distinguish *never arrived* from *arrived silently*. Added one-line `info` logs at each step: `signaling subscribed`, `signal in: <t>`, `kickstart`, `peer <id> → <state>`. This is what turned P2P from unobservable into debuggable, and it's how the two fixes below were found and verified.

## 3. ICE UDP crash guard (`15e163c`)

werift opens raw UDP sockets for ICE. When a candidate probe hits a dead/firewalled address, Linux returns an ICMP unreachable and Node surfaces it as an **uncaught `ECONNREFUSED` on the dgram socket → the whole daemon exits 1 → systemd respawns → crash loop**. So a peer would connect, then the node would die mid-turn before replying. `installIceErrorGuard()` swallows *only* that narrow class of benign UDP-unreachable errors (matched on code + dgram syscall) and lets every real error crash loudly as before.

## 4. Keepalive + reliable reconnect (`f2992ea`) — the "connects then drops at ~2 min" killer

The PWA runs an app-level heartbeat: `PING` over the datachannel every 30s, tear down if no `PONG` within 90s. The node **never answered PING** (it treated every datachannel frame as an opaque gift-wrap and re-broadcast it), so the channel died on the 90s clock — reproduced to the second in Lena's journal (connected → re-offer exactly 2m01s later). And on re-offer, the node fed the fresh-session offer into the **stale `connected` zombie peer** (werift fires no failure event), which can't be revived → reconnect stalled → back to relay forever.

- Node now intercepts `PING`/`PONG` control frames on the datachannel and answers directly, never surfacing them as messages.
- A genuinely-new inbound offer tears down the stale peer and answers on a clean `PeerConnection`; identical relayed offers are deduped by SDP, and the first offer never wipes a peer created only to buffer early ICE candidates.

## Verified — live on Lena, from her own journal

- `signal in: offer` → ICE → **`peer 0aea64d3 → connected`**, then held **13m46s with zero re-offers** (heartbeat answered).
- Re-offer at a later send rebuilt cleanly in ~300ms (`new offer — rebuilding peer` → `connected`).
- `NRestarts=0`, no `ECONNREFUSED` — crash loop gone.
- `tsc` clean; P2P suites 62/62 green.

## Cross-repo — land together

PWA companion: phantomyard/phantomchat#67 — unifies the PWA onto this node's kind-21050 signaling, dials the recipient's advertised `localWsPort`, and drives the P2P badge off **live** connection state. The two PRs are coupled: #67 needs a node running this branch to complete a handshake.
