### PR TITLE
fix(harness): make Pi's local-config option actually work, and stop hiding providers on a fresh install

### DIFF
--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -30,8 +30,11 @@ import {
   modelId,
   type PiModel,
   primaryIsMultimodal,
+  providerChoices,
+  providerEnvVar,
 } from "../lib/piModels.ts";
 import {
+  computeRoutingClears,
   computeRoutingWrites,
   ENV_PI_API_KEY,
   resolvePiApiKeyWrite,
@@ -133,6 +136,33 @@ export async function applyRouting(
   });
   await updateEnvFile(envPath, writes.env);
   return writes;
+}
+
+/**
+ * Erase every routing value the wizard owns, from BOTH stores — the
+ * "Use Pi's own config" path. See `computeRoutingClears` for why this must
+ * actively clear rather than merely skip writing (the old "later" branch was a
+ * no-op that silently kept stale routing alive forever).
+ *
+ * The empty `[harnesses.pi.routing]` table is left behind rather than deleted:
+ * `resolveRouting` maps an empty table to all-undefined, which is exactly the
+ * "no overrides" state we want, and keeping the table avoids churning the TOML
+ * shape. `envPath` is injectable for tests, matching applyRouting.
+ */
+export async function clearPiRouting(
+  configPath: string,
+  envPath: string = userEnvPath(),
+): Promise<ReturnType<typeof computeRoutingClears>> {
+  const clears = computeRoutingClears();
+  await updateConfigToml(configPath, (toml) => {
+    const routing = getIn(toml, ["harnesses", "pi", "routing"]) as
+      | Record<string, unknown>
+      | undefined;
+    if (!routing) return;
+    for (const key of clears.tomlKeys) delete routing[key];
+  });
+  await updateEnvFile(envPath, clears.env);
+  return clears;
 }
 
 function setRoutingKey(
@@ -304,12 +334,19 @@ async function installPi(
  *   1. If Pi isn't on PATH, offer to run the official installer, then redetect
  *      (and update the shared `availability` map so the caller's later prompts
  *      see the freshly-installed binary).
- *   2. Ask "configure now or later?". LATER ⇒ stop here (binary present but
- *      unconfigured is fine — Pi falls back to its own local-store settings when
- *      no per-turn key is threaded).
- *   3. NOW ⇒ collect the Pi API key (stored in ~/.env as PHANTOMBOT_PI_API_KEY,
- *      threaded per-turn onto `--api-key`; NOT written into Pi's own store), then
- *      run the custom routing wizard directly (no "use defaults?" detour).
+ *   2. Ask WHO owns the model config — the real choice behind the old
+ *      "now / later" wording, which described *when* you'd configure rather than
+ *      *what* would drive Pi:
+ *        · "Use Pi's own config" ⇒ delegate to Pi's local settings (what the
+ *          user set by running `pi` and logging into a provider). CLEARS both of
+ *          phantombot's routing stores, then stops — see clearPiRouting for why
+ *          skipping the write isn't enough.
+ *        · "Configure models" ⇒ continue to 3.
+ *   3. Pick the provider (from Pi's full static catalogue, NOT just what's
+ *      already keyed), collect that provider's API key (stored in ~/.env as
+ *      PHANTOMBOT_PI_API_KEY, threaded per-turn onto `--api-key`; NOT written
+ *      into Pi's own store), refresh the model catalogue with it, then run the
+ *      routing wizard for primary / image / coding (no "use defaults?" detour).
  *
  * `availability` is mutated in place when an install succeeds. Returns `true`
  * only when the operator cancelled outright (Esc), so the caller can abort.
@@ -343,34 +380,50 @@ async function configurePi(
     }
   }
 
-  const when = await p.select<"now" | "later">({
-    message: `Configure Pi (${role}) now, or later?`,
+  const mode = await p.select<"configure" | "local">({
+    message: `Pi (${role}): how should models be configured?`,
     options: [
-      { value: "now", label: "now", hint: "API key + model routing" },
       {
-        value: "later",
-        label: "later",
-        hint: "skip — Pi uses its own local-store settings until configured",
+        value: "configure",
+        label: "Configure models",
+        hint: "pick provider + API key, then primary / vision / coding models",
+      },
+      {
+        value: "local",
+        label: "Use Pi's own config",
+        hint: "delegate to Pi's local settings (from `pi` login) — clears any routing here",
       },
     ],
-    initialValue: "now",
+    initialValue: "configure",
   });
-  if (p.isCancel(when)) return true;
-  if (when === "later") {
+  if (p.isCancel(mode)) return true;
+  if (mode === "local") {
+    // ACTIVELY clear both stores — see clearPiRouting/computeRoutingClears. The
+    // old "later" branch returned without clearing, so any previously-configured
+    // routing kept being threaded onto every turn and this option did nothing.
+    await clearPiRouting(config.configPath);
     p.note(
-      "skipped Pi config. With no per-turn API key set, Pi falls back to its own\n" +
-        "local-store settings; re-run `phantombot harness` to configure it later.",
-      "Pi: later",
+      [
+        "Pi will use its own local config (~/.pi/agent/settings.json) — the",
+        "provider + model you set by running `pi` and logging in.",
+        "",
+        `cleared phantombot's Pi routing from ${config.configPath}`,
+        `and ${userEnvPath()} (provider, primary/image/coding model, API key),`,
+        "so no --model/--provider/--api-key is passed and Pi decides for itself.",
+        "",
+        "Re-run `phantombot harness` and pick 'Configure models' to override.",
+      ].join("\n"),
+      "Pi: using Pi's own config",
     );
     return false;
   }
 
-  // NOW: provider FIRST. Pi's `--provider` defaults to google, so a key is
+  // CONFIGURE: provider FIRST. Pi's `--provider` defaults to google, so a key is
   // meaningless until we know which provider it's FOR — and the provider also
   // scopes the key prompt label and the model pickers. Query the model catalog
-  // once here: it yields both the provider list AND the models the routing
-  // wizard will filter, so we don't shell out to `pi --list-models` twice.
-  const models = availability.pi ? await listPiModels(availability.pi) : [];
+  // once here: it yields the models the routing wizard will filter (and marks
+  // which providers are already keyed), so we don't shell out twice.
+  let models = availability.pi ? await listPiModels(availability.pi) : [];
   const currentRouting = resolveRouting(
     getIn(await readConfigToml(config.configPath), [
       "harnesses",
@@ -399,6 +452,21 @@ async function configurePi(
   if (keyWrite.action === "set") {
     await updateEnvFile(userEnvPath(), { [ENV_PI_API_KEY]: keyWrite.value });
     p.note(`saved ${ENV_PI_API_KEY} to ${userEnvPath()}`, "Pi API key");
+    // Refresh the catalog with the key we just took. On a fresh install the
+    // first listing was EMPTY (Pi had no key, so `--list-models` printed "No
+    // models available"), which is what forced the model pickers into free-text.
+    // Now that we hold a key we can populate them — but only by injecting the
+    // provider's NATIVE env var: `--list-models` ignores `--api-key` and reads
+    // auth from its own store / native vars only (see PiProvider.envVar). No
+    // known var (or still empty ⇒ bad key, provider outage) leaves `models` as
+    // it was, and the pickers degrade to free-text rather than dead-ending.
+    const envVar = provider ? providerEnvVar(provider) : undefined;
+    if (availability.pi && envVar) {
+      const refreshed = await listPiModels(availability.pi, undefined, {
+        [envVar]: keyWrite.value,
+      });
+      if (refreshed.length > 0) models = refreshed;
+    }
   } else if (keyWrite.action === "clear") {
     await updateEnvFile(userEnvPath(), { [ENV_PI_API_KEY]: "" });
     p.note(
@@ -568,16 +636,23 @@ const CANCELLED = Symbol("cancelled");
 /**
  * Provider picker. The provider is asked BEFORE the API key (Pi's `--provider`
  * defaults to google, so the key is meaningless without it) and BEFORE the model
- * pickers (it scopes them). Options are the distinct `provider` values from the
- * `pi --list-models` catalog. "(none)" leaves Pi on its own default provider.
- * Falls back to free-text when the catalog is unavailable. Returns the chosen
- * provider name ("" = none), or CANCELLED on abort.
+ * pickers (it scopes them). "(none)" leaves Pi on its own default provider.
+ * Returns the chosen provider id ("" = none), or CANCELLED on abort.
+ *
+ * Options come from `providerChoices`: Pi's STATIC provider catalogue unioned
+ * with whatever `pi --list-models` reported. It used to derive the list from
+ * `--list-models` ALONE, which meant a fresh install — where Pi holds no key and
+ * lists nothing — got an empty picker and fell through to free-text. That's
+ * backwards: the operator is in this wizard precisely to add their first key, so
+ * the full catalogue must be offered regardless of what's already keyed. The
+ * free-text fallback now only triggers in the true degenerate case (no catalogue
+ * at all), which shouldn't happen since the catalogue is a constant.
  */
 async function pickProvider(
   models: readonly PiModel[],
   initial: string | undefined,
 ): Promise<string | typeof CANCELLED> {
-  const providers = [...new Set(models.map((m) => m.provider))].sort();
+  const providers = providerChoices(models);
   if (providers.length === 0) {
     const r = await p.text({
       message: "Pi provider (e.g. openrouter, openai) — blank = Pi's default",
@@ -590,9 +665,15 @@ async function pickProvider(
   const NONE = "";
   const options = [
     { value: NONE, label: "(none)", hint: "Pi's default provider (google)" },
-    ...providers.map((pr) => ({ value: pr, label: pr })),
+    ...providers.map((pr) => ({
+      value: pr.id,
+      label: pr.label,
+      // Surface which providers Pi can already serve models for, so a keyed box
+      // still reads at a glance now that the list is the full catalogue.
+      hint: pr.hasModels ? `${pr.id} — key already configured` : pr.id,
+    })),
   ];
-  const known = initial !== undefined && providers.includes(initial);
+  const known = initial !== undefined && providers.some((pr) => pr.id === initial);
   const r = await p.select<string>({
     message: "Provider (scopes the API key + model list)",
     options,

--- a/src/lib/piModels.ts
+++ b/src/lib/piModels.ts
@@ -98,15 +98,26 @@ export function parsePiModels(stdout: string): PiModel[] {
  * absolute path from harness availability so it works under the systemd
  * unit's narrow PATH.
  */
-export type PiModelsRunner = (bin: string) => Promise<{
+export type PiModelsRunner = (
+  bin: string,
+  /**
+   * Extra env for the child, MERGED over the current process env. Used to hand
+   * Pi a just-entered key via its native var (see PiProvider.envVar) so the
+   * refreshed list includes the newly-keyed provider.
+   */
+  extraEnv?: Record<string, string>,
+) => Promise<{
   exitCode: number;
   stdout: string;
 }>;
 
-const defaultRunner: PiModelsRunner = async (bin) => {
+const defaultRunner: PiModelsRunner = async (bin, extraEnv) => {
   const proc = Bun.spawn([bin, "--list-models"], {
     stdout: "pipe",
     stderr: "ignore",
+    // Undefined ⇒ inherit as before; merge (not replace) so PATH/HOME survive
+    // and Pi can still read its own auth store.
+    env: extraEnv ? { ...process.env, ...extraEnv } : undefined,
   });
   const stdout = await new Response(proc.stdout).text();
   const exitCode = await proc.exited;
@@ -116,14 +127,165 @@ const defaultRunner: PiModelsRunner = async (bin) => {
 export async function listPiModels(
   bin = "pi",
   runner: PiModelsRunner = defaultRunner,
+  extraEnv?: Record<string, string>,
 ): Promise<PiModel[]> {
   try {
-    const { exitCode, stdout } = await runner(bin);
+    const { exitCode, stdout } = await runner(bin, extraEnv);
     if (exitCode !== 0) return [];
     return parsePiModels(stdout);
   } catch {
     return [];
   }
+}
+
+/**
+ * A provider the operator can pick in the wizard.
+ *
+ * `id` is what `pi --provider` expects — Pi's `auth.json` key, which is also the
+ * value printed in the `provider` column of `pi --list-models` (e.g. "openrouter",
+ * "google", "xai"). NOT the display name: Pi's docs call the Gemini provider
+ * "Google Gemini" but its id is `google`.
+ */
+export interface PiProvider {
+  id: string;
+  /** Human label from Pi's provider docs (falls back to `id` for unknowns). */
+  label: string;
+  /**
+   * The provider's NATIVE env var (e.g. OPENROUTER_API_KEY) — Pi's own name for
+   * it, not phantombot's PHANTOMBOT_PI_API_KEY.
+   *
+   * Needed because `pi --list-models` reads auth ONLY from ~/.pi/agent/auth.json
+   * and these native env vars — it ignores `--api-key`/`--provider` (verified
+   * against pi 0.79.1: `pi --list-models --provider openrouter --api-key …`
+   * still prints "No models available"). So to refresh the model list with a key
+   * the operator just typed (and which is NOT in Pi's store), the wizard must
+   * spawn `--list-models` with THIS var injected into the child env.
+   *
+   * undefined for providers we don't have a documented var for (live-only /
+   * post-catalogue providers) ⇒ the refresh is skipped and the pickers fall back
+   * to free-text entry.
+   */
+  envVar?: string;
+  /**
+   * Whether `pi --list-models` currently returns models for this provider —
+   * i.e. Pi already holds a key for it (in ~/.pi/agent/auth.json or the env).
+   * Drives an "already keyed" hint; NOT a filter (see providerChoices).
+   */
+  hasModels: boolean;
+}
+
+/**
+ * The STATIC provider catalogue, transcribed from Pi's own `docs/providers.md`
+ * (the `auth.json key` column → `id`, the `Provider` column → `label`).
+ *
+ * WHY THIS EXISTS: `pi --list-models` only lists models for providers Pi ALREADY
+ * has a key for. On a fresh install it prints "No models available. Use /login…"
+ * — so deriving the provider list from it yielded an EMPTY picker precisely when
+ * the operator was there to add their first key (the chicken-and-egg: you can't
+ * pick a provider to key it, because it isn't listed until it's keyed). The
+ * wizard therefore always offers this catalogue, and merges in whatever
+ * `--list-models` reports on top (see providerChoices).
+ *
+ * Keep in sync with Pi's docs/providers.md when Pi adds providers. A provider
+ * missing here is not fatal: it still shows up if Pi lists models for it, and
+ * the picker's free-text fallback accepts any id.
+ *
+ * NOTE on the Cloudflare entries: Pi also needs CLOUDFLARE_ACCOUNT_ID (and
+ * CLOUDFLARE_GATEWAY_ID for the gateway) alongside the key. We record only the
+ * key var, so the post-key model refresh may come back empty for those two and
+ * the wizard falls back to free-text — degraded, not broken.
+ */
+export const PI_PROVIDER_CATALOG: readonly Omit<PiProvider, "hasModels">[] = [
+  { id: "anthropic", label: "Anthropic", envVar: "ANTHROPIC_API_KEY" },
+  { id: "ant-ling", label: "Ant Ling", envVar: "ANT_LING_API_KEY" },
+  {
+    id: "azure-openai-responses",
+    label: "Azure OpenAI Responses",
+    envVar: "AZURE_OPENAI_API_KEY",
+  },
+  { id: "openai", label: "OpenAI", envVar: "OPENAI_API_KEY" },
+  { id: "deepseek", label: "DeepSeek", envVar: "DEEPSEEK_API_KEY" },
+  { id: "nvidia", label: "NVIDIA NIM", envVar: "NVIDIA_API_KEY" },
+  { id: "google", label: "Google Gemini", envVar: "GEMINI_API_KEY" },
+  { id: "mistral", label: "Mistral", envVar: "MISTRAL_API_KEY" },
+  { id: "groq", label: "Groq", envVar: "GROQ_API_KEY" },
+  { id: "cerebras", label: "Cerebras", envVar: "CEREBRAS_API_KEY" },
+  {
+    id: "cloudflare-ai-gateway",
+    label: "Cloudflare AI Gateway",
+    envVar: "CLOUDFLARE_API_KEY",
+  },
+  {
+    id: "cloudflare-workers-ai",
+    label: "Cloudflare Workers AI",
+    envVar: "CLOUDFLARE_API_KEY",
+  },
+  { id: "xai", label: "xAI", envVar: "XAI_API_KEY" },
+  { id: "openrouter", label: "OpenRouter", envVar: "OPENROUTER_API_KEY" },
+  { id: "vercel-ai-gateway", label: "Vercel AI Gateway", envVar: "AI_GATEWAY_API_KEY" },
+  { id: "zai", label: "ZAI Coding Plan (Global)", envVar: "ZAI_API_KEY" },
+  { id: "zai-coding-cn", label: "ZAI Coding Plan (China)", envVar: "ZAI_CODING_CN_API_KEY" },
+  { id: "opencode", label: "OpenCode Zen", envVar: "OPENCODE_API_KEY" },
+  { id: "opencode-go", label: "OpenCode Go", envVar: "OPENCODE_API_KEY" },
+  { id: "huggingface", label: "Hugging Face", envVar: "HF_TOKEN" },
+  { id: "fireworks", label: "Fireworks", envVar: "FIREWORKS_API_KEY" },
+  { id: "together", label: "Together AI", envVar: "TOGETHER_API_KEY" },
+  { id: "kimi-coding", label: "Kimi For Coding", envVar: "KIMI_API_KEY" },
+  { id: "minimax", label: "MiniMax", envVar: "MINIMAX_API_KEY" },
+  { id: "minimax-cn", label: "MiniMax (China)", envVar: "MINIMAX_CN_API_KEY" },
+  { id: "xiaomi", label: "Xiaomi MiMo", envVar: "XIAOMI_API_KEY" },
+  {
+    id: "xiaomi-token-plan-cn",
+    label: "Xiaomi MiMo Token Plan (China)",
+    envVar: "XIAOMI_TOKEN_PLAN_CN_API_KEY",
+  },
+  {
+    id: "xiaomi-token-plan-ams",
+    label: "Xiaomi MiMo Token Plan (Amsterdam)",
+    envVar: "XIAOMI_TOKEN_PLAN_AMS_API_KEY",
+  },
+  {
+    id: "xiaomi-token-plan-sgp",
+    label: "Xiaomi MiMo Token Plan (Singapore)",
+    envVar: "XIAOMI_TOKEN_PLAN_SGP_API_KEY",
+  },
+];
+
+/** The provider's native API-key env var, or undefined if we don't know one. */
+export function providerEnvVar(providerId: string): string | undefined {
+  return PI_PROVIDER_CATALOG.find((p) => p.id === providerId)?.envVar;
+}
+
+/**
+ * The provider picker's options: the static catalogue UNIONED with every
+ * provider `pi --list-models` actually reported.
+ *
+ * The union matters in both directions:
+ *   - catalogue-only (no key yet)  → still offered, so a fresh install can pick
+ *     a provider and key it. This is the fresh-install fix.
+ *   - live-only (not in catalogue) → still offered, so a provider Pi added after
+ *     this catalogue was written (or a custom/base-url one) is never hidden just
+ *     because we're out of date. Labelled by its bare id.
+ *
+ * Ordering is deliberate: providers Pi already has models for come FIRST (the
+ * operator is most likely picking one of those, and on a configured box that
+ * keeps the familiar short list at the top), then the rest of the catalogue
+ * alphabetically by label. Pure + total, so the picker itself stays thin glue.
+ */
+export function providerChoices(models: readonly PiModel[]): PiProvider[] {
+  const live = new Set(models.map((m) => m.provider));
+  const known = new Map(PI_PROVIDER_CATALOG.map((p) => [p.id, p.label]));
+  const ids = new Set<string>([...known.keys(), ...live]);
+  const byLabel = (a: PiProvider, b: PiProvider) => a.label.localeCompare(b.label);
+  const all = [...ids].map((id) => ({
+    id,
+    label: known.get(id) ?? id,
+    hasModels: live.has(id),
+  }));
+  return [
+    ...all.filter((p) => p.hasModels).sort(byLabel),
+    ...all.filter((p) => !p.hasModels).sort(byLabel),
+  ];
 }
 
 /**

--- a/src/lib/piRouting.ts
+++ b/src/lib/piRouting.ts
@@ -265,3 +265,57 @@ export function computeRoutingWrites(choices: RoutingChoices): RoutingWrites {
 
   return { toml, env };
 }
+
+/**
+ * The TOML keys under `[harnesses.pi.routing]` that the wizard owns. Listed once
+ * so `computeRoutingClears` and the wizard's TOML delete stay in lockstep with
+ * what `computeRoutingWrites` sets.
+ */
+export const ROUTING_TOML_KEYS = [
+  "provider",
+  "primary_model",
+  "image_model",
+  "coding_model",
+] as const;
+
+/**
+ * The inverse of `computeRoutingWrites`: everything the wizard must ERASE for
+ * the "Use Pi's own config" path.
+ *
+ * WHY THIS EXISTS: choosing the old "later" option merely returned early — it
+ * wrote nothing, but it also CLEARED nothing. Routing lives in two places
+ * (config.toml's `[harnesses.pi.routing]` AND ~/.env), and harnesses/pi.ts
+ * re-reads them every turn to thread `--model`/`--provider`/`--api-key`. So once
+ * "now" had been run even once, its values persisted and "later" was a silent
+ * no-op: Pi kept getting the old primary/image/coding routing forever. The note
+ * claiming "Pi falls back to its own local-store settings" was only ever true on
+ * a virgin box. Delegating to Pi's own config REQUIRES actively erasing both
+ * stores, after which pi.ts pushes no flags (its writes are already guarded on
+ * the values being present) and Pi reads ~/.pi/agent/settings.json — the config
+ * the user created when they ran `pi` and logged into their provider.
+ *
+ * The API KEY is cleared too, and that is load-bearing rather than tidiness:
+ * `pi --provider` DEFAULTS TO GOOGLE, so a surviving PHANTOMBOT_PI_API_KEY (say
+ * an OpenRouter key) with the provider erased would be fired at Google every
+ * turn and auth-fail. Clearing the key restores the documented tier-2 fallback
+ * (no `--api-key` flag ⇒ Pi uses its own auth store), which is exactly what
+ * "use Pi's own config" means.
+ *
+ * "" is the unset sentinel for env writes (updateEnvFile / computeRoutingWrites
+ * delete semantics), so this mirrors that convention.
+ */
+export function computeRoutingClears(): {
+  tomlKeys: readonly string[];
+  env: Record<string, string>;
+} {
+  return {
+    tomlKeys: ROUTING_TOML_KEYS,
+    env: {
+      [ENV_PI_PROVIDER]: "",
+      [ENV_PRIMARY_MODEL]: "",
+      [ENV_IMAGE_MODEL]: "",
+      [ENV_CODING_MODEL]: "",
+      [ENV_PI_API_KEY]: "",
+    },
+  };
+}

--- a/tests/cli-harness-routing.test.ts
+++ b/tests/cli-harness-routing.test.ts
@@ -2,9 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { applyRouting } from "../src/cli/harness.ts";
-import { resolveRoutingProvider } from "../src/lib/piRouting.ts";
-import { loadEnvFile } from "../src/lib/envFile.ts";
+import { applyRouting, clearPiRouting } from "../src/cli/harness.ts";
+import {
+  computeRoutingClears,
+  resolveRoutingProvider,
+} from "../src/lib/piRouting.ts";
+import { loadEnvFile, updateEnvFile } from "../src/lib/envFile.ts";
 import { readConfigToml } from "../src/lib/configWriter.ts";
 
 let workdir: string;
@@ -19,6 +22,86 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(workdir, { recursive: true, force: true });
+});
+
+describe("clearPiRouting (the 'Use Pi's own config' path)", () => {
+  test("erases routing from BOTH toml and env after a configured run", async () => {
+    // THE regression: the old "later" option returned early without clearing,
+    // so once "now" had run, its routing persisted and pi.ts kept threading
+    // --model/--provider forever. Configure first, then delegate to Pi.
+    await applyRouting(
+      configPath,
+      {
+        provider: "openrouter",
+        primaryModel: "deepseek-v4-pro",
+        imageModel: "gpt-4o",
+        codingModel: "gpt-5.2-codex",
+      },
+      envPath,
+    );
+    await updateEnvFile(envPath, { PHANTOMBOT_PI_API_KEY: "sk-stale" });
+
+    await clearPiRouting(configPath, envPath);
+
+    const toml = await readConfigToml(configPath);
+    const routing = (toml as any).harnesses.pi.routing;
+    expect(routing.provider).toBeUndefined();
+    expect(routing.primary_model).toBeUndefined();
+    expect(routing.image_model).toBeUndefined();
+    expect(routing.coding_model).toBeUndefined();
+
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_PI_PROVIDER).toBeUndefined();
+    expect(env.PHANTOMBOT_PRIMARY_MODEL).toBeUndefined();
+    expect(env.PHANTOMBOT_IMAGE_MODEL).toBeUndefined();
+    expect(env.PHANTOMBOT_CODING_MODEL).toBeUndefined();
+  });
+
+  test("clears the stale API key too (it would be fired at google)", async () => {
+    // pi --provider defaults to GOOGLE, so a surviving OpenRouter key with the
+    // provider erased auth-fails every turn. Clearing it restores Pi's own
+    // auth-store fallback, which is what 'use Pi's own config' means.
+    await applyRouting(
+      configPath,
+      { provider: "openrouter", primaryModel: "deepseek-v4-pro" },
+      envPath,
+    );
+    await updateEnvFile(envPath, { PHANTOMBOT_PI_API_KEY: "sk-stale" });
+
+    await clearPiRouting(configPath, envPath);
+
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_PI_API_KEY).toBeUndefined();
+  });
+
+  test("leaves unrelated env vars and config alone", async () => {
+    await applyRouting(configPath, { primaryModel: "gpt-5.2" }, envPath);
+    await updateEnvFile(envPath, { TELEGRAM_BOT_TOKEN: "keep-me" });
+
+    await clearPiRouting(configPath, envPath);
+
+    const env = await loadEnvFile(envPath);
+    expect(env.TELEGRAM_BOT_TOKEN).toBe("keep-me");
+  });
+
+  test("is a safe no-op on a virgin box (nothing configured yet)", async () => {
+    await clearPiRouting(configPath, envPath);
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_PRIMARY_MODEL).toBeUndefined();
+  });
+
+  test("clears every key applyRouting can write", () => {
+    // Guard against drift: if computeRoutingWrites learns a new key, this fails
+    // until computeRoutingClears erases it too.
+    const clears = computeRoutingClears();
+    expect([...clears.tomlKeys].sort()).toEqual([
+      "coding_model",
+      "image_model",
+      "primary_model",
+      "provider",
+    ]);
+    expect(Object.values(clears.env).every((v) => v === "")).toBe(true);
+  });
 });
 
 describe("applyRouting", () => {

--- a/tests/lib-piModels.test.ts
+++ b/tests/lib-piModels.test.ts
@@ -3,7 +3,10 @@ import {
   findModel,
   listPiModels,
   parsePiModels,
+  PI_PROVIDER_CATALOG,
   primaryIsMultimodal,
+  providerChoices,
+  providerEnvVar,
 } from "../src/lib/piModels.ts";
 
 // A trimmed but faithful sample of real `pi --list-models` output: a banner
@@ -102,5 +105,94 @@ describe("listPiModels", () => {
       throw new Error("ENOENT");
     });
     expect(models).toEqual([]);
+  });
+
+  test("passes extraEnv through to the runner (post-key refresh)", async () => {
+    // The wizard refreshes the catalog after taking a key by injecting the
+    // provider's NATIVE env var — `--list-models` ignores --api-key. Pin that
+    // the value actually reaches the runner.
+    let seen: Record<string, string> | undefined;
+    await listPiModels(
+      "pi",
+      async (_bin, extraEnv) => {
+        seen = extraEnv;
+        return { exitCode: 0, stdout: SAMPLE };
+      },
+      { OPENROUTER_API_KEY: "sk-test" },
+    );
+    expect(seen).toEqual({ OPENROUTER_API_KEY: "sk-test" });
+  });
+
+  test("extraEnv is undefined when not supplied (inherit, as before)", async () => {
+    let seen: Record<string, string> | undefined | "unset" = "unset";
+    await listPiModels("pi", async (_bin, extraEnv) => {
+      seen = extraEnv;
+      return { exitCode: 0, stdout: SAMPLE };
+    });
+    expect(seen).toBeUndefined();
+  });
+});
+
+describe("providerChoices", () => {
+  // THE fresh-install regression: `pi --list-models` lists nothing until Pi
+  // already holds a key, so deriving providers from it alone left the picker
+  // empty exactly when the operator came to add their first key.
+  test("offers the full catalog when pi lists no models (fresh install)", () => {
+    const choices = providerChoices([]);
+    expect(choices.length).toBe(PI_PROVIDER_CATALOG.length);
+    expect(choices.map((c) => c.id)).toContain("openrouter");
+    expect(choices.map((c) => c.id)).toContain("anthropic");
+    expect(choices.every((c) => c.hasModels === false)).toBe(true);
+  });
+
+  test("marks providers pi already has models for", () => {
+    const choices = providerChoices(parsePiModels(SAMPLE));
+    const keyed = choices.filter((c) => c.hasModels).map((c) => c.id);
+    expect(keyed.sort()).toEqual(["deepseek", "openai", "openrouter"]);
+  });
+
+  test("keyed providers sort first, then the rest by label", () => {
+    const choices = providerChoices(parsePiModels(SAMPLE));
+    const firstUnkeyed = choices.findIndex((c) => !c.hasModels);
+    expect(choices.slice(0, firstUnkeyed).every((c) => c.hasModels)).toBe(true);
+    expect(choices.slice(firstUnkeyed).every((c) => !c.hasModels)).toBe(true);
+    // Keyed block is label-sorted: DeepSeek, OpenAI, OpenRouter.
+    expect(choices.slice(0, 3).map((c) => c.label)).toEqual([
+      "DeepSeek",
+      "OpenAI",
+      "OpenRouter",
+    ]);
+  });
+
+  test("includes live providers missing from the catalog, labelled by id", () => {
+    const choices = providerChoices([
+      { provider: "some-new-provider", model: "m1", supportsImages: false },
+    ]);
+    const found = choices.find((c) => c.id === "some-new-provider");
+    expect(found).toEqual({
+      id: "some-new-provider",
+      label: "some-new-provider",
+      hasModels: true,
+    });
+  });
+
+  test("never duplicates a provider that is both catalogued and live", () => {
+    const choices = providerChoices(parsePiModels(SAMPLE));
+    const ids = choices.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("providerEnvVar", () => {
+  test("maps catalog providers to their native pi env var", () => {
+    expect(providerEnvVar("openrouter")).toBe("OPENROUTER_API_KEY");
+    // Pi's provider id is `google` while its docs label is "Google Gemini" —
+    // the id is what --provider takes, the var is what --list-models reads.
+    expect(providerEnvVar("google")).toBe("GEMINI_API_KEY");
+    expect(providerEnvVar("huggingface")).toBe("HF_TOKEN");
+  });
+
+  test("undefined for an unknown provider (refresh is skipped)", () => {
+    expect(providerEnvVar("some-new-provider")).toBeUndefined();
   });
 });


### PR DESCRIPTION
Two nits in the Pi harness wizard, both of which made the fresh-install path worse than it looked.

## 1. "Use Pi's own config" was a silent no-op

The old `later` branch returned early — it wrote nothing, but it also **cleared nothing**. Routing lives in *two* stores (`config.toml`'s `[harnesses.pi.routing]` **and** `~/.env`), and `harnesses/pi.ts` re-reads them every turn to thread `--model`/`--provider`/`--api-key`. So once "now" had run even once, its values persisted and "later" could never take effect — Pi kept getting the old primary/image/coding routing forever. The note claiming *"Pi falls back to its own local-store settings"* was only ever true on a virgin box.

Delegating to Pi now **actively erases both stores** (`computeRoutingClears` + `clearPiRouting`), after which `pi.ts` pushes no flags (it's already guarded on the values being present) and Pi reads `~/.pi/agent/settings.json` — the config the user created when they ran `pi` and logged into their provider.

The **API key is cleared too**, and that's load-bearing rather than tidiness: `pi --provider` **defaults to google**, so a surviving `PHANTOMBOT_PI_API_KEY` (say an OpenRouter key) with the provider erased would be fired at Google every turn and auth-fail.

## 2. The provider picker was empty on a fresh install

It derived providers from `pi --list-models`, which only lists models for providers Pi **already has a key for**. A fresh install prints `No models available. Use /login…` → no header row → `parsePiModels` returns `[]` → free-text fallback. That's the chicken-and-egg: *you can't pick a provider to key it, because it isn't listed until it's keyed* — precisely backwards, since the operator is in the wizard to add their **first** key.

Adds `PI_PROVIDER_CATALOG` (28 providers transcribed from Pi's own `docs/providers.md`) and `providerChoices()`, which **unions** the catalogue with whatever `--list-models` reported. The union matters both ways:
- catalogue-only (no key yet) → still offered ⇒ **the fresh-install fix**
- live-only (post-catalogue / custom provider) → still offered, never hidden by us being out of date

Keyed providers sort first with an *"key already configured"* hint, so a configured box still reads at a glance.

After the key is taken the catalogue is **refreshed** so the model pickers populate. This has to inject the provider's **native** env var (e.g. `OPENROUTER_API_KEY`) — verified against pi 0.79.1 that `--list-models` **ignores** `--api-key`/`--provider` and reads auth only from `~/.pi/agent/auth.json` + native vars:

```
$ env -i HOME=/tmp/fresh PATH=$PATH pi --list-models --provider openrouter --api-key sk-...
No models available. Use /login to log into a provider via OAuth or API key.

$ env -i HOME=/tmp/fresh PATH=$PATH OPENROUTER_API_KEY=sk-... pi --list-models
provider    model                            context  max-out  thinking  images
openrouter  ~anthropic/claude-opus-latest    1M       128K     yes       yes
... (257 lines)
```

If the refresh comes back empty (bad key, unknown provider, provider outage) the pickers **degrade to free-text** rather than dead-ending the wizard.

## Naming

`now` / `later` → **"Configure models"** / **"Use Pi's own config"**. The old wording described *when* you'd configure; the real choice is *who owns the config*.

## Tests

`bun test` → 2295 pass / 0 fail; `tsc --noEmit` clean.

New: `providerChoices` (fresh-install catalogue, keyed-first ordering, live-only providers, no dupes), `providerEnvVar`, `listPiModels` extraEnv passthrough, and `clearPiRouting` (clears both stores incl. the stale key, leaves unrelated env alone, no-op on a virgin box, plus a drift guard tying `computeRoutingClears` to `computeRoutingWrites`).

The TUI glue stays thin and manually verified, per this file's convention — all the new logic is pure and unit-tested.