### PR TITLE
fix(state): atomic writes for state.json + reply-mode overrides

### DIFF
--- a/src/lib/io.ts
+++ b/src/lib/io.ts
@@ -5,7 +5,7 @@
  * pass capture buffers without faking the full WriteStream API.
  */
 
-import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
 
 export interface WriteSink {
@@ -21,12 +21,26 @@ export interface WriteSink {
  * a torn write is catastrophic — the next `JSON.parse` throws and can brick
  * every command until the file is deleted by hand.
  *
- * The fix is the standard tempfile + rename dance: write the full payload to a
- * sibling temp file, then `rename()` it over the target. rename(2) is atomic on
- * POSIX, so a concurrent reader sees either the complete old file or the
- * complete new file — never a partial one. The temp name carries pid + random
- * so two writers racing on the same target never clobber each other's temp.
- * On any failure the temp file is unlinked (best-effort) and the error rethrown.
+ * The fix is the standard tempfile + fsync + rename dance:
+ *   1. write the full payload to a sibling temp file;
+ *   2. fsync the temp file so its data + metadata are durably on disk BEFORE
+ *      the rename — otherwise a plain write only guarantees the bytes reached
+ *      the OS page cache, and a power loss can leave the renamed target with
+ *      unwritten (zeroed/stale) data on filesystems that reorder data/metadata;
+ *   3. `rename()` it over the target — rename(2) is atomic on POSIX, so a
+ *      concurrent reader sees either the complete old file or the complete new
+ *      file, never a partial one;
+ *   4. fsync the containing directory so the rename itself is durable — without
+ *      this a power loss immediately after rename can lose the directory entry
+ *      update and leave the target missing entirely.
+ *
+ * The temp name carries pid + random so two writers racing on the same target
+ * never clobber each other's temp. On any failure the temp file is unlinked
+ * (best-effort) and the error rethrown.
+ *
+ * Directory fsync is best-effort: some platforms (notably Windows) reject
+ * opening/fsyncing a directory, so that step is swallowed rather than failing
+ * the whole write — the data fsync + atomic rename still hold there.
  *
  * Mirrors the pattern already used in channels/phantomchat/personaStore.ts.
  */
@@ -35,11 +49,29 @@ export async function writeFileAtomic(
   contents: string,
   options?: { mode?: number },
 ): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
+  const dir = dirname(path);
+  await mkdir(dir, { recursive: true });
   const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
   try {
-    await writeFile(tmp, contents, { encoding: "utf8", mode: options?.mode });
+    const fh = await open(tmp, "w", options?.mode);
+    try {
+      await fh.writeFile(contents, { encoding: "utf8" });
+      await fh.sync();
+    } finally {
+      await fh.close();
+    }
     await rename(tmp, path);
+    // Durably persist the rename (the new directory entry) itself.
+    try {
+      const dirFh = await open(dir, "r");
+      try {
+        await dirFh.sync();
+      } finally {
+        await dirFh.close();
+      }
+    } catch {
+      /* directory fsync unsupported on this platform — best-effort */
+    }
   } catch (e) {
     try {
       await unlink(tmp);

--- a/src/lib/io.ts
+++ b/src/lib/io.ts
@@ -1,10 +1,51 @@
 /**
- * Shared minimal IO interfaces for CLI commands.
+ * Shared minimal IO interfaces and helpers for CLI commands.
  *
  * Subcommands take WriteSink instead of NodeJS.WriteStream so tests can
  * pass capture buffers without faking the full WriteStream API.
  */
 
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
 export interface WriteSink {
   write(chunk: string | Uint8Array): boolean | void;
+}
+
+/**
+ * Atomically write `contents` to `path`.
+ *
+ * Plain `writeFile` is NOT atomic: a crash, OOM-kill, or power loss mid-write
+ * leaves a truncated/half-written file on disk. For JSON state files that the
+ * whole process must parse on startup (state.json, reply-mode-overrides.json)
+ * a torn write is catastrophic — the next `JSON.parse` throws and can brick
+ * every command until the file is deleted by hand.
+ *
+ * The fix is the standard tempfile + rename dance: write the full payload to a
+ * sibling temp file, then `rename()` it over the target. rename(2) is atomic on
+ * POSIX, so a concurrent reader sees either the complete old file or the
+ * complete new file — never a partial one. The temp name carries pid + random
+ * so two writers racing on the same target never clobber each other's temp.
+ * On any failure the temp file is unlinked (best-effort) and the error rethrown.
+ *
+ * Mirrors the pattern already used in channels/phantomchat/personaStore.ts.
+ */
+export async function writeFileAtomic(
+  path: string,
+  contents: string,
+  options?: { mode?: number },
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    await writeFile(tmp, contents, { encoding: "utf8", mode: options?.mode });
+    await rename(tmp, path);
+  } catch (e) {
+    try {
+      await unlink(tmp);
+    } catch {
+      /* best-effort cleanup — temp file may not exist */
+    }
+    throw e;
+  }
 }

--- a/src/lib/replyMode.ts
+++ b/src/lib/replyMode.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { xdgStateHome } from "../config.ts";
+import { writeFileAtomic } from "./io.ts";
 
 export type ReplyMode = "text" | "voice";
 export type ReplyModeRequest = ReplyMode | "default";
@@ -53,8 +54,9 @@ async function load(path = replyModeStatePath()): Promise<StoredOverrides> {
 }
 
 async function save(state: StoredOverrides, path = replyModeStatePath()): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf8");
+  // Atomic write: a torn overrides file makes load() throw and drops every
+  // inbound message until it's deleted. Never expose a half-written file.
+  await writeFileAtomic(path, JSON.stringify(state, null, 2) + "\n");
 }
 
 function active(

--- a/src/state.ts
+++ b/src/state.ts
@@ -9,9 +9,10 @@
  * Resolution priority for any value that lives in both: env > state > toml > default.
  */
 
-import { mkdir, readFile, writeFile, appendFile } from "node:fs/promises";
+import { mkdir, readFile, appendFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { xdgDataHome } from "./config.ts";
+import { writeFileAtomic } from "./lib/io.ts";
 
 export interface State {
   default_persona?: string;
@@ -100,8 +101,9 @@ export async function saveState(state: State): Promise<string> {
   const path = statePath();
   const prev = await loadStateForAudit();
   await auditPersonaChange(prev, state);
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf8");
+  // Atomic write: a torn state.json bricks every command that must parse it
+  // on startup (loadState throws), so never expose a half-written file.
+  await writeFileAtomic(path, JSON.stringify(state, null, 2) + "\n");
   return path;
 }
 

--- a/tests/lib-io.test.ts
+++ b/tests/lib-io.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the shared atomic file-write helper (writeFileAtomic).
+ *
+ * The whole point of the helper is that a reader never observes a
+ * half-written file: it writes to a pid/random-suffixed temp sibling and
+ * rename()s it over the target (atomic on POSIX). These tests assert the
+ * observable guarantees — correct contents, parent-dir creation, no leftover
+ * temp files on success, no clobbering under concurrency, and (via a stubbed
+ * failure) that a pre-existing good file survives a failed write intact.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFileAtomic } from "../src/lib/io.ts";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-io-"));
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("writeFileAtomic", () => {
+  test("writes the exact contents to the target", async () => {
+    const target = join(workdir, "state.json");
+    await writeFileAtomic(target, '{"a":1}\n');
+    expect(await readFile(target, "utf8")).toBe('{"a":1}\n');
+  });
+
+  test("creates missing parent directories", async () => {
+    const target = join(workdir, "nested", "deep", "state.json");
+    await writeFileAtomic(target, "hello");
+    expect(await readFile(target, "utf8")).toBe("hello");
+  });
+
+  test("leaves no temp files behind on success", async () => {
+    const target = join(workdir, "state.json");
+    await writeFileAtomic(target, "one");
+    await writeFileAtomic(target, "two");
+    const entries = await readdir(workdir);
+    expect(entries).toEqual(["state.json"]);
+    expect(entries.some((e) => e.endsWith(".tmp"))).toBe(false);
+  });
+
+  test("overwrites an existing file atomically (final contents win)", async () => {
+    const target = join(workdir, "state.json");
+    await writeFile(target, "old", "utf8");
+    await writeFileAtomic(target, "new");
+    expect(await readFile(target, "utf8")).toBe("new");
+  });
+
+  test("concurrent writes never yield a torn file", async () => {
+    const target = join(workdir, "state.json");
+    const payloads = Array.from({ length: 20 }, (_, i) => `payload-${i}`.padEnd(64, "x"));
+    await Promise.all(payloads.map((p) => writeFileAtomic(target, p)));
+    // Whatever won the race, the file must be one *complete* payload — never a
+    // truncated or interleaved mix — and no temp files may linger.
+    const final = await readFile(target, "utf8");
+    expect(payloads).toContain(final);
+    const entries = await readdir(workdir);
+    expect(entries).toEqual(["state.json"]);
+  });
+
+  test("a pre-existing good file survives a failed write", async () => {
+    const target = join(workdir, "state.json");
+    await writeFileAtomic(target, "good");
+    // A non-string payload makes the underlying writeFile reject; the target
+    // must still hold the previous good contents, and no temp file remains.
+    await expect(
+      // @ts-expect-error deliberately bad payload to force a write failure
+      writeFileAtomic(target, { not: "a string" }),
+    ).rejects.toBeDefined();
+    expect(await readFile(target, "utf8")).toBe("good");
+    const entries = await readdir(workdir);
+    expect(entries).toEqual(["state.json"]);
+  });
+});


### PR DESCRIPTION
Closes #280.

## What

Make the two phantombot-owned JSON state files **crash-safe** by writing them atomically.

- New shared helper `writeFileAtomic()` in `src/lib/io.ts` — write to a `${path}.<pid>.<rand>.tmp` sibling, then `rename()` over the target. `rename(2)` is atomic on POSIX, so a concurrent reader sees either the complete old file or the complete new file, never a partial one. Temp file is unlinked (best-effort) on any failure. Mirrors the existing pattern in `channels/phantomchat/personaStore.ts`.
- `src/state.ts` `saveState()` → uses `writeFileAtomic`.
- `src/lib/replyMode.ts` `save()` → uses `writeFileAtomic`.

## Why

Both files were written with a plain, non-atomic `writeFile`. A crash / OOM-kill / power loss mid-write leaves a truncated JSON file:

- torn `state.json` → `loadState()` throws → **every CLI command bricked** until the file is deleted by hand;
- torn `reply-mode-overrides.json` → `load()` throws → **every inbound message dropped**.

This is the **root cause** behind the corruption that #279 tried to tolerate on the read side. Fixing the writer stops the corruption being produced in the first place. See #280 for the full write-up.

## Tests

New `tests/lib-io.test.ts`:
- exact contents written to target
- missing parent dirs created
- no `.tmp` leftover on success
- overwrite is atomic (final contents win)
- **concurrency**: 20 racing writes leave one *complete* payload, never a torn/interleaved file, and no lingering temp
- **a pre-existing good file survives a failed write** (write fails at temp stage, target untouched)

Local run: `bun test` → **2064 pass / 0 fail / 3 skip**, `bun tsc --noEmit` clean.

## Relationship to #279

#279 hardened the *readers*; this fixes the *writer*. Once this merges, #279 can be closed referencing this PR — the read-side tolerance is no longer load-bearing, and #279's broadened `state.ts` catch (which opened a new silent `default_persona`-loss path) is avoided.