### PR TITLE
feat(phantomchat): multi-mirror Blossom send/receive (bot half of PC #88)

### DIFF
--- a/src/channels/core/types.ts
+++ b/src/channels/core/types.ts
@@ -131,6 +131,12 @@ export interface ChannelMessage {
     durationS?: number;
     /** Plaintext byte size from the envelope (used to skip oversized downloads). */
     size?: number;
+    /**
+     * Optional mirror URLs from the envelope (`servers` field). Receive falls
+     * back across these (and hash GETs on the known Blossom list) when the
+     * primary host is down. Absent on pre-#88 clients — primary URL still works.
+     */
+    servers?: string[];
   };
 }
 

--- a/src/channels/phantomchat/blossomFetch.ts
+++ b/src/channels/phantomchat/blossomFetch.ts
@@ -68,41 +68,69 @@ export async function fetchAndDecryptBlossom(
   }
 
   const fetchImpl = opts?.fetchImpl ?? fetch;
-  const known =
-    opts?.knownServers ??
-    (await getBlossomServers().catch(() => DEFAULT_BLOSSOM_SERVERS));
-  const candidates = expandBlossomFetchUrls(
-    url,
-    opts?.expectedSha256Hex,
-    opts?.mirrors,
-    known,
-  );
   const errors: string[] = [];
 
-  for (const candidate of candidates) {
-    try {
-      const res = await fetchImpl(candidate, { signal: opts?.signal });
-      if (!res.ok) {
-        errors.push(`${candidate}: HTTP ${res.status}`);
-        continue;
-      }
-      const ciphertext = Buffer.from(await res.arrayBuffer());
+  // Happy path first: primary URL + envelope mirrors only. Do NOT resolve the
+  // website server list until those fail *and* we have a sha256 to hash-GET
+  // against — otherwise every inbound voice note pays a blossom.json hop
+  // (today often a 404) out of the STT timeout budget.
+  const direct = expandBlossomFetchUrls(
+    url,
+    undefined,
+    opts?.mirrors,
+    [],
+  );
 
-      // Blossom is content-addressed by sha256 of the (encrypted) bytes.
-      // Verifying catches a corrupt/tampered/wrong-blob fetch before we waste
-      // a GCM auth failure (or a paid STT call) on it.
-      if (opts?.expectedSha256Hex) {
-        const got = createHash("sha256").update(ciphertext).digest("hex");
-        if (got !== opts.expectedSha256Hex.toLowerCase()) {
-          errors.push(`${candidate}: sha256 mismatch`);
+  const tryCandidates = async (candidates: string[]): Promise<Buffer | null> => {
+    for (const candidate of candidates) {
+      if (opts?.signal?.aborted) {
+        throw new Error("blossom fetch aborted");
+      }
+      try {
+        const res = await fetchImpl(candidate, { signal: opts?.signal });
+        if (!res.ok) {
+          errors.push(`${candidate}: HTTP ${res.status}`);
           continue;
         }
-      }
+        const ciphertext = Buffer.from(await res.arrayBuffer());
 
-      return decryptCiphertext(ciphertext, key, iv);
-    } catch (e) {
-      errors.push(`${candidate}: ${(e as Error).message}`);
+        // Blossom is content-addressed by sha256 of the (encrypted) bytes.
+        // Verifying catches a corrupt/tampered/wrong-blob fetch before we waste
+        // a GCM auth failure (or a paid STT call) on it.
+        if (opts?.expectedSha256Hex) {
+          const got = createHash("sha256").update(ciphertext).digest("hex");
+          if (got !== opts.expectedSha256Hex.toLowerCase()) {
+            errors.push(`${candidate}: sha256 mismatch`);
+            continue;
+          }
+        }
+
+        return decryptCiphertext(ciphertext, key, iv);
+      } catch (e) {
+        if (opts?.signal?.aborted) throw e;
+        errors.push(`${candidate}: ${(e as Error).message}`);
+      }
     }
+    return null;
+  };
+
+  const directHit = await tryCandidates(direct);
+  if (directHit) return directHit;
+
+  // Only pay for the known-server list when hash-GET can actually help.
+  if (opts?.expectedSha256Hex && /^[0-9a-fA-F]{64}$/.test(opts.expectedSha256Hex)) {
+    const known =
+      opts?.knownServers ??
+      (await getBlossomServers().catch(() => DEFAULT_BLOSSOM_SERVERS));
+    const hashUrls = expandBlossomFetchUrls(
+      // dummy primary already tried; expand only the hash GETs
+      "",
+      opts.expectedSha256Hex,
+      undefined,
+      known,
+    ).filter((u) => u && !direct.includes(u));
+    const hashHit = await tryCandidates(hashUrls);
+    if (hashHit) return hashHit;
   }
 
   throw new Error(`blossom fetch failed: ${errors.join("; ")}`);

--- a/src/channels/phantomchat/blossomFetch.ts
+++ b/src/channels/phantomchat/blossomFetch.ts
@@ -1,26 +1,62 @@
 /*
  * PhantomChat media: fetch a file from Blossom and AES-256-GCM decrypt it.
  *
- * Counterpart to the PWA's encrypt path (phantomchat/src/lib/phantomchat/
- * file-crypto.ts). The PWA encrypts with Web Crypto `AES-GCM`:
+ * Counterpart to the PWA's encrypt path (phantomchat file-crypto.ts) and
+ * multi-GET receive (phantomchat-file-fetch.ts). Tries the primary URL first,
+ * then any mirrors carried in the envelope, then hash-addressed GETs against
+ * our known Blossom server list. Verifies sha256 of the ciphertext when the
+ * sender provided one before decrypting.
+ *
+ * The PWA encrypts with Web Crypto `AES-GCM`:
  *   - 256-bit key (32 bytes), 96-bit IV (12 bytes), both hex on the wire
  *   - Web Crypto APPENDS the 128-bit (16-byte) auth tag to the ciphertext
  *     (output is ciphertext‖tag), whereas Node's GCM wants the tag supplied
  *     separately — so we split the trailing 16 bytes and `setAuthTag`.
- * The encrypted bytes live at a Blossom URL; the key/iv travel inside the
- * NIP-17 gift-wrap envelope, so only the recipient can decrypt.
+ * The key/iv travel inside the NIP-17 gift-wrap envelope, so only the
+ * recipient can decrypt. Blossom only ever sees ciphertext.
  */
 import { createDecipheriv, createHash } from "node:crypto";
+import {
+  DEFAULT_BLOSSOM_SERVERS,
+  expandBlossomFetchUrls,
+  getBlossomServers,
+} from "./blossomServers.ts";
 
 const GCM_TAG_BYTES = 16;
 const KEY_BYTES = 32;
 const IV_BYTES = 12;
 
+export interface FetchDecryptOpts {
+  expectedSha256Hex?: string;
+  /** Extra mirror URLs from the envelope (`servers` field). */
+  mirrors?: readonly string[];
+  /** Override known servers used for hash-GET fallback. */
+  knownServers?: readonly string[];
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+}
+
+function decryptCiphertext(
+  ciphertext: Buffer,
+  key: Buffer,
+  iv: Buffer,
+): Buffer {
+  if (ciphertext.length < GCM_TAG_BYTES) {
+    throw new Error("blossom: ciphertext shorter than the GCM auth tag");
+  }
+  const tag = ciphertext.subarray(ciphertext.length - GCM_TAG_BYTES);
+  const body = ciphertext.subarray(0, ciphertext.length - GCM_TAG_BYTES);
+
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(body), decipher.final()]);
+}
+
 export async function fetchAndDecryptBlossom(
   url: string,
   keyHex: string,
   ivHex: string,
-  opts?: { expectedSha256Hex?: string; signal?: AbortSignal },
+  opts?: FetchDecryptOpts,
 ): Promise<Buffer> {
   const key = Buffer.from(keyHex, "hex");
   const iv = Buffer.from(ivHex, "hex");
@@ -31,29 +67,43 @@ export async function fetchAndDecryptBlossom(
     throw new Error(`blossom: bad iv length ${iv.length} (want ${IV_BYTES})`);
   }
 
-  const res = await fetch(url, { signal: opts?.signal });
-  if (!res.ok) {
-    throw new Error(`blossom fetch ${url}: HTTP ${res.status}`);
-  }
-  const ciphertext = Buffer.from(await res.arrayBuffer());
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const known =
+    opts?.knownServers ??
+    (await getBlossomServers().catch(() => DEFAULT_BLOSSOM_SERVERS));
+  const candidates = expandBlossomFetchUrls(
+    url,
+    opts?.expectedSha256Hex,
+    opts?.mirrors,
+    known,
+  );
+  const errors: string[] = [];
 
-  // Blossom is content-addressed by sha256 of the (encrypted) bytes. Verifying
-  // it catches a corrupt/tampered/wrong-blob fetch before we waste a GCM auth
-  // failure on it (and before STT spends a paid API call on garbage).
-  if (opts?.expectedSha256Hex) {
-    const got = createHash("sha256").update(ciphertext).digest("hex");
-    if (got !== opts.expectedSha256Hex.toLowerCase()) {
-      throw new Error("blossom: sha256 mismatch (corrupt or tampered file)");
+  for (const candidate of candidates) {
+    try {
+      const res = await fetchImpl(candidate, { signal: opts?.signal });
+      if (!res.ok) {
+        errors.push(`${candidate}: HTTP ${res.status}`);
+        continue;
+      }
+      const ciphertext = Buffer.from(await res.arrayBuffer());
+
+      // Blossom is content-addressed by sha256 of the (encrypted) bytes.
+      // Verifying catches a corrupt/tampered/wrong-blob fetch before we waste
+      // a GCM auth failure (or a paid STT call) on it.
+      if (opts?.expectedSha256Hex) {
+        const got = createHash("sha256").update(ciphertext).digest("hex");
+        if (got !== opts.expectedSha256Hex.toLowerCase()) {
+          errors.push(`${candidate}: sha256 mismatch`);
+          continue;
+        }
+      }
+
+      return decryptCiphertext(ciphertext, key, iv);
+    } catch (e) {
+      errors.push(`${candidate}: ${(e as Error).message}`);
     }
   }
 
-  if (ciphertext.length < GCM_TAG_BYTES) {
-    throw new Error("blossom: ciphertext shorter than the GCM auth tag");
-  }
-  const tag = ciphertext.subarray(ciphertext.length - GCM_TAG_BYTES);
-  const body = ciphertext.subarray(0, ciphertext.length - GCM_TAG_BYTES);
-
-  const decipher = createDecipheriv("aes-256-gcm", key, iv);
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(body), decipher.final()]);
+  throw new Error(`blossom fetch failed: ${errors.join("; ")}`);
 }

--- a/src/channels/phantomchat/blossomServers.ts
+++ b/src/channels/phantomchat/blossomServers.ts
@@ -1,0 +1,143 @@
+/**
+ * Canonical Blossom server list — bot half of phantomchat `/blossom.json`.
+ *
+ * The server set is maintained in ONE place: a static `blossom.json` served by
+ * the PhantomChat PWA (`https://chat.phantomyard.ai/blossom.json`). Continues
+ * the same single-source pattern as `relays.json` / `relaysSource.ts`.
+ *
+ * Hardcoded DEFAULT_BLOSSOM_SERVERS is the disaster net only (offline / 404 /
+ * malformed). Shape on the wire: `{ "servers": ["https://…", …] }`.
+ *
+ * Solid free public set (live write-probe 2026-07-17 for encrypted PhantomChat
+ * media as `application/octet-stream`):
+ *   nostr.download / ditto.pub / data.haus
+ * Dropped: primal (mime-filters octet-stream), band / nostr.build (mime wall),
+ * nostrmedia (paid), satellite (auth/flaky).
+ */
+
+import { log } from "../../lib/logger.ts";
+
+/** Where the canonical Blossom list is served. Overridable via env. */
+export const PHANTOMCHAT_BLOSSOM_URL =
+  process.env.PHANTOMCHAT_BLOSSOM_URL?.trim() ||
+  "https://chat.phantomyard.ai/blossom.json";
+
+/**
+ * Disaster-net list. Must accept NIP-24242 + free `application/octet-stream`
+ * PUT and return the blob via GET `/{sha256}`. Prefer ≥3 independent operators.
+ */
+export const DEFAULT_BLOSSOM_SERVERS: readonly string[] = [
+  "https://nostr.download",
+  "https://blossom.ditto.pub",
+  "https://blossom.data.haus",
+];
+
+/** Prefer ≥2 successful PUTs so a single CDN dying mid-day cannot brick a note. */
+export const BLOSSOM_MIRROR_MIN = 2;
+
+interface BlossomJsonShape {
+  servers?: unknown;
+}
+
+function normalizeServer(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function validServers(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const u of v) {
+    if (typeof u !== "string" || !u.startsWith("https://")) continue;
+    const n = normalizeServer(u.trim());
+    if (n.length <= "https://x".length || seen.has(n)) continue;
+    seen.add(n);
+    out.push(n);
+  }
+  return out;
+}
+
+/**
+ * Fetch the canonical Blossom list from `url` (default: the PWA's served file).
+ * Returns the server URLs on success, or `null` on ANY failure so the caller
+ * falls back to the hardcoded seed. Never throws.
+ */
+export async function fetchCanonicalBlossomServers(
+  url: string = PHANTOMCHAT_BLOSSOM_URL,
+  timeoutMs = 5000,
+): Promise<string[] | null> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: ac.signal });
+    if (!res.ok) {
+      log.debug("phantomchat: blossom.json fetch non-ok", { status: res.status });
+      return null;
+    }
+    const data = (await res.json()) as BlossomJsonShape;
+    const servers = validServers(data?.servers);
+    if (servers.length === 0) {
+      log.debug("phantomchat: blossom.json had no valid https entries");
+      return null;
+    }
+    return servers;
+  } catch (e) {
+    log.debug("phantomchat: blossom.json fetch failed", {
+      error: (e as Error).message,
+    });
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve the server list for this call. Always returns ≥1 URL — either the
+ * website list or the disaster-net default. Optional override wins (tests /
+ * ops pin).
+ */
+export async function getBlossomServers(opts?: {
+  servers?: readonly string[];
+}): Promise<readonly string[]> {
+  if (opts?.servers && opts.servers.length > 0) {
+    return opts.servers.map((s) => normalizeServer(s));
+  }
+  const fetched = await fetchCanonicalBlossomServers();
+  return fetched && fetched.length > 0 ? fetched : DEFAULT_BLOSSOM_SERVERS;
+}
+
+/** Build a hash-addressed mirror URL on a given server (BUD-01). */
+export function blossomHashUrl(server: string, sha256: string): string {
+  return `${normalizeServer(server)}/${sha256.toLowerCase()}`;
+}
+
+/**
+ * Expand a primary URL + optional mirror list + known servers into an ordered
+ * unique candidate list for receive: primary → listed mirrors → hash GETs on
+ * our known servers.
+ */
+export function expandBlossomFetchUrls(
+  primaryUrl: string,
+  sha256: string | undefined,
+  mirrors: readonly string[] | undefined,
+  knownServers: readonly string[] = DEFAULT_BLOSSOM_SERVERS,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (u: string | undefined) => {
+    if (!u || typeof u !== "string") return;
+    const n = u.trim();
+    if (!n || seen.has(n)) return;
+    seen.add(n);
+    out.push(n);
+  };
+
+  add(primaryUrl);
+  if (mirrors) {
+    for (const m of mirrors) add(m);
+  }
+  if (sha256 && /^[0-9a-fA-F]{64}$/.test(sha256)) {
+    for (const s of knownServers) add(blossomHashUrl(s, sha256));
+  }
+  return out;
+}

--- a/src/channels/phantomchat/blossomServers.ts
+++ b/src/channels/phantomchat/blossomServers.ts
@@ -2,8 +2,10 @@
  * Canonical Blossom server list — bot half of phantomchat `/blossom.json`.
  *
  * The server set is maintained in ONE place: a static `blossom.json` served by
- * the PhantomChat PWA (`https://chat.phantomyard.ai/blossom.json`). Continues
- * the same single-source pattern as `relays.json` / `relaysSource.ts`.
+ * the PhantomChat PWA (`https://chat.phantomyard.ai/blossom.json`). Same source
+ * of truth as `relays.json`, but loaded with a short in-process TTL cache (not a
+ * startup pin to phantomchat.json) so a 404/hang never burns the STT budget on
+ * every inbound voice note — and a temporary seed fallback is not sticky for an hour.
  *
  * Hardcoded DEFAULT_BLOSSOM_SERVERS is the disaster net only (offline / 404 /
  * malformed). Shape on the wire: `{ "servers": ["https://…", …] }`.
@@ -16,6 +18,16 @@
  */
 
 import { log } from "../../lib/logger.ts";
+
+/** How long a successful website list is reused in-process. */
+const BLOSSOM_LIST_TTL_MS = 60 * 60 * 1000;
+
+let blossomListCache: { servers: readonly string[]; at: number } | null = null;
+
+/** Test / force-refresh hook — not part of the public channel API. */
+export function clearBlossomServersCache(): void {
+  blossomListCache = null;
+}
 
 /** Where the canonical Blossom list is served. Overridable via env. */
 export const PHANTOMCHAT_BLOSSOM_URL =
@@ -95,6 +107,10 @@ export async function fetchCanonicalBlossomServers(
  * Resolve the server list for this call. Always returns ≥1 URL — either the
  * website list or the disaster-net default. Optional override wins (tests /
  * ops pin).
+ *
+ * Caches *successful* website answers for BLOSSOM_LIST_TTL_MS. A 404 / empty /
+ * throw does NOT pin the seed for an hour — we fall back for this call only and
+ * retry the website next time.
  */
 export async function getBlossomServers(opts?: {
   servers?: readonly string[];
@@ -102,8 +118,15 @@ export async function getBlossomServers(opts?: {
   if (opts?.servers && opts.servers.length > 0) {
     return opts.servers.map((s) => normalizeServer(s));
   }
+  if (blossomListCache && Date.now() - blossomListCache.at < BLOSSOM_LIST_TTL_MS) {
+    return blossomListCache.servers;
+  }
   const fetched = await fetchCanonicalBlossomServers();
-  return fetched && fetched.length > 0 ? fetched : DEFAULT_BLOSSOM_SERVERS;
+  if (fetched && fetched.length > 0) {
+    blossomListCache = { servers: fetched, at: Date.now() };
+    return fetched;
+  }
+  return DEFAULT_BLOSSOM_SERVERS;
 }
 
 /** Build a hash-addressed mirror URL on a given server (BUD-01). */

--- a/src/channels/phantomchat/blossomUpload.ts
+++ b/src/channels/phantomchat/blossomUpload.ts
@@ -1,25 +1,32 @@
 /*
  * PhantomChat media: upload an encrypted blob to Blossom.
  *
- * Port of the PWA's uploadToBlossom (phantomchat/src/lib/phantomchat/
- * blossom-upload.ts). Signs a NIP-24242 auth event with our PhantomChat secret
- * key and PUTs the ciphertext to a fallback chain of public Blossom servers,
- * returning the URL of the first server that accepts it. The content address is
- * the sha256 of the encrypted bytes (computed by the caller and carried in the
- * auth event's `x` tag).
+ * Port of the PWA's multi-mirror upload (phantomchat blossom-upload-progress.ts).
+ * Signs a NIP-24242 auth event with our PhantomChat secret key and PUTs the
+ * ciphertext to public Blossom servers until we have ≥BLOSSOM_MIRROR_MIN
+ * successes (or the list is exhausted). Returns the primary URL plus every
+ * successful mirror so the envelope can carry them for multi-GET receive.
+ *
+ * Server list comes from the PWA-served /blossom.json (see blossomServers.ts);
+ * the hardcoded DEFAULT_BLOSSOM_SERVERS is disaster-net only.
  */
 import { finalizeEvent } from "nostr-tools/pure";
 import { log } from "../../lib/logger.ts";
+import {
+  BLOSSOM_MIRROR_MIN,
+  DEFAULT_BLOSSOM_SERVERS,
+  getBlossomServers,
+} from "./blossomServers.ts";
 
-export const BLOSSOM_SERVERS = [
-  "https://blossom.primal.net",
-  "https://cdn.satellite.earth",
-  "https://blossom.band",
-] as const;
+/** @deprecated Prefer DEFAULT_BLOSSOM_SERVERS / getBlossomServers(). */
+export const BLOSSOM_SERVERS = DEFAULT_BLOSSOM_SERVERS;
 
 export interface BlossomUploadResult {
+  /** Primary URL — first successful PUT. Goes in envelope.url. */
   url: string;
   sha256: string;
+  /** Every successful URL including primary. Recipient tries these in order. */
+  mirrors: string[];
 }
 
 /** Upload window the signed auth event stays valid for (matches the PWA). */
@@ -32,12 +39,15 @@ export async function uploadToBlossom(
   mime: string,
   opts?: {
     servers?: readonly string[];
+    /** Min successful mirrors (default BLOSSOM_MIRROR_MIN). At least 1. */
+    minMirrors?: number;
     signal?: AbortSignal;
     fetchImpl?: typeof fetch;
   },
 ): Promise<BlossomUploadResult> {
-  const servers = opts?.servers ?? BLOSSOM_SERVERS;
+  const servers = await getBlossomServers({ servers: opts?.servers });
   const fetchImpl = opts?.fetchImpl ?? fetch;
+  const minMirrors = Math.max(1, opts?.minMirrors ?? BLOSSOM_MIRROR_MIN);
   const now = Math.floor(Date.now() / 1000);
 
   // NIP-24242 Blossom auth: kind-24242 with the action ('upload'), the blob
@@ -60,7 +70,15 @@ export async function uploadToBlossom(
   const authHeader = "Nostr " + Buffer.from(JSON.stringify(event)).toString("base64");
 
   const errors: string[] = [];
+  const mirrors: string[] = [];
+  let firstSha = sha256Hex;
+
   for (const server of servers) {
+    if (opts?.signal?.aborted) {
+      throw new Error("upload aborted");
+    }
+    if (mirrors.length >= minMirrors) break;
+
     try {
       const res = await fetchImpl(`${server}/upload`, {
         method: "PUT",
@@ -80,14 +98,25 @@ export async function uploadToBlossom(
         errors.push(`${server}: no url in response`);
         continue;
       }
-      return { url: data.url, sha256: data.sha256 || sha256Hex };
+      if (!mirrors.includes(data.url)) mirrors.push(data.url);
+      if (data.sha256) firstSha = data.sha256;
     } catch (e) {
-      errors.push(`${server}: ${(e as Error).message}`);
+      const msg = (e as Error).message;
+      if (msg === "upload aborted") throw e;
+      errors.push(`${server}: ${msg}`);
     }
   }
 
-  log.warn("phantomchat: blossom upload failed on all servers", {
-    servers: servers.length,
-  });
-  throw new Error(`all blossom servers failed: ${errors.join("; ")}`);
+  if (mirrors.length === 0) {
+    log.warn("phantomchat: blossom upload failed on all servers", {
+      servers: servers.length,
+    });
+    throw new Error(`all blossom servers failed: ${errors.join("; ")}`);
+  }
+
+  return {
+    url: mirrors[0]!,
+    sha256: firstSha || sha256Hex,
+    mirrors,
+  };
 }

--- a/src/channels/phantomchat/blossomUpload.ts
+++ b/src/channels/phantomchat/blossomUpload.ts
@@ -24,6 +24,7 @@ export const BLOSSOM_SERVERS = DEFAULT_BLOSSOM_SERVERS;
 export interface BlossomUploadResult {
   /** Primary URL — first successful PUT. Goes in envelope.url. */
   url: string;
+  /** Local sha256 of the ciphertext we uploaded. Never trusted from a server. */
   sha256: string;
   /** Every successful URL including primary. Recipient tries these in order. */
   mirrors: string[];
@@ -71,7 +72,6 @@ export async function uploadToBlossom(
 
   const errors: string[] = [];
   const mirrors: string[] = [];
-  let firstSha = sha256Hex;
 
   for (const server of servers) {
     if (opts?.signal?.aborted) {
@@ -98,12 +98,21 @@ export async function uploadToBlossom(
         errors.push(`${server}: no url in response`);
         continue;
       }
+      // Integrity hash is always our local compute. A server-echoed sha is
+      // informational only — never authoritative for the envelope / receiver.
+      if (data.sha256 && data.sha256.toLowerCase() !== sha256Hex.toLowerCase()) {
+        log.debug("phantomchat: blossom server echoed mismatched sha256", {
+          server,
+          echoed: data.sha256,
+          expected: sha256Hex,
+        });
+      }
       if (!mirrors.includes(data.url)) mirrors.push(data.url);
-      if (data.sha256) firstSha = data.sha256;
     } catch (e) {
-      const msg = (e as Error).message;
-      if (msg === "upload aborted") throw e;
-      errors.push(`${server}: ${msg}`);
+      // Mid-PUT aborts surface as DOMException "The operation was aborted"
+      // (wording varies by runtime) — check the signal, not the message.
+      if (opts?.signal?.aborted) throw e;
+      errors.push(`${server}: ${(e as Error).message}`);
     }
   }
 
@@ -116,7 +125,7 @@ export async function uploadToBlossom(
 
   return {
     url: mirrors[0]!,
-    sha256: firstSha || sha256Hex,
+    sha256: sha256Hex,
     mirrors,
   };
 }

--- a/src/channels/phantomchat/blossomUpload.ts
+++ b/src/channels/phantomchat/blossomUpload.ts
@@ -2,10 +2,10 @@
  * PhantomChat media: upload an encrypted blob to Blossom.
  *
  * Port of the PWA's multi-mirror upload (phantomchat blossom-upload-progress.ts).
- * Signs a NIP-24242 auth event with our PhantomChat secret key and PUTs the
- * ciphertext to public Blossom servers until we have ≥BLOSSOM_MIRROR_MIN
- * successes (or the list is exhausted). Returns the primary URL plus every
- * successful mirror so the envelope can carry them for multi-GET receive.
+ * Signs a NIP-24242 auth event with our PhantomChat secret key and fans PUTs
+ * out in parallel to minMirrors hosts (`Promise.allSettled`). Returns the
+ * primary URL plus every successful mirror so the envelope can carry them
+ * for multi-GET receive.
  *
  * Server list comes from the PWA-served /blossom.json (see blossomServers.ts);
  * the hardcoded DEFAULT_BLOSSOM_SERVERS is disaster-net only.
@@ -40,7 +40,7 @@ export async function uploadToBlossom(
   mime: string,
   opts?: {
     servers?: readonly string[];
-    /** Min successful mirrors (default BLOSSOM_MIRROR_MIN). At least 1. */
+    /** Min successful mirrors (default BLOSSOM_MIRROR_MIN). Caps fan-out. */
     minMirrors?: number;
     signal?: AbortSignal;
     fetchImpl?: typeof fetch;
@@ -51,10 +51,14 @@ export async function uploadToBlossom(
   const minMirrors = Math.max(1, opts?.minMirrors ?? BLOSSOM_MIRROR_MIN);
   const now = Math.floor(Date.now() / 1000);
 
+  // Match the PWA: open minMirrors hosts in parallel (timing at max(t),
+  // not t1+t2) without burning full-list egress.
+  const targets = servers.slice(0, minMirrors);
+
   // NIP-24242 Blossom auth: kind-24242 with the action ('upload'), the blob
   // hash ('x'), and an expiration. Signed with our real key — the upload is
   // not gift-wrapped (the blob is already AES-GCM ciphertext; only the
-  // recipient holds the key).
+  // recipient holds the key). One auth event covers every leg.
   const event = finalizeEvent(
     {
       kind: 24242,
@@ -70,16 +74,12 @@ export async function uploadToBlossom(
   );
   const authHeader = "Nostr " + Buffer.from(JSON.stringify(event)).toString("base64");
 
-  const errors: string[] = [];
-  const mirrors: string[] = [];
+  if (opts?.signal?.aborted) {
+    throw new Error("upload aborted");
+  }
 
-  for (const server of servers) {
-    if (opts?.signal?.aborted) {
-      throw new Error("upload aborted");
-    }
-    if (mirrors.length >= minMirrors) break;
-
-    try {
+  const results = await Promise.allSettled(
+    targets.map(async (server) => {
       const res = await fetchImpl(`${server}/upload`, {
         method: "PUT",
         headers: {
@@ -90,13 +90,11 @@ export async function uploadToBlossom(
         signal: opts?.signal,
       });
       if (!res.ok) {
-        errors.push(`${server}: HTTP ${res.status}`);
-        continue;
+        throw new Error(`${server}: HTTP ${res.status}`);
       }
       const data = (await res.json()) as { url?: string; sha256?: string };
       if (!data.url) {
-        errors.push(`${server}: no url in response`);
-        continue;
+        throw new Error(`${server}: no url in response`);
       }
       // Integrity hash is always our local compute. A server-echoed sha is
       // informational only — never authoritative for the envelope / receiver.
@@ -107,18 +105,30 @@ export async function uploadToBlossom(
           expected: sha256Hex,
         });
       }
-      if (!mirrors.includes(data.url)) mirrors.push(data.url);
-    } catch (e) {
-      // Mid-PUT aborts surface as DOMException "The operation was aborted"
-      // (wording varies by runtime) — check the signal, not the message.
-      if (opts?.signal?.aborted) throw e;
-      errors.push(`${server}: ${(e as Error).message}`);
+      return data.url;
+    }),
+  );
+
+  // Mid-fan-out abort: shared signal killed every leg; don't surface partials.
+  if (opts?.signal?.aborted) {
+    throw new Error("upload aborted");
+  }
+
+  const errors: string[] = [];
+  const mirrors: string[] = [];
+  for (const r of results) {
+    if (r.status === "fulfilled") {
+      if (!mirrors.includes(r.value)) mirrors.push(r.value);
+    } else {
+      const msg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      if (opts?.signal?.aborted) continue;
+      errors.push(msg);
     }
   }
 
   if (mirrors.length === 0) {
     log.warn("phantomchat: blossom upload failed on all servers", {
-      servers: servers.length,
+      servers: targets.length,
     });
     throw new Error(`all blossom servers failed: ${errors.join("; ")}`);
   }

--- a/src/channels/phantomchat/channel.ts
+++ b/src/channels/phantomchat/channel.ts
@@ -302,6 +302,16 @@ export function createPhantomchatChannel(
               typeof fm.ivHex === "string" ? fm.ivHex : typeof fm.iv === "string" ? fm.iv : "";
             if (keyHex && ivHex) {
               const mt = typeof fm.mediaType === "string" ? fm.mediaType : (envelope.type as string);
+              // Optional multi-mirror list (phantomchat #88). Accept either
+              // `servers` (canonical) or `mirrors` (older draft) — string URLs only.
+              const rawServers = Array.isArray(fm.servers)
+                ? fm.servers
+                : Array.isArray(fm.mirrors)
+                  ? fm.mirrors
+                  : undefined;
+              const servers = rawServers
+                ?.filter((u: unknown): u is string => typeof u === "string" && u.startsWith("http"))
+                .map((u: string) => u.replace(/\/+$/, ""));
               media = {
                 kind: mt === "voice" || mt === "image" || mt === "video" ? mt : "file",
                 url: fm.url,
@@ -311,6 +321,7 @@ export function createPhantomchatChannel(
                 mimeType: typeof fm.mimeType === "string" ? fm.mimeType : "application/octet-stream",
                 durationS: typeof fm.duration === "number" ? fm.duration : undefined,
                 size: typeof fm.size === "number" ? fm.size : undefined,
+                ...(servers && servers.length > 0 ? { servers } : {}),
               };
             }
           }

--- a/src/channels/phantomchat/channel.ts
+++ b/src/channels/phantomchat/channel.ts
@@ -303,15 +303,20 @@ export function createPhantomchatChannel(
             if (keyHex && ivHex) {
               const mt = typeof fm.mediaType === "string" ? fm.mediaType : (envelope.type as string);
               // Optional multi-mirror list (phantomchat #88). Accept either
-              // `servers` (canonical) or `mirrors` (older draft) — string URLs only.
+              // `servers` (canonical) or `mirrors` (older draft). Sender-
+              // controlled, so https-only + hard cap of 8 (bound fan-out).
               const rawServers = Array.isArray(fm.servers)
                 ? fm.servers
                 : Array.isArray(fm.mirrors)
                   ? fm.mirrors
                   : undefined;
               const servers = rawServers
-                ?.filter((u: unknown): u is string => typeof u === "string" && u.startsWith("http"))
-                .map((u: string) => u.replace(/\/+$/, ""));
+                ?.filter(
+                  (u: unknown): u is string =>
+                    typeof u === "string" && u.startsWith("https://"),
+                )
+                .map((u: string) => u.replace(/\/+$/, ""))
+                .slice(0, 8);
               media = {
                 kind: mt === "voice" || mt === "image" || mt === "video" ? mt : "file",
                 url: fm.url,

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -561,6 +561,7 @@ export async function runPhantomchatServer(
             (async () => {
               const audio = await fetchAndDecryptBlossom(m.url, m.keyHex, m.ivHex, {
                 expectedSha256Hex: m.sha256,
+                mirrors: m.servers,
                 signal: input.signal,
               });
               return transcribe(input.config, audio, m.mimeType);
@@ -611,6 +612,7 @@ export async function runPhantomchatServer(
             const data = await withTimeout(
               fetchAndDecryptBlossom(m.url, m.keyHex, m.ivHex, {
                 expectedSha256Hex: m.sha256,
+                mirrors: m.servers,
                 signal: input.signal,
               }),
               input.config.voice.sttTimeoutMs ?? DEFAULT_STT_TIMEOUT_MS,

--- a/src/channels/phantomchat/transport.ts
+++ b/src/channels/phantomchat/transport.ts
@@ -559,7 +559,9 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
   ): Promise<void> {
     const mimeType = mime || "audio/ogg";
     const enc = encryptFileBytes(audio);
-    const { url } = await uploadToBlossom(
+    // Multi-mirror write (≥2 when possible). Primary URL + every successful
+    // mirror go on the envelope so the PWA can multi-GET if a host dies.
+    const uploaded = await uploadToBlossom(
       enc.ciphertext,
       enc.sha256Hex,
       this.ourSecretKey,
@@ -577,7 +579,7 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     // no decode. "" ⇒ unparseable; omit and let the bubble show length-only.
     const waveform = oggOpusWaveformBase64(audio);
     const fileMeta = JSON.stringify({
-      url,
+      url: uploaded.url,
       sha256: enc.sha256Hex,
       mimeType,
       size: audio.length,
@@ -585,6 +587,8 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
       iv: enc.ivHex,
       // Authoritative media class so the receiver never re-guesses voice vs file.
       mediaType: "voice",
+      // Multi-mirror list (phantomchat #88). Primary first; receivers multi-GET.
+      servers: uploaded.mirrors,
       ...(durationS > 0 ? { duration: durationS } : {}),
       ...(waveform ? { waveform } : {}),
     });

--- a/tests/channels-phantomchat-blossom.test.ts
+++ b/tests/channels-phantomchat-blossom.test.ts
@@ -6,9 +6,14 @@
  *
  * Also covers multi-GET receive: primary host dead → mirror / hash-GET works.
  */
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { fetchAndDecryptBlossom } from "../src/channels/phantomchat/blossomFetch.ts";
+import { clearBlossomServersCache } from "../src/channels/phantomchat/blossomServers.ts";
+
+afterEach(() => {
+  clearBlossomServersCache();
+});
 
 function toHex(bytes: Uint8Array): string {
   return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
@@ -135,6 +140,41 @@ describe("blossomFetch — AES-256-GCM decrypt (PWA round-trip)", () => {
         },
       );
       expect(new Uint8Array(out)).toEqual(new Uint8Array(plaintext));
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("does not fetch blossom.json when the primary URL succeeds", async () => {
+    const plaintext = new TextEncoder().encode("happy-path");
+    const key = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const cryptoKey = await crypto.subtle.importKey("raw", key, { name: "AES-GCM" }, false, [
+      "encrypt",
+    ]);
+    const ct = new Uint8Array(
+      await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, plaintext),
+    );
+    const sha256 = createHash("sha256").update(ct).digest("hex");
+
+    const hits: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: string | URL) => {
+      const u = String(input);
+      hits.push(u);
+      if (u.includes("blossom.json")) return new Response("nope", { status: 404 });
+      return new Response(ct, { status: 200 });
+    }) as unknown as typeof fetch;
+    try {
+      const out = await fetchAndDecryptBlossom(
+        "https://primary.example/" + sha256,
+        toHex(key),
+        toHex(iv),
+        { expectedSha256Hex: sha256 },
+      );
+      expect(new Uint8Array(out)).toEqual(new Uint8Array(plaintext));
+      expect(hits.some((h) => h.includes("blossom.json"))).toBe(false);
+      expect(hits).toEqual(["https://primary.example/" + sha256]);
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/tests/channels-phantomchat-blossom.test.ts
+++ b/tests/channels-phantomchat-blossom.test.ts
@@ -3,8 +3,11 @@
  * The PWA (phantomchat file-crypto.ts) encrypts with Web Crypto, which APPENDS
  * the 16-byte GCM tag to the ciphertext; this asserts the bot's node:crypto
  * decrypt (which splits the tag) recovers the exact plaintext.
+ *
+ * Also covers multi-GET receive: primary host dead → mirror / hash-GET works.
  */
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { fetchAndDecryptBlossom } from "../src/channels/phantomchat/blossomFetch.ts";
 
 function toHex(bytes: Uint8Array): string {
@@ -32,7 +35,11 @@ describe("blossomFetch — AES-256-GCM decrypt (PWA round-trip)", () => {
         "https://blossom.example/x",
         toHex(key),
         toHex(iv),
-        { expectedSha256Hex: sha256 },
+        {
+          expectedSha256Hex: sha256,
+          // Pin known servers empty so we don't hit real defaults.
+          knownServers: [],
+        },
       );
       expect(new Uint8Array(out)).toEqual(new Uint8Array(plaintext));
     } finally {
@@ -50,9 +57,84 @@ describe("blossomFetch — AES-256-GCM decrypt (PWA round-trip)", () => {
           "https://blossom.example/x",
           "00".repeat(32),
           "00".repeat(12),
-          { expectedSha256Hex: "deadbeef" },
+          { expectedSha256Hex: "deadbeef", knownServers: [] },
         ),
-      ).rejects.toThrow(/sha256 mismatch/);
+      ).rejects.toThrow(/sha256 mismatch|blossom fetch failed/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("falls back to a mirror when the primary host 404s", async () => {
+    const plaintext = new TextEncoder().encode("mirror1-ok");
+    const key = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const cryptoKey = await crypto.subtle.importKey("raw", key, { name: "AES-GCM" }, false, [
+      "encrypt",
+    ]);
+    const ct = new Uint8Array(
+      await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, plaintext),
+    );
+    const sha256 = createHash("sha256").update(ct).digest("hex");
+
+    const hits: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: string | URL) => {
+      const u = String(input);
+      hits.push(u);
+      if (u.includes("primary")) return new Response("gone", { status: 404 });
+      if (u.includes("mirror1")) return new Response(ct, { status: 200 });
+      return new Response("nope", { status: 500 });
+    }) as unknown as typeof fetch;
+    try {
+      const out = await fetchAndDecryptBlossom(
+        "https://primary.example/" + sha256,
+        toHex(key),
+        toHex(iv),
+        {
+          expectedSha256Hex: sha256,
+          mirrors: ["https://mirror1.example/" + sha256],
+          knownServers: [],
+        },
+      );
+      expect(new Uint8Array(out)).toEqual(new Uint8Array(plaintext));
+      expect(hits[0]).toContain("primary");
+      expect(hits.some((h) => h.includes("mirror1"))).toBe(true);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("falls back to hash-GET on a known server when envelope mirrors are empty", async () => {
+    const plaintext = new TextEncoder().encode("hash-get-ok");
+    const key = crypto.getRandomValues(new Uint8Array(32));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const cryptoKey = await crypto.subtle.importKey("raw", key, { name: "AES-GCM" }, false, [
+      "encrypt",
+    ]);
+    const ct = new Uint8Array(
+      await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, plaintext),
+    );
+    const sha256 = createHash("sha256").update(ct).digest("hex");
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: string | URL) => {
+      const u = String(input);
+      if (u.startsWith("https://dead.example/")) return new Response("gone", { status: 404 });
+      if (u === `https://nostr.download/${sha256}`) return new Response(ct, { status: 200 });
+      return new Response("nope", { status: 500 });
+    }) as unknown as typeof fetch;
+    try {
+      const out = await fetchAndDecryptBlossom(
+        "https://dead.example/" + sha256,
+        toHex(key),
+        toHex(iv),
+        {
+          expectedSha256Hex: sha256,
+          knownServers: ["https://nostr.download"],
+        },
+      );
+      expect(new Uint8Array(out)).toEqual(new Uint8Array(plaintext));
     } finally {
       globalThis.fetch = origFetch;
     }

--- a/tests/channels-phantomchat-blossomServers.test.ts
+++ b/tests/channels-phantomchat-blossomServers.test.ts
@@ -6,13 +6,16 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   DEFAULT_BLOSSOM_SERVERS,
   blossomHashUrl,
+  clearBlossomServersCache,
   expandBlossomFetchUrls,
   fetchCanonicalBlossomServers,
+  getBlossomServers,
 } from "../src/channels/phantomchat/blossomServers.ts";
 
 const realFetch = globalThis.fetch;
 afterEach(() => {
   (globalThis as unknown as { fetch: typeof fetch }).fetch = realFetch;
+  clearBlossomServersCache();
 });
 
 function mockFetch(impl: (url: string) => Promise<Response>) {
@@ -88,6 +91,46 @@ describe("DEFAULT_BLOSSOM_SERVERS disaster net", () => {
       "https://blossom.ditto.pub",
       "https://blossom.data.haus",
     ]);
+  });
+});
+
+describe("getBlossomServers cache", () => {
+  test("caches a real website answer and does not re-fetch within TTL", async () => {
+    let hits = 0;
+    mockFetch(async () => {
+      hits += 1;
+      return new Response(
+        JSON.stringify({ servers: ["https://cached.example"] }),
+        { status: 200 },
+      );
+    });
+    expect(await getBlossomServers()).toEqual(["https://cached.example"]);
+    expect(await getBlossomServers()).toEqual(["https://cached.example"]);
+    expect(hits).toBe(1);
+  });
+
+  test("does not cache a 404 / empty answer onto the disaster-net seed", async () => {
+    let hits = 0;
+    mockFetch(async () => {
+      hits += 1;
+      return new Response("nope", { status: 404 });
+    });
+    expect(await getBlossomServers()).toEqual([...DEFAULT_BLOSSOM_SERVERS]);
+    expect(await getBlossomServers()).toEqual([...DEFAULT_BLOSSOM_SERVERS]);
+    // Both calls hit the website — seed fallback is not sticky for an hour.
+    expect(hits).toBe(2);
+  });
+
+  test("opts.servers override wins without fetching", async () => {
+    let hits = 0;
+    mockFetch(async () => {
+      hits += 1;
+      return new Response("should not run", { status: 500 });
+    });
+    expect(await getBlossomServers({ servers: ["https://pin.example/"] })).toEqual([
+      "https://pin.example",
+    ]);
+    expect(hits).toBe(0);
   });
 });
 

--- a/tests/channels-phantomchat-blossomServers.test.ts
+++ b/tests/channels-phantomchat-blossomServers.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the bot-side Blossom server list: website fetch, disaster-net
+ * fallback, and multi-GET candidate expansion (primary → mirrors → hash GETs).
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  DEFAULT_BLOSSOM_SERVERS,
+  blossomHashUrl,
+  expandBlossomFetchUrls,
+  fetchCanonicalBlossomServers,
+} from "../src/channels/phantomchat/blossomServers.ts";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = realFetch;
+});
+
+function mockFetch(impl: (url: string) => Promise<Response>) {
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = ((
+    input: string | URL,
+  ) => impl(String(input))) as unknown as typeof fetch;
+}
+
+describe("fetchCanonicalBlossomServers", () => {
+  test("parses a valid blossom.json into an https URL list", async () => {
+    mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          servers: [
+            "https://nostr.download",
+            "https://blossom.ditto.pub/",
+            "https://blossom.data.haus",
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    expect(await fetchCanonicalBlossomServers("https://x/blossom.json")).toEqual([
+      "https://nostr.download",
+      "https://blossom.ditto.pub",
+      "https://blossom.data.haus",
+    ]);
+  });
+
+  test("filters non-https and de-dupes", async () => {
+    mockFetch(async () =>
+      new Response(
+        JSON.stringify({
+          servers: [
+            "https://ok.example",
+            "http://insecure.example",
+            "https://ok.example/",
+            42,
+            null,
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    expect(await fetchCanonicalBlossomServers("https://x/blossom.json")).toEqual([
+      "https://ok.example",
+    ]);
+  });
+
+  test("returns null on non-ok / malformed / empty / throw", async () => {
+    mockFetch(async () => new Response("nope", { status: 404 }));
+    expect(await fetchCanonicalBlossomServers("https://x/blossom.json")).toBeNull();
+
+    mockFetch(async () => new Response(JSON.stringify({ nope: 1 }), { status: 200 }));
+    expect(await fetchCanonicalBlossomServers("https://x/blossom.json")).toBeNull();
+
+    mockFetch(async () =>
+      new Response(JSON.stringify({ servers: ["http://x"] }), { status: 200 }),
+    );
+    expect(await fetchCanonicalBlossomServers("https://x/blossom.json")).toBeNull();
+
+    mockFetch(async () => {
+      throw new Error("network down");
+    });
+    expect(await fetchCanonicalBlossomServers("https://x/blossom.json")).toBeNull();
+  });
+});
+
+describe("DEFAULT_BLOSSOM_SERVERS disaster net", () => {
+  test("is the solid free trio (no mime walls / paid hosts)", () => {
+    expect(DEFAULT_BLOSSOM_SERVERS).toEqual([
+      "https://nostr.download",
+      "https://blossom.ditto.pub",
+      "https://blossom.data.haus",
+    ]);
+  });
+});
+
+describe("expandBlossomFetchUrls", () => {
+  test("orders primary → mirrors → hash GETs on known servers, de-duped", () => {
+    const sha = "ab".repeat(32);
+    const urls = expandBlossomFetchUrls(
+      "https://nostr.download/" + sha,
+      sha,
+      ["https://blossom.ditto.pub/" + sha, "https://nostr.download/" + sha],
+      ["https://nostr.download", "https://blossom.data.haus"],
+    );
+    expect(urls).toEqual([
+      "https://nostr.download/" + sha,
+      "https://blossom.ditto.pub/" + sha,
+      // hash GET on data.haus only (nostr.download already present via primary)
+      blossomHashUrl("https://blossom.data.haus", sha),
+    ]);
+  });
+
+  test("skips hash expansion when sha256 is missing / invalid", () => {
+    expect(
+      expandBlossomFetchUrls("https://primary.example/x", undefined, ["https://m.example/x"]),
+    ).toEqual(["https://primary.example/x", "https://m.example/x"]);
+    expect(expandBlossomFetchUrls("https://primary.example/x", "not-a-hash", [])).toEqual([
+      "https://primary.example/x",
+    ]);
+  });
+});

--- a/tests/channels-phantomchat-channel.test.ts
+++ b/tests/channels-phantomchat-channel.test.ts
@@ -391,7 +391,7 @@ describe("phantomchat channel — voice / media intake", () => {
     // Real DM wire shape (chat-api.sendFileMessage → sendMessage): a typed
     // envelope whose `content` is the file-metadata JSON STRING (key/iv).
     const fileMeta = {
-      url: "https://blossom.primal.net/b8447b96c67839dc9aa4632408a0d35375",
+      url: "https://nostr.download/b8447b96c67839dc9aa4632408a0d35375",
       sha256: "b8447b96c67839dc9aa4632408a0d35375ad6d9c0f42ee6057a5be47eb074b03",
       mimeType: "audio/ogg",
       size: 26050,
@@ -400,6 +400,10 @@ describe("phantomchat channel — voice / media intake", () => {
       mediaType: "voice",
       duration: 9,
       waveform: [0, 0, 8, 255, 255],
+      servers: [
+        "https://nostr.download/b8447b96c67839dc9aa4632408a0d35375",
+        "https://blossom.ditto.pub/b8447b96c67839dc9aa4632408a0d35375",
+      ],
     };
     const { wrap } = wrapEnvelopeToUs(ourPub, {
       id: "chat-99-0",
@@ -427,6 +431,8 @@ describe("phantomchat channel — voice / media intake", () => {
     expect(m.media!.ivHex).toBe(fileMeta.iv); // accepts `iv`
     expect(m.media!.mimeType).toBe("audio/ogg");
     expect(m.media!.durationS).toBe(9);
+    // Multi-mirror list plumbed through for receive multi-GET (#88 bot half).
+    expect(m.media!.servers).toEqual(fileMeta.servers);
     // Receipt keyed off the envelope's app id (PWA file delivery tracker).
     expect(m.messageId).toBe("chat-99-0");
   });
@@ -450,7 +456,7 @@ describe("phantomchat channel — attachment (non-voice) intake", () => {
       content: "check this out",
       timestamp: Date.now(),
       fileMetadata: {
-        url: "https://blossom.primal.net/deadbeefimg",
+        url: "https://nostr.download/deadbeefimg",
         sha256: "deadbeef00000000000000000000000000000000000000000000000000000000",
         mimeType: "image/jpeg",
         size: 845123,
@@ -458,6 +464,10 @@ describe("phantomchat channel — attachment (non-voice) intake", () => {
         ivHex: "22".repeat(12),
         width: 1200,
         height: 800,
+        servers: [
+          "https://nostr.download/deadbeefimg",
+          "https://blossom.data.haus/deadbeefimg",
+        ],
       },
     });
     pool.feed(wrap);
@@ -470,9 +480,13 @@ describe("phantomchat channel — attachment (non-voice) intake", () => {
     const m = got[0]!;
     expect(m.text).toBe("check this out"); // caption preserved
     expect(m.media?.kind).toBe("image");
-    expect(m.media?.url).toBe("https://blossom.primal.net/deadbeefimg");
+    expect(m.media?.url).toBe("https://nostr.download/deadbeefimg");
     expect(m.media?.keyHex).toBe("11".repeat(32)); // accepts `keyHex`
     expect(m.media?.ivHex).toBe("22".repeat(12));
     expect(m.media?.size).toBe(845123);
+    expect(m.media?.servers).toEqual([
+      "https://nostr.download/deadbeefimg",
+      "https://blossom.data.haus/deadbeefimg",
+    ]);
   });
 });

--- a/tests/channels-phantomchat-channel.test.ts
+++ b/tests/channels-phantomchat-channel.test.ts
@@ -489,4 +489,75 @@ describe("phantomchat channel — attachment (non-voice) intake", () => {
       "https://blossom.data.haus/deadbeefimg",
     ]);
   });
+
+  test("drops non-https mirrors from sender-controlled servers list", async () => {
+    const { ourPub, pool, channel } = setup();
+    const ac = new AbortController();
+    const got: ChannelMessage[] = [];
+    const pump = (async () => {
+      for await (const msg of channel.listen!(ac.signal)) got.push(msg);
+    })();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const { wrap } = wrapEnvelopeToUs(ourPub, {
+      id: "http-drop-1",
+      type: "voice",
+      content: JSON.stringify({
+        url: "https://a.example/x",
+        sha256: "aa".repeat(32),
+        mimeType: "audio/ogg",
+        size: 1,
+        key: "bb".repeat(32),
+        iv: "cc".repeat(12),
+        mediaType: "voice",
+        // http:// is sender-controlled and must not survive the filter.
+        servers: ["https://a.example/x", "http://b.example/x"],
+      }),
+      timestamp: Date.now(),
+    });
+    pool.feed(wrap);
+
+    await new Promise((r) => setTimeout(r, 30));
+    ac.abort();
+    await pump;
+
+    expect(got.length).toBe(1);
+    expect(got[0]!.media!.servers).toEqual(["https://a.example/x"]);
+  });
+
+  test("bounds fan-out at 8 servers on receive", async () => {
+    const { ourPub, pool, channel } = setup();
+    const ac = new AbortController();
+    const got: ChannelMessage[] = [];
+    const pump = (async () => {
+      for await (const msg of channel.listen!(ac.signal)) got.push(msg);
+    })();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const many = Array.from({ length: 20 }, (_, i) => `https://s${i}.example/x`);
+    const { wrap } = wrapEnvelopeToUs(ourPub, {
+      id: "bound-8-1",
+      type: "voice",
+      content: JSON.stringify({
+        url: many[0],
+        sha256: "dd".repeat(32),
+        mimeType: "audio/ogg",
+        size: 1,
+        key: "ee".repeat(32),
+        iv: "ff".repeat(12),
+        mediaType: "voice",
+        servers: many,
+      }),
+      timestamp: Date.now(),
+    });
+    pool.feed(wrap);
+
+    await new Promise((r) => setTimeout(r, 30));
+    ac.abort();
+    await pump;
+
+    expect(got.length).toBe(1);
+    expect(got[0]!.media!.servers).toHaveLength(8);
+    expect(got[0]!.media!.servers).toEqual(many.slice(0, 8));
+  });
 });

--- a/tests/channels-phantomchat-fileEncrypt.test.ts
+++ b/tests/channels-phantomchat-fileEncrypt.test.ts
@@ -29,7 +29,7 @@ describe("fileEncrypt — AES-256-GCM encrypt (PWA round-trip)", () => {
         "https://blossom.example/x",
         enc.keyHex,
         enc.ivHex,
-        { expectedSha256Hex: enc.sha256Hex },
+        { expectedSha256Hex: enc.sha256Hex, knownServers: [] },
       );
       expect(new Uint8Array(out)).toEqual(new Uint8Array(plaintext));
     } finally {

--- a/tests/channels-phantomchat-sendVoice.test.ts
+++ b/tests/channels-phantomchat-sendVoice.test.ts
@@ -1,9 +1,8 @@
 /*
  * transport.sendVoice end-to-end: it must AES-256-GCM encrypt the audio, upload
- * the ciphertext to Blossom (NIP-24242-authed PUT), and gift-wrap a
- * `type:"voice"` DM envelope whose `content` is the JSON file-metadata blob the
- * PWA's extractFileMetadata reads. This asserts the full chain so the wire
- * contract can't silently drift from the PWA receive path.
+ * the ciphertext to Blossom (NIP-24242-authed PUT, multi-mirror ≥2), and gift-
+ * wrap a `type:"voice"` DM envelope whose `content` is the JSON file-metadata
+ * blob the PWA's extractFileMetadata reads — including a `servers` mirror list.
  */
 import { describe, expect, test } from "bun:test";
 import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
@@ -15,7 +14,7 @@ import { unwrapV2, type NTNostrEvent } from "../src/lib/nostrCrypto.ts";
 import { fetchAndDecryptBlossom } from "../src/channels/phantomchat/blossomFetch.ts";
 
 describe("phantomchat transport — sendVoice", () => {
-  test("encrypts, uploads to Blossom, and wraps a voice envelope", async () => {
+  test("encrypts, multi-mirror uploads to Blossom, and wraps a voice envelope with servers", async () => {
     const published: NTNostrEvent[] = [];
     const fakePool: RelayPool = {
       subscribeMany() {
@@ -28,22 +27,31 @@ describe("phantomchat transport — sendVoice", () => {
       close() {},
     };
 
-    // Capture the Blossom upload: assert the auth event and stash the bytes so
+    // Capture the Blossom uploads: assert the auth event and stash the bytes so
     // we can prove the round-trip via the metadata key/iv the envelope carries.
     let uploadedBody: Buffer | undefined;
     let authEvent: { kind?: number; tags?: string[][] } | undefined;
+    const uploadHosts: string[] = [];
     const origFetch = globalThis.fetch;
-    globalThis.fetch = (async (url: string, init: RequestInit) => {
-      expect(String(url)).toMatch(/\/upload$/);
-      expect(init.method).toBe("PUT");
-      const auth = (init.headers as Record<string, string>).Authorization ?? "";
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      // disaster-net /blossom.json probe must not break the upload mock
+      if (u.includes("blossom.json") || u.endsWith("/relays.json")) {
+        return new Response("nope", { status: 404 });
+      }
+      expect(u).toMatch(/\/upload$/);
+      expect(init?.method).toBe("PUT");
+      const auth = (init?.headers as Record<string, string>).Authorization ?? "";
       expect(auth.startsWith("Nostr ")).toBe(true);
       authEvent = JSON.parse(
         Buffer.from(auth.slice("Nostr ".length), "base64").toString("utf8"),
       );
-      uploadedBody = Buffer.from(init.body as Uint8Array);
+      uploadedBody = Buffer.from(init?.body as Uint8Array);
+      // Echo a distinct host-specific url so multi-mirror produces ≥2 URLs.
+      const host = u.replace(/\/upload$/, "");
+      uploadHosts.push(host);
       return new Response(
-        JSON.stringify({ url: "https://blossom.example/abc", sha256: "abc" }),
+        JSON.stringify({ url: `${host}/abc`, sha256: "abc" }),
         { status: 200 },
       );
     }) as unknown as typeof fetch;
@@ -64,6 +72,9 @@ describe("phantomchat transport — sendVoice", () => {
       // Blossom auth was a kind-24242 upload event.
       expect(authEvent?.kind).toBe(24242);
       expect(authEvent?.tags?.some((t) => t[0] === "t" && t[1] === "upload")).toBe(true);
+
+      // Multi-mirror: ≥2 successful PUTs (default BLOSSOM_MIRROR_MIN).
+      expect(uploadHosts.length).toBeGreaterThanOrEqual(2);
 
       // A single v2 wrap published (DM voice, no self-wrap — same as text).
       expect(published.length).toBe(1);
@@ -90,13 +101,18 @@ describe("phantomchat transport — sendVoice", () => {
         mimeType: string;
         size: number;
         mediaType: string;
+        servers?: string[];
       };
-      expect(meta.url).toBe("https://blossom.example/abc");
+      expect(meta.url).toBe(`${uploadHosts[0]}/abc`);
       expect(meta.mediaType).toBe("voice");
       expect(meta.mimeType).toBe("audio/ogg");
       expect(meta.size).toBe(audio.length);
       expect(meta.key.length).toBe(64);
       expect(meta.iv.length).toBe(24);
+      // Multi-mirror list on the wire.
+      expect(Array.isArray(meta.servers)).toBe(true);
+      expect(meta.servers!.length).toBeGreaterThanOrEqual(2);
+      expect(meta.servers![0]).toBe(meta.url);
 
       // Full round-trip: the uploaded ciphertext + the envelope's key/iv must
       // decrypt back to the original audio (this is exactly what the recipient
@@ -107,7 +123,7 @@ describe("phantomchat transport — sendVoice", () => {
         meta.url,
         meta.key,
         meta.iv,
-        { expectedSha256Hex: meta.sha256 },
+        { expectedSha256Hex: meta.sha256, knownServers: [] },
       );
       expect(new Uint8Array(recovered)).toEqual(new Uint8Array(audio));
     } finally {


### PR DESCRIPTION
## Summary

Bot-side half of phantomchat media reliability (pairs with [phantomchat#88](https://github.com/phantomyard/phantomchat/pull/88) / [#86](https://github.com/phantomyard/phantomchat/issues/86)).

Without this, the PWA can multi-mirror media and the bot still drops envelope `servers`, one-shot fetches the primary URL, and uploads bot voice to the dead primal/satellite/band trio.

## What / Why / How

**What:** Bot voice in/out and attachment download use the same multi-host Blossom model as the PWA.

**Why:** Public Blossom hosts die, mime-filter, or paywall. A single URL is a single point of failure. Our previous default trio was already broken for free encrypted `application/octet-stream`.

**How (simple, same design as PC #88):**
1. Solid free server list from website `https://chat.phantomyard.ai/blossom.json` (same pattern as `relays.json`). Disaster-net default: `nostr.download`, `blossom.ditto.pub`, `blossom.data.haus`.
2. Write ≥2 mirrors on bot voice upload; put `servers: [...]` on the envelope.
3. Multi-GET receive: primary URL → envelope mirrors → hash GET `{server}/{sha256}` on the known list. Always verify sha256 before decrypt.

## Wire shape

- Compatible with old clients: primary `url` still required; `servers` is optional.
- Old phantombot clients ignore `servers` and keep one-shot GET (no regression if primary is healthy).

## Test plan

- [x] unit: blossomServers fetch + expand
- [x] unit: multi-GET fallback (primary 404 → mirror; dead primary → hash GET)
- [x] unit: sendVoice multi-mirror PUT + envelope.servers
- [x] unit: channel plumbs servers from DM + group envelopes
- [x] channel + server test suites green
- [ ] after merge: voice note PWA → bot with primary host blocked; STT still fires
- [ ] after merge: bot voice reply lands with ≥2 hosts; PWA plays after killing primary

## Out of scope

Media outbox, self-hosted Blossom, group bot voice egress (DM-only).
