### PR TITLE
feat(cli): built-in shell tab-completion, set up on install/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,18 @@ Maintenance:
 | `phantombot nightly [--resume]` | Run or resume memory distillation |
 | `phantombot doctor [--no-repair]` | Check memory health and optionally repair |
 
+## Shell completion
+
+`phantombot install` sets up `<TAB>` completion for `bash`, `zsh`, and `fish`
+automatically — no extra command, no separate opt-in. `phantombot update`
+refreshes it, and `phantombot uninstall` removes it. Open a new shell after
+installing to pick it up.
+
+Completion is dynamic: a small stub in your shell calls back into the binary on
+every `<TAB>`, so it always matches the available subcommands and flags —
+`phantombot p<TAB>` → `persona`, `phantomchat`, `p2p`; `phantombot p2p <TAB>` →
+`status`; `phantombot logs --<TAB>` → `--follow`, `--no-follow`, `--lines`.
+
 ## Telegram
 
 Phantombot runs one or more Telegram long-poll listeners. Each listener needs a

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -15,6 +15,8 @@
 import { defineCommand } from "citty";
 import { basename } from "node:path";
 
+import { installCompletions } from "../lib/completionInstall.ts";
+
 import {
   BunLaunchctlRunner,
   defaultPlistPath,
@@ -250,6 +252,18 @@ export default defineCommand({
   },
   async run() {
     const code = await runInstall();
+    // A successful install wires up shell tab-completion so it works right
+    // away, with no extra step. Best-effort: a completion failure never turns
+    // a successful install into a failure.
+    if (code === 0) {
+      try {
+        await installCompletions();
+      } catch (e) {
+        process.stderr.write(
+          `warning: could not set up shell completion: ${(e as Error).message}\n`,
+        );
+      }
+    }
     process.exitCode = code;
   },
 });

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -10,6 +10,7 @@
 
 import { defineCommand } from "citty";
 
+import { uninstallCompletions } from "../lib/completionInstall.ts";
 import {
   BunLaunchctlRunner,
   defaultPlistPath,
@@ -148,6 +149,13 @@ export default defineCommand({
   },
   async run() {
     const code = await runUninstall();
+    // Remove the shell tab-completion that `install` set up. Best-effort;
+    // leftover stubs are harmless, so a failure never fails the uninstall.
+    try {
+      await uninstallCompletions();
+    } catch {
+      // ignore
+    }
     process.exitCode = code;
   },
 });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -25,6 +25,7 @@ import {
   checkWritable,
   downloadAndVerify,
 } from "../lib/binaryUpdate.ts";
+import { installCompletions } from "../lib/completionInstall.ts";
 import {
   detectSupportedTarget,
   findLatestRelease,
@@ -80,6 +81,11 @@ export interface RunUpdateInput {
   healSystemdUnits?:
     | false
     | ((binPath: string) => Promise<EnsureUnitsCurrentResult | null>);
+  /**
+   * Override, or disable with `false`, the shell-completion refresh that runs
+   * after a successful binary swap. Defaults to installCompletions.
+   */
+  refreshCompletions?: false | ((opts: { out: WriteSink }) => Promise<unknown>);
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -225,6 +231,20 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
           `run 'phantombot install' manually if scheduled tasks stop firing.\n`,
       );
       // Non-fatal — fall through to restart handling.
+    }
+  }
+
+  // 7.6. Refresh shell tab-completion for the freshly-installed binary. This
+  // runs only after a real swap (never on --check or an up-to-date exit), so it
+  // also back-fills completion for anyone who installed an older build.
+  // Best-effort and non-fatal.
+  if (input.refreshCompletions !== false) {
+    try {
+      await (input.refreshCompletions ?? installCompletions)({ out });
+    } catch (e) {
+      err.write(
+        `warning: could not refresh shell completion: ${(e as Error).message}\n`,
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,22 @@ import { runMain } from "citty";
 import { mainCommand } from "./cli/index.ts";
 import { loadConfig, personaDir } from "./config.ts";
 import { isReadOnlyInvocation } from "./lib/cliInvocation.ts";
+import { runComplete } from "./lib/completion.ts";
 import { preloadEnvFiles } from "./lib/envBootstrap.ts";
 import { log } from "./lib/logger.ts";
 import { loadVaultIntoEnv } from "./lib/vault.ts";
 import { migratePlaintextToVault } from "./lib/vaultMigrate.ts";
+
+// Hidden dynamic-completion backend. The shell stubs emitted by
+// `phantombot completion <shell>` call `phantombot _complete -- <words…>` on
+// every <TAB>. Handle it here, before the credential bootstrap, so a tab press
+// is as cheap and side-effect-free as --help and never touches the vault. It is
+// intentionally not a Citty subcommand, so it stays out of --help output.
+if (process.argv[2] === "_complete") {
+  const candidates = await runComplete(mainCommand, process.argv.slice(3));
+  if (candidates.length > 0) process.stdout.write(candidates.join("\n") + "\n");
+  process.exit(0);
+}
 
 // Skip the credential bootstrap entirely for read-only invocations
 // (--help/--version/bare) so they never mutate disk or provision a persona —

--- a/src/lib/cliInvocation.ts
+++ b/src/lib/cliInvocation.ts
@@ -10,9 +10,10 @@
 /**
  * True when the invocation is a read-only one that must not touch disk or
  * provision any state: `--help`/`-h`, `--version`/`-v`, the `help` subcommand,
- * or a bare call with no subcommand (which just prints usage). CI uses
- * `--help`/`--version` as "does the binary run?" smoke tests, so these must be
- * pure — no vault migration, no persona creation.
+ * the hidden `_complete` tab-completion backend, or a bare call with no
+ * subcommand (which just prints usage). CI uses `--help`/`--version` as "does
+ * the binary run?" smoke tests, and every <TAB> spawns `_complete`, so these
+ * must be pure — no vault migration, no persona creation.
  *
  * @param argv the full `process.argv` (element 0 = runtime, 1 = script).
  */
@@ -25,6 +26,7 @@ export function isReadOnlyInvocation(argv: string[]): boolean {
     first === "-h" ||
     first === "--version" ||
     first === "-v" ||
-    first === "help"
+    first === "help" ||
+    first === "_complete"
   );
 }

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -1,0 +1,175 @@
+/**
+ * Shell tab-completion engine for the phantombot CLI.
+ *
+ * Completion is dynamic: the per-shell stub scripts (see completionScript) are
+ * tiny and, on every <TAB>, call back into a hidden `phantombot _complete --
+ * <words…>` command. That command walks the live Citty command tree
+ * (mainCommand) via computeCompletions and prints one candidate per line, so
+ * the completion always matches the actual subcommands and flags.
+ *
+ * `_complete` is intercepted in src/index.ts before the credential bootstrap so
+ * a tab press never touches the vault or provisions a persona, and it is not
+ * registered as a Citty subcommand, so it stays out of `--help` output.
+ */
+
+import type { ArgsDef, CommandDef, Resolvable, SubCommandsDef } from "citty";
+
+/**
+ * Unwrap a Citty `Resolvable<T>` (a plain value, a Promise, or a
+ * zero-arg (async) function) into its concrete value.
+ */
+export async function resolve<T>(x: Resolvable<T> | undefined): Promise<T | undefined> {
+  if (typeof x === "function") return await (x as () => T | Promise<T>)();
+  return await (x as T | Promise<T> | undefined);
+}
+
+/**
+ * Compute completion candidates for a partially-typed command line.
+ *
+ * @param root    the top-level command tree (mainCommand).
+ * @param tokens  every whitespace-separated word AFTER the program name, up to
+ *                and including the word under the cursor. The LAST element is
+ *                the partial word being completed and may be the empty string
+ *                (e.g. when the cursor sits after a trailing space).
+ * @returns       candidate completions, prefix-filtered against the partial
+ *                word and de-duplicated, in a stable order.
+ */
+export async function computeCompletions(
+  root: CommandDef,
+  tokens: string[],
+): Promise<string[]> {
+  const current = tokens[tokens.length - 1] ?? "";
+  const completed = tokens.slice(0, Math.max(0, tokens.length - 1));
+
+  // Descend into subcommands following only the leading, non-flag words. The
+  // first word that is neither a flag nor a known subcommand is a positional
+  // argument of the current node, so descent stops there.
+  let node: CommandDef = root;
+  for (const word of completed) {
+    if (word.startsWith("-")) continue; // flags never select a subcommand
+    const subs = (await resolve(node.subCommands)) as SubCommandsDef | undefined;
+    if (subs && Object.prototype.hasOwnProperty.call(subs, word)) {
+      node = ((await resolve(subs[word])) as CommandDef) ?? node;
+    } else {
+      break;
+    }
+  }
+
+  const subs = (await resolve(node.subCommands)) as SubCommandsDef | undefined;
+  const argsDef = (await resolve(node.args)) as ArgsDef | undefined;
+
+  const flagCandidates: string[] = [];
+  if (argsDef) {
+    for (const [name, def] of Object.entries(argsDef)) {
+      if (def.type === "positional") continue;
+      flagCandidates.push(`--${name}`);
+      if (def.type === "boolean") flagCandidates.push(`--no-${name}`);
+      // `alias` is absent from PositionalArgDef, so read it off a widened view.
+      const alias = (def as { alias?: string | string[] }).alias;
+      const aliases = Array.isArray(alias) ? alias : alias ? [alias] : [];
+      for (const a of aliases) flagCandidates.push(a.length === 1 ? `-${a}` : `--${a}`);
+    }
+  }
+  // Citty injects --help everywhere; --version only exists on the root command.
+  flagCandidates.push("--help");
+  if (node === root) flagCandidates.push("--version");
+
+  const subCandidates = subs ? Object.keys(subs) : [];
+
+  // When the user is typing a flag, only offer flags. Otherwise offer
+  // subcommands if this node has any, else fall back to its flags so a leaf
+  // command still completes something useful on an empty <TAB>.
+  const pool = current.startsWith("-")
+    ? flagCandidates
+    : subCandidates.length
+      ? subCandidates
+      : flagCandidates;
+
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const c of pool) {
+    if (c.startsWith(current) && !seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract the completion word list from a raw `_complete` argv and compute the
+ * candidates. The shell stubs always invoke `phantombot _complete -- <words…>`,
+ * so everything after the first `--` is the verbatim word list (using `--`
+ * keeps half-typed flags like `--foo` out of Citty's own arg parser).
+ */
+export async function runComplete(root: CommandDef, argv: string[]): Promise<string[]> {
+  const dashIndex = argv.indexOf("--");
+  const tokens = dashIndex >= 0 ? argv.slice(dashIndex + 1) : argv;
+  return computeCompletions(root, tokens);
+}
+
+export type CompletionShell = "bash" | "zsh" | "fish";
+
+export const COMPLETION_SHELLS: readonly CompletionShell[] = ["bash", "zsh", "fish"];
+
+export function isCompletionShell(value: string): value is CompletionShell {
+  return (COMPLETION_SHELLS as readonly string[]).includes(value);
+}
+
+/**
+ * Return the shell script that wires <TAB> to the dynamic `_complete` backend.
+ * `install` writes this to the user's shell (see completionInstall).
+ */
+export function completionScript(shell: CompletionShell, program = "phantombot"): string {
+  switch (shell) {
+    case "bash":
+      return bashScript(program);
+    case "zsh":
+      return zshScript(program);
+    case "fish":
+      return fishScript(program);
+  }
+}
+
+function bashScript(program: string): string {
+  return `# ${program} bash completion (installed by \`${program} install\`)
+_${program}_complete() {
+  local cword="\${COMP_CWORD}"
+  local cur="\${COMP_WORDS[cword]}"
+  local tokens=("\${COMP_WORDS[@]:1:cword}")
+  local reply
+  reply="$(${program} _complete -- "\${tokens[@]}" 2>/dev/null)"
+  local IFS=$'\\n'
+  COMPREPLY=($(compgen -W "\${reply}" -- "\${cur}"))
+}
+complete -F _${program}_complete ${program}
+`;
+}
+
+function zshScript(program: string): string {
+  return `#compdef ${program}
+# ${program} zsh completion (installed by \`${program} install\`)
+_${program}() {
+  local -a reply
+  local -a tokens
+  tokens=("\${(@)words[2,$CURRENT]}")
+  local raw
+  raw="$(${program} _complete -- "\${tokens[@]}" 2>/dev/null)"
+  [[ -n "$raw" ]] && reply=("\${(@f)raw}")
+  compadd -- "\${reply[@]}"
+}
+compdef _${program} ${program}
+`;
+}
+
+function fishScript(program: string): string {
+  return `# ${program} fish completion (installed by \`${program} install\`)
+function __${program}_complete
+    set -l tokens (commandline -opc)
+    set -e tokens[1]
+    set -l current (commandline -ct)
+    ${program} _complete -- $tokens "$current" 2>/dev/null
+end
+complete -c ${program} -f -a '(__${program}_complete)'
+`;
+}

--- a/src/lib/completionInstall.ts
+++ b/src/lib/completionInstall.ts
@@ -1,0 +1,244 @@
+/**
+ * Zero-touch installation of the shell tab-completion into the user's shells.
+ *
+ * `phantombot install` and `phantombot update` call `installCompletions()` so
+ * completion "just works" after either, with no extra command to run and no
+ * separate opt-in. `phantombot uninstall` calls `uninstallCompletions()` to
+ * undo it cleanly.
+ *
+ * Strategy per shell — chosen so it works WITHOUT depending on the
+ * bash-completion package being present or `$fpath` being pre-configured, and
+ * without spawning a subprocess on every shell startup:
+ *
+ *   bash / zsh  The stub script (completionScript) is written under
+ *               ~/.config/phantombot/completions/, and a small guarded block is
+ *               appended to ~/.bashrc / ~/.zshrc that sources it. The block is
+ *               delimited by BEGIN/END markers so it is idempotent (re-run
+ *               replaces it) and removable on uninstall.
+ *   fish        The stub is written straight to
+ *               ~/.config/fish/completions/phantombot.fish, which fish
+ *               auto-loads — no rc edit needed.
+ *
+ * On every <TAB> the stub still calls the dynamic `phantombot _complete`
+ * backend, so the completion never drifts from the real command surface.
+ *
+ * POSIX only. On Windows this is a no-op (PowerShell completion is a separate
+ * mechanism); callers get an empty result and print nothing.
+ */
+
+import { readFile, rm, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+
+import { xdgConfigHome } from "../config.ts";
+import { completionScript, type CompletionShell } from "./completion.ts";
+import { writeFileAtomic, type WriteSink } from "./io.ts";
+
+const BLOCK_BEGIN = "# >>> phantombot completion >>>";
+const BLOCK_END = "# <<< phantombot completion <<<";
+
+export interface CompletionInstallOptions {
+  /** Home directory. Defaults to os.homedir(). Tests override. */
+  home?: string;
+  /** XDG config home. Defaults to xdgConfigHome(). Tests override. */
+  configHome?: string;
+  /** The user's login shell path ($SHELL). Defaults to process.env.SHELL. */
+  shell?: string;
+  /** Host platform. Defaults to process.platform. */
+  platform?: NodeJS.Platform;
+  /** Message sink. Defaults to process.stdout. */
+  out?: WriteSink;
+}
+
+/** Absolute paths this module reads and writes, resolved from the options. */
+interface Paths {
+  home: string;
+  bashrc: string;
+  zshrc: string;
+  bashStub: string;
+  zshStub: string;
+  fishCompletion: string;
+}
+
+function resolvePaths(opts: CompletionInstallOptions): Paths {
+  const home = opts.home ?? homedir();
+  const configHome = opts.configHome ?? xdgConfigHome();
+  const stubDir = join(configHome, "phantombot", "completions");
+  return {
+    home,
+    bashrc: join(home, ".bashrc"),
+    zshrc: join(process.env.ZDOTDIR || home, ".zshrc"),
+    bashStub: join(stubDir, "phantombot.bash"),
+    zshStub: join(stubDir, "phantombot.zsh"),
+    fishCompletion: join(configHome, "fish", "completions", "phantombot.fish"),
+  };
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readOrEmpty(p: string): Promise<string> {
+  try {
+    return await readFile(p, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Insert or replace the phantombot block in an rc file's text. Idempotent: a
+ * second call with the same body is a no-op; a changed body replaces the old
+ * block in place. Returns the new file text.
+ */
+export function upsertBlock(existing: string, body: string): string {
+  const block = `${BLOCK_BEGIN}\n${body}\n${BLOCK_END}`;
+  const begin = existing.indexOf(BLOCK_BEGIN);
+  const end = existing.indexOf(BLOCK_END);
+  if (begin !== -1 && end !== -1 && end > begin) {
+    const before = existing.slice(0, begin);
+    const after = existing.slice(end + BLOCK_END.length);
+    return `${before}${block}${after}`;
+  }
+  const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+  const lead = existing.length === 0 ? "" : "\n";
+  return `${existing}${sep}${lead}${block}\n`;
+}
+
+/** Remove the phantombot block from an rc file's text. Returns the new text. */
+export function removeBlock(existing: string): string {
+  const begin = existing.indexOf(BLOCK_BEGIN);
+  const end = existing.indexOf(BLOCK_END);
+  if (begin === -1 || end === -1 || end < begin) return existing;
+  let after = existing.slice(end + BLOCK_END.length);
+  if (after.startsWith("\n")) after = after.slice(1);
+  let before = existing.slice(0, begin);
+  // Also drop the blank line we inserted before the block, if present.
+  if (before.endsWith("\n\n")) before = before.slice(0, -1);
+  return `${before}${after}`;
+}
+
+function bashSourceBody(stub: string): string {
+  return `[ -f "${stub}" ] && . "${stub}"`;
+}
+
+function zshSourceBody(stub: string): string {
+  // compinit must run before the stub's `compdef` call; do it defensively
+  // (a second compinit is cheap and harmless) so completion works even when
+  // the user's .zshrc never sets up the completion system itself.
+  return (
+    `if [ -f "${stub}" ]; then\n` +
+    `  autoload -Uz compinit && compinit -u 2>/dev/null\n` +
+    `  source "${stub}"\n` +
+    `fi`
+  );
+}
+
+/**
+ * Decide which shells to set up: any shell whose rc/config already exists, plus
+ * the user's current login shell (so a fresh box still gets its own shell wired
+ * up even before that rc file exists).
+ */
+async function targetShells(
+  paths: Paths,
+  configHome: string,
+  loginShell: string,
+): Promise<Set<CompletionShell>> {
+  const current = basename(loginShell || "");
+  const shells = new Set<CompletionShell>();
+  if ((await pathExists(paths.bashrc)) || current === "bash") shells.add("bash");
+  if ((await pathExists(paths.zshrc)) || current === "zsh") shells.add("zsh");
+  if ((await pathExists(join(configHome, "fish"))) || current === "fish")
+    shells.add("fish");
+  return shells;
+}
+
+/**
+ * Install shell completion for the user's shells. Best-effort per shell: a
+ * failure on one shell is reported but never throws. Returns the list of shells
+ * successfully wired up.
+ */
+export async function installCompletions(
+  opts: CompletionInstallOptions = {},
+): Promise<{ installed: CompletionShell[] }> {
+  const platform = opts.platform ?? process.platform;
+  if (platform !== "linux" && platform !== "darwin") return { installed: [] };
+
+  const out = opts.out ?? process.stdout;
+  const configHome = opts.configHome ?? xdgConfigHome();
+  const paths = resolvePaths(opts);
+  const shells = await targetShells(
+    paths,
+    configHome,
+    opts.shell ?? process.env.SHELL ?? "",
+  );
+
+  const installed: CompletionShell[] = [];
+  for (const shell of shells) {
+    try {
+      if (shell === "bash") {
+        await writeFileAtomic(paths.bashStub, completionScript("bash"));
+        const next = upsertBlock(
+          await readOrEmpty(paths.bashrc),
+          bashSourceBody(paths.bashStub),
+        );
+        await writeFileAtomic(paths.bashrc, next);
+      } else if (shell === "zsh") {
+        await writeFileAtomic(paths.zshStub, completionScript("zsh"));
+        const next = upsertBlock(
+          await readOrEmpty(paths.zshrc),
+          zshSourceBody(paths.zshStub),
+        );
+        await writeFileAtomic(paths.zshrc, next);
+      } else {
+        await writeFileAtomic(paths.fishCompletion, completionScript("fish"));
+      }
+      installed.push(shell);
+    } catch (e) {
+      out.write(
+        `warning: could not install ${shell} completion: ${(e as Error).message}\n`,
+      );
+    }
+  }
+
+  if (installed.length > 0) {
+    out.write(
+      `installed shell completion: ${installed.join(", ")} ` +
+        `(open a new shell to activate)\n`,
+    );
+  }
+  return { installed };
+}
+
+/**
+ * Remove everything installCompletions() wrote: the stub files, the fish
+ * completion, and the guarded blocks from the rc files. Best-effort; never
+ * throws.
+ */
+export async function uninstallCompletions(
+  opts: CompletionInstallOptions = {},
+): Promise<void> {
+  const platform = opts.platform ?? process.platform;
+  if (platform !== "linux" && platform !== "darwin") return;
+
+  const paths = resolvePaths(opts);
+
+  for (const stub of [paths.bashStub, paths.zshStub, paths.fishCompletion]) {
+    await rm(stub, { force: true }).catch(() => {});
+  }
+
+  for (const rc of [paths.bashrc, paths.zshrc]) {
+    try {
+      const existing = await readFile(rc, "utf8");
+      const next = removeBlock(existing);
+      if (next !== existing) await writeFileAtomic(rc, next);
+    } catch {
+      // rc file absent or unreadable — nothing to clean.
+    }
+  }
+}

--- a/tests/cli-completion.test.ts
+++ b/tests/cli-completion.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the dynamic shell tab-completion engine (src/lib/completion.ts)
+ * and the `phantombot completion` script emitter (src/cli/completion.ts).
+ *
+ * The engine walks the LIVE Citty command tree, so these tests drive it against
+ * `mainCommand` itself — they assert real subcommands/flags come back, which
+ * doubles as a guard that the tree is walkable (Resolvable args/subCommands).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { mainCommand } from "../src/cli/index.ts";
+import {
+  COMPLETION_SHELLS,
+  completionScript,
+  computeCompletions,
+  isCompletionShell,
+  runComplete,
+} from "../src/lib/completion.ts";
+
+const complete = (tokens: string[]) => computeCompletions(mainCommand, tokens);
+
+describe("computeCompletions — subcommand completion", () => {
+  test("empty token offers the top-level subcommands", async () => {
+    const out = await complete([""]);
+    expect(out).toContain("run");
+    expect(out).toContain("install");
+    expect(out).toContain("p2p");
+    // The hidden backend is not a registered subcommand, so never suggested.
+    expect(out).not.toContain("_complete");
+  });
+
+  test("a prefix filters the subcommand list", async () => {
+    const out = await complete(["p"]);
+    expect(out).toContain("p2p");
+    expect(out).toContain("persona");
+    expect(out).toContain("phantomchat");
+    expect(out.every((c) => c.startsWith("p"))).toBe(true);
+    expect(out).not.toContain("run");
+  });
+
+  test("descends into nested subcommands", async () => {
+    // `p2p` has a single `status` subcommand.
+    const out = await complete(["p2p", ""]);
+    expect(out).toEqual(["status"]);
+  });
+
+  test("nested subcommand honours a prefix", async () => {
+    expect(await complete(["p2p", "s"])).toEqual(["status"]);
+    expect(await complete(["p2p", "x"])).toEqual([]);
+  });
+});
+
+describe("computeCompletions — flag completion", () => {
+  test("a leading dash offers the command's flags plus --help", async () => {
+    const out = await complete(["logs", "-"]);
+    expect(out).toContain("--follow");
+    expect(out).toContain("--no-follow"); // boolean args expose a --no- form
+    expect(out).toContain("--lines");
+    expect(out).toContain("--help");
+  });
+
+  test("--no- form is only offered for boolean args", async () => {
+    const out = await complete(["logs", "--no-"]);
+    expect(out).toContain("--no-follow");
+    expect(out).not.toContain("--no-lines"); // string arg
+  });
+
+  test("root offers --version, subcommands do not", async () => {
+    expect(await complete(["--"])).toContain("--version");
+    expect(await complete(["logs", "--"])).not.toContain("--version");
+  });
+
+  test("a leaf command with only flags completes flags on empty tab", async () => {
+    // `restart` has no subcommands and no args → still offers --help.
+    const out = await complete(["restart", ""]);
+    expect(out).toEqual(["--help"]);
+  });
+});
+
+describe("runComplete — argv extraction", () => {
+  test("reads the word list after the '--' separator", async () => {
+    const out = await runComplete(mainCommand, ["--", "p2p", ""]);
+    expect(out).toEqual(["status"]);
+  });
+
+  test("half-typed flags after '--' are treated as words, not parsed", async () => {
+    const out = await runComplete(mainCommand, ["--", "logs", "--fo"]);
+    expect(out).toEqual(["--follow"]);
+  });
+
+  test("falls back to the whole argv when no '--' is present", async () => {
+    const out = await runComplete(mainCommand, ["p2p", ""]);
+    expect(out).toEqual(["status"]);
+  });
+});
+
+describe("completionScript", () => {
+  test("every supported shell is a valid, non-empty script", () => {
+    for (const shell of COMPLETION_SHELLS) {
+      const script = completionScript(shell);
+      expect(script.length).toBeGreaterThan(0);
+      expect(script).toContain("phantombot _complete");
+    }
+  });
+
+  test("bash wires a completion function", () => {
+    expect(completionScript("bash")).toContain("complete -F _phantombot_complete phantombot");
+  });
+
+  test("zsh registers via compdef", () => {
+    expect(completionScript("zsh")).toContain("compdef _phantombot phantombot");
+  });
+
+  test("fish disables file completion", () => {
+    expect(completionScript("fish")).toContain("complete -c phantombot -f");
+  });
+
+  test("isCompletionShell guards the union", () => {
+    expect(isCompletionShell("bash")).toBe(true);
+    expect(isCompletionShell("powershell")).toBe(false);
+  });
+});

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -337,6 +337,7 @@ describe("runUpdate on darwin-arm64", () => {
       err: new CaptureStream(),
       force: true,
       healSystemdUnits: false,
+      refreshCompletions: false,
     });
     expect(code).toBe(0);
     expect(out.text).toContain("phantombot-v1.0.99-darwin-arm64");
@@ -405,6 +406,7 @@ describe("runUpdate on windows-x64", () => {
       err: new CaptureStream(),
       force: true,
       healSystemdUnits: false,
+      refreshCompletions: false,
     });
     expect(code).toBe(0);
     expect(out.text).toContain("phantombot-v1.0.99-windows-x64.exe");
@@ -432,6 +434,7 @@ describe("runUpdate happy path with --force --restart", () => {
       force: true,
       restart: true,
       healSystemdUnits: false,
+      refreshCompletions: false,
     });
     expect(code).toBe(0);
     // New binary swapped in.
@@ -463,6 +466,7 @@ describe("runUpdate happy path with --force --restart", () => {
       force: true,
       // restart NOT set
       healSystemdUnits: false,
+      refreshCompletions: false,
     });
     expect(code).toBe(0);
     expect(calls).not.toContain("restart");
@@ -485,6 +489,7 @@ describe("runUpdate happy path with --force --restart", () => {
       force: true,
       restart: true,
       healSystemdUnits: false,
+      refreshCompletions: false,
     });
     // Exit 0 — the install succeeded; restart is best-effort.
     expect(code).toBe(0);
@@ -518,6 +523,7 @@ describe("runUpdate post-swap systemd heal", () => {
       out,
       err: new CaptureStream(),
       force: true,
+      refreshCompletions: false,
       healSystemdUnits: async (bin) => {
         called.push(bin);
         return { rewrote: [], backups: [], repairedTimers: [] };
@@ -541,6 +547,7 @@ describe("runUpdate post-swap systemd heal", () => {
       out,
       err: new CaptureStream(),
       force: true,
+      refreshCompletions: false,
       healSystemdUnits: async () => ({
         rewrote: ["phantombot-tick.timer", "phantombot.service"],
         backups: [],
@@ -566,6 +573,7 @@ describe("runUpdate post-swap systemd heal", () => {
       out,
       err,
       force: true,
+      refreshCompletions: false,
       healSystemdUnits: async () => {
         throw new Error("dbus is missing");
       },
@@ -629,6 +637,7 @@ describe("runUpdate post-swap systemd heal", () => {
       out: new CaptureStream(),
       err: new CaptureStream(),
       force: true,
+      refreshCompletions: false,
       healSystemdUnits: async () => {
         healCalled = true;
         return null;
@@ -674,6 +683,7 @@ describe("runUpdate confirm injection", () => {
       confirmInstall: async () => true,
       confirmRestart: async () => false,
       healSystemdUnits: false,
+      refreshCompletions: false,
     });
     expect(code).toBe(0);
     expect(calls).not.toContain("restart");

--- a/tests/lib-completionInstall.test.ts
+++ b/tests/lib-completionInstall.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the zero-touch shell-completion installer (completionInstall.ts).
+ *
+ * Everything is driven against a throwaway HOME + XDG config dir so the tests
+ * never touch the developer's real ~/.bashrc / ~/.zshrc / fish config. The
+ * `shell` and `platform` options are injected rather than read from the
+ * environment.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  installCompletions,
+  removeBlock,
+  uninstallCompletions,
+  upsertBlock,
+} from "../src/lib/completionInstall.ts";
+
+let home: string;
+let configHome: string;
+const sink = { write: () => true };
+let savedZdotdir: string | undefined;
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "phantombot-comp-home-"));
+  configHome = await mkdtemp(join(tmpdir(), "phantombot-comp-cfg-"));
+  savedZdotdir = process.env.ZDOTDIR;
+  delete process.env.ZDOTDIR;
+});
+
+afterEach(async () => {
+  if (savedZdotdir === undefined) delete process.env.ZDOTDIR;
+  else process.env.ZDOTDIR = savedZdotdir;
+  await rm(home, { recursive: true, force: true });
+  await rm(configHome, { recursive: true, force: true });
+});
+
+const opts = (extra: Record<string, unknown>) => ({
+  home,
+  configHome,
+  out: sink,
+  platform: "linux" as const,
+  ...extra,
+});
+
+describe("upsertBlock / removeBlock", () => {
+  const body = 'source "/x/y.bash"';
+
+  test("appends a delimited block to empty content", () => {
+    const out = upsertBlock("", body);
+    expect(out).toContain("# >>> phantombot completion >>>");
+    expect(out).toContain(body);
+    expect(out).toContain("# <<< phantombot completion <<<");
+  });
+
+  test("preserves existing content and separates with a blank line", () => {
+    const out = upsertBlock("export FOO=1", body);
+    expect(out.startsWith("export FOO=1\n\n# >>> phantombot")).toBe(true);
+  });
+
+  test("is idempotent — re-inserting the same body does not stack blocks", () => {
+    const once = upsertBlock("export FOO=1", body);
+    const twice = upsertBlock(once, body);
+    expect(twice).toBe(once);
+    expect(twice.match(/phantombot completion >>>/g)?.length).toBe(1);
+  });
+
+  test("replaces a changed body in place", () => {
+    const first = upsertBlock("keep=me", 'source "/old"');
+    const second = upsertBlock(first, 'source "/new"');
+    expect(second).toContain("keep=me");
+    expect(second).toContain('source "/new"');
+    expect(second).not.toContain('source "/old"');
+    expect(second.match(/phantombot completion >>>/g)?.length).toBe(1);
+  });
+
+  test("removeBlock strips the block and its leading blank line", () => {
+    const withBlock = upsertBlock("export FOO=1", body);
+    expect(removeBlock(withBlock)).toBe("export FOO=1\n");
+  });
+
+  test("removeBlock is a no-op when no block is present", () => {
+    expect(removeBlock("export FOO=1\n")).toBe("export FOO=1\n");
+  });
+});
+
+describe("installCompletions", () => {
+  test("bash: writes a stub and sources it from .bashrc", async () => {
+    await writeFile(join(home, ".bashrc"), "export EXISTING=1\n");
+
+    const { installed } = await installCompletions(opts({ shell: "/bin/bash" }));
+    expect(installed).toEqual(["bash"]);
+
+    const stub = await readFile(
+      join(configHome, "phantombot", "completions", "phantombot.bash"),
+      "utf8",
+    );
+    expect(stub).toContain("complete -F _phantombot_complete phantombot");
+
+    const rc = await readFile(join(home, ".bashrc"), "utf8");
+    expect(rc).toContain("export EXISTING=1");
+    expect(rc).toContain("# >>> phantombot completion >>>");
+    expect(rc).toContain('/phantombot/completions/phantombot.bash"');
+  });
+
+  test("zsh: sources the stub and runs compinit before it", async () => {
+    await writeFile(join(home, ".zshrc"), "# my zshrc\n");
+
+    const { installed } = await installCompletions(opts({ shell: "/usr/bin/zsh" }));
+    expect(installed).toEqual(["zsh"]);
+
+    const rc = await readFile(join(home, ".zshrc"), "utf8");
+    expect(rc).toContain("compinit");
+    expect(rc).toContain('/phantombot/completions/phantombot.zsh"');
+  });
+
+  test("fish: drops an auto-loaded completion file, no rc edit", async () => {
+    await mkdir(join(configHome, "fish"), { recursive: true });
+
+    const { installed } = await installCompletions(opts({ shell: "/usr/bin/fish" }));
+    expect(installed).toEqual(["fish"]);
+
+    const fishFile = await readFile(
+      join(configHome, "fish", "completions", "phantombot.fish"),
+      "utf8",
+    );
+    expect(fishFile).toContain("complete -c phantombot -f");
+  });
+
+  test("targets a shell purely because its rc file already exists", async () => {
+    // Current shell is bash, but a ~/.zshrc exists → both get wired up.
+    await writeFile(join(home, ".bashrc"), "");
+    await writeFile(join(home, ".zshrc"), "");
+
+    const { installed } = await installCompletions(opts({ shell: "/bin/bash" }));
+    expect(installed.sort()).toEqual(["bash", "zsh"]);
+  });
+
+  test("is idempotent across repeated installs", async () => {
+    await writeFile(join(home, ".bashrc"), "export EXISTING=1\n");
+    await installCompletions(opts({ shell: "/bin/bash" }));
+    await installCompletions(opts({ shell: "/bin/bash" }));
+    const rc = await readFile(join(home, ".bashrc"), "utf8");
+    expect(rc.match(/phantombot completion >>>/g)?.length).toBe(1);
+  });
+
+  test("windows is a no-op", async () => {
+    const { installed } = await installCompletions(
+      opts({ shell: "pwsh", platform: "win32" as NodeJS.Platform }),
+    );
+    expect(installed).toEqual([]);
+  });
+});
+
+describe("uninstallCompletions", () => {
+  test("removes the stub, the fish file, and the rc block", async () => {
+    await writeFile(join(home, ".bashrc"), "export EXISTING=1\n");
+    await mkdir(join(configHome, "fish"), { recursive: true });
+    await installCompletions(opts({ shell: "/bin/bash" }));
+
+    await uninstallCompletions(opts({}));
+
+    const rc = await readFile(join(home, ".bashrc"), "utf8");
+    expect(rc).toBe("export EXISTING=1\n");
+    expect(rc).not.toContain("phantombot completion");
+
+    // Stub file is gone.
+    await expect(
+      readFile(join(configHome, "phantombot", "completions", "phantombot.bash"), "utf8"),
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
  ## Built-in shell tab-completion, set up on install/update

  ### Summary
  Adds `<TAB>` completion for the phantombot CLI that works out of the box. `phantombot install` sets it up for bash, zsh, and fish; `phantombot update` refreshes it; `phantombot uninstall` removes it. There is no separate command to run and no
  manual step — after installing, open a new shell and `<TAB>` completes subcommands and flags.

  ### How it works
  Completion is dynamic. A small per-shell stub calls a hidden `phantombot _complete` backend on every `<TAB>`. That backend walks the live command tree and prints the candidates, so completion always matches the actual subcommands and flags —
  nothing to regenerate when a command is added. The backend is side-effect-free (it never provisions state, like `--help`) and stays out of `--help` output.

  Coverage: top-level subcommands, nested subcommands, and per-command flags (including the `--no-` form for booleans and `--help`/`--version`). POSIX only; on Windows it's a no-op.

  ### Example
  ```console
  $ phantombot <TAB>
  ask       doctor    harness   install   memory    p2p       run       telegram
  backfill  embedding heartbeat logs      nightly   persona   start     tick
  ...

  $ phantombot p<TAB>
  p2p          persona      phantomchat

  $ phantombot p2p <TAB>
  status

  $ phantombot logs --<TAB>
  --follow     --no-follow  --lines      --help
  ```

  ### Testing
  - Full test suite: 2183 pass, 0 fail (new coverage for the completion engine and the installer).
  - End-to-end: after install, a fresh shell completes subcommands, nested subcommands, and flags exactly as shown above.
