### PR TITLE
fix(vsix): install extension deps in gen script so release CI can build

### DIFF
--- a/scripts/genVscodeVsix.ts
+++ b/scripts/genVscodeVsix.ts
@@ -96,6 +96,28 @@ const version = versionOverride ?? pkg.version;
 const extensionId = `${pkg.publisher}.${pkg.name}`;
 const vsixFileName = `${pkg.name}-${version}.vsix`;
 
+// ── Make sure the extension's own devDeps are present. ──
+// editors/vscode/ is NOT a workspace of the root package.json — it has its own
+// bun.lock and its own (gitignored) node_modules. So the repo-root
+// `bun install` does NOT install esbuild/typescript for it, and a clean
+// checkout has no node_modules there at all.
+//
+// This bit us for real: the release job failed with `esbuild: command not
+// found` (vsce runs the extension's `vscode:prepublish` → `bun run build` →
+// esbuild), while the same script passed locally purely because a dev box
+// happens to have those deps lying around from previous work in that dir.
+// Classic works-on-my-machine, and exactly the kind of silent
+// environment-dependence this script exists to eliminate — so install them
+// here rather than relying on the caller's state.
+//
+// Deliberately BEFORE the version stamp below: --frozen-lockfile compares
+// package.json against bun.lock, and a stamped-in override version would make
+// it fail on a mismatch we created ourselves.
+execFileSync("bun", ["install", "--frozen-lockfile"], {
+  cwd: EXT_DIR,
+  stdio: "inherit",
+});
+
 // ── Build + package into a throwaway temp dir, then read the bytes back. ──
 const tmp = mkdtempSync(join(tmpdir(), "phantombot-vsix-"));
 const vsixPath = join(tmp, vsixFileName);


### PR DESCRIPTION
## Why

The `v1.1.205` release job fails with `esbuild: command not found` (exit 127), and fails identically on every rerun — [failing job](https://github.com/phantomyard/phantombot/actions/runs/29529719537/job/87730655540). This blocks `/update` from shipping the VS Code extension fix that #297 just landed.

Rerunning can't help. Every runner starts clean, which is precisely the problem.

## Root cause

`editors/vscode/` is **not a workspace** of the root `package.json` — no `workspaces` field, its own `bun.lock`, its own gitignored `node_modules`. So the repo-root `bun install --frozen-lockfile` never installs the extension's devDeps.

Then:

```
vsce package
  -> extension's vscode:prepublish
    -> bun run build
      -> esbuild        # not installed on a clean checkout -> exit 127
```

This passed locally purely because a dev box has those deps lying around from prior work in that dir. **That's a works-on-my-machine** — the same class of silent environment-dependence this script exists to eliminate, which makes it an especially fair one to fix properly.

## Fix

One file. The gen script installs the extension's deps itself rather than trusting the caller's state.

Placed **before** the version stamp deliberately: `--frozen-lockfile` compares `package.json` against `bun.lock`, so stamping an override version first would make it fail on a mismatch we created ourselves.

## Verification

Reproduced CI's clean runner locally by moving `editors/vscode/node_modules` out of the way, then running it exactly as the release does:

```
PHANTOMBOT_EXT_VERSION=1.1.206 bun run gen:vscode-vsix

  esbuild ./src/extension.ts --bundle ...     ✅
  DONE Packaged: phantombot-vscode-1.1.206.vsix (5 files, 16.99 KB)
  wrote vscodeExtensionAsset.generated.ts (@1.1.206)
```

Ruling out root-hoisting as a confound — that the build resolved esbuild from somewhere else and the fix did nothing:

| check | result |
|---|---|
| `editors/vscode/node_modules/.bin/esbuild` after run | present (recreated by this change) |
| root `node_modules/.bin/esbuild` | **absent** |

Root has no esbuild, so the build can only have resolved it from the install this change performs.

Also confirmed: `editors/vscode/package.json` restores to `0.4.7` and the tree comes back clean; asset suite 5/5; typecheck clean.

## Caveat

I've proven this works from a clean **dependency** state locally, but the release job itself only truly proves itself on a real merge run. That's the honest limit — same as #297.