### PR TITLE
feat(acp): raise tool-call note cap 80 → 160 chars

### DIFF
--- a/src/harnesses/toolNote.ts
+++ b/src/harnesses/toolNote.ts
@@ -27,8 +27,16 @@
  *   - Never throws. Bad/partial input degrades to the legacy label.
  */
 
-/** Max length of a rendered tool-call title, including the name prefix. */
-export const MAX_TOOL_NOTE_LEN = 80;
+/**
+ * Max length of a rendered tool-call title, including the name prefix.
+ *
+ * Raised 80 → 160 (Andrew, 2026-07-12): 80 clipped mid-argument on ordinary
+ * calls (a `curl` with a header, a long file path), so the panel showed the
+ * tool name and little else. Note the redaction caveat above — a longer cap
+ * surfaces MORE of the raw args, so keep this sink (the editor panel) in mind
+ * before raising it further.
+ */
+export const MAX_TOOL_NOTE_LEN = 160;
 
 /**
  * ACP `ToolKind` — drives the per-tool icon Zed renders in its agent panel.


### PR DESCRIPTION
## What

Raises `MAX_TOOL_NOTE_LEN` in `src/harnesses/toolNote.ts` from **80 → 160**.

## Why

At 80 chars the ACP `tool_call` title clips mid-argument on perfectly ordinary calls — a `curl` with an `Authorization` header, a longish file path — so the agent panel shows the tool name and not much else. Andrew hit this in the Zed panel and asked for 160.

## Scope — one constant, all three editors

The cap is applied **harness-side** in `buildToolNote()`, upstream of the ACP boundary. Zed, VSCode and JetBrains all receive the *already-truncated* string over the wire — none of them clip it themselves, and there is no per-editor buffer. So this one-line change covers all three; no extension work needed.

## Caveat (unchanged, but now matters slightly more)

Per the `#218` design note, tool-call notes are **truncated, not secret-masked**. A larger cap therefore surfaces *more* of the raw args in the panel (e.g. a token inside a `curl -H`). Behaviour is unchanged — the exposure surface just grows — and I have documented this at the constant so the next person raising it sees the trade-off. Flagging explicitly rather than burying it.

## Tests

The existing truncation test is cap-agnostic — it feeds a 200-char input and asserts `note.length === MAX_TOOL_NOTE_LEN` — so it covers the new value with no edit. `bun test tests/harnesses-toolNote.test.ts` → **20/20 pass**. `tsc --noEmit` clean.

---
🐶 Raised by Robbie at Andrew's request.