### PR TITLE
Neutralise personal name in IDENTITY backfill stub example

### DIFF
--- a/src/lib/personaTemplate.ts
+++ b/src/lib/personaTemplate.ts
@@ -218,7 +218,7 @@ export function generateIdentityStub(name: string): string {
 -->
 
 You are ${name}, _<one line: what you are and what you do — e.g. "a personal
-assistant who manages Andrew's admin, finances, and home">_.
+assistant who manages your principal's admin, finances, and home">_.
 
 ## Role
 


### PR DESCRIPTION
Follow-up to #275.

The IDENTITY.md backfill stub (`generateIdentityStub`) had a real principal name (`Andrew's`) baked into its illustrative example line. Templates must be character- and owner-neutral, so this replaces it with a generic placeholder (`your principal's`).

- Only change: one example string in `src/lib/personaTemplate.ts`.
- Verified: no other `Andrew`/`Hodges`/personal references remain in the SOUL or IDENTITY generators. `generateSoulMd` and `generateIdentityMd` were already clean.

Ready for review.