### PR TITLE
fix(vscode): kill the Windows ACP untitled-cwd wedge + silent pi-only collapse

### DIFF
--- a/editors/vscode/src/acpClient.ts
+++ b/editors/vscode/src/acpClient.ts
@@ -26,8 +26,11 @@
  */
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 
 import { snapAwareSpawnEnv } from "./snapEnv.ts";
+import { withHarnessInstallDirsOnPath } from "./harnessPath.ts";
 import {
   ACP_PROTOCOL_VERSION,
   allocId,
@@ -396,6 +399,45 @@ export function buildAcpSpawnCommand(
   return { command: bin, args };
 }
 
+/**
+ * Resolve the cwd to spawn `phantombot acp` in.
+ *
+ * THE BUG THIS FIXES (`spawn phantombot.exe ENOENT (-4058)` on `/untitled-*`
+ * editors, seen through the VS Code ACP extension on Windows): Node's `spawn`
+ * throws ENOENT when the `cwd` option names a directory that doesn't exist —
+ * NOT only when the binary is missing. An untitled/unsaved editor (or a
+ * folderless window before any file is opened) hands VS Code a resource whose
+ * `fsPath` looks like `/untitled-1` or similar — never a real directory on
+ * disk. That candidate cwd flows straight into `spawnAcpTransport`'s `cwd`
+ * option, and the spawn fails at the OS level before phantombot ever starts,
+ * which surfaces to the user as a wedged/declined turn with no useful error.
+ *
+ * The fix: verify the candidate cwd actually exists on disk (a real,
+ * existing directory). If it doesn't, fall back to the home directory —
+ * always real, always spawnable — same spirit as `currentWorkspaceCwd()`
+ * falling back to `process.cwd()` when no workspace folder is open. This is
+ * ONLY the process spawn cwd (`options.cwd` on `child_process.spawn`); it does
+ * NOT change which phantombot *session* the turn binds to — that's a separate
+ * cwd passed to `session/new`/`session/load` over the wire and is unaffected.
+ *
+ * Pure and side-effect-free apart from the injected `exists` check, so the
+ * untitled-editor repro is unit-tested without touching the real filesystem.
+ */
+export function resolveSpawnCwd(
+  candidateCwd: string | undefined,
+  exists: (path: string) => boolean = existsSync,
+  home: () => string = homedir,
+): string {
+  if (candidateCwd && candidateCwd.trim()) {
+    try {
+      if (exists(candidateCwd)) return candidateCwd;
+    } catch {
+      // fall through to home
+    }
+  }
+  return home();
+}
+
 export function spawnAcpTransport(options: AcpClientOptions): AcpTransport {
   const bin = options.binaryPath;
   if (!bin) {
@@ -407,7 +449,9 @@ export function spawnAcpTransport(options: AcpClientOptions): AcpTransport {
   const { command, args } = buildAcpSpawnCommand(bin, options.persona);
 
   const child = spawn(command, args, {
-    cwd: options.cwd,
+    // Guard against `spawn ENOENT (-4058)` on untitled/unsaved editors, whose
+    // resource path is not a real directory — see resolveSpawnCwd() above.
+    cwd: resolveSpawnCwd(options.cwd),
     stdio: ["pipe", "pipe", "pipe"],
     // Never use a shell: shim resolution is handled by cmd.exe above with
     // discrete argv, which keeps attacker-controlled args from being parsed as
@@ -424,7 +468,14 @@ export function spawnAcpTransport(options: AcpClientOptions): AcpTransport {
     // and only when — we're snap-confined; loadConfig then resolves personas_dir
     // from that config (default OR custom), so PHANTOMBOT_PERSONAS_DIR is left
     // unset to avoid overriding a custom persona root.
-    env: snapAwareSpawnEnv(process.env) as NodeJS.ProcessEnv,
+    // Also prepend the well-known harness install dirs (~/.local/bin,
+    // ~/.bun/bin, %APPDATA%\npm, …) so a harness detected by absolute path
+    // (e.g. claude.EXE resolved from state.json) still finds whatever ITS
+    // launch needs on the narrower PATH VS Code hands child processes — see
+    // harnessPath.ts for the parity rationale with the daemon's own search.
+    env: withHarnessInstallDirsOnPath(
+      snapAwareSpawnEnv(process.env),
+    ) as NodeJS.ProcessEnv,
   });
 
   let stdoutBuf = "";

--- a/editors/vscode/src/acpClient.ts
+++ b/editors/vscode/src/acpClient.ts
@@ -26,7 +26,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { statSync } from "node:fs";
 import { homedir } from "node:os";
 
 import { snapAwareSpawnEnv } from "./snapEnv.ts";
@@ -425,12 +425,18 @@ export function buildAcpSpawnCommand(
  */
 export function resolveSpawnCwd(
   candidateCwd: string | undefined,
-  exists: (path: string) => boolean = existsSync,
+  isDirectory: (path: string) => boolean = (p) => {
+    try {
+      return statSync(p).isDirectory();
+    } catch {
+      return false;
+    }
+  },
   home: () => string = homedir,
 ): string {
   if (candidateCwd && candidateCwd.trim()) {
     try {
-      if (exists(candidateCwd)) return candidateCwd;
+      if (isDirectory(candidateCwd)) return candidateCwd;
     } catch {
       // fall through to home
     }

--- a/editors/vscode/src/harnessPath.ts
+++ b/editors/vscode/src/harnessPath.ts
@@ -1,0 +1,112 @@
+/**
+ * PATH parity for the `phantombot acp` subprocess: prepend the well-known
+ * harness install directories the DAEMON already searches via
+ * `src/lib/harnessAvailability.ts:harnessSearchPath()`, so a harness that's
+ * pinned by absolute path in `state.json` (e.g. `claude.EXE` at
+ * `~/.local/bin/claude.EXE`) still has what ITS OWN launch needs on the PATH
+ * the extension hands the child process.
+ *
+ * THE GAP THIS CLOSES: `resolveHarnessBinary()` on the daemon side finds a
+ * harness binary either on PATH or by walking `harnessSearchPath()` and
+ * pins the resolved ABSOLUTE path into `state.json`. Absolute-path resolution
+ * means the extension's spawn of `phantombot acp` finds claude/pi/etc fine
+ * regardless of PATH. But once phantombot decides to run that harness, IT
+ * spawns claude/pi/gemini/codex as ITS OWN child \u2014 and those binaries are
+ * frequently Node scripts (`#!/usr/bin/env node`) or wrapper shims that shell
+ * out to other tools on PATH (see the shebang-needs-interpreter-on-path
+ * lesson, phantombot#240 / withCommandDirOnPath). The daemon (systemd/
+ * scheduled task) has a narrow PATH but phantombot's OWN spawn helpers already
+ * compensate for that per-harness. VS Code hands the ACP child a PATH that is
+ * *editor-inherited*, which on Windows in particular routinely excludes
+ * `~/.local/bin` (where nvm/fnm/volta-installed CLIs and their `node`
+ * interpreter live side by side) \u2014 collapsing an otherwise-healthy
+ * claude-then-pi chain down to pi-only the moment claude's OWN spawn fails
+ * silently inside phantombot's harness code.
+ *
+ * This module mirrors (does not replace) `harnessSearchPath()` server-side \u2014
+ * pure, no fs access beyond what's handed in, so it's unit-testable without
+ * touching a real home directory. It only ADDS directories; it never removes
+ * or reorders what's already on PATH.
+ */
+
+import { posix, win32 } from "node:path";
+
+export type EnvMap = Record<string, string | undefined>;
+
+/**
+ * The well-known harness/tool install directories under `home`, same set as
+ * the daemon's `harnessSearchPath()` static list (minus the dynamic
+ * nvm/fnm-version-directory walk, which needs real fs access the extension
+ * doesn't have at spawn time \u2014 the static list already covers the common
+ * "tool lives in one fixed dir" installers: pi's own installer, bun global
+ * installs, volta, and npm both global and per-user).
+ */
+export function harnessInstallDirs(
+  home: string,
+  platform: NodeJS.Platform,
+  env: EnvMap,
+): string[] {
+  const path = platform === "win32" ? win32 : posix;
+  const dirs = [
+    path.join(home, ".local", "bin"),
+    path.join(home, ".npm-global", "bin"),
+    path.join(home, ".npm", "bin"),
+    path.join(home, ".bun", "bin"),
+    path.join(home, ".volta", "bin"),
+    path.join(home, ".pi", "agent", "bin"),
+    path.join(home, ".local", "share", "pi-node", "bin"),
+    path.join(home, ".local", "share", "pi-node", "current", "bin"),
+  ];
+  if (platform === "win32" && env.APPDATA && env.APPDATA.trim()) {
+    dirs.push(path.join(env.APPDATA, "npm"));
+  }
+  return dirs;
+}
+
+/**
+ * Return a NEW env with `harnessInstallDirs()` prepended to PATH (never
+ * mutates the input, which may be the shared `process.env` reference).
+ * Directories already present anywhere on PATH are not duplicated. Uses
+ * `HOME` (POSIX) or `USERPROFILE` (Windows, falling back to `HOMEDRIVE` +
+ * `HOMEPATH`) from the env being built, so this stays pure \u2014 no
+ * `os.homedir()` call \u2014 and is fully unit-testable with a synthetic env.
+ */
+export function withHarnessInstallDirsOnPath(
+  env: EnvMap,
+  platform: NodeJS.Platform = process.platform,
+): EnvMap {
+  const home = homeFromEnv(env, platform);
+  if (!home) return env;
+
+  const delimiter = platform === "win32" ? ";" : ":";
+  const currentPath = env.PATH ?? env.Path ?? "";
+  const existing = new Set(
+    currentPath.split(delimiter).filter((entry) => entry.length > 0),
+  );
+
+  const toAdd = harnessInstallDirs(home, platform, env).filter(
+    (dir) => !existing.has(dir),
+  );
+  if (toAdd.length === 0) return env;
+
+  const pathKey = platform === "win32" && env.Path !== undefined && env.PATH === undefined
+    ? "Path"
+    : "PATH";
+  const next: EnvMap = { ...env };
+  next[pathKey] = currentPath
+    ? `${toAdd.join(delimiter)}${delimiter}${currentPath}`
+    : toAdd.join(delimiter);
+  return next;
+}
+
+function homeFromEnv(env: EnvMap, platform: NodeJS.Platform): string | undefined {
+  if (platform === "win32") {
+    const userProfile = env.USERPROFILE?.trim();
+    if (userProfile) return userProfile;
+    const drive = env.HOMEDRIVE?.trim();
+    const path = env.HOMEPATH?.trim();
+    if (drive && path) return `${drive}${path}`;
+    return env.HOME?.trim() || undefined;
+  }
+  return env.HOME?.trim() || undefined;
+}

--- a/editors/vscode/tests/acpClient.test.ts
+++ b/editors/vscode/tests/acpClient.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, test } from "bun:test";
 import {
   AcpClient,
   buildAcpSpawnCommand,
+  resolveSpawnCwd,
   type AcpTransport,
 } from "../src/acpClient.ts";
 import { resetIdCounter } from "../src/protocol.ts";
@@ -465,5 +466,51 @@ describe("available_commands_update", () => {
     expect(chunks).toEqual(["hello"]);
     expect(client.availableCommands("s1").map((c) => c.name)).toEqual(["help"]);
     client.dispose();
+  });
+});
+
+describe("resolveSpawnCwd — untitled-editor ENOENT guard", () => {
+  test("returns the candidate cwd when it exists on disk", () => {
+    const cwd = resolveSpawnCwd(
+      "/home/andrew/project",
+      (p) => p === "/home/andrew/project",
+      () => "/home/andrew",
+    );
+    expect(cwd).toBe("/home/andrew/project");
+  });
+
+  test(
+    "falls back to home when the candidate doesn't exist — the untitled-editor " +
+      "repro (spawn ENOENT -4058): VS Code hands an /untitled-1-style resource " +
+      "path that is never a real directory",
+    () => {
+      const cwd = resolveSpawnCwd(
+        "/untitled-1",
+        () => false,
+        () => "/home/andrew",
+      );
+      expect(cwd).toBe("/home/andrew");
+    },
+  );
+
+  test("falls back to home when no candidate is given at all", () => {
+    const cwd = resolveSpawnCwd(undefined, () => false, () => "/home/andrew");
+    expect(cwd).toBe("/home/andrew");
+  });
+
+  test("falls back to home when the exists() check itself throws", () => {
+    const cwd = resolveSpawnCwd(
+      "/some/weird/path",
+      () => {
+        throw new Error("EPERM");
+      },
+      () => "/home/andrew",
+    );
+    expect(cwd).toBe("/home/andrew");
+  });
+
+  test("empty-string candidate is treated as absent, falls back to home", () => {
+    const cwd = resolveSpawnCwd("   ", () => true, () => "/home/andrew");
+    expect(cwd).toBe("/home/andrew");
   });
 });

--- a/editors/vscode/tests/acpClient.test.ts
+++ b/editors/vscode/tests/acpClient.test.ts
@@ -513,4 +513,18 @@ describe("resolveSpawnCwd — untitled-editor ENOENT guard", () => {
     const cwd = resolveSpawnCwd("   ", () => true, () => "/home/andrew");
     expect(cwd).toBe("/home/andrew");
   });
+
+  test(
+    "falls back to home when the candidate exists but is a FILE, not a " +
+      "directory — an existsSync()-only check would wedge the spawn here " +
+      "since Windows cwd must be a real directory",
+    () => {
+      const cwd = resolveSpawnCwd(
+        "/home/andrew/project/notes.txt",
+        (p) => p !== "/home/andrew/project/notes.txt",
+        () => "/home/andrew",
+      );
+      expect(cwd).toBe("/home/andrew");
+    },
+  );
 });

--- a/editors/vscode/tests/harnessPath.test.ts
+++ b/editors/vscode/tests/harnessPath.test.ts
@@ -1,0 +1,104 @@
+/**
+ * PATH-parity tests for the ACP child spawn — reproduces the Windows
+ * pi-only-collapse scenario (claude resolves by absolute path but its OWN
+ * launch fails because `~/.local/bin` isn't on the PATH VS Code hands the
+ * child) and asserts the fix adds the well-known harness install dirs
+ * without disturbing anything already present. Pure, no fs, no `vscode`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  harnessInstallDirs,
+  withHarnessInstallDirsOnPath,
+  type EnvMap,
+} from "../src/harnessPath.ts";
+
+describe("harnessInstallDirs", () => {
+  test("POSIX: covers the same static set as the daemon's harnessSearchPath", () => {
+    const dirs = harnessInstallDirs("/home/andrew", "linux", {});
+    expect(dirs).toContain("/home/andrew/.local/bin");
+    expect(dirs).toContain("/home/andrew/.bun/bin");
+    expect(dirs).toContain("/home/andrew/.volta/bin");
+    expect(dirs).toContain("/home/andrew/.npm-global/bin");
+  });
+
+  test("Windows: adds %APPDATA%\\npm when APPDATA is set", () => {
+    const dirs = harnessInstallDirs(
+      "C:\\Users\\andrew",
+      "win32",
+      { APPDATA: "C:\\Users\\andrew\\AppData\\Roaming" },
+    );
+    expect(dirs).toContain("C:\\Users\\andrew\\AppData\\Roaming\\npm");
+    expect(dirs).toContain("C:\\Users\\andrew\\.local\\bin");
+  });
+
+  test("Windows: omits the APPDATA npm dir when APPDATA is unset", () => {
+    const dirs = harnessInstallDirs("C:\\Users\\andrew", "win32", {});
+    expect(
+      dirs.some((d) => d.toLowerCase().includes("appdata") || d.toLowerCase().includes("roaming")),
+    ).toBe(false);
+  });
+});
+
+describe("withHarnessInstallDirsOnPath", () => {
+  test("POSIX: prepends install dirs ahead of the existing PATH", () => {
+    const env: EnvMap = { HOME: "/home/andrew", PATH: "/usr/bin:/bin" };
+    const next = withHarnessInstallDirsOnPath(env, "linux");
+    expect(next.PATH).toContain("/home/andrew/.local/bin");
+    expect(next.PATH).toContain("/home/andrew/.bun/bin");
+    // Original entries preserved, and at the tail.
+    expect(next.PATH?.endsWith("/usr/bin:/bin")).toBe(true);
+  });
+
+  test("does not duplicate a dir already on PATH", () => {
+    const env: EnvMap = {
+      HOME: "/home/andrew",
+      PATH: "/home/andrew/.local/bin:/usr/bin",
+    };
+    const next = withHarnessInstallDirsOnPath(env, "linux");
+    const occurrences = (next.PATH ?? "").split(":").filter(
+      (e) => e === "/home/andrew/.local/bin",
+    ).length;
+    expect(occurrences).toBe(1);
+  });
+
+  test("never mutates the input env object", () => {
+    const env: EnvMap = { HOME: "/home/andrew", PATH: "/usr/bin" };
+    const snapshot = { ...env };
+    withHarnessInstallDirsOnPath(env, "linux");
+    expect(env).toEqual(snapshot);
+  });
+
+  test("no-op when home cannot be resolved (env has neither HOME nor USERPROFILE)", () => {
+    const env: EnvMap = { PATH: "/usr/bin" };
+    const next = withHarnessInstallDirsOnPath(env, "linux");
+    expect(next).toBe(env);
+  });
+
+  test(
+    "Windows: the pi-only-collapse repro \u2014 claude resolves by absolute path " +
+      "but the extension's PATH lacks ~/.local/bin, so claude's OWN spawn (a " +
+      "Node shebang script needing `node` beside it) would fail; the fix adds " +
+      "the dir so that launch has what it needs",
+    () => {
+      const env: EnvMap = {
+        USERPROFILE: "C:\\Users\\andrew",
+        PATH: "C:\\Windows\\system32;C:\\Windows",
+      };
+      const next = withHarnessInstallDirsOnPath(env, "win32");
+      expect(next.PATH).toContain("C:\\Users\\andrew\\.local\\bin");
+      expect(next.PATH?.split(";")[0]).toBe("C:\\Users\\andrew\\.local\\bin");
+    },
+  );
+
+  test("Windows: falls back to HOMEDRIVE + HOMEPATH when USERPROFILE is unset", () => {
+    const env: EnvMap = {
+      HOMEDRIVE: "C:",
+      HOMEPATH: "\\Users\\andrew",
+      PATH: "C:\\Windows",
+    };
+    const next = withHarnessInstallDirsOnPath(env, "win32");
+    expect(next.PATH).toContain("C:\\Users\\andrew\\.local\\bin");
+  });
+});

--- a/src/connectors/acp/server.ts
+++ b/src/connectors/acp/server.ts
@@ -26,7 +26,7 @@ import type { ActiveTurnHandle } from "../../channels/commands.ts";
 import { type Config, loadConfig, personaDir } from "../../config.ts";
 import { healDefaultPersonaIfBroken } from "../../lib/personaDefault.ts";
 import { buildHarnessChain } from "../../harnesses/buildChain.ts";
-import { resolveHarnessBinsForConfig } from "../../lib/harnessAvailability.ts";
+import { harnessBin, resolveHarnessBinsForConfig } from "../../lib/harnessAvailability.ts";
 import type { Harness } from "../../harnesses/types.ts";
 import type { WriteSink } from "../../lib/io.ts";
 import { openMemoryStore, type MemoryStore } from "../../memory/store.ts";
@@ -134,6 +134,21 @@ export async function runAcpServer(
     );
     return 2;
   }
+
+  // Diagnostic startup line: which persona + which harness chain (with each
+  // harness's resolved bin) this ACP server actually bound to. Nothing about
+  // this ever surfaced before, so a wrong-persona/collapsed-chain wedge (the
+  // VS Code Windows bug, 2026-07-16) failed completely silently — the ONLY
+  // signal was a downstream idle-timeout minutes later with no way to tell
+  // whether claude was even attempted. This line is cheap and always emitted
+  // (not gated on a verbose flag) because stderr here is diagnostics-only
+  // (stdout is the protocol channel) and the extension already forwards it
+  // to the output channel the user can open on demand.
+  logErr.write(
+    `phantombot acp: persona=${persona} chain=[${harnesses
+      .map((h) => `${h.id}:${harnessBin(config, h.id) ?? "?"}`)
+      .join(", ")}]\n`,
+  );
 
   const memory = options.memory ?? (await openMemoryStore(config.memoryDbPath));
   const ownsMemory = !options.memory;

--- a/tests/connectors-acp-server.test.ts
+++ b/tests/connectors-acp-server.test.ts
@@ -1153,4 +1153,39 @@ describe("ACP server — persona resolution & self-heal", () => {
     expect(code).toBe(2);
     expect(err).toContain("persona 'ghost' not found");
   });
+
+  test(
+    "startup logs resolved persona + full harness chain to stderr — the " +
+      "diagnostic that closes the VS Code Windows silent-collapse bug " +
+      "(2026-07-16): a wrong persona or a chain that silently dropped a " +
+      "harness used to be undetectable until an idle-timeout fired minutes " +
+      "later with zero clue why",
+    async () => {
+      const robbie = join(pdir, "personas", "robbie");
+      await mkdir(robbie, { recursive: true });
+      await writeFile(join(robbie, "BOOT.md"), "# Robbie\n", "utf8");
+
+      const input = new PassThrough();
+      const errSink = new CapturingErr();
+      const done = runAcpServer({
+        config: healConfig,
+        memory,
+        harnesses: [
+          new ScriptedHarness("claude", () => []),
+          new ScriptedHarness("pi", () => []),
+        ],
+        input,
+        output: new CapturingOut() as any,
+        logErr: errSink,
+        persona: "robbie",
+      });
+      input.end();
+      await done;
+
+      expect(errSink.buf).toContain("persona=robbie");
+      expect(errSink.buf).toContain("chain=[");
+      expect(errSink.buf).toContain("claude");
+      expect(errSink.buf).toContain("pi");
+    },
+  );
 });


### PR DESCRIPTION
## What
Root-caused and fixed the VS Code ACP extension wedge Andrew hit on Megan's Windows box (`pi timed out after 300000ms` + `(phantombot declined this turn.)`).

## Three fixes

1. **`resolveSpawnCwd()`** (`acpClient.ts`) — Node's `spawn()` throws `ENOENT (-4058)` when the handed `cwd` doesn't exist on disk, not only when the binary is missing. An untitled/unsaved editor resource (`/untitled-1`) is never a real directory — every reopen on one wedged the ACP child before phantombot even started. Falls back to `homedir()`.

2. **`withHarnessInstallDirsOnPath()`** (new `editors/vscode/src/harnessPath.ts`) — prepends the same well-known install dirs the daemon's `harnessSearchPath()` covers (`~/.local/bin`, `~/.bun/bin`, `%APPDATA%\npm`, …) onto the ACP child's PATH. Detecting claude/pi by absolute path is already solved (`state.json`) — but once phantombot decides to *run* a harness, it spawns that binary as its own child, and Node shebang scripts / wrapper shims need their own tools on PATH. VS Code's inherited PATH is narrower than a login shell's on Windows, which silently collapsed the claude→pi chain to pi-only. Every editor turn then rode pi/GLM-5.2, which wedges on long tool calls and hits the 300s idle kill.

3. **Startup diagnostic** (`src/connectors/acp/server.ts`) — the ACP server now always logs `persona=<x> chain=[id:bin, ...]` to stderr on boot, forwarded by the extension to its output channel. This used to fail completely silently.

## Chat history / memory-embedding
No direct fix needed — investigated and confirmed it's the *same* root cause: turns only persist on success (`turn.ts`), so every idle-killed turn from bug #2 never got written, hence nothing to replay on `session/load` or embed. Fixing the collapse restores history/embedding for future turns going forward.

## Tests
- New `editors/vscode/tests/harnessPath.test.ts` (9 cases)
- `resolveSpawnCwd` cases appended to `acpClient.test.ts` (5 cases)
- One new diagnostic-log assertion in `tests/connectors-acp-server.test.ts`
- Full vscode extension suite (127 tests) and phantombot suite (2255 tests) pass. The 2 `harnesses-pi.test.ts` subprocess failures are pre-existing flakes on `main`, unrelated to this change (reproduced on `main` before this branch too).