### PR TITLE
feat(channels): unified interrupt / stop semantics across all channels (#301)

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -50,7 +50,7 @@
         "commands": [
           {
             "name": "stop",
-            "description": "Abort the turn that's currently running"
+            "description": "Abort the running turn and drop anything queued behind it"
           },
           {
             "name": "reset",

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -20,6 +20,7 @@
  *     so the LLM can interpret it (some personas use `/remember`, etc.).
  */
 
+import { stopNoteText } from "./core/backlog.ts";
 import { memoryIndexPath, type Config } from "../config.ts";
 import type { Harness } from "../harnesses/types.ts";
 import { formatElapsedSeconds, truncateLine } from "../lib/format.ts";
@@ -95,6 +96,16 @@ export interface SlashCommandContext {
    * in contexts (DMs, tests) where targeting is irrelevant.
    */
   botUsername?: string;
+  /**
+   * Discard this conversation's pending backlog — every message the user
+   * queued behind the running turn that has not started executing yet — and
+   * return how many were dropped. Wired in by each channel from its
+   * `ConversationBacklog` (src/channels/core/backlog.ts); see `handleStop`.
+   *
+   * Optional so tests and any future embedder can omit it: without it `/stop`
+   * degrades to its historical behaviour of aborting only the active turn.
+   */
+  flushBacklog?: () => number;
 }
 
 export interface SlashCommandResult {
@@ -133,7 +144,10 @@ export const TELEGRAM_BOT_COMMANDS: Array<{
   description: string;
 }> = [
   { command: "start", description: "Show this command list" },
-  { command: "stop", description: "Abort the current turn" },
+  {
+    command: "stop",
+    description: "Abort the current turn and drop anything queued behind it",
+  },
   { command: "reset", description: "Clear this chat's history" },
   { command: "status", description: "Show harness, uptime, context usage" },
   { command: "harness", description: "List or switch the active harness" },
@@ -216,7 +230,7 @@ export async function handleSlashCommand(
 
   switch (cmd) {
     case "/stop":
-      return handleStop(ctx);
+      return await handleStop(ctx);
     case "/reset":
       return handleReset(ctx);
     case "/status":
@@ -462,14 +476,78 @@ async function handleChattiness(
   return { reply };
 }
 
-function handleStop(ctx: SlashCommandContext): SlashCommandResult {
-  if (!ctx.activeTurn) {
+/**
+ * /stop — break-glass panic button. "Kill everything, and make sure you know
+ * you were killed."
+ *
+ * Three things happen, in this order (GitHub #301):
+ *   1. The pending backlog is flushed, so messages the user queued behind the
+ *      running turn never execute. Flushing FIRST matters: aborting the active
+ *      turn lets the serial chain advance, and if the backlog were still live
+ *      the next queued message would start running before we got to drop it.
+ *   2. The active turn is aborted.
+ *   3. An agent-facing note is appended to the conversation history, so the
+ *      NEXT turn reads "you were stopped, don't resume" instead of inferring
+ *      from a truncated history that it should pick the work back up.
+ *
+ * This is the loud sibling of a plain interrupt (a new ordinary message while a
+ * turn runs), which performs steps 1 and 2 SILENTLY and writes no note — there
+ * the user's follow-up message is itself the context the agent needs.
+ */
+async function handleStop(
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  const dropped = ctx.flushBacklog?.() ?? 0;
+  const hadActive = Boolean(ctx.activeTurn);
+
+  // Nothing running and nothing queued — genuinely a no-op. Say so and skip
+  // the history note: writing "you were stopped" when nothing was stopped
+  // would just be a confusing lie in the agent's context window.
+  if (!hadActive && dropped === 0) {
     return { reply: "no active turn to stop" };
   }
-  const elapsedS = ((Date.now() - ctx.activeTurn.startTime) / 1000).toFixed(1);
-  ctx.activeTurn.controller.abort("stop");
-  log.info("commands: /stop fired", { chatId: ctx.chatId, elapsedS });
-  return { reply: `stopped (was running ${elapsedS}s)` };
+
+  let elapsedS = "0.0";
+  if (ctx.activeTurn) {
+    elapsedS = ((Date.now() - ctx.activeTurn.startTime) / 1000).toFixed(1);
+    ctx.activeTurn.controller.abort("stop");
+  }
+
+  // Best-effort: a failed history write must not swallow the acknowledgement
+  // for a command whose entire job — aborting and flushing — has already
+  // succeeded by this point.
+  try {
+    await ctx.memory.appendTurn({
+      persona: ctx.persona,
+      conversation: ctx.conversation,
+      role: "user",
+      text: stopNoteText(dropped),
+      // Control-plane bookkeeping, not something worth retrieving later.
+      embeddable: false,
+    });
+  } catch (e) {
+    log.warn("commands: /stop failed to append the agent-facing note", {
+      chatId: ctx.chatId,
+      conversation: ctx.conversation,
+      error: (e as Error).message,
+    });
+  }
+
+  log.info("commands: /stop fired", {
+    chatId: ctx.chatId,
+    elapsedS,
+    abortedActiveTurn: hadActive,
+    droppedQueued: dropped,
+  });
+
+  const activePart = hadActive
+    ? `stopped (was running ${elapsedS}s)`
+    : "stopped";
+  const backlogPart =
+    dropped > 0
+      ? ` — dropped ${dropped} queued message${dropped === 1 ? "" : "s"}`
+      : "";
+  return { reply: `${activePart}${backlogPart}` };
 }
 
 async function handleReset(

--- a/src/channels/core/backlog.ts
+++ b/src/channels/core/backlog.ts
@@ -1,0 +1,156 @@
+/**
+ * Per-conversation backlog epochs — the shared mechanism behind unified
+ * interrupt and `/stop` semantics on every channel (GitHub #301).
+ *
+ * THE PROBLEM
+ * -----------
+ * Every channel serializes a conversation's work onto a promise chain:
+ * `next = prev.then(() => run(msg))`. That keeps one conversation's turns in
+ * order, which the LLM's history requires. But a `.then()` callback is
+ * COMMITTED the instant it is attached — there is no handle to cancel it. So
+ * when the user interrupts (types again while a turn is running, or hits
+ * `/stop`), aborting the active turn only kills the turn that is running RIGHT
+ * NOW. Anything the user queued behind it still fires, one after another, after
+ * the interrupt — the bot works through a backlog of instructions the user has
+ * explicitly superseded.
+ *
+ * THE MECHANISM
+ * -------------
+ * We cannot un-attach the callbacks, so we make them no-op instead. Each
+ * conversation carries a monotonically increasing EPOCH. A task captures the
+ * current epoch when it is enqueued and re-checks it when it actually starts
+ * running; an interrupt (or `/stop`) bumps the epoch, so every task queued
+ * before that moment finds its captured epoch stale and returns without doing
+ * anything. Tasks enqueued AFTER the bump carry the new epoch and run normally
+ * — which is why the interrupting message itself is unaffected.
+ *
+ * COUNTING WHAT WAS DROPPED
+ * -------------------------
+ * `/stop` has to tell the user how many queued messages it threw away, so we
+ * also track how many tasks are enqueued-but-not-yet-started. `enqueue()`
+ * increments, `claim()` (called at the top of the task body) decrements, so the
+ * counter is exactly the backlog depth — the running task has already claimed
+ * itself out of it. All pending tasks for a conversation necessarily share one
+ * epoch (a flush zeroes the counter and bumps the epoch together), so a single
+ * `{ epoch, pending }` slot per conversation is enough; a stale `claim()` is
+ * rejected without touching the counter, so superseded tasks unwinding late
+ * cannot corrupt the depth of the backlog that replaced them.
+ *
+ * Keys are channel-neutral conversation ids — whatever that channel already
+ * uses for its `activeTurns` map — so `/stop`'s flush and the interrupt path
+ * always address the same queue.
+ */
+
+import { log } from "../../lib/logger.ts";
+
+interface BacklogSlot {
+  /** Current generation. Tasks holding an older value must not run. */
+  epoch: number;
+  /** Tasks enqueued under `epoch` that have not started running yet. */
+  pending: number;
+}
+
+/** Why a flush happened — logged, and used by callers for their own logging. */
+export type FlushReason = "interrupt" | "stop";
+
+export class ConversationBacklog {
+  private readonly slots = new Map<string, BacklogSlot>();
+
+  private slot(key: string): BacklogSlot {
+    let s = this.slots.get(key);
+    if (!s) {
+      s = { epoch: 0, pending: 0 };
+      this.slots.set(key, s);
+    }
+    return s;
+  }
+
+  /**
+   * Register a task about to be chained onto `key`'s serial queue and return
+   * the epoch it must present to {@link claim}. Call this SYNCHRONOUSLY at the
+   * enqueue site, before attaching the `.then()`.
+   */
+  enqueue(key: string): number {
+    const s = this.slot(key);
+    s.pending++;
+    return s.epoch;
+  }
+
+  /**
+   * Call at the very top of a queued task's body. Returns false if the task has
+   * been superseded by a flush since it was enqueued — the caller must then
+   * return immediately without doing any work.
+   */
+  claim(key: string, epoch: number): boolean {
+    const s = this.slot(key);
+    // Stale: a flush already counted this task as dropped and zeroed the
+    // counter. Decrementing here would eat one slot from the NEW backlog.
+    if (epoch !== s.epoch) return false;
+    if (s.pending > 0) s.pending--;
+    return true;
+  }
+
+  /** How many tasks are queued for `key` but have not started running. */
+  pending(key: string): number {
+    return this.slots.get(key)?.pending ?? 0;
+  }
+
+  /**
+   * Discard `key`'s entire pending backlog and return how many tasks were
+   * dropped. The currently-RUNNING task is not counted (it already claimed
+   * itself out of the backlog) and is not affected — callers abort it
+   * separately via its AbortController.
+   */
+  flush(key: string, reason: FlushReason): number {
+    const s = this.slot(key);
+    const dropped = s.pending;
+    s.epoch++;
+    s.pending = 0;
+    if (dropped > 0) {
+      // Info level, never user-visible: an interrupt is silent by design, and
+      // `/stop` reports the count itself in its reply.
+      log.info("backlog: dropped superseded queued messages", {
+        conversation: key,
+        reason,
+        dropped,
+      });
+    }
+    return dropped;
+  }
+
+  /**
+   * Forget a conversation with no work left, so long-lived servers don't
+   * accumulate a slot per peer forever. No-op while anything is still pending —
+   * dropping the slot then would reset the epoch to 0 and let stale tasks
+   * spuriously re-validate.
+   */
+  release(key: string): void {
+    const s = this.slots.get(key);
+    if (s && s.pending === 0) this.slots.delete(key);
+  }
+}
+
+/**
+ * The note `/stop` writes into the conversation so the agent's NEXT turn knows
+ * what happened to the last one.
+ *
+ * `/stop` is break-glass: the user is not asking a question, they are pulling
+ * the plug. Without this note the agent's next turn sees a truncated history
+ * (a user message with no assistant reply, plus whatever partial work the
+ * harness narrated) and its most natural reading is "I was interrupted
+ * mid-task, I should pick that back up" — precisely the behaviour the user just
+ * hit the panic button to prevent. Written as a `user` turn because that is the
+ * role the history replay surfaces as instruction-bearing context.
+ */
+export function stopNoteText(droppedCount: number): string {
+  const backlog =
+    droppedCount > 0
+      ? ` ${droppedCount} queued message${droppedCount === 1 ? "" : "s"} that had not started yet were discarded as well.`
+      : "";
+  return (
+    "[system] The user issued /stop. The turn that was running was aborted." +
+    backlog +
+    " Do not resume, retry, or continue that work, and do not report on it" +
+    " unless asked. Await further instructions."
+  );
+}

--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -58,6 +58,7 @@ import {
   slashCommandTarget,
   TELEGRAM_BOT_COMMANDS,
 } from "../commands.ts";
+import { ConversationBacklog } from "./backlog.ts";
 import {
   hasTextSubstance,
   splitIntoSegments,
@@ -314,6 +315,11 @@ export async function runTelegramServer(
   // We chain `next = prev.then(work)` and store `next` here. When the
   // next message arrives, it chains off the latest entry.
   const chatChains = new Map<string, Promise<void>>();
+  // Epoch registry backing interrupt / `/stop` backlog flushes (#301). The
+  // `.then()` callbacks queued on `chatChains` above cannot be un-attached, so
+  // superseded ones are neutered by bumping this conversation's epoch — see
+  // src/channels/core/backlog.ts.
+  const backlog = new ConversationBacklog();
   // Set of every in-flight worker promise — drained at shutdown / oneShot.
   const inFlight = new Set<Promise<void>>();
 
@@ -508,6 +514,9 @@ export async function runTelegramServer(
             config: input.config,
             serviceControl: input.serviceControl,
             botUsername,
+            // /stop flushes the same per-chat backlog an interrupt does, and
+            // reports the count back to the user.
+            flushBacklog: () => backlog.flush(msg.conversationId, "stop"),
           });
           if (result) {
             try {
@@ -637,13 +646,27 @@ export async function runTelegramServer(
         // chains off `prev` (the aborted turn's worker promise) so
         // the harness's process group has time to clean up before we
         // spawn the next subprocess.
+        //
+        // The interrupt also discards this chat's PENDING BACKLOG — messages
+        // the user queued behind the running turn that have not started yet
+        // (#301). "Pay attention to this instead" has to mean the whole
+        // superseded queue, not just the one turn in flight; otherwise the bot
+        // works through stale instructions one by one after the interrupt.
+        // This is deliberately SILENT: no notice to the user about what was
+        // dropped (that is `/stop`'s job) — just an info log.
+        //
+        // Gated on there actually being an active turn, which is what makes
+        // this an *interrupt*. With nothing running, several messages arriving
+        // together are just a multi-line thought and must all be answered.
         const active = activeTurns.get(msg.conversationId);
         if (active) {
+          const dropped = backlog.flush(msg.conversationId, "interrupt");
           log.info("telegram: new message — interrupting active turn", {
             chatId: msg.conversationId,
             elapsedS: (
               (Date.now() - active.startTime) / 1000
             ).toFixed(1),
+            droppedQueued: dropped,
           });
           active.controller.abort("interrupt");
         }
@@ -654,8 +677,16 @@ export async function runTelegramServer(
         const prev = (chatChains.get(msg.conversationId) ?? Promise.resolve()).catch(
           () => {},
         );
-        const next = prev.then(() =>
-          processChatMessage(msg, {
+        // Captured synchronously, BEFORE the callback is attached: this is the
+        // generation the task belongs to. If an interrupt or /stop bumps the
+        // epoch before the task gets to run, `claim` returns false below and
+        // the task evaporates instead of executing superseded work.
+        const epoch = backlog.enqueue(msg.conversationId);
+        const next = prev.then(async () => {
+          // Superseded by an interrupt or /stop while we sat in the queue —
+          // drop the message on the floor without running it.
+          if (!backlog.claim(msg.conversationId, epoch)) return;
+          await processChatMessage(msg, {
             input,
             harnesses,
             activeTurns,
@@ -671,8 +702,8 @@ export async function runTelegramServer(
             // to write security rules is not.
             principalAuthenticated:
               allowedSet.size > 0 && allowedSet.has(Number(msg.senderId)),
-          }),
-        );
+          });
+        });
         // Detach completed entries so the maps don't leak.
         const tracked = next.finally(() => {
           if (chatChains.get(msg.conversationId) === tracked) {

--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -708,6 +708,10 @@ export async function runTelegramServer(
         const tracked = next.finally(() => {
           if (chatChains.get(msg.conversationId) === tracked) {
             chatChains.delete(msg.conversationId);
+            // We are the settled tail: nothing is queued behind us for this
+            // conversation, so drop its backlog slot too. `release` is a no-op
+            // if anything is still pending, so this can't strand a live epoch.
+            backlog.release(msg.conversationId);
           }
           inFlight.delete(tracked);
         });

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -37,6 +37,7 @@ import {
   type ActiveTurnHandle,
   handleSlashCommand,
 } from "../commands.ts";
+import { ConversationBacklog } from "../core/backlog.ts";
 import {
   TELEGRAM_REPLY_INSTRUCTION,
   VOICE_REPLY_INSTRUCTION,
@@ -364,6 +365,12 @@ export async function runPhantomchatServer(
   // Per-peer promise chain so messages from one peer stay strictly ordered.
   const chains = new Map<string, Promise<void>>();
   const inFlight = new Set<Promise<void>>();
+  // Epoch registry backing interrupt / `/stop` backlog flushes (#301). Keyed by
+  // conversationId — the SAME key as `activeTurns` and the slash context above,
+  // so an interrupt, a `/stop` and a `/status` all address one queue. (The
+  // promise chain itself is keyed by senderId; for DMs, where slash commands
+  // and interrupts live, the two are identical.)
+  const backlog = new ConversationBacklog();
 
   // ===================== AUTH GATE =====================
   // Gate on the CRYPTOGRAPHIC sender (rumor.pubkey, carried as senderId — the
@@ -1092,6 +1099,8 @@ export async function runPhantomchatServer(
       activeTurn: activeTurns.get(msg.conversationId),
       config: input.config,
       serviceControl: input.serviceControl,
+      // /stop flushes the same per-conversation backlog an interrupt does.
+      flushBacklog: () => backlog.flush(msg.conversationId, "stop"),
       // No @username concept on Nostr, and slash handling is DM-only, so there
       // is nothing to disambiguate — leave botUsername undefined.
     }).catch((e: unknown) => {
@@ -1124,13 +1133,38 @@ export async function runPhantomchatServer(
   // Serialize per peer: chain the new work onto that peer's last promise.
   const enqueue = (msg: ChannelMessage): void => {
     const key = msg.senderId;
+
+    // INTERRUPT (#301): a new ordinary message arriving while a turn is running
+    // means "stop what you're doing and listen to me." Abort the active turn
+    // AND discard everything queued behind it — otherwise the bot grinds
+    // through instructions the user has already superseded. Silent by design:
+    // only `/stop` tells the user what it threw away. Gated on an active turn
+    // so that a burst of messages sent while idle is still answered in full.
+    const active = activeTurns.get(msg.conversationId);
+    if (active) {
+      const dropped = backlog.flush(msg.conversationId, "interrupt");
+      log.info("phantomchat: new message — interrupting active turn", {
+        sender: msg.senderId.slice(0, 12) + "…",
+        elapsedS: ((Date.now() - active.startTime) / 1000).toFixed(1),
+        droppedQueued: dropped,
+      });
+      active.controller.abort("interrupt");
+    }
+
+    // Captured synchronously, before the callback is attached — see the
+    // Telegram engine for the full rationale.
+    const epoch = backlog.enqueue(msg.conversationId);
     const prev = chains.get(key) ?? Promise.resolve();
     const next = prev
       .catch(() => {
         // A failed prior turn must not poison the chain — swallow so the next
         // message for this peer still runs.
       })
-      .then(() => handle(msg));
+      .then(async () => {
+        // Superseded while queued — evaporate without running.
+        if (!backlog.claim(msg.conversationId, epoch)) return;
+        await handle(msg);
+      });
     chains.set(key, next);
     inFlight.add(next);
     void next.finally(() => {

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -1171,7 +1171,13 @@ export async function runPhantomchatServer(
       inFlight.delete(next);
       // Drop the chain entry once it's the tail and settled, so the map doesn't
       // grow without bound across many peers.
-      if (chains.get(key) === next) chains.delete(key);
+      if (chains.get(key) === next) {
+        chains.delete(key);
+        // Settled tail for this peer: release its backlog slot as well so
+        // `slots` doesn't accumulate one entry per peer forever. `release`
+        // no-ops while anything is still pending, so a live epoch is safe.
+        backlog.release(msg.conversationId);
+      }
     });
   };
 

--- a/src/connectors/acp/commands.ts
+++ b/src/connectors/acp/commands.ts
@@ -40,7 +40,10 @@ import type { AcpAvailableCommand } from "./protocol.ts";
  * disappears.)
  */
 export const ACP_AVAILABLE_COMMANDS: AcpAvailableCommand[] = [
-  { name: "stop", description: "Abort the turn that's currently running" },
+  {
+    name: "stop",
+    description: "Abort the running turn and drop anything queued behind it",
+  },
   { name: "reset", description: "Clear this thread's history" },
   { name: "status", description: "Show harness, uptime, context usage" },
   {

--- a/src/connectors/acp/server.ts
+++ b/src/connectors/acp/server.ts
@@ -45,6 +45,7 @@ import {
   type JsonRpcId,
   type JsonRpcRequest,
 } from "./protocol.ts";
+import { ConversationBacklog } from "../../channels/core/backlog.ts";
 import { ACP_AVAILABLE_COMMANDS, handleAcpCommand, isAcpCommand } from "./commands.ts";
 import { buildWorkspaceBriefing } from "./briefing.ts";
 import { SessionRegistry, type AcpSession } from "./session.ts";
@@ -157,6 +158,12 @@ export async function runAcpServer(
   const startedAt = Date.now();
   /** Slash commands dispatched out-of-band; drained before the store closes. */
   const inflightCommands = new Set<Promise<void>>();
+  /**
+   * Per-session backlog epochs, keyed by sessionId (#301). Gives ACP the same
+   * interrupt / `/stop` semantics as the chat channels: prompts queued behind a
+   * turn that gets interrupted or stopped are never executed.
+   */
+  const backlog = new ConversationBacklog();
 
   // ── wire helpers — every write goes to OUTPUT (the protocol channel) ──
   const send = (obj: unknown): void => {
@@ -423,6 +430,9 @@ export async function runAcpServer(
         startedAt,
         activeTurn: session.activeTurn,
         config,
+        // /stop flushes this session's queued-but-unstarted prompts, exactly
+        // as an interrupt does, and reports the count in its reply.
+        flushBacklog: () => backlog.flush(session.sessionId, "stop"),
       });
       if (!result) {
         // Unreachable: the caller only routes here when isAcpCommand() is true,
@@ -469,6 +479,53 @@ export async function runAcpServer(
       inflightCommands.delete(task);
     });
     inflightCommands.add(task);
+    return true;
+  }
+
+  /**
+   * Queue a `session/prompt` under this session's backlog epoch (#301).
+   *
+   * Returns false when the message is not a prompt for a session we know, in
+   * which case the caller queues it the plain way (an unknown session must
+   * still reach `dispatch` so it produces the proper invalid-params error).
+   *
+   * INTERRUPT: if a turn is already running for this session, a newly arriving
+   * prompt means the same thing it means on Telegram and PhantomChat — abort
+   * the running turn and discard everything queued behind it, silently. Editors
+   * normally wait for one prompt to resolve before sending the next, so in
+   * practice this is a no-op; it exists so the semantics are identical on every
+   * surface rather than accidentally correct on this one.
+   *
+   * A superseded prompt must still be ANSWERED — a JSON-RPC request we simply
+   * drop would leave the editor's thread spinning forever — so it resolves with
+   * `cancelled`, which is the same stopReason the editor's own stop button
+   * produces and which it already knows how to render.
+   */
+  function maybeQueuePrompt(msg: JsonRpcRequest): boolean {
+    if (msg.method !== "session/prompt" || msg.id === undefined) return false;
+    const p = (msg.params ?? {}) as { sessionId?: unknown };
+    const sessionId = typeof p.sessionId === "string" ? p.sessionId : "";
+    const session = sessions.get(sessionId);
+    if (!session) return false;
+
+    const active = session.activeTurn;
+    if (active) {
+      const dropped = backlog.flush(sessionId, "interrupt");
+      log(
+        `new prompt — interrupting active turn (dropped ${dropped} queued)`,
+      );
+      active.controller.abort("interrupt");
+    }
+
+    const epoch = backlog.enqueue(sessionId);
+    const id = msg.id;
+    queue = queue.then(async () => {
+      if (!backlog.claim(sessionId, epoch)) {
+        send(jsonRpcResult(id, { stopReason: "cancelled" }));
+        return;
+      }
+      await dispatch(msg);
+    });
     return true;
   }
 
@@ -576,6 +633,10 @@ export async function runAcpServer(
       // Out-of-band: a slash command we own. Same reasoning as cancel — it has
       // to be able to reach past a running turn.
       if (maybeDispatchCommand(msg)) continue;
+
+      // A prompt for a known session queues under that session's backlog epoch
+      // so an interrupt or /stop can supersede it while it waits.
+      if (maybeQueuePrompt(msg)) continue;
 
       // Serialize the rest behind the queue.
       const current = msg;

--- a/tests/channels-core-backlog.test.ts
+++ b/tests/channels-core-backlog.test.ts
@@ -84,6 +84,37 @@ describe("ConversationBacklog", () => {
     b.release("c1");
     expect(b.pending("c1")).toBe(0);
   });
+
+  test("release truly deletes the slot — a re-created conversation starts fresh at epoch 0", () => {
+    // This is the property the settled-tail cleanup in the Telegram engine and
+    // PhantomChat server rely on to bound memory: `release` must DROP the slot,
+    // not merely zero its counter the way `flush` does. We prove deletion
+    // observably — the only in-band signal that the slot is gone is that the
+    // NEXT enqueue on the same key hands back epoch 0 (a fresh slot) rather
+    // than the bumped epoch a surviving slot would still carry.
+    const b = new ConversationBacklog();
+    b.enqueue("c1");
+    b.flush("c1", "stop"); // epoch is now 1, pending zeroed but slot survives
+    expect(b.enqueue("c1")).toBe(1); // same slot → still epoch 1
+    b.claim("c1", 1); // drain it back to idle so release can fire
+    b.release("c1"); // idle → slot deleted
+    // Fresh slot: epoch reset to 0. Had release only zeroed like flush, this
+    // would still be 1 and a stale epoch-0 task could never spuriously claim.
+    expect(b.enqueue("c1")).toBe(0);
+  });
+
+  test("release after a full drop-and-drain cycle leaves no residue", () => {
+    // Mirrors the consumer lifecycle: enqueue → interrupt-flush → the running
+    // tail settles and calls release. Afterwards the conversation must be
+    // indistinguishable from one never seen (pending 0, epoch 0).
+    const b = new ConversationBacklog();
+    b.enqueue("c1");
+    b.enqueue("c1");
+    expect(b.flush("c1", "interrupt")).toBe(2); // two queued dropped
+    b.release("c1"); // idle after flush → slot gone
+    expect(b.pending("c1")).toBe(0);
+    expect(b.enqueue("c1")).toBe(0); // brand-new slot
+  });
 });
 
 describe("stopNoteText", () => {

--- a/tests/channels-core-backlog.test.ts
+++ b/tests/channels-core-backlog.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the shared per-conversation backlog epochs
+ * (src/channels/core/backlog.ts) — the mechanism behind unified interrupt and
+ * `/stop` semantics (GitHub #301).
+ *
+ * These cover the epoch bookkeeping in isolation. The channel-level behaviour
+ * ("a second message drops the queued third one") is exercised end-to-end in
+ * channels-telegram.test.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  ConversationBacklog,
+  stopNoteText,
+} from "../src/channels/core/backlog.ts";
+
+describe("ConversationBacklog", () => {
+  test("a task enqueued and claimed with no flush in between runs", () => {
+    const b = new ConversationBacklog();
+    const epoch = b.enqueue("c1");
+    expect(b.claim("c1", epoch)).toBe(true);
+  });
+
+  test("a flush supersedes every task queued before it", () => {
+    const b = new ConversationBacklog();
+    const first = b.enqueue("c1");
+    const second = b.enqueue("c1");
+    expect(b.flush("c1", "interrupt")).toBe(2);
+    expect(b.claim("c1", first)).toBe(false);
+    expect(b.claim("c1", second)).toBe(false);
+  });
+
+  test("a task enqueued AFTER the flush still runs — the interrupting message", () => {
+    const b = new ConversationBacklog();
+    b.enqueue("c1");
+    b.flush("c1", "interrupt");
+    const afterFlush = b.enqueue("c1");
+    expect(b.claim("c1", afterFlush)).toBe(true);
+  });
+
+  test("the running task is not counted as dropped — it already claimed out", () => {
+    const b = new ConversationBacklog();
+    const running = b.enqueue("c1");
+    b.claim("c1", running); // started executing
+    const queued = b.enqueue("c1");
+    // Only the one still waiting is backlog.
+    expect(b.pending("c1")).toBe(1);
+    expect(b.flush("c1", "stop")).toBe(1);
+    expect(b.claim("c1", queued)).toBe(false);
+  });
+
+  test("flushing an idle conversation drops nothing", () => {
+    const b = new ConversationBacklog();
+    expect(b.flush("c1", "stop")).toBe(0);
+  });
+
+  test("a superseded task claiming late does not consume the new backlog's depth", () => {
+    const b = new ConversationBacklog();
+    const stale = b.enqueue("c1");
+    b.flush("c1", "interrupt");
+    const fresh = b.enqueue("c1");
+    // The stale `.then()` finally fires and is rejected...
+    expect(b.claim("c1", stale)).toBe(false);
+    // ...without eating the freshly queued task's slot.
+    expect(b.pending("c1")).toBe(1);
+    expect(b.flush("c1", "stop")).toBe(1);
+    expect(b.claim("c1", fresh)).toBe(false);
+  });
+
+  test("conversations are independent — flushing one leaves the other alone", () => {
+    const b = new ConversationBacklog();
+    const a = b.enqueue("c1");
+    const c = b.enqueue("c2");
+    expect(b.flush("c1", "interrupt")).toBe(1);
+    expect(b.claim("c1", a)).toBe(false);
+    expect(b.claim("c2", c)).toBe(true);
+  });
+
+  test("release forgets an idle conversation but never a busy one", () => {
+    const b = new ConversationBacklog();
+    const epoch = b.enqueue("c1");
+    b.release("c1"); // still pending — must be a no-op
+    expect(b.claim("c1", epoch)).toBe(true);
+    b.release("c1");
+    expect(b.pending("c1")).toBe(0);
+  });
+});
+
+describe("stopNoteText", () => {
+  test("tells the agent it was stopped and must not resume", () => {
+    const note = stopNoteText(0);
+    expect(note).toContain("/stop");
+    expect(note.toLowerCase()).toContain("aborted");
+    expect(note).toContain("Do not resume");
+    expect(note).toContain("Await further instructions");
+    // Nothing was queued, so no backlog sentence.
+    expect(note).not.toContain("discarded");
+  });
+
+  test("mentions the dropped backlog when there was one, pluralized", () => {
+    expect(stopNoteText(1)).toContain("1 queued message that had not started");
+    expect(stopNoteText(3)).toContain("3 queued messages that had not started");
+  });
+});

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -3451,10 +3451,21 @@ describe("runTelegramServer slash commands", () => {
     // was just wiped) or the message text is empty (voice STT aborted
     // before it ran).
     const stored = await memory.recentTurns("phantom", "telegram:1001", 10);
-    expect(stored).toEqual([
-      { role: "user", text: "kick off something slow" },
-      { role: "assistant", text: "[interrupted before reply]" },
-    ]);
+    expect(stored).toContainEqual({
+      role: "user",
+      text: "kick off something slow",
+    });
+    expect(stored).toContainEqual({
+      role: "assistant",
+      text: "[interrupted before reply]",
+    });
+    // /stop also leaves an agent-facing note (#301) so the next turn knows it
+    // was stopped on purpose and must not resume the abandoned work.
+    expect(
+      stored.some(
+        (t) => t.role === "user" && t.text.includes("The user issued /stop"),
+      ),
+    ).toBe(true);
   });
 
   test("a second non-slash message interrupts an in-flight turn (no reply for the aborted one)", async () => {


### PR DESCRIPTION
Implements the interrupt / `/stop` semantics Andrew and I agreed on in #301, applied uniformly across **Telegram, PhantomChat and the ACP connector**.

## Semantics
- **Interrupt** (a new message arrives while a turn is running) = *"I've changed my mind — listen to me now."* Aborts the active turn **and drops the queued backlog** for that conversation, **silently**. You sent the interrupting message, so you already know what you cancelled; a "dropped N messages" notice would just be noise.
- **`/stop`** = break-glass panic. Aborts the active turn, drops the backlog, replies with a **visible ack + dropped count**, and writes a `[system]` note into history so the agent's *next* turn knows it was stopped, drops the work, and **awaits instructions** instead of resuming.

This is a deliberate departure from the "always report the drop" position (#301): the visible notice lives on `/stop` only; interrupt is intentionally quiet.

## Mechanism
Channels serialize a conversation onto a promise chain (`next = prev.then(() => run(msg))`). A `.then()` callback can't be un-attached, so we make superseded ones **no-op**: a per-conversation **epoch** (`ConversationBacklog`). A task captures the epoch at enqueue and re-checks on start; interrupt/`/stop` bump the epoch, so everything queued before the bump returns without running. The interrupting message carries the new epoch and runs normally. A pending counter gives `/stop` its exact dropped count.

## Changed
- `src/channels/core/backlog.ts` — new `ConversationBacklog` + `stopNoteText`
- `src/channels/core/engine.ts`, `src/channels/commands.ts` — Telegram interrupt + `/stop` flush/note
- `src/channels/phantomchat/server.ts` — same on PhantomChat
- `src/connectors/acp/server.ts`, `commands.ts` — same on ACP; updated `stop` description
- `editors/vscode/package.json` — mirrored the new `stop` description (manifest drift guard)

## Tests
- New `ConversationBacklog` unit tests (epoch/flush/count invariants)
- Telegram drop-count coverage
- Full suite: **2319 pass, 0 fail**, typecheck clean

cc @lena-phantom — this is the spec we landed on; happy to fold in refinements.