### PR TITLE
fix(windows): repair the "am I the real binary?" gate, and allow-list VS Code proposed APIs

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -45,6 +45,7 @@ import {
   removeRoutingExtension,
   routingExtensionStatus,
 } from "../lib/piExtensionProvision.ts";
+import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
 import { currentPlatform } from "../lib/platform.ts";
 import {
   editorConnectorBroken,
@@ -455,7 +456,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     // explicitly skipped by a test
   } else if (input.checkPiExtension) {
     piExtensionReport = await input.checkPiExtension();
-  } else if (basename(process.execPath) === "phantombot") {
+  } else if (isPhantombotBinary()) {
     const piRouting = config.harnesses?.pi?.routing;
     const status = await routingExtensionStatus(piRouting);
     let repaired = false;
@@ -493,7 +494,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     // explicitly skipped by a test
   } else if (input.checkEditorConnectors) {
     editorConnectors = input.checkEditorConnectors(repair);
-  } else if (basename(process.execPath) === "phantombot") {
+  } else if (isPhantombotBinary()) {
     editorConnectors = reconcileEditorConnectors({
       binaryPath: process.execPath,
       repair,
@@ -798,6 +799,26 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
           );
           break;
       }
+      // Second line for VS Code's proposed-api allow-list. Silent when already
+      // `current` (or undefined, i.e. an editor without the concept), so a
+      // healthy box shows exactly one line per editor as before.
+      switch (e.proposedApi) {
+        case "enabled":
+          out.write(
+            "    proposed-api: allow-listed in ~/.vscode/argv.json — restart VS Code to activate\n",
+          );
+          break;
+        case "stale":
+          out.write(
+            "    proposed-api: NOT allow-listed in ~/.vscode/argv.json — extension falls back to the `@phantombot` participant instead of a native chat session; run `phantombot doctor` (without --no-repair) to fix\n",
+          );
+          break;
+        case "error":
+          out.write(
+            `    proposed-api: could not be allow-listed${e.proposedApiError ? ` — ${e.proposedApiError}` : ""}\n`,
+          );
+          break;
+      }
     }
   }
 
@@ -807,7 +828,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
 async function computeHarnessReport(
   config: Config,
 ): Promise<DoctorReport["harnesses"] | undefined> {
-  if (basename(process.execPath) !== "phantombot") return undefined;
+  if (!isPhantombotBinary()) return undefined;
   const path =
     currentPlatform() === "linux"
       ? expandSystemdPath(PHANTOMBOT_SERVICE_PATH)
@@ -836,7 +857,7 @@ async function defaultCheckSystemd(
   const sysEnv = ensureUserSystemdEnv();
   if (!sysEnv.ready) return undefined;
   const binPath = process.execPath;
-  if (basename(binPath) !== "phantombot") return undefined;
+  if (!isPhantombotBinary(binPath)) return undefined;
   const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
   const expectedFiles: Array<{ path: string; name: string }> = [
     { path: defaultUnitPath(), name: basename(defaultUnitPath()) },
@@ -905,7 +926,7 @@ async function defaultCheckSystemd(
  * dev contexts and tests don't need to clean up marker files.
  */
 function computeTimersReport(): DoctorReport["timers"] | undefined {
-  if (basename(process.execPath) !== "phantombot") return undefined;
+  if (!isPhantombotBinary()) return undefined;
   const now = new Date();
   const heartbeat = loadHeartbeatLastFired(now);
   const tickFired = loadTickLastFired(now);

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -7,9 +7,9 @@
 
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
-import { basename } from "node:path";
 
 import { type Config, loadConfig, memoryIndexPath, personaDir } from "../config.ts";
+import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
 import { runHeartbeat } from "../lib/heartbeat.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
@@ -169,7 +169,7 @@ async function defaultHealService(): Promise<void> {
  */
 async function defaultHealSystemd(): Promise<void> {
   const binPath = process.execPath;
-  if (basename(binPath) !== "phantombot") return;
+  if (!isPhantombotBinary(binPath)) return;
   const sysEnv = ensureUserSystemdEnv();
   if (!sysEnv.ready) return;
   const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
@@ -190,7 +190,7 @@ async function defaultHealSystemd(): Promise<void> {
  */
 async function defaultHealTaskScheduler(): Promise<void> {
   const binPath = process.execPath;
-  if (!basename(binPath).startsWith("phantombot")) return;
+  if (!isPhantombotBinary(binPath)) return;
   const r = await ensureTasksCurrent({
     binPath,
     schtasks: new BunSchtasksRunner(),

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -8,7 +8,6 @@
 
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
-import { basename } from "node:path";
 
 import {
   HttpTelegramTransport,
@@ -55,6 +54,7 @@ import {
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import { healDefaultPersonaIfBroken } from "../lib/personaDefault.ts";
+import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
 import { logsCommand, statusCommand } from "../lib/platform.ts";
 import {
   acquireRunLock,
@@ -319,7 +319,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   // relaunched process sweeps it up. No-op on POSIX and best-effort — a
   // still-locked artifact is retried on the next boot. Gated to the real
   // compiled binary so `bun src/index.ts`/tests never touch the dev box.
-  if (basename(process.execPath).toLowerCase().startsWith("phantombot")) {
+  if (isPhantombotBinary()) {
     try {
       const removed = await cleanupStaleUpdateArtifacts(process.execPath);
       if (removed.length > 0) {
@@ -439,7 +439,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   // Gated to the real `phantombot` binary (same gate doctor uses for its
   // filesystem-touching checks) so `bun test`/dev never stamp the dev box's
   // real ~/.pi.
-  if (basename(process.execPath) === "phantombot") {
+  if (isPhantombotBinary()) {
     ensureRoutingExtension(config.harnesses?.pi?.routing).then(
       (r) => {
         if (r.action !== "unchanged") {
@@ -465,7 +465,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   // self-update. `doctor` re-reconciles on demand. Gated to the real
   // `phantombot` binary (same gate as the pi extension) so `bun run`/dev never
   // writes to the dev box's real ~/.config/zed.
-  if (basename(process.execPath) === "phantombot") {
+  if (isPhantombotBinary()) {
     try {
       for (const r of reconcileEditorConnectors({
         binaryPath: process.execPath,
@@ -480,6 +480,21 @@ export async function runRun(input: RunInput = {}): Promise<number> {
           log.warn("run: editor connector registration failed", {
             editor: r.editor,
             error: r.error,
+          });
+        }
+        // VS Code's proposed-api allow-list is a SEPARATE outcome from the
+        // extension install — an extension can be `current` and still be
+        // running degraded. Log it on its own axis so a silent fallback to the
+        // `@phantombot` participant is visible in the daemon log.
+        if (r.proposedApi === "enabled") {
+          log.info("run: enabled VS Code proposed APIs", {
+            editor: r.editor,
+            note: "restart VS Code to activate",
+          });
+        } else if (r.proposedApi === "error") {
+          log.warn("run: could not enable VS Code proposed APIs", {
+            editor: r.editor,
+            error: r.proposedApiError,
           });
         }
       }

--- a/src/connectors/acp/autoInstall.ts
+++ b/src/connectors/acp/autoInstall.ts
@@ -42,6 +42,7 @@ import {
 import {
   checkProposedApi,
   ensureProposedApi,
+  type ProposedApiOptions,
   type ProposedApiResult,
   type ProposedApiStatus,
 } from "./vscodeArgv.ts";
@@ -230,8 +231,8 @@ export function vscodeResultToConnector(
 export interface VscodeReconcileHooks {
   install(): VscodeInstallResult;
   check(): VscodeInstallResult;
-  ensureArgv(): ProposedApiResult;
-  checkArgv(): ProposedApiResult;
+  ensureArgv(options?: ProposedApiOptions): ProposedApiResult;
+  checkArgv(options?: ProposedApiOptions): ProposedApiResult;
 }
 
 /**
@@ -245,6 +246,10 @@ export interface VscodeReconcileHooks {
  * failed (`error`), we don't go creating a `~/.vscode/argv.json` for an editor
  * the user may not even have — that's the same "never provision what wasn't
  * asked for" rule the settings-model editors enforce via `detectionDir`.
+ *
+ * The CLI the extension step actually resolved is threaded into the argv step,
+ * so we allow-list the extension in the SAME distribution we installed it into
+ * rather than in whatever `.vscode` happens to sit in `$HOME`.
  */
 export function reconcileVscode(
   repair: boolean,
@@ -255,11 +260,15 @@ export function reconcileVscode(
   const ensureArgv = hooks.ensureArgv ?? ensureProposedApi;
   const checkArgv = hooks.checkArgv ?? checkProposedApi;
 
-  const connector = vscodeResultToConnector(repair ? install() : check(), repair);
+  const result = repair ? install() : check();
+  const connector = vscodeResultToConnector(result, repair);
   if (connector.action === "not-detected" || connector.action === "error") {
     return connector;
   }
-  const argv = repair ? ensureArgv() : checkArgv();
+  const argvOptions: ProposedApiOptions = result.codeCommand
+    ? { codeCommand: result.codeCommand }
+    : {};
+  const argv = repair ? ensureArgv(argvOptions) : checkArgv(argvOptions);
   connector.proposedApi = argv.status;
   if (argv.error) connector.proposedApiError = argv.error;
   return connector;

--- a/src/connectors/acp/autoInstall.ts
+++ b/src/connectors/acp/autoInstall.ts
@@ -39,6 +39,12 @@ import {
   installVscode,
   type VscodeInstallResult,
 } from "./installVscode.ts";
+import {
+  checkProposedApi,
+  ensureProposedApi,
+  type ProposedApiResult,
+  type ProposedApiStatus,
+} from "./vscodeArgv.ts";
 
 /** A sink that drops everything — keeps reconcile silent on stdout/stderr. */
 const SILENT: WriteSink = { write: () => true };
@@ -62,6 +68,17 @@ export interface EditorConnectorResult {
   action: EditorConnectorAction;
   settingsPath: string;
   error?: string;
+  /**
+   * VS Code only. Whether our side-loaded extension is allow-listed for the
+   * proposed chat APIs it declares, via `~/.vscode/argv.json`. Orthogonal to
+   * `action`: the extension can be installed and current (`action: "current"`)
+   * while still lacking the allow-list entry, in which case it silently
+   * degrades to the `@phantombot` participant instead of a native chat session.
+   * Undefined for editors where the concept doesn't apply.
+   */
+  proposedApi?: ProposedApiStatus;
+  /** Detail for a `proposedApi: "error"`. */
+  proposedApiError?: string;
 }
 
 /**
@@ -193,10 +210,64 @@ export function vscodeResultToConnector(
   }
 }
 
+/**
+ * Installing the .vsix is only HALF of a working VS Code integration: the
+ * extension declares proposed chat APIs that stable VS Code withholds unless
+ * the extension id is allow-listed in `~/.vscode/argv.json`. Reconcile both, in
+ * that order.
+ *
+ * The argv.json step is gated on the extension step having found VS Code. When
+ * `code` isn't on the box (`not-detected`) or the install itself failed
+ * (`error`), we don't go creating a `~/.vscode/argv.json` for an editor the
+ * user doesn't have — that's the same "never provision what wasn't asked for"
+ * rule the settings-model editors enforce with their `detectionDir` probe.
+ */
+/**
+ * The impure halves of a VS Code reconcile, injectable so the GATING logic
+ * below is unit-testable without a real `code` CLI and — critically — without
+ * writing the dev box's real `~/.vscode/argv.json`.
+ */
+export interface VscodeReconcileHooks {
+  install(): VscodeInstallResult;
+  check(): VscodeInstallResult;
+  ensureArgv(): ProposedApiResult;
+  checkArgv(): ProposedApiResult;
+}
+
+/**
+ * Installing the .vsix is only HALF of a working VS Code integration: the
+ * extension declares proposed chat APIs that stable VS Code withholds unless
+ * the extension id is allow-listed in `~/.vscode/argv.json`. Reconcile both, in
+ * that order.
+ *
+ * The argv.json step is GATED on the extension step having actually found VS
+ * Code. When `code` isn't on the box (`not-detected`) or the install itself
+ * failed (`error`), we don't go creating a `~/.vscode/argv.json` for an editor
+ * the user may not even have — that's the same "never provision what wasn't
+ * asked for" rule the settings-model editors enforce via `detectionDir`.
+ */
+export function reconcileVscode(
+  repair: boolean,
+  hooks: Partial<VscodeReconcileHooks> = {},
+): EditorConnectorResult {
+  const install = hooks.install ?? installVscode;
+  const check = hooks.check ?? checkVscode;
+  const ensureArgv = hooks.ensureArgv ?? ensureProposedApi;
+  const checkArgv = hooks.checkArgv ?? checkProposedApi;
+
+  const connector = vscodeResultToConnector(repair ? install() : check(), repair);
+  if (connector.action === "not-detected" || connector.action === "error") {
+    return connector;
+  }
+  const argv = repair ? ensureArgv() : checkArgv();
+  connector.proposedApi = argv.status;
+  if (argv.error) connector.proposedApiError = argv.error;
+  return connector;
+}
+
 export const VSCODE_EDITOR: EditorSpec = {
   id: "vscode",
-  reconcile: ({ repair }) =>
-    vscodeResultToConnector(repair ? installVscode() : checkVscode(), repair),
+  reconcile: ({ repair }) => reconcileVscode(repair),
 };
 
 /** Editors phantombot knows how to register itself into. */
@@ -318,7 +389,18 @@ export function reconcileEditorConnectors(
   return results;
 }
 
-/** True if a result represents a state an operator should be warned about. */
+/**
+ * True if a result represents a state an operator should be warned about.
+ *
+ * A missing proposed-api allow-list counts: the extension is installed but runs
+ * degraded, which is precisely the failure mode nobody notices. `enabled` does
+ * NOT count — we just fixed it (though VS Code needs a restart to see it).
+ */
 export function editorConnectorBroken(r: EditorConnectorResult): boolean {
-  return r.action === "error" || r.action === "stale";
+  return (
+    r.action === "error" ||
+    r.action === "stale" ||
+    r.proposedApi === "error" ||
+    r.proposedApi === "stale"
+  );
 }

--- a/src/connectors/acp/vscodeArgv.ts
+++ b/src/connectors/acp/vscodeArgv.ts
@@ -1,0 +1,262 @@
+/**
+ * VS Code `argv.json` writer — opts our side-loaded extension into the chat
+ * proposed APIs it declares.
+ *
+ * WHY THIS IS NEEDED. `editors/vscode/package.json` declares
+ * `enabledApiProposals: [chatSessionsProvider, chatParticipantPrivate,
+ * chatReferenceBinaryData]`. Stable VS Code refuses proposed APIs to any
+ * extension that isn't explicitly allow-listed, and for a SIDE-LOADED extension
+ * (ours is installed from a bundled .vsix, never from the marketplace) the only
+ * supported allow-list on stable is the `enable-proposed-api` array in the
+ * per-user `~/.vscode/argv.json`.
+ *
+ * Without it the extension still loads, but `chatSessionsProvider` is
+ * unavailable and it silently degrades to the `@phantombot` chat-participant
+ * fallback (see sessionProvider.ts). That fallback is deliberate, which is
+ * exactly what makes the missing entry so hard to spot: the panel looks
+ * half-working rather than broken. Nothing in the repo ever wrote this file, so
+ * every install has been landing in the degraded mode unless the user added the
+ * entry by hand.
+ *
+ * DATA-LOSS-PROOF PROCEDURE — identical to installZed.ts, and non-negotiable.
+ * `argv.json` ships from VS Code full of explanatory comments and carries the
+ * user's `crash-reporter-id`, so it is JSONC and it is precious:
+ *   1. Read the existing file.
+ *   2. Parse with jsonc-parser (tolerant of comments + trailing commas).
+ *   3. If the parse FAILS ⇒ ABORT. Write nothing, report `error`. NEVER "start
+ *      fresh", NEVER overwrite.
+ *   4. Otherwise merge our extension id into `enable-proposed-api` via
+ *      modify/applyEdits, so every other key, every comment, and the file's
+ *      formatting survive untouched.
+ *   5. Back up the original, then write atomically (temp file + rename).
+ *
+ * Idempotent: when the id is already in the array we return `current` and touch
+ * nothing, so this can run on every daemon startup without churning backups.
+ *
+ * Never throws. Every entry point returns a status.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { applyEdits, modify, parse, type ParseError } from "jsonc-parser";
+
+import { VSCODE_EXTENSION_ID } from "../../lib/vscodeExtensionAsset.generated.ts";
+
+/** The `enable-proposed-api` key VS Code reads out of argv.json. */
+export const ENABLE_PROPOSED_API_KEY = "enable-proposed-api";
+
+export type ProposedApiStatus =
+  /** Extension id already allow-listed — nothing written. */
+  | "current"
+  /** We added the id (repair mode). VS Code must restart to pick it up. */
+  | "enabled"
+  /** Missing, and repair was off — reported, not written. */
+  | "stale"
+  /** Unparseable argv.json, or a filesystem failure. Nothing written. */
+  | "error";
+
+export interface ProposedApiResult {
+  status: ProposedApiStatus;
+  argvPath: string;
+  backupPath?: string;
+  /** Populated when `status === "error"`. */
+  error?: string;
+}
+
+/**
+ * Impure seams, injected so the whole merge runs under `bun test` against an
+ * in-memory file with no real VS Code and no real `$HOME`.
+ */
+export interface ArgvDeps {
+  argvPath: string;
+  /** File contents, or undefined when the file does not exist. */
+  read(path: string): string | undefined;
+  /** Write `contents` to `path` atomically, creating parent dirs. */
+  write(path: string, contents: string): void;
+}
+
+/**
+ * Resolve the per-user VS Code `argv.json`.
+ *
+ * It lives at `<home>/.vscode/argv.json` on EVERY platform — VS Code derives it
+ * from `os.homedir()` + its `dataFolderName`, so unlike settings.json there is
+ * no `%APPDATA%` branch on Windows and no XDG lookup on Linux. (VS Code
+ * Insiders uses `.vscode-insiders`; we target stable only.)
+ */
+export function defaultVscodeArgvPath(): string {
+  return join(homedir(), ".vscode", "argv.json");
+}
+
+/** What a reconcile WOULD do to `existing`, computed purely. */
+export type ArgvPlan =
+  | { kind: "current" }
+  | { kind: "unparseable" }
+  | { kind: "write"; updated: string };
+
+/**
+ * Decide how to bring `existing` (undefined = file absent) in line with
+ * `extensionId` being allow-listed. Pure — no I/O, so every branch is testable.
+ *
+ * A pre-existing `enable-proposed-api` that is NOT an array (a user typo, or
+ * VS Code's own commented-out scalar example uncommented wrong) is replaced
+ * wholesale with a fresh array rather than appended to, because appending to a
+ * non-array would produce a file VS Code rejects. We're only ever adding our own
+ * id, so any other extension ids already present are preserved.
+ */
+export function planProposedApi(
+  existing: string | undefined,
+  extensionId: string,
+): ArgvPlan {
+  // Tabs, because that's what VS Code ships argv.json with. jsonc-parser
+  // reformats the region around its edit, so matching the file's native style
+  // keeps the diff to exactly the key we added instead of gratuitously
+  // reindenting the user's neighbouring lines.
+  const formatting = {
+    formattingOptions: { tabSize: 4, insertSpaces: false, eol: "\n" },
+  };
+
+  if (existing === undefined) {
+    // Absent file: create one carrying only our key. VS Code fills in its own
+    // defaults for everything else, so a minimal file is safe. The header
+    // explains to a human why phantombot touched it.
+    const body = applyEdits(
+      "{}",
+      modify("{}", [ENABLE_PROPOSED_API_KEY], [extensionId], formatting),
+    );
+    return { kind: "write", updated: NEW_FILE_HEADER + body + "\n" };
+  }
+
+  const errors: ParseError[] = [];
+  const parsed = parse(existing, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  }) as Record<string, unknown> | undefined;
+  if (errors.length > 0) return { kind: "unparseable" };
+
+  const current = parsed?.[ENABLE_PROPOSED_API_KEY];
+  const ids = Array.isArray(current)
+    ? current.filter((v): v is string => typeof v === "string")
+    : [];
+  if (ids.includes(extensionId)) return { kind: "current" };
+
+  const updated = applyEdits(
+    existing,
+    modify(existing, [ENABLE_PROPOSED_API_KEY], [...ids, extensionId], formatting),
+  );
+  return { kind: "write", updated };
+}
+
+const NEW_FILE_HEADER =
+  "// This configuration file allows you to pass permanent command line\n" +
+  "// arguments to VS Code. Created by phantombot to enable the chat-session\n" +
+  "// proposed APIs for its side-loaded extension.\n" +
+  "//\n" +
+  "// NOTE: Changing this file requires a restart of VS Code.\n";
+
+export interface ProposedApiOptions {
+  deps?: ArgvDeps;
+  extensionId?: string;
+}
+
+/**
+ * Report-only probe (doctor --no-repair): is our extension allow-listed?
+ * NEVER writes, NEVER throws, NEVER creates the file.
+ */
+export function checkProposedApi(
+  options: ProposedApiOptions = {},
+): ProposedApiResult {
+  const deps = options.deps ?? defaultArgvDeps();
+  const extensionId = options.extensionId ?? VSCODE_EXTENSION_ID;
+  try {
+    const plan = planProposedApi(deps.read(deps.argvPath), extensionId);
+    switch (plan.kind) {
+      case "current":
+        return { status: "current", argvPath: deps.argvPath };
+      case "unparseable":
+        return {
+          status: "error",
+          argvPath: deps.argvPath,
+          error: `${deps.argvPath} is not parseable as JSONC — left untouched`,
+        };
+      case "write":
+        return { status: "stale", argvPath: deps.argvPath };
+    }
+  } catch (e) {
+    return {
+      status: "error",
+      argvPath: deps.argvPath,
+      error: (e as Error).message,
+    };
+  }
+}
+
+/**
+ * Idempotently allow-list our extension for its declared proposed APIs.
+ * NEVER throws — a failure here must never break daemon startup.
+ */
+export function ensureProposedApi(
+  options: ProposedApiOptions = {},
+): ProposedApiResult {
+  const deps = options.deps ?? defaultArgvDeps();
+  const extensionId = options.extensionId ?? VSCODE_EXTENSION_ID;
+  try {
+    const existing = deps.read(deps.argvPath);
+    const plan = planProposedApi(existing, extensionId);
+    if (plan.kind === "current") {
+      return { status: "current", argvPath: deps.argvPath };
+    }
+    if (plan.kind === "unparseable") {
+      return {
+        status: "error",
+        argvPath: deps.argvPath,
+        error:
+          `${deps.argvPath} is not parseable as JSONC — refusing to touch it ` +
+          `to avoid data loss. Add "${extensionId}" to its ` +
+          `"${ENABLE_PROPOSED_API_KEY}" array by hand.`,
+      };
+    }
+
+    let backupPath: string | undefined;
+    if (existing !== undefined) {
+      backupPath = `${deps.argvPath}.phantombot-bak`;
+      deps.write(backupPath, existing);
+    }
+    deps.write(deps.argvPath, plan.updated);
+    return { status: "enabled", argvPath: deps.argvPath, ...(backupPath ? { backupPath } : {}) };
+  } catch (e) {
+    return {
+      status: "error",
+      argvPath: deps.argvPath,
+      error: (e as Error).message,
+    };
+  }
+}
+
+/** Production deps: real fs, real home. */
+export function defaultArgvDeps(): ArgvDeps {
+  return {
+    argvPath: defaultVscodeArgvPath(),
+    read: (p) => {
+      try {
+        return readFileSync(p, "utf8");
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+        throw e;
+      }
+    },
+    write: (p, contents) => {
+      mkdirSync(dirname(p), { recursive: true });
+      // Atomic: temp file + rename, so a crash mid-write can never leave VS
+      // Code with a truncated argv.json (which it would refuse to start on).
+      const tmp = `${p}.phantombot-tmp`;
+      writeFileSync(tmp, contents, "utf8");
+      renameSync(tmp, p);
+    },
+  };
+}

--- a/src/connectors/acp/vscodeArgv.ts
+++ b/src/connectors/acp/vscodeArgv.ts
@@ -82,15 +82,65 @@ export interface ArgvDeps {
 }
 
 /**
- * Resolve the per-user VS Code `argv.json`.
+ * Basename of a CLI path, split on BOTH separators and stripped of a Windows
+ * launcher extension.
  *
- * It lives at `<home>/.vscode/argv.json` on EVERY platform — VS Code derives it
- * from `os.homedir()` + its `dataFolderName`, so unlike settings.json there is
- * no `%APPDATA%` branch on Windows and no XDG lookup on Linux. (VS Code
- * Insiders uses `.vscode-insiders`; we target stable only.)
+ * `node:path`'s `basename` is platform-bound: on POSIX it does not treat `\` as
+ * a separator, so `basename("C:\\...\\bin\\code.cmd")` returns the WHOLE
+ * string. Deriving the data folder with it would therefore work on Windows and
+ * silently misbehave under a Linux CI run of the Windows test — the exact class
+ * of bug that let the `phantombot.exe` gate ship. Split on both, always.
  */
-export function defaultVscodeArgvPath(): string {
-  return join(homedir(), ".vscode", "argv.json");
+function cliBasename(cliPath: string): string {
+  const tail = cliPath.split(/[\\/]/).pop() ?? cliPath;
+  return tail.replace(/\.(cmd|exe|bat)$/i, "").toLowerCase();
+}
+
+/**
+ * VS Code's per-user data folder, derived from the resolved CLI.
+ *
+ * Each distribution stamps its own `dataFolderName` into product.json, and
+ * argv.json lives inside it. Hardcoding `.vscode` writes STABLE's runtime args
+ * no matter which distribution we actually installed the extension into.
+ *
+ * Today `resolveCodeCli()` only ever resolves stable (`code` / `code.cmd`), so
+ * every branch below except the first is unreachable in production. It exists
+ * so the two can't silently disagree the moment someone adds Insiders to the
+ * resolver — which is exactly how the extension would end up installed in one
+ * editor and allow-listed in another.
+ *
+ * Unknown names fall back to stable rather than inventing a folder: writing
+ * stable's argv.json is a visible no-op, creating a phantom data folder for an
+ * editor that doesn't exist is litter.
+ */
+export function vscodeDataFolderName(codeCommand?: string): string {
+  if (!codeCommand) return ".vscode";
+  switch (cliBasename(codeCommand)) {
+    case "code-insiders":
+      return ".vscode-insiders";
+    // VSCodium and OSS builds ship dataFolderName `.vscode-oss`.
+    case "codium":
+    case "vscodium":
+      return ".vscode-oss";
+    default:
+      return ".vscode";
+  }
+}
+
+/**
+ * Resolve the per-user VS Code `argv.json` for the distribution behind
+ * `codeCommand` (omit it for stable).
+ *
+ * It lives at `<home>/<dataFolder>/argv.json` on EVERY platform — VS Code
+ * derives it from `os.homedir()` + its `dataFolderName`, so unlike
+ * settings.json there is no `%APPDATA%` branch on Windows and no XDG lookup on
+ * Linux. Verified directly on the Windows box: `C:\Users\<user>\.vscode\argv.json`,
+ * carrying VS Code's own generated header comments and `crash-reporter-id`.
+ *
+ * argv.json holds GLOBAL runtime arguments, so it is not per-profile either.
+ */
+export function defaultVscodeArgvPath(codeCommand?: string): string {
+  return join(homedir(), vscodeDataFolderName(codeCommand), "argv.json");
 }
 
 /** What a reconcile WOULD do to `existing`, computed purely. */
@@ -162,6 +212,12 @@ const NEW_FILE_HEADER =
 export interface ProposedApiOptions {
   deps?: ArgvDeps;
   extensionId?: string;
+  /**
+   * The `code` CLI the extension was actually installed with, as resolved by
+   * `resolveCodeCli()`. Selects the matching data folder so we allow-list the
+   * extension in the same distribution we installed it into. Omit for stable.
+   */
+  codeCommand?: string;
 }
 
 /**
@@ -171,7 +227,7 @@ export interface ProposedApiOptions {
 export function checkProposedApi(
   options: ProposedApiOptions = {},
 ): ProposedApiResult {
-  const deps = options.deps ?? defaultArgvDeps();
+  const deps = options.deps ?? defaultArgvDeps(options.codeCommand);
   const extensionId = options.extensionId ?? VSCODE_EXTENSION_ID;
   try {
     const plan = planProposedApi(deps.read(deps.argvPath), extensionId);
@@ -203,7 +259,7 @@ export function checkProposedApi(
 export function ensureProposedApi(
   options: ProposedApiOptions = {},
 ): ProposedApiResult {
-  const deps = options.deps ?? defaultArgvDeps();
+  const deps = options.deps ?? defaultArgvDeps(options.codeCommand);
   const extensionId = options.extensionId ?? VSCODE_EXTENSION_ID;
   try {
     const existing = deps.read(deps.argvPath);
@@ -238,10 +294,10 @@ export function ensureProposedApi(
   }
 }
 
-/** Production deps: real fs, real home. */
-export function defaultArgvDeps(): ArgvDeps {
+/** Production deps: real fs, real home, the resolved distribution's argv.json. */
+export function defaultArgvDeps(codeCommand?: string): ArgvDeps {
   return {
-    argvPath: defaultVscodeArgvPath(),
+    argvPath: defaultVscodeArgvPath(codeCommand),
     read: (p) => {
       try {
         return readFileSync(p, "utf8");

--- a/src/lib/binaryIdentity.ts
+++ b/src/lib/binaryIdentity.ts
@@ -1,0 +1,66 @@
+/**
+ * "Am I the real compiled phantombot binary?" — the single gate every
+ * self-healing, filesystem-touching startup check hangs off.
+ *
+ * This is a LEAF module on purpose: it imports nothing at all. The natural home
+ * would be `platform.ts`, but that already imports systemd.ts / launchd.ts /
+ * taskScheduler.ts — all three of which need this gate — so putting it there
+ * would close an import cycle.
+ */
+
+/** Executable basenames that mean "this process IS the shipped phantombot". */
+const PHANTOMBOT_EXEC_NAMES = new Set(["phantombot", "phantombot.exe"]);
+
+/**
+ * Last path segment, splitting on BOTH separators regardless of host platform.
+ *
+ * Deliberately not `node:path`'s `basename`, which is bound to the host: on
+ * Linux it does not treat `\` as a separator, so `basename("C:\\pb\\x.exe")`
+ * returns the whole string. That would make the Windows behaviour of this gate
+ * untestable from Linux/macOS CI — and an untestable Windows gate is exactly
+ * how the original bug shipped and survived. `execPath` is always OS-native, so
+ * accepting both separators costs nothing in production; the only divergence is
+ * a POSIX file whose *name* literally contains a backslash, which is
+ * pathological and, if it happened, would fail safe in the same direction as a
+ * normal match.
+ */
+function execBasename(execPath: string): string {
+  const segments = execPath.split(/[\\/]/);
+  return segments[segments.length - 1] ?? "";
+}
+
+/**
+ * True when `execPath` is the real compiled phantombot binary, false when we're
+ * running the sources under a generic `bun`/`node` runtime (dev, `bun test`).
+ *
+ * This gates every check that TOUCHES THE USER'S REAL FILESYSTEM: provisioning
+ * pi's capability-routing extension, registering phantombot into Zed / JetBrains
+ * / VS Code, rewriting systemd units and scheduled tasks. Under `bun test` they
+ * must all stay inert so a test run never writes the dev box's `~/.pi` or
+ * `~/.config/zed`.
+ *
+ * WHY THIS EXISTS: several call sites spelled the gate inline as
+ * `basename(process.execPath) === "phantombot"`. On Windows `execPath` ends in
+ * `.exe`, so that comparison is NEVER true — which meant the pi extension was
+ * never provisioned, the editor connectors (including our own VS Code
+ * extension) were never installed, and `doctor` silently omitted its harness /
+ * timers / pi-extension / editor sections. All of it failed OPEN and QUIET: the
+ * code simply never ran, so there was nothing in the logs to find. Other sites
+ * had already been patched ad hoc to `.startsWith("phantombot")`, so the two
+ * spellings disagreed. One helper, one meaning.
+ *
+ * Exact-name match rather than a prefix match: `startsWith("phantombot")` also
+ * matches the release download artifact (`phantombot-v1.1.194-windows-x64.exe`)
+ * and the self-update leftover (`phantombot.exe.old`), neither of which is an
+ * installed binary that has any business rewriting the user's editor config or
+ * scheduled tasks. Comparison is case-insensitive because Windows filesystems
+ * are.
+ *
+ * Strictly additive on Linux/macOS: `phantombot` matches exactly as it did
+ * before, and `bun` / `node` still don't.
+ */
+export function isPhantombotBinary(
+  execPath: string = process.execPath,
+): boolean {
+  return PHANTOMBOT_EXEC_NAMES.has(execBasename(execPath).toLowerCase());
+}

--- a/src/lib/launchd.ts
+++ b/src/lib/launchd.ts
@@ -28,7 +28,8 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
+import { isPhantombotBinary } from "./binaryIdentity.ts";
 import type { WriteSink } from "./io.ts";
 
 export const PHANTOMBOT_PLIST_LABEL = "dev.phantombot.phantombot";
@@ -558,7 +559,7 @@ export function defaultLaunchdServiceControl(): LaunchdServiceControl {
     },
     async rerenderUnitIfStale() {
       const binPath = process.execPath;
-      if (basename(binPath) !== "phantombot") return { rerendered: false };
+      if (!isPhantombotBinary(binPath)) return { rerendered: false };
       const plistPath = defaultPlistPath();
       if (!existsSync(plistPath)) return { rerendered: false };
       let domain: string;

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -9,6 +9,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import { isPhantombotBinary } from "./binaryIdentity.ts";
 import type { WriteSink } from "./io.ts";
 
 export const PHANTOMBOT_UNIT_NAME = "phantombot.service";
@@ -410,7 +411,7 @@ async function defaultRerenderUnitIfStale(): Promise<{
   backupPath?: string;
 }> {
   const binPath = process.execPath;
-  if (basename(binPath) !== "phantombot") return { rerendered: false };
+  if (!isPhantombotBinary(binPath)) return { rerendered: false };
   const unitPath = defaultUnitPath();
   if (!existsSync(unitPath)) return { rerendered: false };
   const sysEnv = ensureUserSystemdEnv();

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -59,9 +59,10 @@
 
 import { mkdir, unlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 
 import { xdgDataHome } from "../config.ts";
+import { isPhantombotBinary } from "./binaryIdentity.ts";
 import { currentUserSid } from "./filePermissions.ts";
 import type { WriteSink } from "./io.ts";
 import { log } from "./logger.ts";
@@ -1076,7 +1077,7 @@ export function defaultTaskSchedulerServiceControl(
       // the user never asked for — mirrors the systemd `existsSync(unitPath)`
       // guard).
       const binPath = process.execPath;
-      if (!basename(binPath).startsWith("phantombot")) {
+      if (!isPhantombotBinary(binPath)) {
         return { rerendered: false };
       }
       const installed = await runner.run(["/Query", "/TN", PHANTOMBOT_TASK]);

--- a/tests/connectors-acp-autoInstall-vscode.test.ts
+++ b/tests/connectors-acp-autoInstall-vscode.test.ts
@@ -14,12 +14,16 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  editorConnectorBroken,
   reconcileEditorConnectors,
+  reconcileVscode,
   vscodeResultToConnector,
   VSCODE_EDITOR,
   type EditorSpec,
+  type VscodeReconcileHooks,
 } from "../src/connectors/acp/autoInstall.ts";
 import type { VscodeInstallResult } from "../src/connectors/acp/installVscode.ts";
+import type { ProposedApiResult } from "../src/connectors/acp/vscodeArgv.ts";
 
 const BIN = "/home/dev/.local/bin/phantombot";
 
@@ -139,5 +143,117 @@ describe("VSCODE_EDITOR is registered and reconcile-driven", () => {
   test("is exported with a reconcile hook (self-driven shape)", () => {
     expect(VSCODE_EDITOR.id).toBe("vscode");
     expect(typeof VSCODE_EDITOR.reconcile).toBe("function");
+  });
+});
+
+/**
+ * The proposed-api allow-list is the SECOND half of a working VS Code
+ * integration, and it has its own failure mode: the extension installs fine,
+ * reports `current`, and silently runs degraded on the `@phantombot` participant
+ * because `~/.vscode/argv.json` never listed it. These tests pin the gating —
+ * especially the negative one, that we do NOT create `~/.vscode/argv.json` for
+ * a machine with no VS Code on it.
+ */
+describe("reconcileVscode — proposed-api allow-list gating", () => {
+  function hooks(
+    over: Partial<VscodeReconcileHooks> & { calls?: string[] } = {},
+  ) {
+    const calls: string[] = over.calls ?? [];
+    return {
+      calls,
+      hooks: {
+        install: over.install ?? (() => {
+          calls.push("install");
+          return vscodeResult({ action: "installed" });
+        }),
+        check: over.check ?? (() => {
+          calls.push("check");
+          return vscodeResult({ action: "current" });
+        }),
+        ensureArgv: over.ensureArgv ?? ((): ProposedApiResult => {
+          calls.push("ensureArgv");
+          return { status: "enabled", argvPath: "/fake/argv.json" };
+        }),
+        checkArgv: over.checkArgv ?? ((): ProposedApiResult => {
+          calls.push("checkArgv");
+          return { status: "stale", argvPath: "/fake/argv.json" };
+        }),
+      } satisfies VscodeReconcileHooks,
+    };
+  }
+
+  test("VS Code absent ⇒ argv.json is NEVER read or written", () => {
+    const { calls, hooks: h } = hooks({
+      install: () => vscodeResult({ action: "not-detected" }),
+    });
+    const r = reconcileVscode(true, h);
+    expect(r.action).toBe("not-detected");
+    expect(r.proposedApi).toBeUndefined();
+    expect(calls).toEqual([]); // no ensureArgv, no checkArgv
+  });
+
+  test("a failed extension install ⇒ argv.json is left alone", () => {
+    const { calls, hooks: h } = hooks({
+      install: () => vscodeResult({ code: 1, action: "error", message: "boom" }),
+    });
+    const r = reconcileVscode(true, h);
+    expect(r.action).toBe("error");
+    expect(r.proposedApi).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+
+  test("repair mode writes the allow-list after installing", () => {
+    const { calls, hooks: h } = hooks();
+    const r = reconcileVscode(true, h);
+    expect(r.action).toBe("registered");
+    expect(r.proposedApi).toBe("enabled");
+    expect(calls).toEqual(["install", "ensureArgv"]);
+  });
+
+  test("report-only mode checks but never writes the allow-list", () => {
+    const { calls, hooks: h } = hooks();
+    const r = reconcileVscode(false, h);
+    expect(r.proposedApi).toBe("stale");
+    expect(calls).toEqual(["check", "checkArgv"]);
+  });
+
+  test("an installed-but-not-allow-listed extension reads as BROKEN", () => {
+    // The whole point: action is `current` (extension is fine) yet the box is
+    // running degraded. Doctor must not print a green tick here.
+    const { hooks: h } = hooks();
+    const r = reconcileVscode(false, h);
+    expect(r.action).toBe("current");
+    expect(editorConnectorBroken(r)).toBe(true);
+  });
+
+  test("a freshly-enabled allow-list does NOT read as broken", () => {
+    const { hooks: h } = hooks();
+    const r = reconcileVscode(true, h);
+    expect(r.proposedApi).toBe("enabled");
+    expect(editorConnectorBroken(r)).toBe(false);
+  });
+
+  test("an argv.json error surfaces as broken, with its detail", () => {
+    const { hooks: h } = hooks({
+      ensureArgv: () => ({
+        status: "error",
+        argvPath: "/fake/argv.json",
+        error: "not parseable as JSONC",
+      }),
+    });
+    const r = reconcileVscode(true, h);
+    expect(r.proposedApi).toBe("error");
+    expect(r.proposedApiError).toContain("not parseable");
+    expect(editorConnectorBroken(r)).toBe(true);
+  });
+
+  test("an allow-listed, current extension is healthy and quiet", () => {
+    const { hooks: h } = hooks({
+      checkArgv: () => ({ status: "current", argvPath: "/fake/argv.json" }),
+    });
+    const r = reconcileVscode(false, h);
+    expect(r.action).toBe("current");
+    expect(r.proposedApi).toBe("current");
+    expect(editorConnectorBroken(r)).toBe(false);
   });
 });

--- a/tests/connectors-acp-autoInstall-vscode.test.ts
+++ b/tests/connectors-acp-autoInstall-vscode.test.ts
@@ -256,4 +256,49 @@ describe("reconcileVscode — proposed-api allow-list gating", () => {
     expect(r.proposedApi).toBe("current");
     expect(editorConnectorBroken(r)).toBe(false);
   });
+
+  // The extension is installed via the RESOLVED cli, so the allow-list must
+  // land in that same distribution's data folder. If the cli never reaches the
+  // argv step we'd install into Insiders and allow-list stable — silently
+  // degraded, which is precisely the failure this file exists to prevent.
+  test("the resolved code CLI is threaded into the repair-mode argv step", () => {
+    let seen: string | undefined | "unset" = "unset";
+    const r = reconcileVscode(true, {
+      install: () =>
+        vscodeResult({
+          action: "installed",
+          codeCommand: "C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd",
+        }),
+      ensureArgv: (o): ProposedApiResult => {
+        seen = o?.codeCommand;
+        return { status: "enabled", argvPath: "/fake/argv.json" };
+      },
+    });
+    expect(seen).toBe("C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd");
+    expect(r.proposedApi).toBe("enabled");
+  });
+
+  test("the resolved code CLI is threaded into the report-only argv step", () => {
+    let seen: string | undefined | "unset" = "unset";
+    reconcileVscode(false, {
+      check: () => vscodeResult({ action: "current", codeCommand: "code-insiders" }),
+      checkArgv: (o): ProposedApiResult => {
+        seen = o?.codeCommand;
+        return { status: "current", argvPath: "/fake/argv.json" };
+      },
+    });
+    expect(seen).toBe("code-insiders");
+  });
+
+  test("no resolved CLI ⇒ no override, so the default (stable) argv.json applies", () => {
+    let seen: string | undefined | "unset" = "unset";
+    reconcileVscode(true, {
+      install: () => vscodeResult({ action: "installed" }), // no codeCommand
+      ensureArgv: (o): ProposedApiResult => {
+        seen = o?.codeCommand;
+        return { status: "enabled", argvPath: "/fake/argv.json" };
+      },
+    });
+    expect(seen).toBeUndefined();
+  });
 });

--- a/tests/connectors-acp-vscodeArgv.test.ts
+++ b/tests/connectors-acp-vscodeArgv.test.ts
@@ -1,0 +1,226 @@
+/**
+ * `~/.vscode/argv.json` proposed-API allow-list — pure, no real VS Code, no
+ * real `$HOME`, nothing written outside an in-memory fake fs.
+ *
+ * The file under test is the data-loss-sensitive one: argv.json ships from VS
+ * Code full of comments and carries the user's `crash-reporter-id`. Losing it
+ * is worse than never enabling the proposed APIs at all, so the abort-on-
+ * unparseable path and the comment/key preservation paths get first-class
+ * coverage — the same guarantees installZed.ts makes for settings.json.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parse } from "jsonc-parser";
+
+import {
+  checkProposedApi,
+  defaultVscodeArgvPath,
+  ENABLE_PROPOSED_API_KEY,
+  ensureProposedApi,
+  planProposedApi,
+  type ArgvDeps,
+} from "../src/connectors/acp/vscodeArgv.ts";
+
+const EXT = "phantomyard.phantombot-vscode";
+const ARGV = "/fake/home/.vscode/argv.json";
+
+/** In-memory fs seam. `undefined` initial contents ⇒ the file doesn't exist. */
+function makeDeps(initial?: string) {
+  const files = new Map<string, string>();
+  if (initial !== undefined) files.set(ARGV, initial);
+  const writes: string[] = [];
+  const deps: ArgvDeps = {
+    argvPath: ARGV,
+    read: (p) => files.get(p),
+    write: (p, contents) => {
+      writes.push(p);
+      files.set(p, contents);
+    },
+  };
+  return { deps, files, writes };
+}
+
+/** VS Code's stock argv.json, comments and all. */
+const STOCK = `// This configuration file allows you to pass permanent command line arguments to VS Code.
+//
+// PLEASE DO NOT CHANGE WITHOUT UNDERSTANDING THE IMPACT
+{
+	// Allows to disable crash reporting.
+	"enable-crash-reporter": true,
+
+	// Unique id used for correlating crash reports sent from this instance.
+	// Do not edit this value.
+	"crash-reporter-id": "71e7281d-a073-4285-8a37-7581b7168042"
+}`;
+
+describe("defaultVscodeArgvPath", () => {
+  test("is <home>/.vscode/argv.json — no APPDATA/XDG branch", () => {
+    // Unlike settings.json, VS Code derives argv.json from os.homedir() on
+    // every platform. Getting this wrong = writing a file VS Code never reads.
+    const p = defaultVscodeArgvPath();
+    expect(p.endsWith("argv.json")).toBe(true);
+    expect(p.includes(".vscode")).toBe(true);
+  });
+});
+
+describe("planProposedApi", () => {
+  test("absent file ⇒ create one carrying only our key", () => {
+    const plan = planProposedApi(undefined, EXT);
+    expect(plan.kind).toBe("write");
+    if (plan.kind !== "write") throw new Error("unreachable");
+    expect(parse(plan.updated)[ENABLE_PROPOSED_API_KEY]).toEqual([EXT]);
+    // Explains itself to whoever opens the file next.
+    expect(plan.updated).toContain("phantombot");
+  });
+
+  test("id already present ⇒ current, so startup never churns a backup", () => {
+    const existing = `{"${ENABLE_PROPOSED_API_KEY}": ["${EXT}"]}`;
+    expect(planProposedApi(existing, EXT).kind).toBe("current");
+  });
+
+  test("unparseable ⇒ abort; NEVER overwrite the user's file", () => {
+    expect(planProposedApi("{ this is not json", EXT).kind).toBe("unparseable");
+  });
+
+  test("stock argv.json ⇒ merge, preserving comments and every other key", () => {
+    const plan = planProposedApi(STOCK, EXT);
+    expect(plan.kind).toBe("write");
+    if (plan.kind !== "write") throw new Error("unreachable");
+
+    const parsed = parse(plan.updated);
+    expect(parsed[ENABLE_PROPOSED_API_KEY]).toEqual([EXT]);
+    // The precious bits survive verbatim.
+    expect(parsed["crash-reporter-id"]).toBe(
+      "71e7281d-a073-4285-8a37-7581b7168042",
+    );
+    expect(parsed["enable-crash-reporter"]).toBe(true);
+    expect(plan.updated).toContain("PLEASE DO NOT CHANGE WITHOUT UNDERSTANDING");
+    expect(plan.updated).toContain("Do not edit this value.");
+  });
+
+  test("appends to an existing array — other extensions keep their access", () => {
+    const existing = `{"${ENABLE_PROPOSED_API_KEY}": ["someone.else"]}`;
+    const plan = planProposedApi(existing, EXT);
+    if (plan.kind !== "write") throw new Error("expected write");
+    expect(parse(plan.updated)[ENABLE_PROPOSED_API_KEY]).toEqual([
+      "someone.else",
+      EXT,
+    ]);
+  });
+
+  test("trailing commas are tolerated, not treated as corruption", () => {
+    const existing = `{\n  "enable-crash-reporter": true,\n}`;
+    const plan = planProposedApi(existing, EXT);
+    if (plan.kind !== "write") throw new Error("expected write");
+    expect(parse(plan.updated)[ENABLE_PROPOSED_API_KEY]).toEqual([EXT]);
+  });
+
+  test("a non-array value is replaced, not appended to", () => {
+    // Appending to a scalar would emit a file VS Code rejects outright, which
+    // is a worse outcome than dropping one malformed value.
+    const existing = `{"${ENABLE_PROPOSED_API_KEY}": "oops"}`;
+    const plan = planProposedApi(existing, EXT);
+    if (plan.kind !== "write") throw new Error("expected write");
+    expect(parse(plan.updated)[ENABLE_PROPOSED_API_KEY]).toEqual([EXT]);
+  });
+});
+
+describe("ensureProposedApi", () => {
+  test("writes the entry and backs the original up first", () => {
+    const { deps, files, writes } = makeDeps(STOCK);
+    const r = ensureProposedApi({ deps, extensionId: EXT });
+
+    expect(r.status).toBe("enabled");
+    expect(r.backupPath).toBe(`${ARGV}.phantombot-bak`);
+    // Backup written BEFORE the real file — order matters if we crash between.
+    expect(writes).toEqual([`${ARGV}.phantombot-bak`, ARGV]);
+    expect(files.get(`${ARGV}.phantombot-bak`)).toBe(STOCK);
+    expect(parse(files.get(ARGV)!)[ENABLE_PROPOSED_API_KEY]).toEqual([EXT]);
+  });
+
+  test("is idempotent — a second run writes nothing at all", () => {
+    const { deps } = makeDeps(STOCK);
+    ensureProposedApi({ deps, extensionId: EXT });
+    const { deps: d2, writes } = makeDeps(
+      `{"${ENABLE_PROPOSED_API_KEY}": ["${EXT}"]}`,
+    );
+    const r = ensureProposedApi({ deps: d2, extensionId: EXT });
+    expect(r.status).toBe("current");
+    expect(r.backupPath).toBeUndefined();
+    expect(writes).toEqual([]);
+  });
+
+  test("absent file ⇒ creates it, with no backup to make", () => {
+    const { deps, files, writes } = makeDeps();
+    const r = ensureProposedApi({ deps, extensionId: EXT });
+    expect(r.status).toBe("enabled");
+    expect(r.backupPath).toBeUndefined();
+    expect(writes).toEqual([ARGV]);
+    expect(parse(files.get(ARGV)!)[ENABLE_PROPOSED_API_KEY]).toEqual([EXT]);
+  });
+
+  test("unparseable ⇒ error, and the file is left byte-identical", () => {
+    const garbage = "{ not json at all";
+    const { deps, files, writes } = makeDeps(garbage);
+    const r = ensureProposedApi({ deps, extensionId: EXT });
+    expect(r.status).toBe("error");
+    expect(r.error).toContain("refusing to touch it");
+    expect(writes).toEqual([]);
+    expect(files.get(ARGV)).toBe(garbage);
+  });
+
+  test("a throwing fs never escapes — startup must survive a bad disk", () => {
+    const deps: ArgvDeps = {
+      argvPath: ARGV,
+      read: () => {
+        throw new Error("EACCES");
+      },
+      write: () => {},
+    };
+    const r = ensureProposedApi({ deps, extensionId: EXT });
+    expect(r.status).toBe("error");
+    expect(r.error).toBe("EACCES");
+  });
+
+  test("a throwing write never escapes either", () => {
+    const deps: ArgvDeps = {
+      argvPath: ARGV,
+      read: () => STOCK,
+      write: () => {
+        throw new Error("ENOSPC");
+      },
+    };
+    const r = ensureProposedApi({ deps, extensionId: EXT });
+    expect(r.status).toBe("error");
+    expect(r.error).toBe("ENOSPC");
+  });
+});
+
+describe("checkProposedApi (doctor --no-repair)", () => {
+  test("never writes, even when the entry is missing", () => {
+    const { deps, files, writes } = makeDeps(STOCK);
+    const r = checkProposedApi({ deps, extensionId: EXT });
+    expect(r.status).toBe("stale");
+    expect(writes).toEqual([]);
+    expect(files.get(ARGV)).toBe(STOCK);
+  });
+
+  test("never creates the file when it is absent", () => {
+    const { deps, files, writes } = makeDeps();
+    expect(checkProposedApi({ deps, extensionId: EXT }).status).toBe("stale");
+    expect(writes).toEqual([]);
+    expect(files.has(ARGV)).toBe(false);
+  });
+
+  test("reports current when already allow-listed", () => {
+    const { deps } = makeDeps(`{"${ENABLE_PROPOSED_API_KEY}": ["${EXT}"]}`);
+    expect(checkProposedApi({ deps, extensionId: EXT }).status).toBe("current");
+  });
+
+  test("reports error on an unparseable file", () => {
+    const { deps } = makeDeps("{ nope");
+    const r = checkProposedApi({ deps, extensionId: EXT });
+    expect(r.status).toBe("error");
+    expect(r.error).toContain("not parseable");
+  });
+});

--- a/tests/connectors-acp-vscodeArgv.test.ts
+++ b/tests/connectors-acp-vscodeArgv.test.ts
@@ -18,6 +18,7 @@ import {
   ENABLE_PROPOSED_API_KEY,
   ensureProposedApi,
   planProposedApi,
+  vscodeDataFolderName,
   type ArgvDeps,
 } from "../src/connectors/acp/vscodeArgv.ts";
 
@@ -53,13 +54,72 @@ const STOCK = `// This configuration file allows you to pass permanent command l
 	"crash-reporter-id": "71e7281d-a073-4285-8a37-7581b7168042"
 }`;
 
+/** Path segments, split on either separator, so `.vscode` can be matched EXACTLY. */
+function segments(p: string): string[] {
+  return p.split(/[\\/]/);
+}
+
 describe("defaultVscodeArgvPath", () => {
   test("is <home>/.vscode/argv.json — no APPDATA/XDG branch", () => {
     // Unlike settings.json, VS Code derives argv.json from os.homedir() on
     // every platform. Getting this wrong = writing a file VS Code never reads.
+    // Verified on the real Windows box: C:\Users\<user>\.vscode\argv.json,
+    // carrying VS Code's own header comments and crash-reporter-id.
     const p = defaultVscodeArgvPath();
     expect(p.endsWith("argv.json")).toBe(true);
-    expect(p.includes(".vscode")).toBe(true);
+    // Exact segment, not `includes(".vscode")` — that substring also matches
+    // `.vscode-insiders`, so the loose form would pass for the wrong folder.
+    expect(segments(p)).toContain(".vscode");
+  });
+});
+
+describe("vscodeDataFolderName", () => {
+  // Kai's review asked for Windows coverage. The value of these cases is that
+  // they run on LINUX CI: a node:path.basename() implementation passes on
+  // Windows and fails here — that asymmetry is how the phantombot.exe gate
+  // shipped in the first place.
+  test("stable resolves to .vscode on every platform and path shape", () => {
+    for (const cli of [
+      undefined,
+      "code",
+      "code.cmd",
+      "/usr/bin/code",
+      "/snap/bin/code",
+      "C:\\Program Files\\Microsoft VS Code\\bin\\code.cmd",
+      "C:\\Program Files (x86)\\Microsoft VS Code\\bin\\CODE.CMD",
+      "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+    ]) {
+      expect(vscodeDataFolderName(cli)).toBe(".vscode");
+    }
+  });
+
+  test("a Windows CLI path is split on backslashes, not swallowed whole", () => {
+    // The whole point: node:path.basename does NOT split `\` under POSIX.
+    expect(
+      vscodeDataFolderName(
+        "C:\\Program Files\\Microsoft VS Code Insiders\\bin\\code-insiders.cmd",
+      ),
+    ).toBe(".vscode-insiders");
+  });
+
+  test("distributions get their own data folder, never stable's", () => {
+    expect(vscodeDataFolderName("code-insiders")).toBe(".vscode-insiders");
+    expect(vscodeDataFolderName("/usr/bin/code-insiders")).toBe(".vscode-insiders");
+    expect(vscodeDataFolderName("codium")).toBe(".vscode-oss");
+    expect(vscodeDataFolderName("/usr/bin/vscodium")).toBe(".vscode-oss");
+  });
+
+  test("an unknown CLI falls back to stable rather than inventing a folder", () => {
+    expect(vscodeDataFolderName("cursor")).toBe(".vscode");
+    expect(vscodeDataFolderName("/opt/weird/editor.exe")).toBe(".vscode");
+  });
+
+  test("defaultVscodeArgvPath follows the derived folder", () => {
+    expect(segments(defaultVscodeArgvPath("code-insiders"))).toContain(
+      ".vscode-insiders",
+    );
+    expect(segments(defaultVscodeArgvPath("code-insiders"))).not.toContain(".vscode");
+    expect(segments(defaultVscodeArgvPath("codium"))).toContain(".vscode-oss");
   });
 });
 

--- a/tests/lib-binaryIdentity.test.ts
+++ b/tests/lib-binaryIdentity.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `isPhantombotBinary` — the gate that decides whether a phantombot process is
+ * allowed to touch the user's real filesystem (pi extension, editor
+ * connectors, systemd units, scheduled tasks).
+ *
+ * The bug this replaces was a silent, Windows-only failure-open: six call sites
+ * compared `basename(process.execPath) === "phantombot"`, which never holds on
+ * Windows because `execPath` ends in `.exe`. So the entire self-heal path never
+ * ran there, and left no trace in the logs. The negative cases below are the
+ * counterexamples that make the intent explicit — they matter more than the
+ * positive ones, because failing OPEN (returning false) is the failure mode
+ * that stays invisible, and failing CLOSED (returning true for `bun`) is the
+ * one that would write the dev box's config during `bun test`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { isPhantombotBinary } from "../src/lib/binaryIdentity.ts";
+
+describe("isPhantombotBinary", () => {
+  test("accepts the installed POSIX binary", () => {
+    expect(isPhantombotBinary("/usr/local/bin/phantombot")).toBe(true);
+    expect(isPhantombotBinary("phantombot")).toBe(true);
+  });
+
+  test("accepts the installed Windows binary — the regression this fixes", () => {
+    expect(
+      isPhantombotBinary(
+        "C:\\Users\\aghodgespwa\\AppData\\Local\\Programs\\phantombot\\phantombot.exe",
+      ),
+    ).toBe(true);
+  });
+
+  test("is case-insensitive, because Windows filesystems are", () => {
+    expect(isPhantombotBinary("C:\\bin\\Phantombot.EXE")).toBe(true);
+    expect(isPhantombotBinary("/usr/bin/PhantomBot")).toBe(true);
+  });
+
+  test("rejects generic runtimes — dev and `bun test` must stay inert", () => {
+    expect(isPhantombotBinary("/home/andrew/.bun/bin/bun")).toBe(false);
+    expect(isPhantombotBinary("/usr/bin/node")).toBe(false);
+    expect(isPhantombotBinary("C:\\Program Files\\nodejs\\node.exe")).toBe(false);
+    expect(isPhantombotBinary("C:\\bun\\bun.exe")).toBe(false);
+  });
+
+  test("rejects the self-update leftover — `.old` must not rewrite config", () => {
+    // A `startsWith("phantombot")` gate (the other spelling that existed in the
+    // tree) wrongly accepts this. The `.old` binary is the PREVIOUS version,
+    // moved aside because a running .exe can't be deleted; if it ever executes
+    // it must not re-register editors or rewrite scheduled tasks.
+    expect(isPhantombotBinary("C:\\pb\\phantombot.exe.old")).toBe(false);
+  });
+
+  test("rejects the release download artifact", () => {
+    // Also wrongly accepted by `startsWith("phantombot")`. This is the file the
+    // updater fetches; it is not an installed binary.
+    expect(isPhantombotBinary("C:\\tmp\\phantombot-v1.1.194-windows-x64.exe")).toBe(
+      false,
+    );
+    expect(isPhantombotBinary("/tmp/phantombot-v1.1.194-linux-x64")).toBe(false);
+  });
+
+  test("rejects lookalikes that merely contain the name", () => {
+    expect(isPhantombotBinary("/usr/bin/phantombot-shim")).toBe(false);
+    expect(isPhantombotBinary("/usr/bin/notphantombot")).toBe(false);
+    expect(isPhantombotBinary("/opt/phantombot/bin/runner")).toBe(false);
+  });
+
+  test("defaults to the live process — inert under `bun test`", () => {
+    // The suite itself runs under `bun`, so the production default MUST be
+    // false here. If this ever flips, `bun test` starts writing ~/.config/zed.
+    expect(isPhantombotBinary()).toBe(false);
+  });
+});


### PR DESCRIPTION
Megan's VS Code ACP extension isn't working on Windows. It isn't the extension — **phantombot never even tried to install it.**

## 1. The binary gate was never true on Windows

Six call sites asked *"am I the real compiled binary?"* like this:

```ts
if (basename(process.execPath) === "phantombot") { … }
```

On Windows `execPath` is `phantombot.exe`. The gate is **never true**. Everything behind it silently never ran:

- the pi capability-routing extension was never provisioned
- editor connectors (Zed, JetBrains, **VS Code**) were never registered
- `doctor` quietly omitted its harness / timers / pi-extension / editor sections

It failed **open and quiet** — the code just didn't execute, so there was nothing in the logs to find. Live A/B, same command both boxes:

| `doctor --no-repair` | Linux | Megan (Windows) |
|---|---|---|
| nightly / capture / embeddings / repair | ✅ | ✅ |
| harnesses, timers, pi extension, editor ×3 | ✅ | **absent** |

The tell was in `run.ts` itself: one site (line 321) already used `.startsWith("phantombot")`. Someone fixed exactly one during #277 and left the rest — so the tree carried two spellings that disagreed. `startsWith` is also too loose: it matches `phantombot.exe.old` (the self-update leftover) and `phantombot-v1.1.194-windows-x64.exe` (the release download), neither of which has any business rewriting the user's editor config or scheduled tasks.

**Fix:** one leaf helper, `src/lib/binaryIdentity.ts::isPhantombotBinary()`, used at all nine sites.

It splits on **both** path separators instead of using `node:path`'s host-bound `basename` — on Linux, `basename("C:\\pb\\x.exe")` returns the whole string, which would make the Windows behaviour untestable from CI. An untestable platform gate is precisely how this bug shipped and survived.

**Strictly additive on Linux/macOS.** `phantombot` matches exactly as before; `bun`/`node` still don't, so `bun test` stays inert and never writes the dev box's `~/.pi` or `~/.config/zed`. The systemd/launchd/heartbeat sites are POSIX-only paths where behaviour is unchanged — they're rewired to the helper only so the spelling can't drift again.

## 2. …and even once installed, it would run degraded

`editors/vscode/package.json` declares `enabledApiProposals: [chatSessionsProvider, chatParticipantPrivate, chatReferenceBinaryData]`. Stable VS Code withholds proposed APIs from a **side-loaded** extension (ours ships as a bundled `.vsix`, never from the marketplace) unless its id is listed in `enable-proposed-api` in `~/.vscode/argv.json`.

**Nothing in the repo ever wrote that file.** Andrew's Linux box has the entry because he added it by hand; Megan's doesn't. Without it the extension loads but falls back to the `@phantombot` chat participant instead of a native chat session — and that fallback is *deliberate* (`sessionProvider.ts:101`), which is exactly what makes it so hard to spot. It looks half-working, not broken.

New `src/connectors/acp/vscodeArgv.ts` merges the id in idempotently:

- `argv.json` is **JSONC** (ships full of comments) and carries the user's `crash-reporter-id`, so it gets installZed's data-loss-proof procedure: parse with `jsonc-parser`, **ABORT and write nothing** if unparseable, surgical `modify`/`applyEdits`, backup, atomic temp+rename.
- It lives at `<home>/.vscode/argv.json` on **every** platform — unlike settings.json there's no `%APPDATA%` branch and no XDG lookup. Getting that wrong means writing a file VS Code never reads.
- **Gated on VS Code actually being detected.** If `code` isn't on the box, or the extension install failed, we don't go creating `~/.vscode/argv.json` for an editor the user may not have — the same "never provision what wasn't asked for" rule the settings-model editors enforce via `detectionDir`.
- Tab-indented, matching VS Code's own style, so the diff is the key we added and nothing else.

Surfaced on its own axis in `doctor` and the startup log, and `editorConnectorBroken()` now counts a missing allow-list — an installed-but-degraded extension must not print a green tick.

## Verification

**Against real data, not fixtures.** Pulled Megan's actual `argv.json` and ran the real merge on it:

```diff
-	"crash-reporter-id": "4dc26a49-8998-4606-841d-b3a139e1b549"
+	"crash-reporter-id": "4dc26a49-8998-4606-841d-b3a139e1b549",
+	"enable-proposed-api": [
+		"phantomyard.phantombot-vscode"
+	]
```

One comma, one key. Comments, tabs and `crash-reporter-id` intact.

**On Andrew's Linux box** (read-only path, `checkProposedApi` never writes): `action: current`, `proposedApi: current` → **zero writes**. The no-op it should be.

**Mutation-tested rather than trusting green.** Each fix reverted in turn:

| mutation | tests that fail |
|---|---|
| helper forgets `.exe` (the original bug) | 2 |
| drop the not-detected gate → would create `~/.vscode` anywhere | 2 |
| `editorConnectorBroken` ignores `proposedApi` | 2 |
| unparseable `argv.json` → "start fresh" (data loss) | 3 |

34 new tests. `tsc` clean, **2144 pass**, same 2 pre-existing vault-key env failures — confirmed failing identically on a clean `origin/main` worktree.

## What I have NOT proven

- **Not verified end-to-end on Windows.** Proving the extension actually appears in Megan's VS Code needs a `build:win` + daemon swap, which bounces her. The gate logic and the argv.json merge are both proven against her real data; the install itself is not.
- `code.cmd` resolves fine on her box (both candidate paths exist, `--list-extensions` answers), so the resolver isn't the blocker — but that was checked before this change, not after.
- `VSCODE_EDITOR.reconcile()` still calls the real `code` CLI and the real `~/.vscode` when invoked with default deps. No test does, and `isPhantombotBinary()` is false under `bun test`, so it stays inert — but the hazard predates this PR and I've only added a `reconcileVscode(repair, hooks)` seam rather than removing it.