### PR TITLE
fix(notify): persist delivered notifications as assistant turns

### DIFF
--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -47,6 +47,10 @@ import { loadPhantomchatPersonaConfig } from "../channels/phantomchat/personaSto
 import { synthesize, ttsSupport } from "../lib/audio.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
+import {
+  openMemoryStore,
+  type MemoryStore,
+} from "../memory/store.ts";
 
 /**
  * Send a phantomchat (Nostr NIP-17 DM) text to `recipientHex`. Default builds a
@@ -101,6 +105,12 @@ export interface RunNotifyInput {
   transport?: TelegramTransport;
   /** Inject for testing. Default: one-shot SimplePool gift-wrap publish. */
   phantomchatSend?: PhantomchatNotifySend;
+  /**
+   * Inject for testing. Default: openMemoryStore(config.memoryDbPath), opened
+   * lazily on the first successful send and closed by runNotify. An injected
+   * store is NOT closed (ownership stays with the caller).
+   */
+  memory?: MemoryStore;
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -186,9 +196,41 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
     return 2;
   }
 
+  // ── Notification persistence ─────────────────────────────────────────
+  // A notify that only goes out the transport is invisible to the persona:
+  // the turn store never sees it, so a user replying to the notification has
+  // no assistant turn anchoring what they're replying about. Persist each
+  // delivered notification as an assistant turn under the recipient's
+  // conversation key (same conventions as the channels: `telegram:<chatId>`,
+  // `phantomchat:<recipientHex>`). Best-effort: persistence failure is logged
+  // and swallowed — delivery already happened and the exit code reflects
+  // delivery, not bookkeeping. The store opens lazily on first use so a
+  // fully-failed notify never touches the DB.
+  let ownedStore: MemoryStore | undefined;
+  const persistNotification = async (conversation: string, text: string) => {
+    try {
+      const store =
+        input.memory ??
+        (ownedStore ??= await openMemoryStore(config.memoryDbPath));
+      await store.appendTurn({
+        persona,
+        conversation,
+        role: "assistant",
+        text: `[notification] ${text}`,
+      });
+    } catch (e) {
+      log.warn("notify: failed to persist notification turn", {
+        conversation,
+        error: (e as Error).message,
+      });
+    }
+  };
+
   // ── Telegram send (broadcast to all owners) ───────────────────────────
   let textSent = 0;
   let voiceSent = 0;
+  let pcSent = 0;
+  try {
   if (tgTargets.length > 0) {
     // Pre-synthesize ONCE if voice was requested (not per recipient, not per
     // account). Telegram-only — Nostr DMs carry no audio. Doing it before the
@@ -231,10 +273,17 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
           if (input.message) {
             await transport.sendMessage(chatId, input.message);
             textSent++;
+            await persistNotification(`telegram:${chatId}`, input.message);
           }
           if (voiceAudio) {
             await transport.sendVoice(chatId, voiceAudio.data, voiceAudio.mime);
             voiceSent++;
+            // Voice-only notify: persist the spoken text so the reply threads
+            // against what the user actually heard. (When both flags are given
+            // the message row above already anchors the conversation.)
+            if (!input.message && input.voice) {
+              await persistNotification(`telegram:${chatId}`, input.voice);
+            }
           }
         } catch (e) {
           log.warn("notify: telegram send failed", {
@@ -250,7 +299,6 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
   // Nostr DMs are text-only: send --message, or fall back to the --voice text
   // so a voice-only notify still reaches owners here as text. Each recipient is
   // an independent send — a failure is logged and swallowed.
-  let pcSent = 0;
   if (pcTarget) {
     const text = input.message ?? input.voice;
     if (text) {
@@ -264,6 +312,7 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
             text,
           });
           pcSent++;
+          await persistNotification(`phantomchat:${recipientHex}`, text);
         } catch (e) {
           log.warn("notify: phantomchat send failed", {
             recipient: recipientHex.slice(0, 12) + "…",
@@ -272,6 +321,9 @@ export async function runNotify(input: RunNotifyInput = {}): Promise<number> {
         }
       }
     }
+  }
+  } finally {
+    if (ownedStore) await ownedStore.close();
   }
 
   const channels = [

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
 import { nip19 } from "nostr-tools";
 import { runNotify, type PhantomchatNotifySend } from "../src/cli/notify.ts";
+import { openMemoryStore } from "../src/memory/store.ts";
 import type {
   TelegramMessage,
   TelegramTransport,
@@ -460,5 +461,108 @@ describe("runNotify phantomchat (broadcast)", () => {
     expect(got).toEqual([bHex]);
     expect(err.text).toBe("");
     expect(out.text).toContain("phantomchat(text=1)");
+  });
+});
+
+describe("runNotify turn persistence", () => {
+  // A delivered notification must land in the turn store as an assistant turn
+  // under the recipient's conversation key — otherwise the user's reply to it
+  // has no context anchor (issue #303).
+
+  test("telegram message persists [notification] assistant turn per delivered recipient", async () => {
+    const memory = await openMemoryStore(":memory:");
+    try {
+      const code = await runNotify({
+        config: baseConfig(),
+        message: "deploy finished — want the diff?",
+        transport: new FakeTransport(),
+        memory,
+        out: new CaptureStream(),
+        err: new CaptureStream(),
+      });
+      expect(code).toBe(0);
+      for (const chatId of ["42", "99"]) {
+        const turns = await memory.recentTurns("phantom", `telegram:${chatId}`, 10);
+        expect(turns).toEqual([
+          { role: "assistant", text: "[notification] deploy finished — want the diff?" },
+        ]);
+      }
+    } finally {
+      await memory.close();
+    }
+  });
+
+  test("a failed recipient gets no persisted turn (history stays truthful)", async () => {
+    const memory = await openMemoryStore(":memory:");
+    try {
+      const code = await runNotify({
+        config: baseConfig(),
+        message: "partial fan-out",
+        transport: new FakeTransport(["42"]),
+        memory,
+        out: new CaptureStream(),
+        err: new CaptureStream(),
+      });
+      expect(code).toBe(0); // 99 still landed
+      expect(await memory.recentTurns("phantom", "telegram:42", 10)).toEqual([]);
+      expect(await memory.recentTurns("phantom", "telegram:99", 10)).toEqual([
+        { role: "assistant", text: "[notification] partial fan-out" },
+      ]);
+    } finally {
+      await memory.close();
+    }
+  });
+
+  test("phantomchat notify persists under phantomchat:<recipientHex>", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pc-notify-persist-"));
+    const dir = join(root, "phantom");
+    mkdirSync(dir, { recursive: true });
+    const nsec = nip19.nsecEncode(generateSecretKey());
+    const ownerNpub = nip19.npubEncode(getPublicKey(generateSecretKey()));
+    writeFileSync(
+      join(dir, "phantomchat.json"),
+      JSON.stringify({ nsec, relays: ["wss://relay.example"], allowed_npubs: [ownerNpub] }),
+      { mode: 0o600 },
+    );
+    const cfg = baseConfig();
+    cfg.personasDir = root;
+    cfg.channels.telegram = undefined;
+
+    const memory = await openMemoryStore(":memory:");
+    try {
+      const ownerHex = nip19.decode(ownerNpub).data as string;
+      const code = await runNotify({
+        config: cfg,
+        message: "relay incident resolved",
+        phantomchatSend: async () => {},
+        memory,
+        out: new CaptureStream(),
+        err: new CaptureStream(),
+      });
+      expect(code).toBe(0);
+      expect(
+        await memory.recentTurns("phantom", `phantomchat:${ownerHex}`, 10),
+      ).toEqual([
+        { role: "assistant", text: "[notification] relay incident resolved" },
+      ]);
+    } finally {
+      await memory.close();
+    }
+  });
+
+  test("persistence failure is swallowed — delivery still succeeds, exit 0", async () => {
+    const memory = await openMemoryStore(":memory:");
+    await memory.close(); // closed store → appendTurn throws on write
+    const transport = new FakeTransport();
+    const code = await runNotify({
+      config: baseConfig(),
+      message: "bookkeeping is down",
+      transport,
+      memory,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(code).toBe(0);
+    expect(transport.sent).toHaveLength(2); // both recipients still notified
   });
 });


### PR DESCRIPTION
Closes #303.

## Problem
`phantombot notify` delivered straight through the transports (Telegram Bot API, Nostr gift-wrap) and exited — nothing landed in the persona's turn store. From the conversation's perspective the notification didn't exist, so when the user replied to a notification's call to action, `recentTurns` history had no assistant turn anchoring what they were replying about.

## Fix
In `runNotify`, after each successful per-recipient send, persist an assistant turn via the existing `MemoryStore.appendTurn`:

- **Conversation key** follows channel convention: `telegram:<chatId>`, `phantomchat:<recipientHex>`
- **Text** = `message ?? voice`, prefixed `[notification]` so the agent recognizes it as out-of-band; voice-only notifies persist the spoken text
- **Truthful history** — failed recipients get no turn
- **Best-effort bookkeeping** — persistence errors are logged and swallowed; the exit code keeps reflecting delivery only
- Store opens **lazily** on first delivered send via `openMemoryStore(config.memoryDbPath)`, closed in a `finally`, injectable for tests
- No schema change; `embeddable` defaults true so notifications stay FTS/vector-searchable

## Tests
4 new tests in `tests/cli-notify.test.ts`:
- telegram message → `[notification]` assistant turn per delivered recipient (`telegram:42`, `telegram:99`)
- failed recipient gets no turn while the delivered one does
- phantomchat notify persists under `phantomchat:<recipientHex>`
- closed/broken store → delivery still succeeds, exit 0

Suite: 2327 tests, only the 2 pre-existing PiHarness env failures (also fail on clean `origin/main` on this host). Typecheck clean.