### PR TITLE
fix(crypto): mirror the ms sub-second ordering tag on kind-14 rumors

### DIFF
--- a/src/lib/nostrCrypto.ts
+++ b/src/lib/nostrCrypto.ts
@@ -468,7 +468,15 @@ export async function wrapV2(
   replyTo?: { eventId: string; relayUrl?: string },
 ): Promise<{ event: NTNostrEvent; rumorId: string }> {
   const senderPubHex = getPublicKey(senderSk);
-  const tags: string[][] = [["p", recipientPubHex], ["v", "pc-v2"]];
+  // ONE Date.now() for BOTH created_at and the ms tag — see MS_TAG. Two calls
+  // can straddle a second boundary and desync the sub-second slot from the
+  // second it belongs to.
+  const nowMs = Date.now();
+  const tags: string[][] = [
+    ["p", recipientPubHex],
+    ["v", "pc-v2"],
+    buildMsTag(nowMs),
+  ];
   if (replyTo) {
     tags.push(["e", replyTo.eventId, replyTo.relayUrl || "", "reply"]);
   }
@@ -476,7 +484,7 @@ export async function wrapV2(
   // Rumor (kind 14, unsigned) — same structure as NIP-17 rumor
   const rumor = {
     kind: 14,
-    created_at: Math.floor(Date.now() / 1000),
+    created_at: Math.floor(nowMs / 1000),
     tags,
     content,
     pubkey: senderPubHex,
@@ -588,6 +596,46 @@ export function isV2Event(event: NTNostrEvent): boolean {
 // ==================== Low-level pipeline ====================
 
 /**
+ * Sub-second ordering tag: `['ms', '0'-'999']` on the kind-14 rumor.
+ *
+ * Message order in the PWA is decided by a `mid` = `created_at * 1e6 + slot`.
+ * `created_at` only has WHOLE-SECOND resolution, so two messages sent in the
+ * same second tie — and the legacy tiebreak was a HASH of the event id, which
+ * is stable across devices but NOT chronological. Same-second pairs therefore
+ * rendered in coin-flip order. This tag carries the real millisecond so the
+ * tiebreak is both deterministic and chronological.
+ *
+ * MUST stay byte-identical to phantomchat's `MS_TAG` (src/lib/phantomchat/
+ * nostr-crypto.ts) — both repos hash the rumor, so a divergent tag set forks
+ * the rumor id and breaks the shared protocol vector. Additive and ignorable:
+ * stock Nostr clients drop unknown tags, so this stays interop-safe. Messages
+ * without the tag fall back to the legacy hash tiebreak.
+ *
+ * INVARIANT: the ms value MUST come from the SAME `Date.now()` call that
+ * produced the rumor's `created_at`. A second `Date.now()` can straddle a
+ * second boundary and place the message a full second out of order.
+ */
+export const MS_TAG = "ms";
+
+/** Build the ['ms', '0'-'999'] rumor tag from a millisecond epoch instant. */
+export function buildMsTag(nowMs: number): string[] {
+  return [MS_TAG, String(((nowMs % 1000) + 1000) % 1000)];
+}
+
+/**
+ * Read the sub-second slot (0-999) from a rumor's tags. Returns undefined for
+ * legacy messages that predate the tag, or for a malformed value — callers then
+ * fall back to the legacy hash tiebreak so old history keeps its existing order.
+ */
+export function getMsSlotFromTags(tags?: string[][]): number | undefined {
+  const tag = tags?.find((t) => t?.[0] === MS_TAG);
+  if (!tag) return undefined;
+  const ms = Number(tag[1]);
+  if (!Number.isInteger(ms) || ms < 0 || ms > 999) return undefined;
+  return ms;
+}
+
+/**
  * Create an unsigned rumor event (NIP-17 kind 14). The rumor is NOT signed —
  * it has an `id` (its canonical hash) but no `sig`. The id is what receiver
  * and sender converge on after unwrap.
@@ -598,10 +646,16 @@ export function createRumor(
   tags?: string[][],
 ): UnsignedEvent {
   const pubkey = getPublicKey(senderSk);
+  // ONE Date.now() for BOTH created_at and the ms tag — see MS_TAG.
+  const nowMs = Date.now();
+  const baseTags = tags || [];
   const event = {
     kind: 14,
-    created_at: Math.floor(Date.now() / 1000),
-    tags: tags || [],
+    created_at: Math.floor(nowMs / 1000),
+    // Don't double-stamp if a caller already supplied an ms tag.
+    tags: baseTags.some((t) => t?.[0] === MS_TAG)
+      ? baseTags
+      : [...baseTags, buildMsTag(nowMs)],
     content,
     pubkey,
   };

--- a/tests/lib-nostrCrypto.test.ts
+++ b/tests/lib-nostrCrypto.test.ts
@@ -21,6 +21,7 @@ import {
   createGiftWrap,
   createRumor,
   getConversationKey,
+  getMsSlotFromTags,
   nip44Encrypt,
   unwrapNip17Message,
   wrapNip17Message,
@@ -437,10 +438,17 @@ describe("PhantomChat Protocol v2 — cross-repo shared test vector", () => {
   // Deterministic inner half — these bytes MUST match across repos
   const EXPECTED_SYMMETRIC_KEY =
     "20be5fd3f2476eed59a6eeac45331d88e8f5a2204591f3604d57c87b1eada7fc";
+  // Re-pinned when the ['ms', …] sub-second ordering tag was added to the
+  // kind-14 rumor (see MS_TAG in src/lib/nostrCrypto.ts). The tag is part of
+  // the hashed tag set, so it changes the rumor id — phantomchat's copy of this
+  // vector MUST be re-pinned to the same value in the same change.
   const EXPECTED_RUMOR_ID =
-    "1012a22578e51593cad513f022acd569452a8a22a3560e9af260049edcdc4435";
+    "3ded8957dfc336570634322ed9e8ace9b12cf89c9533560a4d139864f98d8c0c";
   const PLAINTEXT = "test vector plaintext";
   const FIXED_CREATED_AT = 1700000000;
+  // Date.now() is pinned to FIXED_CREATED_AT * 1000 → an exact second boundary,
+  // so the sub-second slot is 0.
+  const EXPECTED_MS_SLOT = "0";
 
   test("symmetric key derivation matches cross-repo vector", async () => {
     clearSymmetricKeyCache();
@@ -456,11 +464,45 @@ describe("PhantomChat Protocol v2 — cross-repo shared test vector", () => {
     const rumor = {
       kind: 14,
       created_at: FIXED_CREATED_AT,
-      tags: [["p", recipientPk], ["v", "pc-v2"]],
+      tags: [
+        ["p", recipientPk],
+        ["v", "pc-v2"],
+        ["ms", EXPECTED_MS_SLOT],
+      ],
       content: PLAINTEXT,
       pubkey: senderPk,
     };
     expect(getEventHash(rumor as never)).toBe(EXPECTED_RUMOR_ID);
+  });
+
+  test("wrapV2 stamps the ms ordering tag on the rumor", async () => {
+    clearSymmetricKeyCache();
+    const realDateNow = Date.now;
+    // 250ms past the second boundary — the slot must carry the real remainder,
+    // and created_at must still floor to the same whole second.
+    Date.now = () => FIXED_CREATED_AT * 1000 + 250;
+    try {
+      const { event } = await wrapV2(senderSk, recipientPk, PLAINTEXT);
+      const rumor = await unwrapV2(event, recipientSk);
+      expect(rumor.created_at).toBe(FIXED_CREATED_AT);
+      expect(getMsSlotFromTags(rumor.tags)).toBe(250);
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
+  test("getMsSlotFromTags falls back to undefined for legacy/malformed tags", () => {
+    // Legacy rumor (predates the tag) → undefined → caller uses hash tiebreak
+    expect(getMsSlotFromTags([["p", recipientPk], ["v", "pc-v2"]])).toBeUndefined();
+    expect(getMsSlotFromTags(undefined)).toBeUndefined();
+    // Malformed values must never produce a bogus slot
+    expect(getMsSlotFromTags([["ms", "1000"]])).toBeUndefined();
+    expect(getMsSlotFromTags([["ms", "-1"]])).toBeUndefined();
+    expect(getMsSlotFromTags([["ms", "abc"]])).toBeUndefined();
+    expect(getMsSlotFromTags([["ms", "12.5"]])).toBeUndefined();
+    // Valid boundaries
+    expect(getMsSlotFromTags([["ms", "0"]])).toBe(0);
+    expect(getMsSlotFromTags([["ms", "999"]])).toBe(999);
   });
 
   test("full wrap/unwrap roundtrip with fixed keys produces correct rumor", async () => {


### PR DESCRIPTION
## Why

PhantomChat orders messages by `mid = created_at * 1e6 + slot`. `created_at` is **whole-second only**, so two messages sent in the same second tie — and the legacy tiebreak was a **hash of the event id**: stable across devices, but not chronological. Same-second pairs therefore rendered in **coin-flip order** (Andrew hit this: a reply landed above the message it was replying to).

phantomchat now stamps the real millisecond into an `['ms', '0'-'999']` tag on the kind-14 rumor and uses it as the sub-second slot — deterministic *and* chronological. This PR mirrors that on the bot side.

**Why the bot needs it too:** without the tag, phantombot's messages have no ms, fall back to the hash slot, and a bot reply landing in the same second as the user's own message can still render out of order. A half-applied ordering rule is worse than none.

## What changed

- `MS_TAG` / `buildMsTag` / `getMsSlotFromTags` — byte-identical to the phantomchat side.
- Minted in **both** rumor builders (`wrapV2` + `createRumor`) from the **same `Date.now()`** that sets `created_at`. Invariant: a second `Date.now()` call can straddle a second boundary and put the message a full second out of order.
- Cross-repo shared vector **re-pinned** (`1012a225… → 3ded8957…`) plus new coverage for the tag mint and the legacy/malformed fallback.

## Wire-format note

The tag is **additive and ignorable** — stock Nostr clients (Damus, Amethyst) drop unknown tags, so decryption and interop are unaffected, and legacy messages without the tag keep the hash slot.

But it **is** part of the hashed tag set, so it changes the rumor id. That's exactly what the cross-repo vector exists to catch — **both repos must land together**:

- phantomchat: https://github.com/phantomyard/phantomchat/pull/74 (branch `fix/reliability-grind`, commit `96eb071`)

## Testing

- `tests/lib-nostrCrypto.test.ts`: **25/25 pass**, including the re-pinned vector.
- Full suite: 2109 pass. The 2 `PiHarness routing (subprocess)` failures are **pre-existing on clean `main`** (verified by stashing this change) — unrelated to this PR.
- **Not verified headless:** the actual same-second render order on two real devices. That's a live two-device check once both sides deploy.