### PR TITLE
fix(nightly): run maintenance stages MCP-free so a dead connector can't wedge essence

### DIFF
--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -94,6 +94,10 @@ async function runNightlyTurn(opts: {
       idleTimeoutMs: STAGE_IDLE_TIMEOUT_MS,
       hardTimeoutMs: STAGE_HARD_TIMEOUT_MS,
       systemPromptSuffix: NIGHTLY_SUFFIX,
+      // Nightly needs no MCP; running MCP-free stops an unauthenticated remote
+      // connector from wedging the --print startup and killing a stage on the
+      // idle timeout (essence "timed out with no output"). See HarnessRequest.mcpMode.
+      mcpMode: "none",
     })) {
       if (chunk.type === "text") finalReply += chunk.text;
       if (chunk.type === "done") finalReply = chunk.finalText;

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -114,7 +114,7 @@ export class ClaudeHarness implements Harness {
     }
     try {
 
-    const args = this.buildArgs(req.systemPrompt, req.toolsMode, systemPromptFile);
+    const args = this.buildArgs(req.systemPrompt, req.toolsMode, systemPromptFile, req.mcpMode);
     log.debug("claude.invoke spawning", {
       bin: this.config.bin,
       argCount: args.length,
@@ -180,6 +180,8 @@ export class ClaudeHarness implements Harness {
     // (`--system-prompt-file`) instead of inline (`--system-prompt <text>`)
     // to stay under the command-line length limit.
     systemPromptFile?: string,
+    // `"none"` runs this turn with ZERO MCP servers — see the block below.
+    mcpMode?: "none",
   ): string[] {
     const args = [
       "--print",
@@ -221,6 +223,20 @@ export class ClaudeHarness implements Harness {
     // is moot when there are no tools to permit — belt and suspenders.)
     if (toolsMode === "none") {
       args.push("--tools", "");
+    }
+    // MCP-free mode for background turns (nightly stages). By default claude
+    // initialises EVERY configured MCP server on startup, including the user's
+    // remote claude.ai connectors. An unauthenticated remote connector blocks
+    // the init handshake waiting on an OAuth flow that can never complete in a
+    // non-interactive `--print` run, so the FIRST stage (essence) emits nothing
+    // and gets killed at the idle ceiling ("timed out with no output"). Nightly
+    // needs no MCP at all, so `--strict-mcp-config` tells claude to use ONLY the
+    // servers in `--mcp-config` (ignoring ~/.claude.json + connectors), and an
+    // empty server map means zero servers → nothing to hang on. Interactive
+    // persona turns omit mcpMode and keep their Gmail / Calendar / Drive
+    // connectors untouched.
+    if (mcpMode === "none") {
+      args.push("--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}');
     }
     // Per-invocation settings injection. Layers additively on top of the user's
     // own ~/.claude/settings.json — we don't touch that file, so an operator

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -78,6 +78,24 @@ export interface HarnessRequest {
    * harnesses still gets screening on that one. Optional; normal turns omit.
    */
   toolsMode?: "none";
+  /**
+   * MCP capability mode. Omitted = the harness's normal turn, which loads
+   * every MCP server the CLI is configured with (including the user's remote
+   * claude.ai connectors). `"none"` runs the turn with ZERO MCP servers.
+   *
+   * This exists for BACKGROUND turns — the nightly maintenance stages — which
+   * need no MCP at all. On a non-interactive `--print` run an unauthenticated
+   * remote connector blocks the startup handshake on an OAuth flow that can
+   * never complete, so the turn emits nothing and is killed at the idle
+   * ceiling. Skipping MCP entirely removes that failure mode. Interactive
+   * persona turns omit this and keep their connectors.
+   *
+   * Each harness maps `"none"` to its CLI's native "restrict MCP config" flag:
+   *   - claude → `--strict-mcp-config --mcp-config '{"mcpServers":{}}'`
+   * Harnesses without such a flag ignore it (they don't share claude's
+   * connector-startup hang). Optional; normal turns omit.
+   */
+  mcpMode?: "none";
 }
 
 export type HarnessChunk =

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -69,6 +69,12 @@ export interface TurnInput {
   /** Extra text appended to the system prompt. Used by nightly to inject distillation directives. */
   systemPromptSuffix?: string;
   /**
+   * Run this turn with ZERO MCP servers. Set by background callers (nightly)
+   * so an unauthenticated remote claude.ai connector can't wedge the
+   * non-interactive `--print` startup handshake. See HarnessRequest.mcpMode.
+   */
+  mcpMode?: "none";
+  /**
    * Append PRE_TOOL_NARRATION_INSTRUCTION to the system prompt — asks
    * the model to say one short sentence before each tool call so
    * streaming channels have something to render during the silence
@@ -247,6 +253,7 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
     workingDir: input.workingDir ?? homedir(),
     idleTimeoutMs: input.idleTimeoutMs,
     hardTimeoutMs: input.hardTimeoutMs,
+    mcpMode: input.mcpMode,
     signal: input.signal,
   })) {
     if (chunk.type === "text") finalText += chunk.text;

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -514,6 +514,34 @@ describe("ClaudeHarness subprocess invocation passes injected settings", () => {
     expect(texts).not.toContain("--tools");
   });
 
+  test("mcpMode 'none' (background/nightly) runs MCP-free via --strict-mcp-config + empty --mcp-config", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });
+    const chunks = await collect(h.invoke(newRequest({ mcpMode: "none" })));
+    const texts = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    // --strict-mcp-config ignores every ambient MCP source (~/.claude.json +
+    // remote connectors); the empty server map means zero servers to init, so
+    // an unauthenticated connector can't wedge the --print startup handshake.
+    expect(texts).toContain("--strict-mcp-config");
+    expect(texts).toContain("--mcp-config");
+    expect(texts).toContain('{"mcpServers":{}}');
+  });
+
+  test("a normal turn (no mcpMode) keeps MCP connectors — no --strict-mcp-config", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });
+    const chunks = await collect(h.invoke(newRequest()));
+    const texts = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    expect(texts).not.toContain("--strict-mcp-config");
+    expect(texts).not.toContain("--mcp-config");
+  });
+
   test("pre-prompting trim flags ride along on every turn", async () => {
     process.env.FAKE_CLAUDE_MODE = "argv";
     const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });


### PR DESCRIPTION
## Problem

Nightly runs report `nightly: ok` but the **essence stage fails most nights**:

```
stage 'essence': claude timed out after 300000ms with no output (likely wedged on a tool call)
```

Root cause is **MCP server startup, not a tool call inside the turn.** Each nightly stage spawns `claude --print`, which initialises every configured MCP server on startup — including the user's remote claude.ai connectors. When a remote connector is unauthenticated (here: `claude.ai Netsuite Production` and `claude.ai Microsoft 365`), it blocks the init handshake waiting on an OAuth flow that can never complete in a non-interactive `--print` run. essence is the *first* stage, so it eats the hang: zero output → killed at the 300000ms idle ceiling. "wedged on a tool call" is the harness guessing; it actually wedged before emitting anything. It's intermittent because it depends on how the dead endpoint responds that minute.

## Fix

Nightly maintenance needs no MCP at all. This adds an `mcpMode: "none"` flag on `HarnessRequest` (parallel to the existing `toolsMode: "none"`):

- `src/cli/nightly.ts` sets `mcpMode: "none"` on every stage turn.
- `src/orchestrator/turn.ts` threads it from `TurnInput` into the request.
- `src/harnesses/claude.ts` maps `"none"` → `--strict-mcp-config --mcp-config '{"mcpServers":{}}'`: use ONLY the (empty) inline config, ignoring `~/.claude.json` and connectors, so there are zero servers to init and nothing to hang on.

Interactive persona turns omit the flag and keep their Gmail / Calendar / Drive connectors untouched. Harnesses without a strict-MCP flag ignore `mcpMode` (they don't share claude's connector-startup hang).

## Tests

- New tests in `tests/harnesses-claude.test.ts`: `mcpMode: "none"` emits `--strict-mcp-config` + empty `--mcp-config`; a normal turn emits neither.
- `bun run typecheck` clean; `bun test tests/harnesses-claude.test.ts` 57/57; orchestrator/nightly/fallback suites 87/87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)