### PR TITLE
fix(windows): reap orphaned daemon trees and unwedge the run-lock

### DIFF
--- a/src/lib/runLock.ts
+++ b/src/lib/runLock.ts
@@ -25,14 +25,24 @@
  * start-time, so we can tell "the original phantombot is alive" from "a
  * stranger inherited its PID" and reclaim the stale lock in the latter case.
  *
- * The token is best-effort and Linux-specific (/proc). On platforms where we
- * can't read it (macOS and Windows), we degrade to the old PID-only liveness
- * check — no worse than before. The only cost of the degraded path is that a
- * crash-then-PID-recycle can make a stale lock look live until the lock file is
- * removed; on Windows that file lives in per-user %TEMP% and is trivially
- * cleared, matching the long-accepted macOS behaviour.
+ * The token is best-effort and platform-specific: /proc on Linux, CIM
+ * (Win32_Process.CreationDate) on Windows. On platforms where we can't read it
+ * (macOS), we degrade to the old PID-only liveness check — no worse than
+ * before. The only cost of the degraded path is that a crash-then-PID-recycle
+ * can make a stale lock look live until the lock file is removed.
+ *
+ * ── Why Windows needs this MORE than Linux (2026-07-10) ──
+ * The daemon is force-killed (`taskkill /F`) on every stop/restart/self-update,
+ * so `release()` never runs and the lock FILE always survives its holder. The
+ * next daemon start therefore ALWAYS lands on the stale-lock path and leans
+ * entirely on the liveness check. With bare PID liveness, a recycled PID makes
+ * a dead holder look alive and phantombot refuses to start — permanently, until
+ * someone deletes %TEMP%\phantombot.run.lock by hand. That's a wedged bot with
+ * no error anyone would think to look for, which is why the degraded path is
+ * no longer acceptable here.
  */
 
+import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -209,14 +219,57 @@ function bootId(): string | undefined {
 }
 
 /**
+ * Windows instance token: the process's creation time, which the kernel stamps
+ * per process instance. A recycled PID belongs to a process created later, so
+ * its CreationDate differs and the token changes — exactly the property we need.
+ *
+ * Costs one PowerShell spawn (~300ms). That's tolerable because this runs at
+ * most twice per `phantombot run` startup (once to write our own token, once to
+ * check the previous holder's) and never on a hot path. Bounded by `timeout` so
+ * a wedged PowerShell can't hang daemon startup; on any failure we return
+ * undefined and fall back to bare PID liveness.
+ *
+ * Exported for testing.
+ */
+export function _windowsInstanceToken(pid: number): string | undefined {
+  // The PID is read back out of the lock file; never interpolate it into the
+  // CIM filter without proving it's a plain positive integer.
+  if (!Number.isInteger(pid) || pid <= 0) return undefined;
+  try {
+    const out = execFileSync(
+      "powershell",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}")` +
+          `.CreationDate.ToUniversalTime().ToString('o')`,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 5_000,
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    ).trim();
+    return out ? `win:${out}` : undefined;
+  } catch {
+    // PowerShell missing, timed out, or the PID vanished mid-query.
+    return undefined;
+  }
+}
+
+/**
  * A token that uniquely identifies a running process instance: boot id +
  * the process start-time (field 22 of /proc/<pid>/stat, in clock ticks since
  * boot). Recycled PIDs get a different start-time, so the token changes.
  *
- * Returns undefined when /proc isn't available (e.g. macOS) — callers treat
- * that as "fall back to bare PID liveness".
+ * On Windows we use the CIM creation-time token instead. Returns undefined when
+ * neither is available (e.g. macOS) — callers treat that as "fall back to bare
+ * PID liveness".
  */
 function processInstanceToken(pid: number): string | undefined {
+  if (process.platform === "win32") return _windowsInstanceToken(pid);
   const boot = bootId();
   if (boot === undefined) return undefined;
   try {

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -64,6 +64,7 @@ import { basename, join } from "node:path";
 import { xdgDataHome } from "../config.ts";
 import { currentUserSid } from "./filePermissions.ts";
 import type { WriteSink } from "./io.ts";
+import { log } from "./logger.ts";
 
 export const TASK_FOLDER = "\\Phantombot";
 export const PHANTOMBOT_TASK = "\\Phantombot\\phantombot";
@@ -372,6 +373,12 @@ export class BunSchtasksRunner implements SchtasksRunner {
 export interface RunningProcess {
   pid: number;
   commandLine: string;
+  /** Image name, e.g. "phantombot.exe". Empty when the lister can't see it. */
+  name?: string;
+  /** Parent PID as reported by the OS. May point at a long-dead process. */
+  parentPid?: number;
+  /** Process creation time (ms since epoch), used to reject recycled parents. */
+  createdMs?: number;
 }
 
 /**
@@ -380,8 +387,12 @@ export interface RunningProcess {
  * out to PowerShell (CIM) and taskkill.
  */
 export interface ProcessManager {
-  /** All running processes whose image name equals `image` (e.g. phantombot.exe). */
-  listByImage(image: string): Promise<RunningProcess[]>;
+  /**
+   * EVERY running process, with parentage. We can't filter to phantombot.exe:
+   * the orphans we must reap are the daemon's harness children (claude.exe,
+   * node.exe, cmd.exe, …), which carry unrelated image names.
+   */
+  listAll(): Promise<RunningProcess[]>;
   /** Force-terminate a single process by PID (best-effort; never throws). */
   kill(pid: number): Promise<void>;
 }
@@ -406,17 +417,138 @@ export function isDaemonCommandLine(commandLine: string): boolean {
   return firstArg.toLowerCase() === "run";
 }
 
+/**
+ * Every descendant of `rootPid`, breadth-first (nearest children first).
+ *
+ * ── Why the creation-time guard ──
+ * Windows never reparents orphans, so a dead process's PID can be recycled
+ * while its children still name it as `parentPid`. Worse, a BRAND NEW,
+ * unrelated process can be handed the recycled PID and inherit a pile of
+ * bogus "children". Walking parentage naively would then kill innocent
+ * processes.
+ *
+ * A genuine child is always created AFTER its parent. So we only follow an
+ * edge when the child's creation time is >= the parent's. When either
+ * timestamp is missing we follow the edge anyway — degrading to the previous
+ * (unguarded) behaviour rather than silently under-reaping.
+ *
+ * Exported for testing.
+ */
+export function descendantsOf(
+  procs: readonly RunningProcess[],
+  rootPid: number,
+): number[] {
+  const byParent = new Map<number, RunningProcess[]>();
+  for (const p of procs) {
+    if (p.parentPid === undefined) continue;
+    const siblings = byParent.get(p.parentPid);
+    if (siblings) siblings.push(p);
+    else byParent.set(p.parentPid, [p]);
+  }
+  const createdOf = new Map<number, number | undefined>(
+    procs.map((p) => [p.pid, p.createdMs]),
+  );
+
+  const out: number[] = [];
+  const seen = new Set<number>([rootPid]); // also guards parentage cycles
+  let frontier = [rootPid];
+  while (frontier.length > 0) {
+    const next: number[] = [];
+    for (const parent of frontier) {
+      const parentCreated = createdOf.get(parent);
+      for (const child of byParent.get(parent) ?? []) {
+        if (seen.has(child.pid)) continue;
+        // Reject a recycled-PID parent: a real child can't predate its parent.
+        if (
+          parentCreated !== undefined &&
+          child.createdMs !== undefined &&
+          child.createdMs < parentCreated
+        ) {
+          continue;
+        }
+        seen.add(child.pid);
+        out.push(child.pid);
+        next.push(child.pid);
+      }
+    }
+    frontier = next;
+  }
+  return out;
+}
+
+/** Does this process look like the phantombot binary? */
+function isPhantombotImage(p: RunningProcess): boolean {
+  return (p.name ?? "").toLowerCase() === "phantombot.exe";
+}
+
+/**
+ * The exact PIDs `stop()`/`restart()` must terminate, in kill order.
+ *
+ * For each stray `phantombot run` daemon we take the daemon PLUS its whole
+ * descendant tree — the harness processes (claude.exe and its children) that
+ * `taskkill /F /PID` leaves behind as orphans, because it terminates one
+ * process and Windows has no process groups to sweep the rest.
+ *
+ * ── Why not just `taskkill /T` ──
+ * `/T` would be simpler, but it kills the tree from the root DOWN — and the
+ * CLI invoker running `restart` is frequently a DESCENDANT of the daemon
+ * (the agent's own Bash tool shells out to `phantombot restart`). `/T` would
+ * therefore kill the very process that still has to call `schtasks /Run`,
+ * turning an instant restart into a silent 60-second wait for the keep-alive
+ * trigger. So we enumerate the tree ourselves and subtract our own subtree.
+ *
+ * Order is root-first: the daemon dies before its children, so it can't spawn
+ * a fresh harness while we're partway through reaping the old one.
+ *
+ * Exported for testing.
+ */
+export function daemonKillOrder(
+  procs: readonly RunningProcess[],
+  selfPid: number,
+): number[] {
+  // Never kill ourselves, nor anything we spawned (e.g. the powershell we
+  // just used to enumerate). Our ANCESTORS are fair game — the daemon above
+  // us must still die; Windows simply leaves us with a dangling parent PID.
+  const protectedPids = new Set<number>([
+    selfPid,
+    ...descendantsOf(procs, selfPid),
+  ]);
+
+  const order: number[] = [];
+  const queued = new Set<number>();
+  for (const p of procs) {
+    if (p.pid === selfPid) continue;
+    if (!isPhantombotImage(p)) continue;
+    if (!isDaemonCommandLine(p.commandLine)) continue;
+    if (protectedPids.has(p.pid)) continue;
+    for (const pid of [p.pid, ...descendantsOf(procs, p.pid)]) {
+      if (protectedPids.has(pid) || queued.has(pid)) continue;
+      queued.add(pid);
+      order.push(pid);
+    }
+  }
+  return order;
+}
+
 export class BunProcessManager implements ProcessManager {
-  async listByImage(image: string): Promise<RunningProcess[]> {
+  async listAll(): Promise<RunningProcess[]> {
     // CIM gives us the full CommandLine (tasklist does not), which we need to
-    // tell the daemon (`... run`) apart from the CLI invoker (`... restart`).
+    // tell the daemon (`... run`) apart from the CLI invoker (`... restart`),
+    // plus ParentProcessId/CreationDate for safe tree-walking. CreationDate is
+    // projected to a round-trip ISO string: piping a raw CIM DateTime through
+    // ConvertTo-Json yields a shape that varies by PowerShell version.
     const script =
-      `Get-CimInstance Win32_Process -Filter "Name='${image}'" | ` +
-      `Select-Object ProcessId,CommandLine | ConvertTo-Json -Compress`;
+      "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine," +
+      "@{N='Created';E={$_.CreationDate.ToUniversalTime().ToString('o')}} | ConvertTo-Json -Compress";
     try {
       const proc = Bun.spawn(
         ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
-        { env: { ...process.env }, stdout: "pipe", stderr: "pipe" },
+        {
+          env: { ...process.env },
+          stdout: "pipe",
+          stderr: "pipe",
+          windowsHide: true,
+        },
       );
       const stdout = await new Response(proc.stdout).text();
       await proc.exited;
@@ -425,10 +557,17 @@ export class BunProcessManager implements ProcessManager {
       const parsed = JSON.parse(trimmed);
       const rows = Array.isArray(parsed) ? parsed : [parsed];
       return rows
-        .map((r) => ({
-          pid: Number(r?.ProcessId),
-          commandLine: String(r?.CommandLine ?? ""),
-        }))
+        .map((r) => {
+          const created = Date.parse(String(r?.Created ?? ""));
+          const parent = Number(r?.ParentProcessId);
+          return {
+            pid: Number(r?.ProcessId),
+            commandLine: String(r?.CommandLine ?? ""),
+            name: String(r?.Name ?? ""),
+            parentPid: Number.isFinite(parent) ? parent : undefined,
+            createdMs: Number.isNaN(created) ? undefined : created,
+          };
+        })
         .filter((r) => Number.isFinite(r.pid) && r.pid > 0);
     } catch {
       // PowerShell missing / JSON malformed → treat as "nothing to kill".
@@ -438,10 +577,14 @@ export class BunProcessManager implements ProcessManager {
 
   async kill(pid: number): Promise<void> {
     try {
+      // No `/T`: `daemonKillOrder` already enumerated the tree, minus our own
+      // subtree. `/T` here could sweep up the CLI invoker running `restart`.
       const proc = Bun.spawn(["taskkill", "/F", "/PID", String(pid)], {
         env: { ...process.env },
         stdout: "ignore",
         stderr: "ignore",
+        // Without this every reaped PID flashes a console window on the desktop.
+        windowsHide: true,
       });
       await proc.exited;
     } catch {
@@ -450,24 +593,74 @@ export class BunProcessManager implements ProcessManager {
   }
 }
 
+/** Injectable clock/sleep so the wait loop is testable without real delays. */
+export interface WaitDeps {
+  sleep: (ms: number) => Promise<void>;
+  timeoutMs: number;
+  intervalMs: number;
+}
+
+const defaultWaitDeps: WaitDeps = {
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  timeoutMs: 10_000,
+  intervalMs: 100,
+};
+
 /**
- * Kill every stray `phantombot run` daemon reported by the process manager,
- * skipping the current process (the CLI invoker running stop/restart). This is
- * the reliable teardown `schtasks /End` fails to guarantee.
+ * Block until none of `pids` are running, or the timeout expires.
+ *
+ * `taskkill /F` returns as soon as the OS *accepts* the termination request,
+ * not when the process is actually gone. `restart()` used to fire
+ * `schtasks /Run` immediately afterwards, so the new daemon could start while
+ * the old one still held the single-instance run-lock — the new process saw a
+ * live holder, refused to start, and the restart silently no-opped. Waiting
+ * for the PIDs to actually disappear closes that race.
+ *
+ * Returns true if everything exited, false on timeout (caller proceeds anyway —
+ * a stuck PID shouldn't wedge `stop()` forever).
+ */
+export async function waitForProcessesGone(
+  pm: ProcessManager,
+  pids: readonly number[],
+  deps: WaitDeps = defaultWaitDeps,
+): Promise<boolean> {
+  if (pids.length === 0) return true;
+  const target = new Set(pids);
+  const deadline = Date.now() + deps.timeoutMs;
+  for (;;) {
+    const alive = (await pm.listAll()).filter((p) => target.has(p.pid));
+    if (alive.length === 0) return true;
+    if (Date.now() >= deadline) {
+      log.warn("taskScheduler: processes still alive after kill timeout", {
+        pids: alive.map((p) => p.pid),
+      });
+      return false;
+    }
+    await deps.sleep(deps.intervalMs);
+  }
+}
+
+/**
+ * Kill every stray `phantombot run` daemon AND its orphaned descendants,
+ * skipping the current process (the CLI invoker running stop/restart) and
+ * anything it spawned. This is the reliable teardown `schtasks /End` fails to
+ * guarantee. Blocks until the killed PIDs are actually gone, so a following
+ * `schtasks /Run` can't race the old process's run-lock.
+ *
+ * Returns the number of processes killed.
  */
 export async function killDaemonProcesses(
   pm: ProcessManager,
   selfPid: number,
+  waitDeps: WaitDeps = defaultWaitDeps,
 ): Promise<number> {
-  const procs = await pm.listByImage("phantombot.exe");
-  let killed = 0;
-  for (const p of procs) {
-    if (p.pid === selfPid) continue;
-    if (!isDaemonCommandLine(p.commandLine)) continue;
-    await pm.kill(p.pid);
-    killed++;
+  const procs = await pm.listAll();
+  const victims = daemonKillOrder(procs, selfPid);
+  for (const pid of victims) {
+    await pm.kill(pid);
   }
-  return killed;
+  await waitForProcessesGone(pm, victims, waitDeps);
+  return victims.length;
 }
 
 /**

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -382,6 +382,21 @@ export interface RunningProcess {
 }
 
 /**
+ * Process enumeration failed, so the set of running processes is UNKNOWN.
+ *
+ * Distinct from "no processes matched". Conflating the two is dangerous: a
+ * transient PowerShell/CIM failure would otherwise read as "every victim has
+ * exited", letting `restart()` fire `schtasks /Run` while the old daemon still
+ * holds the run-lock — the exact race this module exists to close.
+ */
+export class ProcessEnumerationError extends Error {
+  constructor(cause: string) {
+    super(`failed to enumerate running processes: ${cause}`);
+    this.name = "ProcessEnumerationError";
+  }
+}
+
+/**
  * Enumerate + terminate Windows processes. Abstracted behind an interface so
  * `stop()`/`restart()` are unit-testable with a fake — the real backend shells
  * out to PowerShell (CIM) and taskkill.
@@ -391,6 +406,9 @@ export interface ProcessManager {
    * EVERY running process, with parentage. We can't filter to phantombot.exe:
    * the orphans we must reap are the daemon's harness children (claude.exe,
    * node.exe, cmd.exe, …), which carry unrelated image names.
+   *
+   * MUST throw {@link ProcessEnumerationError} rather than return `[]` when the
+   * query fails. An empty array is a positive claim that nothing is running.
    */
   listAll(): Promise<RunningProcess[]>;
   /** Force-terminate a single process by PID (best-effort; never throws). */
@@ -540,6 +558,8 @@ export class BunProcessManager implements ProcessManager {
     const script =
       "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine," +
       "@{N='Created';E={$_.CreationDate.ToUniversalTime().ToString('o')}} | ConvertTo-Json -Compress";
+    let stdout: string;
+    let exitCode: number;
     try {
       const proc = Bun.spawn(
         ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
@@ -550,29 +570,43 @@ export class BunProcessManager implements ProcessManager {
           windowsHide: true,
         },
       );
-      const stdout = await new Response(proc.stdout).text();
-      await proc.exited;
-      const trimmed = stdout.trim();
-      if (!trimmed) return [];
-      const parsed = JSON.parse(trimmed);
-      const rows = Array.isArray(parsed) ? parsed : [parsed];
-      return rows
-        .map((r) => {
-          const created = Date.parse(String(r?.Created ?? ""));
-          const parent = Number(r?.ParentProcessId);
-          return {
-            pid: Number(r?.ProcessId),
-            commandLine: String(r?.CommandLine ?? ""),
-            name: String(r?.Name ?? ""),
-            parentPid: Number.isFinite(parent) ? parent : undefined,
-            createdMs: Number.isNaN(created) ? undefined : created,
-          };
-        })
-        .filter((r) => Number.isFinite(r.pid) && r.pid > 0);
-    } catch {
-      // PowerShell missing / JSON malformed → treat as "nothing to kill".
-      return [];
+      stdout = await new Response(proc.stdout).text();
+      exitCode = await proc.exited;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new ProcessEnumerationError(`could not spawn powershell: ${msg}`);
     }
+    if (exitCode !== 0) {
+      throw new ProcessEnumerationError(`powershell exited ${exitCode}`);
+    }
+    const trimmed = stdout.trim();
+    // Win32_Process always contains at least the powershell process running
+    // this very query, so empty output can only mean the query failed — never
+    // that no processes exist.
+    if (!trimmed) {
+      throw new ProcessEnumerationError("powershell produced no output");
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new ProcessEnumerationError(`malformed JSON: ${msg}`);
+    }
+    const rows = Array.isArray(parsed) ? parsed : [parsed];
+    return rows
+      .map((r) => {
+        const created = Date.parse(String(r?.Created ?? ""));
+        const parent = Number(r?.ParentProcessId);
+        return {
+          pid: Number(r?.ProcessId),
+          commandLine: String(r?.CommandLine ?? ""),
+          name: String(r?.Name ?? ""),
+          parentPid: Number.isFinite(parent) ? parent : undefined,
+          createdMs: Number.isNaN(created) ? undefined : created,
+        };
+      })
+      .filter((r) => Number.isFinite(r.pid) && r.pid > 0);
   }
 
   async kill(pid: number): Promise<void> {
@@ -607,6 +641,14 @@ const defaultWaitDeps: WaitDeps = {
 };
 
 /**
+ * Outcome of {@link waitForProcessesGone}. `gone: true` is a positive proof of
+ * exit — never a fallback for "we couldn't tell".
+ */
+export type WaitOutcome =
+  | { gone: true }
+  | { gone: false; reason: "timeout" | "enumeration-failed"; detail: string };
+
+/**
  * Block until none of `pids` are running, or the timeout expires.
  *
  * `taskkill /F` returns as soon as the OS *accepts* the termination request,
@@ -616,28 +658,64 @@ const defaultWaitDeps: WaitDeps = {
  * live holder, refused to start, and the restart silently no-opped. Waiting
  * for the PIDs to actually disappear closes that race.
  *
- * Returns true if everything exited, false on timeout (caller proceeds anyway —
- * a stuck PID shouldn't wedge `stop()` forever).
+ * Fails closed: if enumeration itself fails we do NOT know whether the victims
+ * exited, so we keep polling (a transient PowerShell hiccup recovers on the
+ * next tick) and, if it never recovers, report `enumeration-failed` rather than
+ * claiming success.
  */
 export async function waitForProcessesGone(
   pm: ProcessManager,
   pids: readonly number[],
   deps: WaitDeps = defaultWaitDeps,
-): Promise<boolean> {
-  if (pids.length === 0) return true;
+): Promise<WaitOutcome> {
+  if (pids.length === 0) return { gone: true };
   const target = new Set(pids);
   const deadline = Date.now() + deps.timeoutMs;
   for (;;) {
-    const alive = (await pm.listAll()).filter((p) => target.has(p.pid));
-    if (alive.length === 0) return true;
+    let alive: number[] | undefined;
+    let enumError: string | undefined;
+    try {
+      alive = (await pm.listAll())
+        .filter((p) => target.has(p.pid))
+        .map((p) => p.pid);
+    } catch (e) {
+      // UNKNOWN, not "gone". Keep waiting; maybe the next poll succeeds.
+      enumError = e instanceof Error ? e.message : String(e);
+    }
+    if (alive && alive.length === 0) return { gone: true };
     if (Date.now() >= deadline) {
+      if (enumError !== undefined) {
+        log.warn("taskScheduler: cannot confirm processes exited", {
+          pids: [...target],
+          error: enumError,
+        });
+        return { gone: false, reason: "enumeration-failed", detail: enumError };
+      }
       log.warn("taskScheduler: processes still alive after kill timeout", {
-        pids: alive.map((p) => p.pid),
+        pids: alive,
       });
-      return false;
+      return {
+        gone: false,
+        reason: "timeout",
+        detail: `still alive after ${deps.timeoutMs}ms: ${(alive ?? []).join(", ")}`,
+      };
     }
     await deps.sleep(deps.intervalMs);
   }
+}
+
+/** Result of {@link killDaemonProcesses}. */
+export interface KillResult {
+  /** How many PIDs we issued a kill for. */
+  killed: number;
+  /**
+   * True only when we positively observed every victim exit (or found none to
+   * kill). False means the daemon MAY still be running — callers must not start
+   * a replacement.
+   */
+  confirmed: boolean;
+  /** Why we couldn't confirm, when `confirmed` is false. */
+  detail?: string;
 }
 
 /**
@@ -647,20 +725,34 @@ export async function waitForProcessesGone(
  * guarantee. Blocks until the killed PIDs are actually gone, so a following
  * `schtasks /Run` can't race the old process's run-lock.
  *
- * Returns the number of processes killed.
+ * Never throws: an enumeration failure is reported as `confirmed: false` so the
+ * caller can fail closed rather than start a second daemon on top of the first.
  */
 export async function killDaemonProcesses(
   pm: ProcessManager,
   selfPid: number,
   waitDeps: WaitDeps = defaultWaitDeps,
-): Promise<number> {
-  const procs = await pm.listAll();
+): Promise<KillResult> {
+  let procs: RunningProcess[];
+  try {
+    procs = await pm.listAll();
+  } catch (e) {
+    // We don't know whether a daemon is running, so we can't claim we stopped
+    // it. Report unconfirmed and let the caller decide.
+    const detail = e instanceof Error ? e.message : String(e);
+    log.warn("taskScheduler: cannot enumerate processes; skipping kill", {
+      error: detail,
+    });
+    return { killed: 0, confirmed: false, detail };
+  }
   const victims = daemonKillOrder(procs, selfPid);
   for (const pid of victims) {
     await pm.kill(pid);
   }
-  await waitForProcessesGone(pm, victims, waitDeps);
-  return victims.length;
+  const outcome = await waitForProcessesGone(pm, victims, waitDeps);
+  return outcome.gone
+    ? { killed: victims.length, confirmed: true }
+    : { killed: victims.length, confirmed: false, detail: outcome.detail };
 }
 
 /**
@@ -900,6 +992,8 @@ export function defaultTaskSchedulerServiceControl(
   runner: SchtasksRunner = new BunSchtasksRunner(),
   processManager: ProcessManager = new BunProcessManager(),
   selfPid: number = process.pid,
+  // Injectable so stop()/restart() are testable without real 10s waits.
+  waitDeps: WaitDeps = defaultWaitDeps,
 ): TaskSchedulerServiceControl {
   return {
     async isActive() {
@@ -928,10 +1022,19 @@ export function defaultTaskSchedulerServiceControl(
       // /End on a stopped task is harmless.
       const r = await runner.run(["/Change", "/TN", PHANTOMBOT_TASK, "/DISABLE"]);
       await runner.run(["/End", "/TN", PHANTOMBOT_TASK]);
-      await killDaemonProcesses(processManager, selfPid);
-      return r.exitCode === 0
-        ? { ok: true }
-        : { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
+      const kill = await killDaemonProcesses(processManager, selfPid, waitDeps);
+      if (r.exitCode !== 0) {
+        return { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
+      }
+      // An unconfirmed kill is a failed stop, not a successful one — say so
+      // rather than letting a surviving daemon look like a clean shutdown.
+      if (!kill.confirmed) {
+        return {
+          ok: false,
+          stderr: `could not confirm the daemon stopped: ${kill.detail ?? "unknown"}`,
+        };
+      }
+      return { ok: true };
     },
     async restart() {
       // Kill any running instance, then start a fresh one — the schtasks
@@ -943,7 +1046,23 @@ export function defaultTaskSchedulerServiceControl(
       // actually gone so /Run doesn't bounce off the single-instance lock.
       await runner.run(["/Change", "/TN", PHANTOMBOT_TASK, "/ENABLE"]);
       await runner.run(["/End", "/TN", PHANTOMBOT_TASK]);
-      await killDaemonProcesses(processManager, selfPid);
+      const kill = await killDaemonProcesses(processManager, selfPid, waitDeps);
+      // Fail closed. If we can't prove the old daemon is gone, `/Run` would
+      // bounce off its still-held run-lock and silently no-op — leaving the old
+      // binary running while we report success. Skipping `/Run` costs at most
+      // 60s: the keep-alive trigger re-enabled above relaunches the task once
+      // the old process really has exited.
+      if (!kill.confirmed) {
+        log.warn("taskScheduler: skipping /Run — old daemon not confirmed gone", {
+          detail: kill.detail,
+        });
+        return {
+          ok: false,
+          stderr:
+            `could not confirm the old daemon exited (${kill.detail ?? "unknown"}); ` +
+            `skipped /Run — the keep-alive trigger will relaunch within 60s`,
+        };
+      }
       const r = await runner.run(["/Run", "/TN", PHANTOMBOT_TASK]);
       return r.exitCode === 0
         ? { ok: true }

--- a/tests/lib-runLock.test.ts
+++ b/tests/lib-runLock.test.ts
@@ -12,6 +12,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  _windowsInstanceToken,
   acquireRunLock,
   defaultLockPath,
   isLockHandle,
@@ -144,5 +145,21 @@ describe("defaultLockPath", () => {
     } finally {
       if (saved !== undefined) process.env.XDG_RUNTIME_DIR = saved;
     }
+  });
+});
+
+describe("_windowsInstanceToken", () => {
+  // The PID is read back out of an on-disk lock file and interpolated into a
+  // PowerShell CIM filter, so it must be proven to be a plain positive integer
+  // before it ever reaches a command line.
+  test("rejects non-integer, negative, and zero PIDs before spawning", () => {
+    for (const bad of [NaN, 0, -1, 1.5, Infinity]) {
+      expect(_windowsInstanceToken(bad)).toBeUndefined();
+    }
+  });
+
+  test("degrades to undefined when PowerShell is unavailable", () => {
+    if (process.platform === "win32") return; // real PowerShell would answer
+    expect(_windowsInstanceToken(process.pid)).toBeUndefined();
   });
 });

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -20,6 +20,8 @@ import {
   generateNightlyTaskXml,
   generatePhantombotTaskXml,
   generateTickTaskXml,
+  daemonKillOrder,
+  descendantsOf,
   installPhantombotTasks,
   isDaemonCommandLine,
   killDaemonProcesses,
@@ -27,6 +29,8 @@ import {
   LAUNCHER_VBS,
   type ProcessManager,
   type RunningProcess,
+  type WaitDeps,
+  waitForProcessesGone,
   type SchtasksResult,
   type SchtasksRunner,
   taskLogPaths,
@@ -484,36 +488,183 @@ describe("isDaemonCommandLine", () => {
   });
 });
 
-/** A ProcessManager fake: canned process list + records killed PIDs. */
+/** Shorthand for a phantombot.exe process row. */
+function pb(
+  pid: number,
+  args: string,
+  parentPid?: number,
+  createdMs?: number,
+): RunningProcess {
+  return {
+    pid,
+    commandLine: `"${BIN}" ${args}`,
+    name: "phantombot.exe",
+    parentPid,
+    createdMs,
+  };
+}
+
+/** Shorthand for a non-phantombot child process (harness, shell, …). */
+function child(
+  pid: number,
+  name: string,
+  parentPid: number,
+  createdMs?: number,
+): RunningProcess {
+  return { pid, commandLine: name, name, parentPid, createdMs };
+}
+
+/**
+ * A ProcessManager fake: canned process list + records killed PIDs. Killed
+ * processes actually disappear from `listAll()` so `waitForProcessesGone`
+ * terminates — unless the PID is in `unkillable`, which simulates a wedged
+ * process for the timeout path.
+ */
 class FakeProcessManager implements ProcessManager {
   killed: number[] = [];
-  constructor(private procs: RunningProcess[]) {}
-  async listByImage(): Promise<RunningProcess[]> {
+  listCalls = 0;
+  constructor(
+    private procs: RunningProcess[],
+    private unkillable: number[] = [],
+  ) {}
+  async listAll(): Promise<RunningProcess[]> {
+    this.listCalls++;
     return this.procs;
   }
   async kill(pid: number): Promise<void> {
     this.killed.push(pid);
+    if (this.unkillable.includes(pid)) return;
+    this.procs = this.procs.filter((p) => p.pid !== pid);
   }
 }
 
+/** Wait deps that never actually sleep, for deterministic tests. */
+const fastWait: WaitDeps = {
+  sleep: async () => {},
+  timeoutMs: 50,
+  intervalMs: 1,
+};
+
+describe("descendantsOf", () => {
+  test("walks the tree breadth-first", () => {
+    const procs = [
+      pb(100, "run"),
+      child(200, "cmd.exe", 100),
+      child(300, "claude.exe", 200),
+      child(400, "node.exe", 300),
+      child(500, "unrelated.exe", 1),
+    ];
+    expect(descendantsOf(procs, 100)).toEqual([200, 300, 400]);
+    expect(descendantsOf(procs, 500)).toEqual([]);
+  });
+
+  test("rejects a recycled parent PID: a child cannot predate its parent", () => {
+    // PID 100 died; a NEW process was handed PID 100 at t=5000. The old
+    // process's children (created t=1000) still name 100 as their parent, but
+    // they are not descendants of the new occupant and must not be killed.
+    const procs = [
+      pb(100, "run", undefined, 5000),
+      child(200, "innocent.exe", 100, 1000),
+    ];
+    expect(descendantsOf(procs, 100)).toEqual([]);
+  });
+
+  test("follows the edge when either timestamp is missing", () => {
+    const procs = [pb(100, "run"), child(200, "cmd.exe", 100)];
+    expect(descendantsOf(procs, 100)).toEqual([200]);
+  });
+
+  test("survives a parentage cycle without looping forever", () => {
+    const procs = [
+      { pid: 1, commandLine: "a", name: "a", parentPid: 2 },
+      { pid: 2, commandLine: "b", name: "b", parentPid: 1 },
+    ];
+    expect(descendantsOf(procs, 1)).toEqual([2]);
+  });
+});
+
+describe("daemonKillOrder", () => {
+  test("kills the daemon AND its orphan-prone harness tree, daemon first", () => {
+    const procs = [
+      pb(100, "run"),
+      child(200, "cmd.exe", 100),
+      child(300, "claude.exe", 200),
+      pb(999, "restart"), // CLI invoker, unrelated parent
+    ];
+    expect(daemonKillOrder(procs, 999)).toEqual([100, 200, 300]);
+  });
+
+  test("skips self, non-daemon phantombot.exe, and non-phantombot images", () => {
+    const procs = [
+      pb(100, "run"), // daemon → kill
+      pb(200, "restart"), // CLI invoker → skip
+      pb(300, "run"), // second daemon → kill
+      pb(999, "run"), // self → skip even though daemon
+      child(400, "claude.exe", 1), // unrelated tree → skip
+    ];
+    expect(daemonKillOrder(procs, 999)).toEqual([100, 300]);
+  });
+
+  test("never kills the CLI invoker even when it is a DESCENDANT of the daemon", () => {
+    // The regression that rules out `taskkill /T`: the agent's Bash tool runs
+    // `phantombot restart`, so the invoker hangs off the daemon it must kill.
+    // The daemon still dies; we and our own children survive to call /Run.
+    const procs = [
+      pb(100, "run"), // the daemon → must die
+      child(200, "claude.exe", 100), // harness → must die
+      child(300, "cmd.exe", 200), // harness's shell → must die
+      pb(999, "restart", 300), // ← us, a descendant of the daemon
+      child(1000, "powershell.exe", 999), // ← spawned by us (the process lister)
+    ];
+    const order = daemonKillOrder(procs, 999);
+    expect(order).toContain(100);
+    expect(order).not.toContain(999);
+    expect(order).not.toContain(1000);
+    expect(order[0]).toBe(100); // daemon first: it can't spawn a fresh harness
+  });
+
+  test("no daemons → empty kill set", () => {
+    expect(daemonKillOrder([pb(1, "restart")], 999)).toEqual([]);
+  });
+});
+
+describe("waitForProcessesGone", () => {
+  test("returns true once the PIDs disappear", async () => {
+    const pm = new FakeProcessManager([pb(100, "run")]);
+    await pm.kill(100);
+    expect(await waitForProcessesGone(pm, [100], fastWait)).toBe(true);
+  });
+
+  test("returns false when a PID never exits (bounded, does not hang)", async () => {
+    const pm = new FakeProcessManager([pb(100, "run")], [100]);
+    await pm.kill(100);
+    expect(await waitForProcessesGone(pm, [100], fastWait)).toBe(false);
+  });
+
+  test("empty pid list short-circuits without listing", async () => {
+    const pm = new FakeProcessManager([]);
+    expect(await waitForProcessesGone(pm, [], fastWait)).toBe(true);
+    expect(pm.listCalls).toBe(0);
+  });
+});
+
 describe("killDaemonProcesses", () => {
-  test("kills daemon PIDs, skips self and non-daemon processes", async () => {
+  test("kills the daemon tree and waits for it to actually exit", async () => {
     const pm = new FakeProcessManager([
-      { pid: 100, commandLine: `"${BIN}" run` }, // daemon → kill
-      { pid: 200, commandLine: `"${BIN}" restart` }, // CLI invoker → skip
-      { pid: 300, commandLine: `"${BIN}" run` }, // second daemon → kill
-      { pid: 999, commandLine: `"${BIN}" run` }, // self → skip even though daemon
+      pb(100, "run"),
+      child(200, "claude.exe", 100),
+      pb(999, "restart"),
     ]);
-    const killed = await killDaemonProcesses(pm, 999);
-    expect(pm.killed).toEqual([100, 300]);
+    const killed = await killDaemonProcesses(pm, 999, fastWait);
+    expect(pm.killed).toEqual([100, 200]);
     expect(killed).toBe(2);
+    // Proves we polled for exit rather than returning straight after taskkill.
+    expect(pm.listCalls).toBeGreaterThan(1);
   });
 
   test("no daemons → nothing killed", async () => {
-    const pm = new FakeProcessManager([
-      { pid: 1, commandLine: `"${BIN}" restart` },
-    ]);
-    expect(await killDaemonProcesses(pm, 999)).toBe(0);
+    const pm = new FakeProcessManager([pb(1, "restart")]);
+    expect(await killDaemonProcesses(pm, 999, fastWait)).toBe(0);
     expect(pm.killed).toEqual([]);
   });
 });
@@ -521,10 +672,7 @@ describe("killDaemonProcesses", () => {
 describe("service control stop/restart kill the stray daemon", () => {
   test("stop(): disable + end + kill daemon (not the CLI invoker)", async () => {
     const st = new FakeSchtasks();
-    const pm = new FakeProcessManager([
-      { pid: 100, commandLine: `"${BIN}" run` },
-      { pid: 555, commandLine: `"${BIN}" stop` }, // this CLI
-    ]);
+    const pm = new FakeProcessManager([pb(100, "run"), pb(555, "stop")]);
     const svc = defaultTaskSchedulerServiceControl(st, pm, 555);
     const r = await svc.stop();
     expect(r.ok).toBe(true);
@@ -536,14 +684,25 @@ describe("service control stop/restart kill the stray daemon", () => {
 
   test("restart(): enable + end + kill daemon + run", async () => {
     const st = new FakeSchtasks();
-    const pm = new FakeProcessManager([
-      { pid: 100, commandLine: `"${BIN}" run` },
-    ]);
+    const pm = new FakeProcessManager([pb(100, "run")]);
     const svc = defaultTaskSchedulerServiceControl(st, pm, 555);
     const r = await svc.restart();
     expect(r.ok).toBe(true);
     const verbs = st.calls.map((c) => c[0]);
     expect(verbs).toEqual(["/Change", "/End", "/Run"]);
     expect(pm.killed).toEqual([100]);
+  });
+
+  test("restart(): /Run fires only AFTER the old daemon is gone", async () => {
+    // The run-lock race: `schtasks /Run` used to fire while the old process
+    // still held the single-instance lock, so the new daemon refused to start.
+    const st = new FakeSchtasks();
+    const pm = new FakeProcessManager([pb(100, "run")]);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555);
+    await svc.restart();
+    const runIdx = st.calls.findIndex((c) => c[0] === "/Run");
+    expect(runIdx).toBeGreaterThanOrEqual(0);
+    // By the time /Run was issued, PID 100 no longer appears in listAll().
+    expect((await pm.listAll()).map((p) => p.pid)).not.toContain(100);
   });
 });

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -27,6 +27,7 @@ import {
   killDaemonProcesses,
   launcherVbsPath,
   LAUNCHER_VBS,
+  ProcessEnumerationError,
   type ProcessManager,
   type RunningProcess,
   type WaitDeps,
@@ -523,12 +524,20 @@ function child(
 class FakeProcessManager implements ProcessManager {
   killed: number[] = [];
   listCalls = 0;
+  /** Number of leading listAll() calls that throw, simulating a CIM hiccup. */
+  failListsFor = 0;
+  /** When true, every listAll() throws. */
+  alwaysFailList = false;
   constructor(
     private procs: RunningProcess[],
     private unkillable: number[] = [],
   ) {}
   async listAll(): Promise<RunningProcess[]> {
     this.listCalls++;
+    if (this.alwaysFailList || this.failListsFor > 0) {
+      this.failListsFor--;
+      throw new ProcessEnumerationError("powershell produced no output");
+    }
     return this.procs;
   }
   async kill(pid: number): Promise<void> {
@@ -629,22 +638,46 @@ describe("daemonKillOrder", () => {
 });
 
 describe("waitForProcessesGone", () => {
-  test("returns true once the PIDs disappear", async () => {
+  test("reports gone once the PIDs disappear", async () => {
     const pm = new FakeProcessManager([pb(100, "run")]);
     await pm.kill(100);
-    expect(await waitForProcessesGone(pm, [100], fastWait)).toBe(true);
+    expect(await waitForProcessesGone(pm, [100], fastWait)).toEqual({
+      gone: true,
+    });
   });
 
-  test("returns false when a PID never exits (bounded, does not hang)", async () => {
+  test("times out when a PID never exits (bounded, does not hang)", async () => {
     const pm = new FakeProcessManager([pb(100, "run")], [100]);
     await pm.kill(100);
-    expect(await waitForProcessesGone(pm, [100], fastWait)).toBe(false);
+    const out = await waitForProcessesGone(pm, [100], fastWait);
+    expect(out.gone).toBe(false);
+    expect(out).toMatchObject({ reason: "timeout" });
   });
 
   test("empty pid list short-circuits without listing", async () => {
     const pm = new FakeProcessManager([]);
-    expect(await waitForProcessesGone(pm, [], fastWait)).toBe(true);
+    expect(await waitForProcessesGone(pm, [], fastWait)).toEqual({ gone: true });
     expect(pm.listCalls).toBe(0);
+  });
+
+  // The regression Kai flagged: enumeration failure used to surface as [],
+  // which read as "every victim exited" and green-lit `schtasks /Run`.
+  test("a persistent enumeration failure never reports gone", async () => {
+    const pm = new FakeProcessManager([pb(100, "run")], [100]);
+    pm.alwaysFailList = true;
+    const out = await waitForProcessesGone(pm, [100], fastWait);
+    expect(out.gone).toBe(false);
+    expect(out).toMatchObject({ reason: "enumeration-failed" });
+  });
+
+  test("a transient enumeration failure recovers and still confirms exit", async () => {
+    const pm = new FakeProcessManager([pb(100, "run")]);
+    await pm.kill(100); // actually gone…
+    pm.failListsFor = 2; // …but the first two polls can't see that
+    expect(await waitForProcessesGone(pm, [100], fastWait)).toEqual({
+      gone: true,
+    });
+    expect(pm.listCalls).toBeGreaterThan(2);
   });
 });
 
@@ -655,17 +688,35 @@ describe("killDaemonProcesses", () => {
       child(200, "claude.exe", 100),
       pb(999, "restart"),
     ]);
-    const killed = await killDaemonProcesses(pm, 999, fastWait);
+    const r = await killDaemonProcesses(pm, 999, fastWait);
     expect(pm.killed).toEqual([100, 200]);
-    expect(killed).toBe(2);
+    expect(r).toEqual({ killed: 2, confirmed: true });
     // Proves we polled for exit rather than returning straight after taskkill.
     expect(pm.listCalls).toBeGreaterThan(1);
   });
 
-  test("no daemons → nothing killed", async () => {
+  test("no daemons → nothing killed, still confirmed", async () => {
     const pm = new FakeProcessManager([pb(1, "restart")]);
-    expect(await killDaemonProcesses(pm, 999, fastWait)).toBe(0);
+    expect(await killDaemonProcesses(pm, 999, fastWait)).toEqual({
+      killed: 0,
+      confirmed: true,
+    });
     expect(pm.killed).toEqual([]);
+  });
+
+  test("enumeration failure → kills nothing and reports unconfirmed", async () => {
+    const pm = new FakeProcessManager([pb(100, "run")]);
+    pm.alwaysFailList = true;
+    const r = await killDaemonProcesses(pm, 999, fastWait);
+    expect(r.confirmed).toBe(false);
+    expect(r.killed).toBe(0);
+    expect(pm.killed).toEqual([]); // never blind-kill on an unknown process set
+  });
+
+  test("victim survives taskkill → reports unconfirmed", async () => {
+    const pm = new FakeProcessManager([pb(100, "run")], [100]);
+    const r = await killDaemonProcesses(pm, 999, fastWait);
+    expect(r).toMatchObject({ killed: 1, confirmed: false });
   });
 });
 
@@ -673,7 +724,7 @@ describe("service control stop/restart kill the stray daemon", () => {
   test("stop(): disable + end + kill daemon (not the CLI invoker)", async () => {
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run"), pb(555, "stop")]);
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
     const r = await svc.stop();
     expect(r.ok).toBe(true);
     const verbs = st.calls.map((c) => c[0]);
@@ -685,7 +736,7 @@ describe("service control stop/restart kill the stray daemon", () => {
   test("restart(): enable + end + kill daemon + run", async () => {
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run")]);
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
     const r = await svc.restart();
     expect(r.ok).toBe(true);
     const verbs = st.calls.map((c) => c[0]);
@@ -698,11 +749,47 @@ describe("service control stop/restart kill the stray daemon", () => {
     // still held the single-instance lock, so the new daemon refused to start.
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run")]);
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
     await svc.restart();
     const runIdx = st.calls.findIndex((c) => c[0] === "/Run");
     expect(runIdx).toBeGreaterThanOrEqual(0);
     // By the time /Run was issued, PID 100 no longer appears in listAll().
     expect((await pm.listAll()).map((p) => p.pid)).not.toContain(100);
+  });
+
+  test("restart(): enumeration failure must NOT fire /Run", async () => {
+    // Fail closed. A transient CIM failure once read as "everything exited",
+    // so /Run raced the still-held run-lock and silently no-opped while we
+    // reported success. The keep-alive trigger is the recovery path instead.
+    const st = new FakeSchtasks();
+    const pm = new FakeProcessManager([pb(100, "run")]);
+    pm.alwaysFailList = true;
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const r = await svc.restart();
+    expect(r.ok).toBe(false);
+    expect(st.calls.map((c) => c[0])).not.toContain("/Run");
+    // The keep-alive trigger must still have been re-enabled, or nothing
+    // would ever relaunch the daemon.
+    expect(st.calls.map((c) => c[0])).toContain("/Change");
+    expect(r.stderr ?? "").toContain("keep-alive");
+  });
+
+  test("restart(): an unkillable daemon must NOT fire /Run", async () => {
+    const st = new FakeSchtasks();
+    const pm = new FakeProcessManager([pb(100, "run")], [100]);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const r = await svc.restart();
+    expect(r.ok).toBe(false);
+    expect(st.calls.map((c) => c[0])).not.toContain("/Run");
+  });
+
+  test("stop(): enumeration failure reports failure, not a clean stop", async () => {
+    const st = new FakeSchtasks();
+    const pm = new FakeProcessManager([pb(100, "run")]);
+    pm.alwaysFailList = true;
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const r = await svc.stop();
+    expect(r.ok).toBe(false);
+    expect(r.stderr ?? "").toContain("could not confirm");
   });
 });


### PR DESCRIPTION
Windows `stop`/`restart` left orphaned processes behind and could silently fail to restart. Three distinct bugs on the service-control path, all found chasing the "two bun tasks in Task Manager" report.

## The bugs

**1. Orphaned harness trees.** `BunProcessManager.kill` ran `taskkill /F /PID <pid>` — one process, no tree. Windows has no process groups, so the daemon's harness children survived as orphans. Observed live on the Alpha VM: `claude.exe` + 8 children whose parent PID was long dead, plus two zombie `wscript`→`cmd` launcher chains.

**2. `restart()` raced the run-lock.** `taskkill /F` returns when the OS *accepts* the request, not when the process is gone. `schtasks /Run` fired immediately after, so the new daemon could start while the old one still held the single-instance lock, see a live holder, and refuse to start — a restart that silently no-ops.

**3. A recycled PID could wedge the daemon permanently.** The run-lock instance token was Linux-only (`/proc`), so Windows fell back to bare PID liveness. Because the daemon is *always* force-killed, `release()` never runs and the lock file always outlives its holder — every Windows start lands on the stale-lock path and leans entirely on that check. A recycled PID made a dead holder look alive, and phantombot refused to start until someone hand-deleted `%TEMP%\phantombot.run.lock`.

## Why not just `taskkill /T`

`/T` is the obvious fix for (1) and it's wrong. It kills the tree **root-down**, and the CLI invoker running `restart` is frequently a **descendant of the daemon** — the agent's own Bash tool shells out to `phantombot restart`. `/T` would kill the very process that still has to call `schtasks /Run`, turning an instant restart into a silent 60-second wait for the keep-alive trigger.

So we enumerate the tree ourselves (CIM `ParentProcessId`) and subtract our own PID and subtree. The daemon is killed **first** so it can't spawn a fresh harness mid-reap.

## The creation-time guard

Windows never reparents orphans, so a dead process's PID can be recycled while its old children still name it as parent — and a brand-new unrelated process inherits a pile of bogus "children". Walking parentage naively would kill innocent processes.

This is not hypothetical: on Alpha, orphaned `claude.exe` (PID 4712) still names dead PID **7216** as its parent. If 7216 were recycled into a new daemon, an unguarded walk would reap that tree.

A genuine child is always created *after* its parent, so we reject edges where the child predates the parent. Missing timestamps follow the edge (degrade to the old behaviour rather than under-reap).

## Changes

- `ProcessManager.listByImage` → `listAll()` (parentage + creation time; the orphans we must reap are `claude.exe`/`node.exe`, not `phantombot.exe`).
- New pure, exported `descendantsOf()` and `daemonKillOrder()`.
- New `waitForProcessesGone()` — `killDaemonProcesses` now blocks until the PIDs actually vanish, bounded; a wedged PID logs and proceeds rather than hanging `stop()` forever.
- `runLock`: Windows instance token from `Win32_Process.CreationDate`. PID is validated as a positive integer before it's interpolated into the CIM filter.
- `windowsHide` on the `taskkill`/`powershell` spawns — they otherwise flash a console window for every reaped PID.

## Verification

- `tsc` clean. Full suite **2103 pass**; the only 2 failures are pre-existing (`PiHarness … --api-key`), and fail identically on a clean `origin/main` worktree — a real PI key in my vault leaks into those assertions.
- New tests cover BFS walking, the recycled-parent guard, parentage cycles, the bounded exit-wait, and the **"invoker is a descendant of the daemon"** case that rules out `/T`.
- The CIM projection and the real orphan tree were verified **read-only on the Alpha VM** — including that `Date.parse` handles PowerShell's 7-fraction-digit ISO timestamps and that a null `CommandLine` coalesces safely.

## Known limitation

Trees already orphaned *before* this lands have no live parent to walk from, so they aren't swept. Sweeping every parentless `claude.exe` would risk killing a user's own interactive Claude session, so those are left to a reboot or a manual kill. Alpha currently has one such tree.

## Not yet done

Not verified on the real Windows runtime end-to-end — that needs a `build:win` + daemon swap on Alpha, which bounces Megan. Happy to do that on request.