### PR TITLE
fix(memory): re-embed turns stranded behind the index cursor

### DIFF
--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -95,7 +95,7 @@ export async function runHeartbeatCli(
           memory: store,
           settings: turnIndexing,
         });
-        if (flush.triggered > 0) {
+        if (flush.triggered > 0 || flush.repaired > 0) {
           log.info("heartbeat: flushed conversation turn tails", { ...flush });
         }
       } finally {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -280,6 +280,13 @@ export async function runMemoryIndex(
           (r.embeddingFailures > 0
             ? `, ${r.embeddingFailures} embed failure(s)`
             : "") +
+          // The repair pass is the only thing that can reach turns stranded
+          // behind the cursor by an earlier embed failure, so say so out loud
+          // when it does — otherwise a silent self-heal looks like a no-op run.
+          (r.repaired > 0 ? `, ${r.repaired} re-embedded (repair)` : "") +
+          (r.repairFailures > 0
+            ? `, ${r.repairFailures} repair failure(s)`
+            : "") +
           `\n`,
       );
     } finally {

--- a/src/config.ts
+++ b/src/config.ts
@@ -136,6 +136,19 @@ export interface TurnIndexingSettings {
    * to 0 to disable the time-based flush (count trigger only).
    */
   flushAfterHours: number;
+  /**
+   * Self-healing budget for turns that reached the FTS index but whose
+   * embedding call failed (a 429, a network blip, a provider outage). Those
+   * turns sit *behind* the `lastTurnId` cursor, so no cursor-driven path —
+   * the batch trigger, the age flush, the sweep, not even
+   * `memory index --turns --force` — will ever look at them again. They stay
+   * lexical-only forever, silently, and embed failures arrive in bursts, so a
+   * bad ten minutes permanently demotes every turn in that window.
+   *
+   * Each sweep re-embeds up to this many such turns, found by a cursor-free
+   * scan for FTS rows with no embedding row. Set to 0 to disable the repair.
+   */
+  repairBatchSize: number;
 }
 
 export const DEFAULT_TURN_INDEXING: TurnIndexingSettings = {
@@ -143,6 +156,7 @@ export const DEFAULT_TURN_INDEXING: TurnIndexingSettings = {
   interval: 20,
   batchSize: 200,
   flushAfterHours: 2,
+  repairBatchSize: 32,
 };
 
 /**
@@ -732,12 +746,19 @@ function buildTurnIndexingConfig(
     asInt(process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS) ??
     asInt(tomlTurnIndexing.flush_after_hours) ??
     DEFAULT_TURN_INDEXING.flushAfterHours;
+  const repairBatchSize =
+    asInt(process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_REPAIR_BATCH_SIZE) ??
+    asInt(tomlTurnIndexing.repair_batch_size) ??
+    DEFAULT_TURN_INDEXING.repairBatchSize;
   return {
     enabled,
     interval: Math.max(1, Math.min(10_000, interval)),
     batchSize: Math.max(1, Math.min(5_000, batchSize)),
     // 0 disables the time-based flush; otherwise clamp to a sane 1h..1yr.
     flushAfterHours: Math.max(0, Math.min(8_760, flushAfterHours)),
+    // 0 disables the repair pass. Capped so one sweep can't fire off an
+    // unbounded burst of embedding calls at a provider that may be rate-limiting.
+    repairBatchSize: Math.max(0, Math.min(1_000, repairBatchSize)),
   };
 }
 

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -489,6 +489,58 @@ export class MemoryIndex {
     return row?.text_sha;
   }
 
+  /**
+   * Write ONLY the embedding row for an already-indexed turn. Unlike
+   * upsertTurn this never touches turn_docs, so the repair pass can add a
+   * missing vector without rewriting (or accidentally duplicating) the FTS
+   * row that is already there and correct.
+   */
+  upsertTurnEmbedding(path: string, vec: Float32Array, textSha: string): void {
+    const buf = Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength);
+    this.db
+      .prepare(
+        "INSERT OR REPLACE INTO turn_embeddings " +
+          "(path, vec, text_sha, embedded_at) VALUES (?, ?, ?, ?)",
+      )
+      .run(path, buf, textSha, new Date().toISOString());
+  }
+
+  /**
+   * Turns that made it into the FTS index but have no embedding — i.e. the
+   * embed call failed at index time. Found by scanning for the *absence* of
+   * an embedding row rather than by walking the turn cursor, which is the
+   * whole point: these rows sit behind `last_turn_id`, so every cursor-driven
+   * path skips them permanently.
+   *
+   * Quarantined turns (embeddable=0) are structurally excluded — the indexer
+   * never writes a turn_docs row for them at all, so a scan rooted in
+   * turn_docs cannot reach one. The repair pass therefore cannot resurrect a
+   * held untrusted payload into the vector index, by construction and not by
+   * a filter someone could later drop.
+   *
+   * `content` is returned straight from the FTS row, so the text we re-embed
+   * is byte-identical to the text that is searchable — no round-trip to the
+   * raw turn store, and no risk of the two drifting.
+   */
+  turnsMissingEmbeddings(
+    persona: string,
+    limit: number,
+  ): Array<{ path: string; content: string }> {
+    if (limit <= 0) return [];
+    return this.db
+      .prepare(
+        `SELECT d.path AS path, d.content AS content
+           FROM turn_docs d
+           LEFT JOIN turn_embeddings e ON e.path = d.path
+          WHERE d.persona = ? AND e.path IS NULL
+          LIMIT ?`,
+      )
+      .all(persona, Math.floor(limit)) as Array<{
+      path: string;
+      content: string;
+    }>;
+  }
+
   turnIndexState(
     persona: string,
     conversation: string,

--- a/src/orchestrator/turnIndexer.ts
+++ b/src/orchestrator/turnIndexer.ts
@@ -15,7 +15,7 @@ import {
   memoryIndexPath,
   type TurnIndexingSettings,
 } from "../config.ts";
-import { defaultEmbedder, sha256 } from "../lib/embedJob.ts";
+import { defaultEmbedder, type Embedder, sha256 } from "../lib/embedJob.ts";
 import { log } from "../lib/logger.ts";
 import {
   MemoryIndex,
@@ -35,6 +35,11 @@ export interface IndexConversationTurnsInput {
    * A no-op when there is no unindexed tail.
    */
   force?: boolean;
+  /**
+   * Override the embedder resolved from config. Tests inject a stub here;
+   * production leaves it unset and gets `defaultEmbedder(config)`.
+   */
+  embedder?: Embedder;
 }
 
 export interface IndexConversationTurnsResult {
@@ -105,7 +110,7 @@ export async function indexConversationTurnsIfDue(
       };
     }
 
-    const embedder = defaultEmbedder(input.config);
+    const embedder = input.embedder ?? defaultEmbedder(input.config);
     let afterId = state?.lastTurnId ?? 0;
     let indexed = 0;
     let embedded = 0;
@@ -208,6 +213,8 @@ export interface FlushDueConversationsInput {
   settings: TurnIndexingSettings;
   /** Force-flush every conversation's tail regardless of count/age. */
   force?: boolean;
+  /** Test seam; production resolves the embedder from config. */
+  embedder?: Embedder;
 }
 
 export interface FlushDueConversationsResult {
@@ -218,6 +225,123 @@ export interface FlushDueConversationsResult {
   indexed: number;
   embedded: number;
   embeddingFailures: number;
+  /** Previously-failed turns that the repair pass re-embedded this sweep. */
+  repaired: number;
+  /** Turns the repair pass tried and failed to embed again. */
+  repairFailures: number;
+}
+
+/** How many consecutive repair failures before we assume the provider is down. */
+const REPAIR_GIVE_UP_AFTER_CONSECUTIVE_FAILURES = 3;
+
+export interface RepairMissingTurnEmbeddingsInput {
+  config: Config;
+  persona: string;
+  settings: TurnIndexingSettings;
+  embedder?: Embedder;
+}
+
+export interface RepairMissingTurnEmbeddingsResult {
+  repaired: number;
+  failures: number;
+}
+
+/**
+ * Re-embed turns that are in the FTS index but have no vector — the residue
+ * of embed calls that failed at index time (429s, outages, network blips).
+ *
+ * Why this needs to exist at all: `indexConversationTurnsIfDue` advances
+ * `lastTurnId` past a turn whether or not its embedding succeeded (it must —
+ * the alternative is a poisoned turn wedging the cursor and stalling the
+ * whole conversation). The consequence is that a failed turn falls *behind*
+ * the cursor and no cursor-driven path can ever revisit it: not the batch
+ * trigger, not the age flush, not the sweep, not `memory index --turns
+ * --force` (which force-flushes the *tail*, it does not rescan). Without this
+ * pass, a turn that failed to embed is lexical-only forever. That's a silent,
+ * one-way degradation, and because embed failures arrive in bursts it takes
+ * out whole contiguous windows of history at a time.
+ *
+ * Bounded (`repairBatchSize` per sweep) and idempotent: a repaired turn gains
+ * an embedding row and therefore drops out of the scan. If the embedder is
+ * still failing we bail after a few consecutive errors rather than spending
+ * the whole budget hammering a provider that is evidently down — the next
+ * sweep will pick up where this one left off.
+ *
+ * Never throws.
+ */
+export async function repairMissingTurnEmbeddings(
+  input: RepairMissingTurnEmbeddingsInput,
+): Promise<RepairMissingTurnEmbeddingsResult> {
+  const result: RepairMissingTurnEmbeddingsResult = {
+    repaired: 0,
+    failures: 0,
+  };
+  if (!input.settings.enabled) return result;
+  if (input.settings.repairBatchSize <= 0) return result;
+
+  const embedder = input.embedder ?? defaultEmbedder(input.config);
+  // No embedder configured: every turn is legitimately vector-less and there
+  // is nothing to repair. Bail before touching the DB — otherwise an
+  // embeddings-disabled install would scan its entire history every sweep.
+  if (!embedder) return result;
+
+  let ix: MemoryIndex | undefined;
+  try {
+    ix = await MemoryIndex.open(memoryIndexPath(input.persona));
+    const stale = ix.turnsMissingEmbeddings(
+      input.persona,
+      input.settings.repairBatchSize,
+    );
+    if (stale.length === 0) return result;
+
+    let consecutiveFailures = 0;
+    for (const row of stale) {
+      const r = await embedder(row.content);
+      if (r.ok) {
+        ix.upsertTurnEmbedding(row.path, r.values, sha256(row.content));
+        result.repaired++;
+        consecutiveFailures = 0;
+        continue;
+      }
+      result.failures++;
+      consecutiveFailures++;
+      if (
+        consecutiveFailures >= REPAIR_GIVE_UP_AFTER_CONSECUTIVE_FAILURES
+      ) {
+        log.warn("turn-index repair: embedder still failing; deferring", {
+          persona: input.persona,
+          repaired: result.repaired,
+          failures: result.failures,
+          error: r.error,
+        });
+        break;
+      }
+    }
+
+    if (result.repaired > 0 || result.failures > 0) {
+      log.info("turn-index repair: re-embedded previously failed turns", {
+        persona: input.persona,
+        repaired: result.repaired,
+        failures: result.failures,
+        // Turns this pass looked at, capped at repairBatchSize. Deliberately
+        // NOT a "remaining" count: the scan is bounded, so we don't know the
+        // true backlog without a second query, and reporting a batch-relative
+        // remainder as if it were the total would read as "all clear" on a run
+        // that in fact left thousands of turns unrepaired.
+        batch: stale.length,
+        batchFull: stale.length >= input.settings.repairBatchSize,
+      });
+    }
+    return result;
+  } catch (e) {
+    log.warn("turn-index repair: failed; embeddings left as-is", {
+      persona: input.persona,
+      error: (e as Error).message,
+    });
+    return result;
+  } finally {
+    ix?.close();
+  }
 }
 
 /**
@@ -242,6 +366,8 @@ export async function flushDueConversationTurns(
     indexed: 0,
     embedded: 0,
     embeddingFailures: 0,
+    repaired: 0,
+    repairFailures: 0,
   };
   if (!input.settings.enabled) return summary;
 
@@ -265,6 +391,7 @@ export async function flushDueConversationTurns(
       memory: input.memory,
       settings: input.settings,
       force: input.force,
+      embedder: input.embedder,
     });
     if (r?.triggered) {
       summary.triggered++;
@@ -274,7 +401,21 @@ export async function flushDueConversationTurns(
     }
   }
 
-  if (summary.triggered > 0) {
+  // Self-heal *after* the flush, so any turn whose embedding just failed above
+  // is already visible to the scan and gets its first retry on the very next
+  // sweep rather than waiting a cycle. Runs once per persona (the index DB is
+  // per-persona), not once per conversation — the scan isn't conversation-scoped,
+  // which is what lets it find turns stranded behind any conversation's cursor.
+  const repair = await repairMissingTurnEmbeddings({
+    config: input.config,
+    persona: input.persona,
+    settings: input.settings,
+    embedder: input.embedder,
+  });
+  summary.repaired = repair.repaired;
+  summary.repairFailures = repair.failures;
+
+  if (summary.triggered > 0 || summary.repaired > 0) {
     log.info("turn-index sweep: flushed conversation tails", { ...summary });
   }
   return summary;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -48,6 +48,7 @@ const ENV_KEYS = [
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_INTERVAL",
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_BATCH_SIZE",
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS",
+  "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_REPAIR_BATCH_SIZE",
   "PHANTOMBOT_STATE",
   "XDG_CONFIG_HOME",
   "XDG_DATA_HOME",
@@ -654,6 +655,7 @@ enabled = false
 interval = 30
 batch_size = 400
 flush_after_hours = 6
+repair_batch_size = 8
 `);
     const c = await loadConfig();
     expect(c.retrieval!.turnIndexing).toEqual({
@@ -661,6 +663,7 @@ flush_after_hours = 6
       interval: 30,
       batchSize: 400,
       flushAfterHours: 6,
+      repairBatchSize: 8,
     });
   });
 
@@ -671,17 +674,20 @@ enabled = false
 interval = 30
 batch_size = 400
 flush_after_hours = 6
+repair_batch_size = 8
 `);
     process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_ENABLED = "true";
     process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_INTERVAL = "20";
     process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_BATCH_SIZE = "50";
     process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS = "1";
+    process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_REPAIR_BATCH_SIZE = "4";
     const c = await loadConfig();
     expect(c.retrieval!.turnIndexing).toEqual({
       enabled: true,
       interval: 20,
       batchSize: 50,
       flushAfterHours: 1,
+      repairBatchSize: 4,
     });
   });
 

--- a/tests/orchestrator-turnIndexer.test.ts
+++ b/tests/orchestrator-turnIndexer.test.ts
@@ -15,10 +15,12 @@ import {
 } from "../src/config.ts";
 import { MemoryIndex } from "../src/lib/memoryIndex.ts";
 import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
+import type { Embedder } from "../src/lib/embedJob.ts";
 import {
   flushDueConversationTurns,
   indexConversationTurnsIfDue,
   makeTurnIndexer,
+  repairMissingTurnEmbeddings,
 } from "../src/orchestrator/turnIndexer.ts";
 
 let workdir: string;
@@ -111,6 +113,7 @@ describe("indexConversationTurnsIfDue", () => {
       interval: 1,
       batchSize: 200,
       flushAfterHours: 0,
+      repairBatchSize: 0,
     };
 
     // Quarantined raw payload (would otherwise FTS-match "Etna secret").
@@ -362,5 +365,348 @@ describe("makeTurnIndexer", () => {
       memory,
     );
     expect(typeof fn).toBe("function");
+  });
+});
+
+/**
+ * Repair pass for turns that reached FTS but whose embedding call failed.
+ *
+ * The trap being pinned here (phantombot#293): the indexer advances
+ * `lastTurnId` past a turn whether or not its embed succeeded. A failed turn
+ * therefore sits BEHIND the cursor, and every cursor-driven path — batch
+ * trigger, age flush, sweep, and `memory index --turns --force` — selects work
+ * via `turnsAfterId(..., lastTurnId)`. None of them can ever see it again. It
+ * stays lexical-only forever, silently.
+ */
+describe("repairMissingTurnEmbeddings", () => {
+  /** Stub embedder: fails while `failing` is true, otherwise returns a vector. */
+  function stubEmbedder(): {
+    embedder: Embedder;
+    calls: () => number;
+    setFailing: (v: boolean) => void;
+  } {
+    let failing = false;
+    let calls = 0;
+    const embedder: Embedder = async (_text: string) => {
+      calls++;
+      if (failing) return { ok: false, error: "429 rate limited" };
+      return { ok: true, values: new Float32Array([0.1, 0.2, 0.3]), dims: 3 };
+    };
+    return {
+      embedder,
+      calls: () => calls,
+      setFailing: (v) => {
+        failing = v;
+      },
+    };
+  }
+
+  const settings = (over: Partial<typeof DEFAULT_RETRIEVAL.turnIndexing> = {}) => ({
+    ...DEFAULT_RETRIEVAL.turnIndexing,
+    interval: 1,
+    flushAfterHours: 0,
+    ...over,
+  });
+
+  /** How many indexed turns currently have no embedding row. */
+  async function missingCount(): Promise<number> {
+    const ix = await MemoryIndex.open(memoryIndexPath("phantom"));
+    const n = ix.turnsMissingEmbeddings("phantom", 1_000).length;
+    ix.close();
+    return n;
+  }
+
+  async function embeddedCount(): Promise<number> {
+    const db = new Database(memoryIndexPath("phantom"));
+    const row = db
+      .query("SELECT COUNT(*) AS c FROM turn_embeddings")
+      .get() as { c: number };
+    db.close();
+    return row.c;
+  }
+
+  test("a failed embed leaves an FTS row with no vector, and the cursor moves past it", async () => {
+    const stub = stubEmbedder();
+    stub.setFailing(true);
+    await appendPair(1);
+
+    const r = await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+
+    expect(r?.triggered).toBe(true);
+    expect(r?.embeddingFailures).toBe(2);
+    expect(r?.embedded).toBe(0);
+    // Searchable lexically...
+    const ix = await MemoryIndex.open(memoryIndexPath("phantom"));
+    expect(ix.search("Vesuvius pension", { scope: "turns" }).length).toBeGreaterThan(0);
+    ix.close();
+    // ...but with no vector at all.
+    expect(await embeddedCount()).toBe(0);
+    expect(await missingCount()).toBe(2);
+  });
+
+  test("no cursor-driven path can recover a failed turn — not even --force", async () => {
+    // This is the bug. Fail the embed, then run the operator escape hatch
+    // (force flush) with a HEALTHY embedder. It force-flushes the *tail*; it
+    // does not rescan. So the stranded turns stay vector-less.
+    const stub = stubEmbedder();
+    stub.setFailing(true);
+    await appendPair(1);
+    await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+    expect(await embeddedCount()).toBe(0);
+
+    // Embedder recovers. Force-flush, but with the repair pass disabled so we
+    // isolate the cursor path.
+    stub.setFailing(false);
+    await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings({ repairBatchSize: 0 }),
+      force: true,
+      embedder: stub.embedder,
+    });
+
+    // Still zero: force-flush only looks at turns AFTER lastTurnId.
+    expect(await embeddedCount()).toBe(0);
+    expect(await missingCount()).toBe(2);
+  });
+
+  test("the repair pass re-embeds turns stranded behind the cursor", async () => {
+    const stub = stubEmbedder();
+    stub.setFailing(true);
+    await appendPair(1);
+    await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+    expect(await embeddedCount()).toBe(0);
+
+    stub.setFailing(false);
+    const r = await repairMissingTurnEmbeddings({
+      config: baseConfig(),
+      persona: "phantom",
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+
+    expect(r.repaired).toBe(2);
+    expect(r.failures).toBe(0);
+    expect(await embeddedCount()).toBe(2);
+    expect(await missingCount()).toBe(0);
+  });
+
+  test("repair is idempotent — a second pass spends no embedding calls", async () => {
+    const stub = stubEmbedder();
+    stub.setFailing(true);
+    await appendPair(1);
+    await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+
+    stub.setFailing(false);
+    await repairMissingTurnEmbeddings({
+      config: baseConfig(),
+      persona: "phantom",
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+    const afterFirst = stub.calls();
+
+    const second = await repairMissingTurnEmbeddings({
+      config: baseConfig(),
+      persona: "phantom",
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+
+    expect(second.repaired).toBe(0);
+    // A repaired turn now has an embedding row, so it drops out of the scan.
+    expect(stub.calls()).toBe(afterFirst);
+  });
+
+  test("the heartbeat sweep self-heals a previously failed turn", async () => {
+    // End-to-end: the sweep is what the 30-min heartbeat calls, so this is the
+    // path that actually makes the bug self-correcting in production.
+    const stub = stubEmbedder();
+    stub.setFailing(true);
+    await appendPair(1);
+    await flushDueConversationTurns({
+      config: baseConfig(),
+      persona: "phantom",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+    expect(await embeddedCount()).toBe(0);
+
+    stub.setFailing(false);
+    const sweep = await flushDueConversationTurns({
+      config: baseConfig(),
+      persona: "phantom",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+
+    expect(sweep.repaired).toBe(2);
+    expect(await embeddedCount()).toBe(2);
+  });
+
+  test("a quarantined turn is never resurrected by the repair pass", async () => {
+    // Security invariant. A held untrusted payload (embeddable=0) has no
+    // turn_docs row at all, so a scan rooted in turn_docs structurally cannot
+    // reach it. The repair pass must not become a back door into the vector
+    // index for quarantined content.
+    const stub = stubEmbedder();
+    stub.setFailing(true);
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:1001",
+      role: "user",
+      text: "Etna secret quarantined payload",
+      embeddable: false,
+    });
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:1001",
+      role: "user",
+      text: "Stromboli indexable",
+      embeddable: true,
+    });
+    await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+
+    stub.setFailing(false);
+    const r = await repairMissingTurnEmbeddings({
+      config: baseConfig(),
+      persona: "phantom",
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+
+    // Only the embeddable turn was repaired — the quarantined one is invisible.
+    expect(r.repaired).toBe(1);
+    const ix = await MemoryIndex.open(memoryIndexPath("phantom"));
+    expect(ix.search("Etna secret quarantined", { scope: "turns" })).toEqual([]);
+    ix.close();
+  });
+
+  test("gives up early when the embedder is still down, instead of burning the budget", async () => {
+    const stub = stubEmbedder();
+    stub.setFailing(true);
+    for (let i = 1; i <= 10; i++) await appendPair(i);
+    await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+    const afterIndex = stub.calls();
+    expect(await missingCount()).toBe(20);
+
+    // Embedder is STILL failing. Budget is 20, but we should bail after a few
+    // consecutive failures rather than firing 20 doomed calls at a provider
+    // that is evidently rate-limiting us.
+    const r = await repairMissingTurnEmbeddings({
+      config: baseConfig(),
+      persona: "phantom",
+      settings: settings({ repairBatchSize: 20 }),
+      embedder: stub.embedder,
+    });
+
+    expect(r.repaired).toBe(0);
+    expect(r.failures).toBe(3);
+    expect(stub.calls() - afterIndex).toBe(3);
+    // Nothing lost — the tail is still there for the next sweep.
+    expect(await missingCount()).toBe(20);
+  });
+
+  test("repairBatchSize bounds one pass, and 0 disables the repair", async () => {
+    const stub = stubEmbedder();
+    stub.setFailing(true);
+    for (let i = 1; i <= 5; i++) await appendPair(i);
+    await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings(),
+      embedder: stub.embedder,
+    });
+    expect(await missingCount()).toBe(10);
+
+    stub.setFailing(false);
+
+    const off = await repairMissingTurnEmbeddings({
+      config: baseConfig(),
+      persona: "phantom",
+      settings: settings({ repairBatchSize: 0 }),
+      embedder: stub.embedder,
+    });
+    expect(off.repaired).toBe(0);
+    expect(await missingCount()).toBe(10);
+
+    const bounded = await repairMissingTurnEmbeddings({
+      config: baseConfig(),
+      persona: "phantom",
+      settings: settings({ repairBatchSize: 4 }),
+      embedder: stub.embedder,
+    });
+    expect(bounded.repaired).toBe(4);
+    expect(await missingCount()).toBe(6);
+  });
+
+  test("no embedder configured: nothing is treated as broken", async () => {
+    // An embeddings-disabled install has zero vectors by design. The repair
+    // pass must not decide the entire history is damaged and try to fix it.
+    await appendPair(1);
+    await indexConversationTurnsIfDue({
+      config: baseConfig(),
+      persona: "phantom",
+      conversation: "telegram:1001",
+      memory,
+      settings: settings(),
+    });
+
+    const r = await repairMissingTurnEmbeddings({
+      config: baseConfig(), // embeddings.provider = "none"
+      persona: "phantom",
+      settings: settings(),
+    });
+
+    expect(r.repaired).toBe(0);
+    expect(r.failures).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #293.

## The bug

A turn whose embedding call failed at index time stays **lexical-only forever**, and nothing can fix it — including the manual escape hatch.

`indexConversationTurnsIfDue` advances `lastTurnId` past a turn whether or not its embed succeeded. It *has* to: the alternative is one poisoned turn wedging the cursor and stalling the entire conversation. But the consequence is that a failed turn falls **behind** the cursor — and every path that selects work does so via `turnsAfterId(..., lastTurnId)`:

| Path | Sees a stranded turn? |
|---|---|
| 20-turn batch trigger | ❌ |
| `flushAfterHours` age flush | ❌ |
| 30-min heartbeat sweep | ❌ |
| `memory index --turns --force` | ❌ — force-flushes the *tail*, doesn't rescan |

So there was no recovery path at all. It's silent (the FTS half still returns hits, so recall degrades rather than breaks), it's one-way, and because embed failures arrive in **bursts** — 429s, quota, provider outages — a bad ten minutes permanently demotes every turn in that window. It only ever accumulates.

## The fix

A bounded, **cursor-free** repair pass: scan for FTS rows with no embedding row, re-embed them, done. It runs at the end of the existing per-persona sweep, so the heartbeat *and* `memory index --turns` both self-heal for free.

- **Bounded** — `repairBatchSize` per sweep (default 32, `0` disables).
- **Idempotent** — a repaired turn gains an embedding row and drops out of the scan, costing zero embedding calls thereafter.
- **Backs off** — bails after 3 consecutive failures rather than firing the whole budget at a provider that's evidently down. Next sweep picks up where it left off.
- Re-embeds `turn_docs.content` directly, so the text that gets vectorised is byte-identical to the text that's searchable.

`MemoryIndex.turnEmbeddingSha()` turned out to be defined and called from **nowhere** — the primitive for exactly this repair, anticipated and never wired up.

## Two properties worth reviewing closely

**Quarantined turns are excluded structurally, not by a filter.** The indexer never writes a `turn_docs` row for an `embeddable=0` turn, and the scan is rooted in `turn_docs` — so the repair pass *cannot* become a back door that resurrects a held untrusted payload into the vector index. That's by construction, not by a condition someone could later drop. Pinned by a test regardless.

**With no embedder configured, the pass no-ops.** An embeddings-disabled install has zero vectors by design; the repair must not conclude the entire history is damaged and try to "fix" it.

## Tests

Adds an `embedder` test seam to the indexer. There was previously **no way to inject a fake embedder** (`defaultEmbedder(config)` was called inline) — which is exactly why the embed-failure path shipped with no coverage at all.

9 new tests, including the one that pins the trap: `--force` with a *healthy* embedder still cannot recover a stranded turn. That's the invariant that makes the repair pass necessary rather than redundant, and it should fail loudly if someone ever "simplifies" this away.

`bun run typecheck` clean. Full suite: **2240 pass, 2 fail** — both failures are pre-existing on `main` (`harnesses-pi.test.ts` asserts `--api-key` is absent, but a real `PHANTOMBOT_PI_API_KEY` in the environment gets threaded through; unrelated to this change).

## Not addressed

A turn that fails *deterministically* (e.g. pathological content) gets retried once per sweep forever, burning one call a tick. Self-limiting and visible in the logs, but if it shows up in practice it wants a failure counter.