### PR TITLE
fix(channels): stop shipping a trailing emoji as its own bubble

### DIFF
--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -59,6 +59,7 @@ import {
   TELEGRAM_BOT_COMMANDS,
 } from "../commands.ts";
 import {
+  hasTextSubstance,
   splitIntoSegments,
   StreamSegmenter,
 } from "../streamSegmenter.ts";
@@ -1029,6 +1030,17 @@ async function processChatMessage(
     kind: "narration" | "final" | "error",
   ) => {
     if (text.trim().length === 0) return;
+    // A bubble with no letters or digits ("⚡", "👍") is a sign-off, not an
+    // answer. It reaches here as the streamed leftover: the splitter cut the
+    // real bubble at a sentence boundary and PUBLISHED it, so there is nothing
+    // left to merge into — suppress it instead. Only once something real has
+    // already gone out; a reply that is genuinely just "👍" still sends.
+    if (
+      !hasTextSubstance(text) &&
+      narrationBubblesSent + finalBubblesSent > 0
+    ) {
+      return;
+    }
     try {
       await input.transport.sendMessage(msg.conversationId, text);
       if (kind === "narration") narrationBubblesSent++;

--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -1033,12 +1033,14 @@ async function processChatMessage(
     // A bubble with no letters or digits ("⚡", "👍") is a sign-off, not an
     // answer. It reaches here as the streamed leftover: the splitter cut the
     // real bubble at a sentence boundary and PUBLISHED it, so there is nothing
-    // left to merge into — suppress it instead. Only once something real has
-    // already gone out; a reply that is genuinely just "👍" still sends.
-    if (
-      !hasTextSubstance(text) &&
-      narrationBubblesSent + finalBubblesSent > 0
-    ) {
+    // left to merge into — suppress it instead.
+    //
+    // Gate on FINAL bubbles only. Narration ("Restarting the service now…")
+    // is not an answer, so it must never license suppressing one: if the
+    // model's entire reply is "👍", that emoji IS the answer and has to ship
+    // even though narration already went out. An orphaned sign-off always
+    // trails a published *final* bubble, so this still catches every one.
+    if (!hasTextSubstance(text) && finalBubblesSent > 0) {
       return;
     }
     try {

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -681,10 +681,11 @@ export async function runPhantomchatServer(
     let finalCandidateSentChars = 0;
     let finalReply: string | undefined;
     let requestedReplyMode: ReplyModeRequest | undefined;
-    // Bubbles actually published this turn (narration or final). Gates the
-    // orphaned-sign-off suppression in sendBubble: nothing out yet means the
-    // fragment IS the reply, so it must still send.
-    let bubblesSent = 0;
+    // FINAL bubbles actually published this turn. Gates the orphaned-sign-off
+    // suppression in sendBubble: no final bubble out yet means the fragment IS
+    // the reply, so it must still send. Narration is deliberately NOT counted
+    // here — see the comment in sendBubble.
+    let finalBubblesSent = 0;
 
     // Reply-modality routing (mirrors core/engine.ts). Default: mirror the
     // input — a voice note in → a voice note back, text in → text out. An
@@ -747,7 +748,10 @@ export async function runPhantomchatServer(
     // the final reply path. groupTypingMembers is the same set the reply path
     // broadcasts to (inbound p-tags ∪ { sender }). Best-effort: a failed bubble
     // is logged, not thrown, so one dropped progress line never aborts the turn.
-    const sendBubble = async (text: string): Promise<void> => {
+    const sendBubble = async (
+      text: string,
+      kind: "narration" | "final" = "final",
+    ): Promise<void> => {
       if (text.trim().length === 0) return;
       // A bubble with no letters or digits ("⚡", "👍") is a sign-off, not an
       // answer. It reaches here as the streamed leftover: the splitter cut the
@@ -755,9 +759,14 @@ export async function runPhantomchatServer(
       // nothing left to merge into — suppress it instead. This matters most
       // here: the newest event drives the push notification, so an orphaned
       // emoji becomes a notification reading "max: ⚡" with the real answer
-      // buried above it. Only once something real has already gone out; a
-      // reply that is genuinely just "👍" still sends.
-      if (!hasTextSubstance(text) && bubblesSent > 0) return;
+      // buried above it.
+      //
+      // Gate on FINAL bubbles only. Narration is not an answer, so it must
+      // never license suppressing one: if the model's whole reply is "👍",
+      // that emoji IS the answer and has to ship even though narration
+      // already went out — otherwise the push notification becomes the
+      // narration and the confirmation never arrives.
+      if (!hasTextSubstance(text) && finalBubblesSent > 0) return;
       try {
         if (msg.groupId) {
           await transport.sendGroupMessage(
@@ -770,7 +779,7 @@ export async function runPhantomchatServer(
           // and publishes both wraps. conversationId === recipient hex pubkey.
           await transport.sendMessage(senderHex, text);
         }
-        bubblesSent++;
+        if (kind === "final") finalBubblesSent++;
       } catch (e) {
         log.warn("phantomchat: bubble send failed", {
           error: (e as Error).message,
@@ -803,7 +812,7 @@ export async function runPhantomchatServer(
     const narration = createNarrationController({
       streaming,
       enabled: narrationEnabled,
-      send: sendBubble,
+      send: (text) => sendBubble(text, "narration"),
     });
 
     const resetFinalCandidate = (): void => {

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -52,6 +52,7 @@ import {
   matchPersonaNames,
 } from "../core/routing.ts";
 import {
+  hasTextSubstance,
   splitIntoSegments,
   StreamSegmenter,
 } from "../streamSegmenter.ts";
@@ -680,6 +681,10 @@ export async function runPhantomchatServer(
     let finalCandidateSentChars = 0;
     let finalReply: string | undefined;
     let requestedReplyMode: ReplyModeRequest | undefined;
+    // Bubbles actually published this turn (narration or final). Gates the
+    // orphaned-sign-off suppression in sendBubble: nothing out yet means the
+    // fragment IS the reply, so it must still send.
+    let bubblesSent = 0;
 
     // Reply-modality routing (mirrors core/engine.ts). Default: mirror the
     // input — a voice note in → a voice note back, text in → text out. An
@@ -744,6 +749,15 @@ export async function runPhantomchatServer(
     // is logged, not thrown, so one dropped progress line never aborts the turn.
     const sendBubble = async (text: string): Promise<void> => {
       if (text.trim().length === 0) return;
+      // A bubble with no letters or digits ("⚡", "👍") is a sign-off, not an
+      // answer. It reaches here as the streamed leftover: the splitter cut the
+      // real bubble at a sentence boundary and PUBLISHED it, so there is
+      // nothing left to merge into — suppress it instead. This matters most
+      // here: the newest event drives the push notification, so an orphaned
+      // emoji becomes a notification reading "max: ⚡" with the real answer
+      // buried above it. Only once something real has already gone out; a
+      // reply that is genuinely just "👍" still sends.
+      if (!hasTextSubstance(text) && bubblesSent > 0) return;
       try {
         if (msg.groupId) {
           await transport.sendGroupMessage(
@@ -756,6 +770,7 @@ export async function runPhantomchatServer(
           // and publishes both wraps. conversationId === recipient hex pubkey.
           await transport.sendMessage(senderHex, text);
         }
+        bubblesSent++;
       } catch (e) {
         log.warn("phantomchat: bubble send failed", {
           error: (e as Error).message,

--- a/src/channels/streamSegmenter.ts
+++ b/src/channels/streamSegmenter.ts
@@ -194,6 +194,41 @@ export class StreamSegmenter {
   }
 }
 
+/**
+ * Does this text carry any actual content — a letter or a digit?
+ *
+ * A bubble made only of emoji or punctuation ("⚡", "👍", "—") reads as a
+ * sign-off when it sits under a real answer, but it is not an answer. On
+ * surfaces where the newest message becomes the push notification and the
+ * chat-list preview (PhantomChat), a trailing sign-off bubble IS the whole
+ * notification — the user sees "max: ⚡" and reasonably concludes they were
+ * ignored. Callers use this to keep such fragments attached to the bubble
+ * they belong to, rather than shipping them standalone.
+ */
+export function hasTextSubstance(text: string): boolean {
+  return /[\p{L}\p{N}]/u.test(text);
+}
+
+/**
+ * Fold a trailing substance-free fragment back into the bubble before it.
+ *
+ * The sentence splitter treats "…all merged. ⚡" as two sentences, because the
+ * emoji follows terminal punctuation — so a reply that signs off with an emoji
+ * ends with a 1-character segment. Merging is only possible when the whole text
+ * is segmented in one pass (`splitIntoSegments`); a live `StreamSegmenter` may
+ * already have published the previous bubble, so the streaming callers suppress
+ * the orphan instead. Kept here so both strategies share one definition of
+ * "this fragment is not an answer".
+ */
+export function coalesceTrailingFragment(segments: string[]): string[] {
+  if (segments.length < 2) return segments;
+  const last = segments[segments.length - 1]!;
+  if (hasTextSubstance(last)) return segments;
+  const merged = segments.slice(0, -1);
+  merged[merged.length - 1] += last;
+  return merged;
+}
+
 export function splitIntoSegments(
   text: string,
   options: StreamSegmenterOptions,
@@ -201,7 +236,7 @@ export function splitIntoSegments(
   const s = new StreamSegmenter(options);
   const out = s.push(text).segments;
   out.push(...s.finish().segments);
-  return out;
+  return coalesceTrailingFragment(out);
 }
 
 function fenceMarker(line: string): "```" | "~~~" | undefined {

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -996,6 +996,39 @@ describe("phantomchat streaming bubbles", () => {
     expect(await dmBubbles(pool, senderSk)).toEqual(["👍"]);
   });
 
+  test("an emoji-only answer still sends after narration has gone out", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    // The regression the first cut of this fix shipped: the suppression gate
+    // counted NARRATION bubbles too, so an emoji-only final answer was
+    // dropped once narration had gone out — and here the newest event drives
+    // the push notification, so the user's phone would buzz with
+    // "Restarting the service now" and the actual confirmation would never
+    // arrive. Narration is not an answer. The text chunk carries no terminal
+    // punctuation on purpose: that keeps it below the final-answer splitter,
+    // so the progress chunk turns it into narration rather than a published
+    // final bubble.
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "Restarting the service now" },
+      { type: "progress", note: "systemctl restart" },
+      { type: "done", finalText: "👍" },
+    ]);
+
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "restart it",
+      streaming: STREAM_ONE_PER_SENTENCE,
+      waitMs: 150,
+    });
+
+    const bubbles = await dmBubbles(pool, senderSk);
+    expect(bubbles).toContain("👍");
+    expect(bubbles[bubbles.length - 1]).toBe("👍");
+  });
+
   test("group reply streams as multiple group broadcasts", async () => {
     const andrewSk = generateSecretKey();
     const botSk = generateSecretKey();

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -948,6 +948,54 @@ describe("phantomchat streaming bubbles", () => {
     expect(await dmBubbles(pool, senderSk)).toEqual(["First.", "Second."]);
   });
 
+  test("a trailing sign-off never lands as its own bubble", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    // The shape that shipped "max: ⚡" as a push notification. The emoji
+    // follows terminal punctuation, so the sentence splitter calls it a
+    // sentence of its own; the real bubble is already PUBLISHED by the time it
+    // arrives as the leftover suffix, so there is nothing to merge into and it
+    // must be suppressed at the send boundary.
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "All merged. " },
+      { type: "done", finalText: "All merged. ⚡" },
+    ]);
+
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "did it land?",
+      streaming: STREAM_ONE_PER_SENTENCE,
+      waitMs: 150,
+    });
+
+    expect(await dmBubbles(pool, senderSk)).toEqual(["All merged."]);
+  });
+
+  test("a reply that is only a sign-off still sends", async () => {
+    const senderSk = generateSecretKey();
+    const botSk = generateSecretKey();
+    // Nothing precedes it, so the emoji IS the answer — suppressing it here
+    // would turn a real reply into silence.
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "👍" },
+    ]);
+
+    const pool = await runOnce({
+      senderSk,
+      botSk,
+      allowedHex: [getPublicKey(senderSk)],
+      harness,
+      text: "ship it",
+      streaming: STREAM_ONE_PER_SENTENCE,
+      waitMs: 150,
+    });
+
+    expect(await dmBubbles(pool, senderSk)).toEqual(["👍"]);
+  });
+
   test("group reply streams as multiple group broadcasts", async () => {
     const andrewSk = generateSecretKey();
     const botSk = generateSecretKey();

--- a/tests/channels-streamSegmenter.test.ts
+++ b/tests/channels-streamSegmenter.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
-import { splitIntoSegments, StreamSegmenter } from "../src/channels/streamSegmenter.ts";
+import {
+  coalesceTrailingFragment,
+  hasTextSubstance,
+  splitIntoSegments,
+  StreamSegmenter,
+} from "../src/channels/streamSegmenter.ts";
+
+// Production sizing (src/config.ts DEFAULT_TELEGRAM_STREAMING). The trailing
+// sign-off bug only reproduces at real bubble sizes — the reply has to be long
+// enough to get cut before the emoji — so the regression tests below pin these
+// rather than the toy values the older cases use.
+const PROD = { maxSentences: 4, maxChars: 700 };
 
 describe("StreamSegmenter", () => {
   test("cuts prose after the configured sentence count", () => {
@@ -61,5 +72,82 @@ describe("StreamSegmenter", () => {
     expect(s.push("ts\nconst x = 1;\n```\n").segments).toEqual([
       "```ts\nconst x = 1;\n```\n",
     ]);
+  });
+});
+
+describe("hasTextSubstance", () => {
+  test("letters and digits count as substance", () => {
+    expect(hasTextSubstance("Done.")).toBe(true);
+    expect(hasTextSubstance("286")).toBe(true);
+    expect(hasTextSubstance("ok 👍")).toBe(true);
+    // Non-Latin scripts are letters too — \p{L}, not [a-z].
+    expect(hasTextSubstance("готово")).toBe(true);
+    expect(hasTextSubstance("完了")).toBe(true);
+  });
+
+  test("emoji and punctuation alone do not", () => {
+    expect(hasTextSubstance("⚡")).toBe(false);
+    expect(hasTextSubstance("👍")).toBe(false);
+    expect(hasTextSubstance("🎉🔧")).toBe(false);
+    expect(hasTextSubstance(" — ")).toBe(false);
+    expect(hasTextSubstance("!!!")).toBe(false);
+  });
+});
+
+describe("coalesceTrailingFragment", () => {
+  test("folds an orphaned sign-off back into the previous bubble", () => {
+    expect(coalesceTrailingFragment(["All merged. ", "⚡"])).toEqual([
+      "All merged. ⚡",
+    ]);
+  });
+
+  test("leaves a trailing bubble that says something alone", () => {
+    expect(coalesceTrailingFragment(["First. ", "Second."])).toEqual([
+      "First. ",
+      "Second.",
+    ]);
+  });
+
+  test("never swallows a reply that is ONLY a sign-off", () => {
+    // Nothing precedes it, so the emoji IS the whole answer.
+    expect(coalesceTrailingFragment(["👍"])).toEqual(["👍"]);
+    expect(coalesceTrailingFragment([])).toEqual([]);
+  });
+});
+
+describe("trailing sign-off regression (turn 1936)", () => {
+  // The shape that shipped a standalone "⚡" bubble to PhantomChat, where the
+  // newest event becomes the push notification ("max: ⚡").
+  //
+  // What makes it bite is the SENTENCE cap, not the char cap: at exactly
+  // maxSentences the splitter flushes the bubble, and the emoji — which the
+  // sentence segmenter calls a sentence of its own, because it follows terminal
+  // punctuation — lands after the cut with nothing to ride along with. So the
+  // reply must be a multiple of maxSentences long. An earlier draft of this test
+  // used a 9-sentence reply and passed with the fix reverted: the emoji simply
+  // rode out on the short final bubble and never orphaned.
+  const reply =
+    "The gate was wrong on Windows and the fix has landed. " +
+    "I checked the box rather than assuming it. " +
+    "The extension now shows up in the editor list. " +
+    "Everything is reconciled and #76 is merged. ⚡";
+
+  test("the sign-off never ships as its own bubble", () => {
+    const segments = splitIntoSegments(reply, PROD);
+    expect(segments.length).toBeGreaterThan(0);
+    for (const segment of segments) {
+      expect(hasTextSubstance(segment)).toBe(true);
+    }
+  });
+
+  test("the sign-off is preserved, attached to the real answer", () => {
+    const segments = splitIntoSegments(reply, PROD);
+    expect(segments.at(-1)!.trimEnd().endsWith("⚡")).toBe(true);
+    // Nothing dropped: the bubbles still reconstruct the reply exactly.
+    expect(segments.join("")).toBe(reply);
+  });
+
+  test("a reply that is only a sign-off still sends", () => {
+    expect(splitIntoSegments("⚡", PROD)).toEqual(["⚡"]);
   });
 });

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -1032,6 +1032,42 @@ describe("runTelegramServer dispatch", () => {
     expect(transport.sent.map((s) => s.text.trim())).toEqual(["👍"]);
   });
 
+  test("an emoji-only answer still sends after narration has gone out", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      conversationId: "1001",
+      senderId: "42",
+      text: "restart it",
+    });
+    // The regression the first cut of this fix shipped: the suppression gate
+    // counted NARRATION bubbles too, so once "Restarting the service now"
+    // went out, an emoji-only final answer was silently dropped and the user
+    // got the narration as their last message — the confirmation never
+    // arrived. Narration is not an answer and must not license suppressing
+    // one. The text chunk carries no terminal punctuation on purpose: that
+    // keeps it below the final-answer splitter, so the progress chunk turns
+    // it into narration rather than a published final bubble.
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "Restarting the service now" },
+      { type: "progress", note: "systemctl restart" },
+      { type: "done", finalText: "👍" },
+    ]);
+    await runTelegramServer({
+      config: oneSentencePerBubble(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    const sent = transport.sent.map((s) => s.text.trim());
+    expect(sent).toContain("👍");
+    expect(sent[sent.length - 1]).toBe("👍");
+  });
+
   test("rejects messages from non-allowed users when allowlist is set", async () => {
     const transport = new FakeTransport();
     transport.pendingUpdates.push({

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -965,6 +965,73 @@ describe("runTelegramServer dispatch", () => {
     ]);
   });
 
+  // A reply that signs off with an emoji ("…all merged. ⚡") splits into two
+  // sentences, because the emoji follows terminal punctuation. The real bubble
+  // is already SENT by the time the emoji arrives as the leftover suffix, so it
+  // cannot be merged — it must be suppressed, or the user gets a bubble (and on
+  // PhantomChat, a push notification) that says nothing but "⚡".
+  const oneSentencePerBubble = (): Config => ({
+    ...baseConfig(),
+    telegramStreaming: {
+      narrationFlushMs: 0,
+      bubbleMaxSentences: 1,
+      bubbleMaxChars: 700,
+      bubbleDelayMs: 0,
+      voiceMaxSentences: 3,
+    },
+  });
+
+  test("a trailing sign-off never lands as its own bubble", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      conversationId: "1001",
+      senderId: "42",
+      text: "did it land?",
+    });
+    const harness = new ScriptedHarness("fake", [
+      { type: "text", text: "All merged. " },
+      { type: "done", finalText: "All merged. ⚡" },
+    ]);
+    await runTelegramServer({
+      config: oneSentencePerBubble(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.sent.map((s) => s.text.trim())).toEqual(["All merged."]);
+  });
+
+  test("a reply that is only a sign-off still sends", async () => {
+    const transport = new FakeTransport();
+    transport.pendingUpdates.push({
+      updateId: 1,
+      conversationId: "1001",
+      senderId: "42",
+      text: "ship it",
+    });
+    // Nothing precedes it, so the emoji IS the answer — suppressing it here
+    // would turn a real reply into silence.
+    const harness = new ScriptedHarness("fake", [
+      { type: "done", finalText: "👍" },
+    ]);
+    await runTelegramServer({
+      config: oneSentencePerBubble(),
+      memory,
+      harnesses: [harness],
+      agentDir,
+      persona: "phantom",
+      transport,
+      oneShot: true,
+    });
+
+    expect(transport.sent.map((s) => s.text.trim())).toEqual(["👍"]);
+  });
+
   test("rejects messages from non-allowed users when allowlist is set", async () => {
     const transport = new FakeTransport();
     transport.pendingUpdates.push({


### PR DESCRIPTION
## What Andrew saw

A PhantomChat push notification reading **"max: ⚡"** — a lightning bolt and nothing else — for a message I had, in fact, fully answered. He replied "An answer please." He was right to.

## Not lost messages

First thing I checked, since that was the report. **512 PhantomChat turns in the store, 0 user messages without a reply. 0 turn failures and 0 relay/publish errors in 7 days.** Nothing is being dropped. This is a *rendering* bug.

## Root cause

The sentence segmenter treats a trailing emoji as a **sentence of its own**, because it follows terminal punctuation. When the sentence before it lands exactly on the bubble boundary (`bubbleMaxSentences`, 4 in prod), the splitter flushes the real answer and the emoji is left over alone:

```
[0] len=188  "The gate was wrong on Windows and the fix has landed. …#76 is merged. "
[1] len=1    "⚡"
```

On **Telegram** that reads as a harmless sign-off bubble under the answer — which is why it went unnoticed for weeks. On **PhantomChat** the newest event drives the chat-list preview *and* the push notification, so the sign-off **becomes the entire notification** and the answer is buried above it. Same bug, different blast radius.

## Not new, and not just ⚡

Latent since the segmenter shipped (`b078dac`, #134, 2026-05-28). Firing since **2026-06-26** — daily, across **73 replies**. It is any trailing emoji, not just my sign-off: 👍 🔧 🦴 👂 🌙 🎉. Four `Stopped. 👍` replies on 2026-06-30 mean four bubbles that said nothing but 👍.

## The fix

Two paths, because the reply is **not always segmented in one pass** — this is the part I got wrong on the first pass and had to correct:

| path | what happens | fix |
|---|---|---|
| whole-text (`splitIntoSegments`) | all bubbles known before any send | **coalesce** the orphan into the previous bubble — emoji preserved, just attached |
| streaming (`StreamSegmenter.push`) | previous bubble is **already published** when the emoji arrives as the leftover suffix | nothing to merge into → **suppress** at the send boundary |

Suppression is gated on having already sent a bubble this turn, so a reply that is genuinely just `👍` still sends. One shared predicate (`hasTextSubstance`) so both strategies agree on what "not an answer" means. `\p{L}\p{N}`, not `[a-z]` — "готово" and "完了" are substance.

## Testing

- **Mutation-tested all five** rather than trusting green: drop the coalesce → 1 fail; drop either send guard → 1 fail each; suppress unconditionally (ignoring the "already sent" gate) → 1 fail each, both channels.
- The mutation run **caught a bad test of my own**: my first regression fixture was a 9-sentence reply, which passes *with the fix reverted* — the emoji rides out on the short final bubble and never orphans. The bug needs a sentence count that is a **multiple of** `bubbleMaxSentences`. Fixture rewritten, and the reason is written down in the test so nobody "simplifies" it back.
- Coverage on **both** channels (`channels-telegram.test.ts`, `channels-phantomchat-server.test.ts`), driving the real streaming loops, plus unit coverage on the segmenter.

`tsc` clean. **2195 pass.** The 2 `PiHarness` failures are pre-existing and environmental (`PHANTOMBOT_PI_API_KEY` present in my env from the vault) — confirmed identical on clean `main`, not introduced here.

## Not verified

No daemon swap yet, so this is not yet confirmed against a live relay — the evidence is the reproduction plus the two channel-level tests. Happy to deploy and watch a real sign-off land as one bubble if you want it proven end to end.