### PR TITLE
fix: tolerate corrupt JSON state files instead of throwing

### DIFF
--- a/src/lib/replyMode.ts
+++ b/src/lib/replyMode.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { xdgStateHome } from "../config.ts";
+import { log } from "./logger.ts";
 
 export type ReplyMode = "text" | "voice";
 export type ReplyModeRequest = ReplyMode | "default";
@@ -40,6 +41,12 @@ function key(persona: string, conversation: string): string {
   return `${persona}\u0000${conversation}`;
 }
 
+/**
+ * A corrupt/unreadable overrides file degrades to empty rather than throwing:
+ * overrides are ephemeral (10-min TTL) and the file self-heals on the next
+ * save(). Throwing here would abort every incoming message (engine.ts calls
+ * touchReplyModeOverride outside any try) until the file is deleted by hand.
+ */
 async function load(path = replyModeStatePath()): Promise<StoredOverrides> {
   try {
     const parsed = JSON.parse(await readFile(path, "utf8"));
@@ -47,8 +54,13 @@ async function load(path = replyModeStatePath()): Promise<StoredOverrides> {
       ? (parsed as StoredOverrides)
       : {};
   } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") return {};
-    throw e;
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      log.warn("replyMode: overrides file unreadable, treating as empty", {
+        error: (e as Error).message,
+        path,
+      });
+    }
+    return {};
   }
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -12,6 +12,7 @@
 import { mkdir, readFile, writeFile, appendFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { xdgDataHome } from "./config.ts";
+import { log } from "./lib/logger.ts";
 
 export interface State {
   default_persona?: string;
@@ -25,14 +26,25 @@ export function statePath(): string {
   );
 }
 
+/**
+ * A corrupt/unreadable state.json degrades to empty rather than throwing:
+ * loadConfig() calls this unguarded on nearly every command, so throwing
+ * would brick the whole CLI — including the persona/config commands whose
+ * writes are the only way to repair a bad file.
+ */
 export async function loadState(): Promise<State> {
   try {
     const content = await readFile(statePath(), "utf8");
     const parsed = JSON.parse(content);
     return typeof parsed === "object" && parsed !== null ? parsed : {};
   } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") return {};
-    throw e;
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      log.warn("state: state.json unreadable, treating as empty", {
+        error: (e as Error).message,
+        path: statePath(),
+      });
+    }
+    return {};
   }
 }
 

--- a/tests/lib-replyMode.test.ts
+++ b/tests/lib-replyMode.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -119,5 +119,22 @@ describe("reply mode overrides", () => {
     expect(
       await getReplyModeOverride({ persona: "kai", conversation: "telegram:1" }),
     ).toBeUndefined();
+  });
+
+  test("a corrupt overrides file reads as empty and self-heals on next save", async () => {
+    await writeFile(replyModeStatePath(), '{"truncated', "utf8");
+
+    expect(
+      await touchReplyModeOverride({ persona: "kai", conversation: "telegram:1" }),
+    ).toBeUndefined();
+
+    await setReplyModeOverride({
+      persona: "kai",
+      conversation: "telegram:1",
+      mode: "voice",
+    });
+    expect(
+      await getReplyModeOverride({ persona: "kai", conversation: "telegram:1" }),
+    ).toBe("voice");
   });
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -57,6 +57,11 @@ describe("saveState — round-trip", () => {
     await saveState({ default_persona: "kai" });
     expect(await loadState()).toEqual({ default_persona: "kai" });
   });
+
+  test("loadState treats a malformed state.json as empty instead of throwing", async () => {
+    await writeFile(stateFile, '{"default_persona": "kai"', "utf8");
+    expect(await loadState()).toEqual({});
+  });
 });
 
 describe("saveHarnessBins", () => {


### PR DESCRIPTION
# fix: tolerate corrupt JSON state files instead of throwing

**Branch:** `fix/corrupt-json-state` → `main`

## Summary

A truncated or malformed JSON state file — the kind left behind by a crash or power loss mid-write, since both writers use plain non-atomic `writeFile` — permanently broke Phantombot in two places:

- **`src/lib/replyMode.ts`** — `load()` only tolerated `ENOENT`; a `JSON.parse` `SyntaxError` (which has no `.code`) was rethrown. `touchReplyModeOverride()` is called at the top level of `processChatMessage` (outside any try block), so a corrupt `reply-mode-overrides.json` made every incoming Telegram message abort before the harness ran. The bot silently dropped all messages until the file was deleted by hand.
- **`src/state.ts`** — same pattern in `loadState()`. A corrupt `state.json` propagated through the unguarded `loadConfig()` call and crashed every CLI subcommand at startup — including the persona/config commands that are the only way to repair the file.

## Changes

- Both loaders now degrade to empty state (`{}`) with a `log.warn` for any non-`ENOENT` failure, matching the tolerant readers already in `nightly.ts`, `updateNotify.ts`, and `piExtensionProvision.ts`.
- Data loss is bounded: reply-mode overrides are ephemeral (10-minute TTL) and both files self-heal on the next `save()`.

## Tests

- New regression test: corrupt overrides file reads as empty and self-heals on the next save (`tests/lib-replyMode.test.ts`).
- New regression test: malformed `state.json` loads as `{}` instead of throwing (`tests/state.test.ts`).
- Full suite: 2068 pass / 0 fail; `bun tsc --noEmit` clean.