### PR TITLE
fix(windows): explicit deferred relaunch on self-update/restart

### DIFF
--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -36,6 +36,7 @@ import {
 } from "./systemd.ts";
 import {
   defaultTaskSchedulerServiceControl,
+  scheduleWindowsRelaunch,
   taskLogPaths,
 } from "./taskScheduler.ts";
 
@@ -82,6 +83,14 @@ export interface SelfRestartOpts {
    * SIGTERM so `phantombot run`'s existing shutdown handler drains cleanly.
    */
   triggerShutdown?: () => void;
+  /**
+   * Test seam for the Windows deferred-relaunch scheduler. Production uses
+   * `scheduleWindowsRelaunch`, which detaches a watcher that waits for this
+   * process to exit and then starts the swapped binary.
+   */
+  scheduleRelaunch?: (opts: {
+    selfPid: number;
+  }) => Promise<{ ok: boolean; stderr?: string }>;
 }
 
 /**
@@ -96,15 +105,26 @@ export interface SelfRestartOpts {
  * (`systemctl --user restart` / `launchctl kickstart`). Those SIGTERM us and
  * the supervisor relaunches — safe to call from within the unit.
  *
- * Windows: exit cleanly (emit SIGTERM → the run loop's handler drains and
- * returns); the always-on scheduled task's keep-alive trigger relaunches the
- * swapped binary while the user remains logged in.
+ * Windows: schedule a detached deferred relaunch of the swapped binary FIRST,
+ * then exit cleanly (emit SIGTERM → the run loop's handler drains and returns).
+ * The watcher waits for us to release the run-lock, then starts the new binary
+ * — mirroring the Linux systemd-run deferred restart. We no longer rely on the
+ * always-on task's keep-alive trigger as the primary relaunch path: its
+ * IgnoreNew run-accounting can wedge and never relaunch (the Megan v1.1.212
+ * self-update that sat dead for hours). Keep-alive remains a backstop if the
+ * watcher fails to spawn.
  */
 export async function selfRestart(
   opts: SelfRestartOpts,
 ): Promise<{ ok: boolean; stderr?: string }> {
   const platform = opts.procPlatform ?? process.platform;
   if (platform === "win32") {
+    // Schedule the relaunch BEFORE tripping shutdown: the watcher captures our
+    // pid, blocks on our exit, then launches the swapped binary. A spawn
+    // failure here is non-fatal — we still exit and fall back to the keep-alive
+    // trigger — but we surface it so the caller can log it.
+    const scheduleRelaunch = opts.scheduleRelaunch ?? scheduleWindowsRelaunch;
+    const relaunch = await scheduleRelaunch({ selfPid: process.pid });
     const trigger =
       opts.triggerShutdown ??
       (() => {
@@ -113,7 +133,14 @@ export async function selfRestart(
         process.emit("SIGTERM" as NodeJS.Signals);
       });
     trigger();
-    return { ok: true };
+    return relaunch.ok
+      ? { ok: true }
+      : {
+          ok: false,
+          stderr:
+            `deferred relaunch scheduling failed (${relaunch.stderr ?? "unknown"}); ` +
+            `falling back to the keep-alive trigger`,
+        };
   }
   return opts.serviceControl.restart();
 }

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -1028,6 +1028,106 @@ async function launchDaemonDirectly(): Promise<void> {
   }
 }
 
+/** Injectable spawn seam so {@link scheduleWindowsRelaunch} is unit-testable. */
+export type RelaunchSpawn = (
+  argv: string[],
+) => Promise<{ ok: boolean; stderr?: string }>;
+
+export interface ScheduleWindowsRelaunchOpts {
+  /** PID whose exit the watcher blocks on. Defaults to process.pid. */
+  selfPid?: number;
+  /**
+   * How long the watcher waits for the current daemon to exit before it
+   * launches anyway. Should exceed run.ts's SHUTDOWN_GRACE_MS (5s force-exit
+   * watchdog) with headroom. Default 30s.
+   */
+  graceSeconds?: number;
+  /** Defaults to process.execPath — the on-disk (freshly-swapped) binary. */
+  binPath?: string;
+  /** Test seam. Defaults to a detached Bun.spawn of powershell. */
+  spawnImpl?: RelaunchSpawn;
+}
+
+/**
+ * Schedule a DEFERRED, self-detached relaunch of the phantombot daemon, then
+ * return so the caller can exit.
+ *
+ * Why this exists: on Windows the `/update` and `/restart` in-process flows
+ * (see {@link selfRestart} in platform.ts) used to just SIGTERM themselves and
+ * trust the always-on task's 1-minute keep-alive TimeTrigger to bring the
+ * swapped binary back. That trigger is NOT a dependable relaunch path: it runs
+ * under MultipleInstancesPolicy=IgnoreNew, and once the task's run-accounting
+ * wedges (a terminated instance the scheduler never clears) the "missed runs"
+ * counter climbs while the daemon never actually starts. That is exactly how
+ * Megan self-updated to v1.1.212 and then sat dead for hours — the update
+ * installed cleanly, the old process force-exited, and nothing relaunched.
+ *
+ * The fix mirrors the Linux `systemd-run` deferred-restart pattern: spawn a
+ * tiny detached PowerShell watcher that (1) blocks until THIS process exits —
+ * releasing the single-instance run-lock — then (2) `Start-Process`es the
+ * freshly-swapped binary hidden, with the same redirected logs the scheduler
+ * writes. It is launched via an outer `Start-Process` so it fully detaches
+ * from our process tree and outlives our own exit (a bare Bun.spawn child would
+ * be reaped when the task instance ends). The keep-alive trigger stays as a
+ * backstop if the watcher ever fails to spawn.
+ */
+export async function scheduleWindowsRelaunch(
+  opts: ScheduleWindowsRelaunchOpts = {},
+): Promise<{ ok: boolean; stderr?: string }> {
+  const selfPid = opts.selfPid ?? process.pid;
+  const graceSeconds = opts.graceSeconds ?? 30;
+  const binPath = opts.binPath ?? process.execPath;
+  const { out, err } = taskLogPaths("phantombot");
+
+  // Inner watcher: wait for the current daemon to exit (Wait-Process returns
+  // immediately if the pid is already gone; -Timeout caps a wedged shutdown so
+  // we still relaunch), then launch the swapped binary detached. Encoded as
+  // base64 UTF-16LE so the outer -Command layer needs no nested quoting.
+  const watcher = [
+    `Wait-Process -Id ${selfPid} -Timeout ${graceSeconds} -ErrorAction SilentlyContinue;`,
+    `Start-Process -FilePath ${powershellQuote(binPath)}`,
+    `-ArgumentList @('run')`,
+    `-WorkingDirectory ${powershellQuote(process.cwd())}`,
+    `-WindowStyle Hidden`,
+    `-RedirectStandardOutput ${powershellQuote(out)}`,
+    `-RedirectStandardError ${powershellQuote(err)}`,
+  ].join(" ");
+  const encoded = Buffer.from(watcher, "utf16le").toString("base64");
+
+  // Outer layer: detach the watcher from our process tree so it survives our
+  // exit. Start-Process returns as soon as the watcher is launched.
+  const detach =
+    `Start-Process powershell ` +
+    `-ArgumentList @('-NoProfile','-NonInteractive','-EncodedCommand','${encoded}') ` +
+    `-WindowStyle Hidden`;
+
+  const spawnImpl = opts.spawnImpl ?? defaultRelaunchSpawn;
+  return spawnImpl([
+    "powershell",
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    detach,
+  ]);
+}
+
+const defaultRelaunchSpawn: RelaunchSpawn = async (argv) => {
+  const child = Bun.spawn(argv, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    windowsHide: true,
+    env: { ...process.env },
+  });
+  const [stderr, exitCode] = await Promise.all([
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return exitCode === 0
+    ? { ok: true }
+    : { ok: false, stderr: stderr.trim() || `powershell exited ${exitCode}` };
+};
+
 /**
  * Default TaskSchedulerServiceControl backed by real schtasks. Returns
  * isActive=false on any error so callers can treat "task unknown" the same as

--- a/tests/lib-platform.test.ts
+++ b/tests/lib-platform.test.ts
@@ -169,19 +169,44 @@ describe("selfRestart", () => {
     expect(r.stderr).toBe("boom");
   });
 
-  test("Windows: triggers a clean exit and never calls schtasks restart()", async () => {
+  test("Windows: schedules a deferred relaunch, then triggers a clean exit and never calls schtasks restart()", async () => {
     const { svc, calls } = trackingSvc({ ok: true });
     let shutdowns = 0;
+    const relaunchCalls: number[] = [];
     const r = await selfRestart({
       serviceControl: svc,
       procPlatform: "win32",
+      scheduleRelaunch: async ({ selfPid }) => {
+        relaunchCalls.push(selfPid);
+        return { ok: true };
+      },
       triggerShutdown: () => {
         shutdowns++;
       },
     });
     expect(r.ok).toBe(true);
-    // The keep-alive relaunches us; we must NOT End/Run our own task tree.
+    // We must NOT End/Run our own task tree — the detached watcher relaunches us.
     expect(calls.length).toBe(0);
+    // Relaunch is scheduled with our pid BEFORE we go down.
+    expect(relaunchCalls).toEqual([process.pid]);
     expect(shutdowns).toBe(1);
+  });
+
+  test("Windows: still exits when relaunch scheduling fails, and surfaces the fallback", async () => {
+    const { svc } = trackingSvc({ ok: true });
+    let shutdowns = 0;
+    const r = await selfRestart({
+      serviceControl: svc,
+      procPlatform: "win32",
+      scheduleRelaunch: async () => ({ ok: false, stderr: "powershell exited 1" }),
+      triggerShutdown: () => {
+        shutdowns++;
+      },
+    });
+    // Non-fatal: we still trigger shutdown (keep-alive is the backstop)...
+    expect(shutdowns).toBe(1);
+    // ...but the failure is surfaced for logging.
+    expect(r.ok).toBe(false);
+    expect(r.stderr).toContain("keep-alive");
   });
 });

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -27,6 +27,7 @@ import {
   killDaemonProcesses,
   launcherVbsPath,
   LAUNCHER_VBS,
+  scheduleWindowsRelaunch,
   ProcessEnumerationError,
   type ProcessManager,
   type RunningProcess,
@@ -816,5 +817,49 @@ describe("service control stop/restart kill the stray daemon", () => {
     const r = await svc.stop();
     expect(r.ok).toBe(false);
     expect(r.stderr ?? "").toContain("could not confirm");
+  });
+});
+
+describe("scheduleWindowsRelaunch", () => {
+  test("detaches a watcher that waits on our pid, then relaunches — via one Start-Process", async () => {
+    let captured: string[] | null = null;
+    const r = await scheduleWindowsRelaunch({
+      selfPid: 4242,
+      graceSeconds: 30,
+      binPath: "C:\\Users\\me\\phantombot.exe",
+      spawnImpl: async (argv) => {
+        captured = argv;
+        return { ok: true };
+      },
+    });
+    expect(r.ok).toBe(true);
+    expect(captured).not.toBeNull();
+    const argv = captured as unknown as string[];
+    // Outer invocation is a hidden, detaching Start-Process of powershell.
+    expect(argv[0]).toBe("powershell");
+    const outer = argv[argv.length - 1] ?? "";
+    expect(outer).toContain("Start-Process powershell");
+    expect(outer).toContain("-WindowStyle Hidden");
+    expect(outer).toContain("-EncodedCommand");
+
+    // The encoded inner watcher must block on our pid, then launch the binary.
+    const m = outer.match(/-EncodedCommand','([^']+)'/);
+    expect(m).not.toBeNull();
+    const inner = Buffer.from((m as RegExpMatchArray)[1] ?? "", "base64").toString(
+      "utf16le",
+    );
+    expect(inner).toContain("Wait-Process -Id 4242 -Timeout 30");
+    expect(inner).toContain("phantombot.exe");
+    expect(inner).toContain("@('run')");
+    expect(inner).toContain("-WindowStyle Hidden");
+    expect(inner).toContain("-RedirectStandardOutput");
+  });
+
+  test("surfaces a spawn failure without throwing", async () => {
+    const r = await scheduleWindowsRelaunch({
+      spawnImpl: async () => ({ ok: false, stderr: "powershell exited 1" }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.stderr).toContain("powershell exited 1");
   });
 });


### PR DESCRIPTION
## Summary

Windows `/update` (and `/restart`) relied **solely** on the always-on scheduled task's 1-minute keep-alive `TimeTrigger` to bring the swapped binary back after the running process exits. That trigger is not a dependable relaunch path: under `MultipleInstancesPolicy=IgnoreNew`, once the task's run-accounting wedges (a terminated instance the scheduler never clears), the "missed runs" counter climbs while the daemon **never actually starts**.

This is exactly how **Megan self-updated to v1.1.212 and then sat dead for ~2h**:

- Update installed cleanly (downloaded, sha256-verified, binary swapped, VS Code ext upgraded).
- Old process force-exited via `run.ts`'s `SHUTDOWN_GRACE_MS` (5s) watchdog → `process.exit(0)`.
- Nothing relaunched. `LastTaskResult` frozen at `0x40010004` (`SCHED_S_TASK_TERMINATED`), **2000+ missed runs**, `State=Ready`, zero `phantombot.exe` processes.

Root cause is the update→restart gap that #306 left open — #306 hardened the task lifecycle but deliberately **kept** the fragile keep-alive-only restart path.

## Fix

Mirror the Linux `systemd-run` deferred-restart pattern. `selfRestart()` on Windows now **schedules a detached relaunch before exiting**:

1. New `scheduleWindowsRelaunch()` in `taskScheduler.ts` spawns a tiny **detached** PowerShell watcher (via an outer `Start-Process`, so it outlives our process tree).
2. The watcher `Wait-Process`es on the current pid — blocking until we exit and **release the single-instance run-lock** — then `Start-Process`es the freshly-swapped binary hidden, with the scheduler's own redirected logs.
3. Only then does `selfRestart()` trip the normal SIGTERM shutdown.

The keep-alive trigger remains a **backstop** if the watcher ever fails to spawn; a spawn failure is non-fatal and surfaced for logging.

## Why not just flip the exit code?

Considered making the forced-exit path return non-zero so the task's existing `RestartOnFailure` (`RestartCount=3`) engages. Rejected: that would also make a deliberate `/stop` trip RestartOnFailure and fight the shutdown. The deferred watcher is deterministic and doesn't overload exit-code semantics. `RestartOnFailure` stays as a third-line net.

## Testing

- `bun tsc --noEmit` clean.
- Full suite: **2329 pass / 0 fail**.
- New tests: the scheduling argv (encoded watcher waits on pid, then launches the binary hidden with redirected logs), the spawn-failure fallback, and the updated Windows `selfRestart` flow (schedules relaunch with our pid, never End/Runs its own task tree).

## Deploy note

Megan was already brought back up manually (launched v1.1.212 directly via the VBS launcher). This PR makes the **next** self-update relaunch on its own.