### PR TITLE
feat(windows): run-when-logged-off install mode + persona-scoped task names

### DIFF
--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -766,7 +766,7 @@ export async function maybePromptRestart(
   );
   if (!proceed) {
     p.note(
-      `skipped — restart later with: ${restartCommand()}`,
+      `skipped — restart later with: ${await restartCommand()}`,
       "Restart",
     );
     return;

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -119,7 +119,7 @@ export async function runHeartbeatCli(
       if (input.healSystemd) {
         await input.healSystemd();
       } else {
-        await defaultHealService();
+        await defaultHealService(persona);
       }
     } catch (e) {
       log.warn("heartbeat: service self-heal threw unexpectedly", {
@@ -151,12 +151,12 @@ export async function runHeartbeatCli(
  * Silent on healthy boxes; logs a notice only on repair. A no-op on any
  * platform without a backend.
  */
-async function defaultHealService(): Promise<void> {
+async function defaultHealService(persona?: string): Promise<void> {
   switch (currentPlatform()) {
     case "linux":
       return defaultHealSystemd();
     case "windows":
-      return defaultHealTaskScheduler();
+      return defaultHealTaskScheduler(persona);
     default:
       return; // macOS (launchd self-heals via KeepAlive) and unsupported hosts
   }
@@ -188,11 +188,12 @@ async function defaultHealSystemd(): Promise<void> {
  * updated-binary case). Only fires when we ARE the compiled binary
  * (`phantombot.exe`), so a dev `bun src/index.ts` run never rewrites tasks.
  */
-async function defaultHealTaskScheduler(): Promise<void> {
+async function defaultHealTaskScheduler(persona?: string): Promise<void> {
   const binPath = process.execPath;
   if (!isPhantombotBinary(binPath)) return;
   const r = await ensureTasksCurrent({
     binPath,
+    persona,
     schtasks: new BunSchtasksRunner(),
   });
   if (r.rewrote.length > 0) {

--- a/src/cli/import-persona.ts
+++ b/src/cli/import-persona.ts
@@ -446,7 +446,7 @@ async function maybeRestartHint(
   if (await svc.isActive()) {
     out.write(
       "\nphantombot is currently running. Restart to pick up the imported persona/config:\n" +
-        `  ${restartCommand()}\n`,
+        `  ${await restartCommand()}\n`,
     );
   }
 }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -14,6 +14,7 @@
 
 import { defineCommand } from "citty";
 import { basename } from "node:path";
+import * as p from "@clack/prompts";
 
 import { installCompletions } from "../lib/completionInstall.ts";
 
@@ -39,8 +40,10 @@ import {
 } from "../lib/systemd.ts";
 import {
   BunSchtasksRunner,
+  currentPersonaName,
   installPhantombotTasks,
   type SchtasksRunner,
+  type TaskLogon,
 } from "../lib/taskScheduler.ts";
 import type { WriteSink } from "../lib/io.ts";
 
@@ -93,6 +96,26 @@ export interface RunInstallInput {
   schtasks?: SchtasksRunner;
   /** Override the current-user SID for testing (Windows). */
   sid?: string;
+  /** Override the persona the Windows tasks supervise (testing). */
+  persona?: string;
+  /**
+   * Windows logon-mode prompt seams (testing). When absent, the real
+   * @clack/prompts flow runs — but only on a TTY; a non-interactive install
+   * (scripted, CI, SSH without -t) silently takes the interactive-token
+   * default.
+   */
+  promptRunLoggedOff?: () => Promise<boolean | null>;
+  promptPassword?: () => Promise<string | null>;
+  /** `COMPUTER\user` resolution seam (testing). Defaults to `whoami`. */
+  whoami?: () => Promise<string>;
+  /**
+   * Scripted-mode flags (Windows): skip the TUI prompt entirely. With
+   * `--run-logged-off`, the password comes from --windows-password or the
+   * PHANTOMBOT_WINDOWS_PASSWORD env var; without either (and no TTY to ask),
+   * install fails with a clear message rather than hanging.
+   */
+  runLoggedOff?: boolean;
+  windowsPassword?: string;
   /** Directory for transient Task Scheduler XML import files (Windows tests). */
   xmlDir?: string;
   /** Override systemd-env detection for testing. */
@@ -224,10 +247,22 @@ async function runInstallWindows(
   err: WriteSink,
 ): Promise<number> {
   const schtasks = input.schtasks ?? new BunSchtasksRunner();
+  const persona = input.persona ?? (await currentPersonaName());
+
+  // Ask whether the daemon should also run when NOBODY is logged on
+  // (headless VM, Windows-update reboots). That requires Task Scheduler to
+  // store the Windows password with the task; default stays the safer
+  // interactive-token mode. Prompts only run on a real TTY — scripted
+  // installs keep the default.
+  const logon = await resolveWindowsLogon(input, err);
+  if (!logon) return 2; // user cancelled the prompt
+
   const result = await installPhantombotTasks({
     binPath,
+    persona,
     sid: input.sid,
     xmlDir: input.xmlDir,
+    logon,
     schtasks,
     out,
     err,
@@ -235,10 +270,96 @@ async function runInstallWindows(
   if (!result.installed) return 1;
 
   out.write(
-    `\nThese tasks run for the current Windows user while logged in.\n` +
-      manageHints(),
+    logon.mode === "password"
+      ? `\nThese tasks run as ${logon.username} whether or not anyone is logged on (starts at boot).\n` +
+          manageHints()
+      : `\nThese tasks run for the current Windows user while logged in.\n` +
+          manageHints(),
   );
   return 0;
+}
+
+type WindowsLogonChoice = TaskLogon & { password?: string };
+
+/**
+ * The install-time "run when logged off?" flow. Returns the chosen logon
+ * config, or null when the user cancels. Non-interactive invocations (no
+ * TTY) skip the prompts and take the interactive default — a scripted
+ * install must never block on a question nobody can answer.
+ */
+async function resolveWindowsLogon(
+  input: RunInstallInput,
+  err: WriteSink,
+): Promise<WindowsLogonChoice | null> {
+  // Scripted mode: flags/env decide, no prompts. Explicit false is the same
+  // interactive-token install as answering "no".
+  if (input.runLoggedOff !== undefined) {
+    if (!input.runLoggedOff) return { mode: "interactive" };
+    const username = await (input.whoami ?? defaultWhoami)();
+    const password =
+      input.windowsPassword ?? process.env.PHANTOMBOT_WINDOWS_PASSWORD;
+    if (!password) {
+      err.write(
+        "--run-logged-off needs the Windows password via --windows-password or PHANTOMBOT_WINDOWS_PASSWORD\n",
+      );
+      return null;
+    }
+    return { mode: "password", username, password };
+  }
+
+  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const askLoggedOff =
+    input.promptRunLoggedOff ??
+    (interactive
+      ? async () => {
+          const answer = await p.confirm({
+            message:
+              "Run phantombot when you are logged off? (survives reboots without login; requires your Windows password)",
+            initialValue: false,
+          });
+          if (p.isCancel(answer)) return null;
+          return answer;
+        }
+      : undefined);
+  if (!askLoggedOff) return { mode: "interactive" };
+
+  const wantsLoggedOff = await askLoggedOff();
+  if (wantsLoggedOff === null) {
+    err.write("install cancelled\n");
+    return null;
+  }
+  if (!wantsLoggedOff) return { mode: "interactive" };
+
+  const username = await (input.whoami ?? defaultWhoami)();
+  const askPassword =
+    input.promptPassword ??
+    (async () => {
+      const answer = await p.password({
+        message: `Windows password for ${username} (stored encrypted with the scheduled task):`,
+        validate: (v) =>
+          !v || v.length === 0 ? "password may not be empty" : undefined,
+      });
+      if (p.isCancel(answer)) return null;
+      return answer;
+    });
+  const password = await askPassword();
+  if (password === null) {
+    err.write("install cancelled\n");
+    return null;
+  }
+  return { mode: "password", username, password };
+}
+
+/** `COMPUTER\user` (or `DOMAIN\user`) for schtasks /RU. */
+async function defaultWhoami(): Promise<string> {
+  const proc = Bun.spawn(["whoami"], { stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  const name = stdout.trim();
+  if (exitCode !== 0 || !name) {
+    throw new Error("could not resolve the current Windows user via whoami");
+  }
+  return name;
 }
 
 export default defineCommand({
@@ -247,8 +368,32 @@ export default defineCommand({
     description:
       "Install the host-appropriate service unit for `phantombot run` (systemd --user on Linux, launchd LaunchAgent on macOS, Task Scheduler logon task on Windows) and start it.",
   },
-  async run() {
-    const code = await runInstall();
+  args: {
+    "run-logged-off": {
+      type: "boolean",
+      description:
+        "Windows: run whether or not anyone is logged on (stores the Windows password with the scheduled task; pair with --windows-password or PHANTOMBOT_WINDOWS_PASSWORD). Skips the prompt.",
+    },
+    "interactive": {
+      type: "boolean",
+      description:
+        "Windows: run only while the user is logged on (skips the prompt; the default).",
+    },
+    "windows-password": {
+      type: "string",
+      description:
+        "Windows: account password for --run-logged-off. Prefer the PHANTOMBOT_WINDOWS_PASSWORD env var to keep it out of shell history.",
+    },
+  },
+  async run({ args }) {
+    const code = await runInstall({
+      runLoggedOff: args["run-logged-off"]
+        ? true
+        : args["interactive"]
+          ? false
+          : undefined,
+      windowsPassword: args["windows-password"],
+    });
     // A successful install wires up shell tab-completion so it works right
     // away, with no extra step. Best-effort: a completion failure never turns
     // a successful install into a failure.

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -307,7 +307,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     err.write(
       `phantombot is already running (pid ${Number.isFinite(lock.pid) ? lock.pid : "unknown"}; lock at ${lock.path})\n` +
         `view logs:    ${logsCommand()}\n` +
-        `status:       ${statusCommand()}\n` +
+        `status:       ${await statusCommand()}\n` +
         "stop the other instance first, or remove the lock if it's stale.\n",
     );
     return 1;

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -54,6 +54,9 @@ export interface RunUninstallInput {
   domain?: string;
   /** Persona whose Windows tasks to remove (defaults to current persona). */
   persona?: string;
+  /** Override the current Windows user's SID (tests). Production resolves
+   * it live — only tasks owned by this account are deleted. */
+  sid?: string;
 }
 
 export async function runUninstall(
@@ -140,6 +143,7 @@ async function runUninstallWindows(
   const schtasks = input.schtasks ?? new BunSchtasksRunner();
   await uninstallPhantombotTasks({
     persona: input.persona,
+    sid: input.sid,
     schtasks,
     out,
     err,

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -52,6 +52,8 @@ export interface RunUninstallInput {
   ensureSystemdEnv?: () => UserSystemdEnv;
   platform?: "linux" | "darwin" | "windows" | "unsupported";
   domain?: string;
+  /** Persona whose Windows tasks to remove (defaults to current persona). */
+  persona?: string;
 }
 
 export async function runUninstall(
@@ -136,7 +138,12 @@ async function runUninstallWindows(
   err: WriteSink,
 ): Promise<number> {
   const schtasks = input.schtasks ?? new BunSchtasksRunner();
-  await uninstallPhantombotTasks({ schtasks, out, err });
+  await uninstallPhantombotTasks({
+    persona: input.persona,
+    schtasks,
+    out,
+    err,
+  });
   out.write("uninstall complete\n");
   return 0;
 }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -316,13 +316,13 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
       out.write("restarted phantombot.service.\n");
     } else {
       err.write(
-        `restart failed: ${r.stderr ?? "unknown"} — run '${restartCommand()}' manually.\n`,
+        `restart failed: ${r.stderr ?? "unknown"} — run '${await restartCommand()}' manually.\n`,
       );
       // Don't fail the whole command; the binary swap succeeded. The
       // user just needs to restart by hand.
     }
   } else if (!input.force) {
-    out.write(`restart with: ${restartCommand()}\n`);
+    out.write(`restart with: ${await restartCommand()}\n`);
   }
 
   return 0;

--- a/src/lib/filePermissions.ts
+++ b/src/lib/filePermissions.ts
@@ -43,6 +43,21 @@ export function currentUserSid(): string {
 }
 
 /**
+ * Current account as `COMPUTER\\user` (or `DOMAIN\\user`) — what plain
+ * `whoami` prints. Password-mode scheduled tasks carry THIS string (not a
+ * SID) in their Principal <UserId>, so ownership checks need it alongside
+ * currentUserSid().
+ */
+export function currentUserName(): string {
+  const res = Bun.spawnSync(["whoami"]);
+  const out = new TextDecoder().decode(res.stdout).trim();
+  if (res.exitCode !== 0 || !out) {
+    throw new Error("could not resolve current user name (whoami: no output)");
+  }
+  return out;
+}
+
+/**
  * Restrict `path` so ONLY the current user can access it. No-op on POSIX (the
  * file's mode 0o600 already governs); applies an owner-only ACL on Windows.
  * Throws on Windows if the lockdown cannot be verified to have succeeded.

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -35,9 +35,11 @@ import {
   type ServiceControl,
 } from "./systemd.ts";
 import {
+  currentPersonaName,
   defaultTaskSchedulerServiceControl,
   scheduleWindowsRelaunch,
   taskLogPaths,
+  taskNames,
 } from "./taskScheduler.ts";
 
 export type { ServiceControl };
@@ -169,13 +171,36 @@ function noopServiceControl(): ServiceControl {
   };
 }
 
+/**
+ * Overrides for the command-hint helpers. `platform` fakes the host OS and
+ * `persona` fakes the persona name so the Windows hint shapes are testable
+ * on any host; production callers pass nothing.
+ */
+export interface HintOverrides {
+  platform?: Platform;
+  persona?: string;
+}
+
+/**
+ * The persona-scoped main daemon task this process belongs to. Install
+ * registers `\Phantombot\phantombot-<persona>` (see taskScheduler.ts), so
+ * every Windows hint below must name THAT task — the legacy unsuffixed name
+ * addresses a task that no longer exists after install.
+ */
+async function windowsMainTaskName(over?: HintOverrides): Promise<string> {
+  const persona = over?.persona ?? (await currentPersonaName());
+  return taskNames(persona).main;
+}
+
 /** Copy-pasteable command string the user can run to restart phantombot. */
-export function restartCommand(): string {
-  switch (currentPlatform()) {
+export async function restartCommand(over?: HintOverrides): Promise<string> {
+  switch (over?.platform ?? currentPlatform()) {
     case "darwin":
       return `launchctl kickstart -k gui/$(id -u)/dev.phantombot.phantombot`;
-    case "windows":
-      return `schtasks /End /TN "\\Phantombot\\phantombot" & schtasks /Run /TN "\\Phantombot\\phantombot"`;
+    case "windows": {
+      const task = await windowsMainTaskName(over);
+      return `schtasks /End /TN "${task}" & schtasks /Run /TN "${task}"`;
+    }
     case "linux":
     default:
       return "systemctl --user restart phantombot";
@@ -183,12 +208,14 @@ export function restartCommand(): string {
 }
 
 /** Copy-pasteable command string the user can run to start phantombot. */
-export function startCommand(): string {
-  switch (currentPlatform()) {
+export async function startCommand(over?: HintOverrides): Promise<string> {
+  switch (over?.platform ?? currentPlatform()) {
     case "darwin":
       return `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.phantombot.phantombot.plist`;
-    case "windows":
-      return `schtasks /Change /TN "\\Phantombot\\phantombot" /ENABLE & schtasks /Run /TN "\\Phantombot\\phantombot"`;
+    case "windows": {
+      const task = await windowsMainTaskName(over);
+      return `schtasks /Change /TN "${task}" /ENABLE & schtasks /Run /TN "${task}"`;
+    }
     case "linux":
     default:
       return "systemctl --user start phantombot";
@@ -196,12 +223,14 @@ export function startCommand(): string {
 }
 
 /** Copy-pasteable command string the user can run to stop phantombot. */
-export function stopCommand(): string {
-  switch (currentPlatform()) {
+export async function stopCommand(over?: HintOverrides): Promise<string> {
+  switch (over?.platform ?? currentPlatform()) {
     case "darwin":
       return `launchctl bootout gui/$(id -u)/dev.phantombot.phantombot`;
-    case "windows":
-      return `schtasks /Change /TN "\\Phantombot\\phantombot" /DISABLE & schtasks /End /TN "\\Phantombot\\phantombot"`;
+    case "windows": {
+      const task = await windowsMainTaskName(over);
+      return `schtasks /Change /TN "${task}" /DISABLE & schtasks /End /TN "${task}"`;
+    }
     case "linux":
     default:
       return "systemctl --user stop phantombot";
@@ -209,12 +238,12 @@ export function stopCommand(): string {
 }
 
 /** Copy-pasteable command string for "show me the service status". */
-export function statusCommand(): string {
-  switch (currentPlatform()) {
+export async function statusCommand(over?: HintOverrides): Promise<string> {
+  switch (over?.platform ?? currentPlatform()) {
     case "darwin":
       return `launchctl print gui/$(id -u)/dev.phantombot.phantombot`;
     case "windows":
-      return `schtasks /Query /TN "\\Phantombot\\phantombot" /V /FO LIST`;
+      return `schtasks /Query /TN "${await windowsMainTaskName(over)}" /V /FO LIST`;
     case "linux":
     default:
       return "systemctl --user status phantombot";

--- a/src/lib/serviceLifecycle.ts
+++ b/src/lib/serviceLifecycle.ts
@@ -38,7 +38,7 @@ export interface LifecycleOptions {
 /** Past-tense success line + the copy-pasteable manual hint per action. */
 function actionText(action: LifecycleAction): {
   done: string;
-  hint: () => string;
+  hint: () => Promise<string>;
 } {
   switch (action) {
     case "start":
@@ -70,8 +70,8 @@ export async function runLifecycleAction(
     return 0;
   }
   err.write(
-    `${opts.action} failed: ${r.stderr ?? "unknown"} — run '${hint()}' manually.\n` +
-      `(check status with: ${statusCommand()})\n`,
+    `${opts.action} failed: ${r.stderr ?? "unknown"} — run '${await hint()}' manually.\n` +
+      `(check status with: ${await statusCommand()})\n`,
   );
   return 1;
 }

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -12,7 +12,7 @@
  *     `schtasks /Create` needs no elevation, unlike a true Windows Service
  *     (a real SCM registration, which is what WinSW does).
  *   - Two logon modes, chosen at `phantombot install` time and persisted in
- *     windows-logon.json beside the launcher script:
+ *     windows-logon-<persona>.json beside the launcher script:
  *       · "interactive" (default): InteractiveToken principal, no stored
  *         password — but the tasks only run while the user is LOGGED ON
  *         (the launchd-like model from #201).
@@ -66,7 +66,7 @@ import { join } from "node:path";
 
 import { xdgDataHome } from "../config.ts";
 import { isPhantombotBinary } from "./binaryIdentity.ts";
-import { currentUserSid } from "./filePermissions.ts";
+import { currentUserName, currentUserSid } from "./filePermissions.ts";
 import type { WriteSink } from "./io.ts";
 import { log } from "./logger.ts";
 
@@ -160,10 +160,12 @@ export async function writeTaskLogon(
 ): Promise<void> {
   await mkdir(launcherDir(), { recursive: true });
   await writeFile(logonMarkerPath(persona), JSON.stringify(logon, null, 2), "utf8");
-  // Migrate away from the shared pre-scoping marker once any persona has a
-  // scoped one — leaving it would keep it authoritative for other personas'
-  // fallback reads.
-  await unlink(legacyLogonMarkerPath()).catch(() => {});
+  // The legacy shared marker is deliberately LEFT IN PLACE: it is the only
+  // record of the logon mode for personas installed before the scoping, and
+  // deleting it here (when persona B installs) would silently downgrade
+  // persona A's heal/relaunch to interactive, re-breaking headless operation.
+  // Scoped markers always win reads, so the stale file is inert for anyone
+  // who has reinstalled.
 }
 
 /** Read the persisted logon choice for `persona`; defaults to interactive
@@ -215,8 +217,17 @@ function launcherDir(): string {
   return join(xdgDataHome(), "phantombot");
 }
 
-/** Absolute path of the shared hidden-launcher VBScript. */
-export function launcherVbsPath(): string {
+/** Absolute path of THIS persona's hidden-launcher VBScript. The launcher
+ * is persona-scoped because uninstall deletes it — a shared script would
+ * leave every other persona's tasks pointing at a file that no longer
+ * exists. */
+export function launcherVbsPath(persona: string): string {
+  return join(launcherDir(), `phantombot-launch-${persona}.vbs`);
+}
+
+/** Pre-persona-scoping shared launcher location. Only the legacy pre-rename
+ * tasks still reference it, so it may only be removed once those are gone. */
+export function legacyLauncherVbsPath(): string {
   return join(launcherDir(), "phantombot-launch.vbs");
 }
 
@@ -246,14 +257,14 @@ export const LAUNCHER_VBS =
   "sh.Run cmd, 0, True\r\n";
 
 /**
- * Write the shared hidden-launcher script to its stable location (idempotent;
- * overwrites so a template change lands on the next install/self-heal). The
- * parent dir doubles as the data dir whose logs\ subfolder the tasks redirect
- * into, so we ensure it exists here too.
+ * Write this persona's hidden-launcher script to its stable location
+ * (idempotent; overwrites so a template change lands on the next
+ * install/self-heal). The parent dir doubles as the data dir whose logs\
+ * subfolder the tasks redirect into, so we ensure it exists here too.
  */
-async function writeLauncherVbs(): Promise<void> {
+async function writeLauncherVbs(persona: string): Promise<void> {
   await mkdir(launcherDir(), { recursive: true });
-  await writeFile(launcherVbsPath(), LAUNCHER_VBS, "utf8");
+  await writeFile(launcherVbsPath(persona), LAUNCHER_VBS, "utf8");
 }
 
 /**
@@ -268,6 +279,7 @@ export function buildLauncherArguments(
   args: readonly string[],
   outLog: string,
   errLog: string,
+  launcherPath: string,
 ): string {
   const q = (s: string) => `"${s}"`;
   return [
@@ -275,7 +287,7 @@ export function buildLauncherArguments(
     // default), which would itself be a visible popup - the exact thing this
     // launcher exists to avoid.
     "//B",
-    q(launcherVbsPath()),
+    q(launcherPath),
     q(binPath),
     q(args.join(" ")),
     q(outLog),
@@ -288,6 +300,8 @@ interface TaskXmlOptions {
   description: string;
   /** Current user's SID — principal + logon-trigger UserId. */
   sid: string;
+  /** Persona — scopes the hidden-launcher path baked into the action. */
+  persona: string;
   label: TaskLabel;
   binPath: string;
   args: readonly string[];
@@ -308,6 +322,7 @@ function generateTaskXml(opts: TaskXmlOptions): string {
     opts.args,
     outLog,
     errLog,
+    launcherVbsPath(opts.persona),
   );
   const workingDir = homedir();
 
@@ -430,6 +445,7 @@ export function generatePhantombotTaskXml(
     uri: taskNames(persona).main,
     description: `phantombot always-on agent (phantombot run) [${persona}]`,
     sid,
+    persona,
     label: "phantombot",
     binPath,
     args: ["run"],
@@ -451,6 +467,7 @@ export function generateHeartbeatTaskXml(
     uri: taskNames(persona).heartbeat,
     description: `phantombot heartbeat (every 30 minutes) [${persona}]`,
     sid,
+    persona,
     label: "heartbeat",
     binPath,
     args: ["heartbeat"],
@@ -479,6 +496,7 @@ export function generateNightlyTaskXml(
     uri: taskNames(persona).nightly,
     description: `phantombot nightly (daily at 02:00) [${persona}]`,
     sid,
+    persona,
     label: "nightly",
     binPath,
     args: ["nightly"],
@@ -499,6 +517,7 @@ export function generateTickTaskXml(
     uri: taskNames(persona).tick,
     description: `phantombot tick (every 60 seconds) [${persona}]`,
     sid,
+    persona,
     label: "tick",
     binPath,
     args: ["tick"],
@@ -1013,24 +1032,42 @@ export function taskPrincipalUserId(xml: string): string | undefined {
 
 type OwnedDeleteOutcome = "deleted" | "absent" | "kept-foreign" | "failed";
 
+/** Identity a task principal is matched against for ownership. Password-mode
+ * tasks carry `COMPUTER\\user` (not a SID) in their Principal <UserId>, so
+ * the account name is needed in addition to the SID. */
+interface TaskOwner {
+  sid: string;
+  username?: string;
+}
+
+function principalMatchesOwner(principal: string, owner: TaskOwner): boolean {
+  const p = principal.toLowerCase();
+  return (
+    p === owner.sid.toLowerCase() ||
+    (owner.username !== undefined && p === owner.username.toLowerCase())
+  );
+}
+
 /**
  * Delete a scheduled task ONLY when it provably belongs to this Windows
  * account. Task Scheduler folders are machine-global — every local user's
  * tasks live in the same `\Phantombot\` namespace — so a blind `/Delete`
  * from persona A's install could kill persona B's (or another Windows
  * user's) still-active daemon task. Ownership is proven by the principal
- * SID in the task's exported XML; when the task is missing, the XML won't
- * parse, or the SID belongs to someone else, the task is left untouched.
+ * in the task's exported XML matching either the current SID (interactive
+ * tasks) or the current `COMPUTER\\user` account name (password-mode
+ * tasks); when the task is missing, the XML won't parse, or the principal
+ * belongs to someone else, the task is left untouched.
  */
 async function deleteTaskIfOwned(
   schtasks: SchtasksRunner,
   name: string,
-  ownerSid: string,
+  owner: TaskOwner,
 ): Promise<OwnedDeleteOutcome> {
   const q = await schtasks.run(["/Query", "/TN", name, "/XML"]);
   if (q.exitCode !== 0) return "absent";
   const principal = taskPrincipalUserId(q.stdout);
-  if (principal === undefined || principal.toLowerCase() !== ownerSid.toLowerCase()) {
+  if (principal === undefined || !principalMatchesOwner(principal, owner)) {
     return "kept-foreign";
   }
   const r = await schtasks.run(["/Delete", "/TN", name, "/F"]);
@@ -1047,13 +1084,13 @@ async function deleteTaskIfOwned(
 export async function deleteLegacyTasks(
   schtasks: SchtasksRunner,
   keep: readonly string[],
-  ownerSid: string,
+  owner: TaskOwner,
 ): Promise<{ removed: string[]; keptForeign: string[] }> {
   const removed: string[] = [];
   const keptForeign: string[] = [];
   for (const name of LEGACY_TASK_NAMES) {
     if (keep.includes(name)) continue;
-    const outcome = await deleteTaskIfOwned(schtasks, name, ownerSid);
+    const outcome = await deleteTaskIfOwned(schtasks, name, owner);
     if (outcome === "deleted") removed.push(name);
     else if (outcome === "kept-foreign") keptForeign.push(name);
   }
@@ -1066,6 +1103,10 @@ export interface InstallTaskSchedulerOptions {
   persona: string;
   /** Override the current user's SID (tests). Production resolves it live. */
   sid?: string;
+  /** Override the current `COMPUTER\\user` account name (tests). Needed to
+   * prove ownership of PASSWORD-mode tasks, whose principal is the account
+   * name rather than the SID. */
+  accountName?: string;
   /** Directory for the transient XML import files (tests). Defaults to %TEMP%. */
   xmlDir?: string;
   /**
@@ -1092,6 +1133,10 @@ export async function installPhantombotTasks(
   opts: InstallTaskSchedulerOptions,
 ): Promise<{ installed: boolean }> {
   const sid = opts.sid ?? currentUserSid();
+  const owner: TaskOwner = {
+    sid,
+    username: opts.accountName ?? currentUserName(),
+  };
   const xmlDir = opts.xmlDir ?? tmpdir();
   const logon = opts.logon ?? { mode: "interactive" as const };
 
@@ -1122,7 +1167,7 @@ export async function installPhantombotTasks(
   const legacy = await deleteLegacyTasks(
     opts.schtasks,
     taskNames(opts.persona).all,
-    sid,
+    owner,
   );
   for (const name of legacy.removed) {
     opts.out.write(`removed legacy scheduled task: ${name}\n`);
@@ -1144,6 +1189,9 @@ export interface UninstallTaskSchedulerOptions {
   persona?: string;
   /** Override the current user's SID (tests). Production resolves it live. */
   sid?: string;
+  /** Override the current `COMPUTER\\user` account name (tests) — see
+   * InstallTaskSchedulerOptions.accountName. */
+  accountName?: string;
   schtasks: SchtasksRunner;
   out: WriteSink;
   err: WriteSink;
@@ -1162,11 +1210,18 @@ export async function uninstallPhantombotTasks(
   opts: UninstallTaskSchedulerOptions,
 ): Promise<{ removed: boolean }> {
   const persona = opts.persona ?? (await currentPersonaName());
-  const sid = opts.sid ?? currentUserSid();
+  const owner: TaskOwner = {
+    sid: opts.sid ?? currentUserSid(),
+    username: opts.accountName ?? currentUserName(),
+  };
   const names = taskNames(persona);
   const ordered = [names.tick, names.nightly, names.heartbeat, names.main];
+  const legacyOutcomes: OwnedDeleteOutcome[] = [];
   for (const name of [...ordered, ...LEGACY_TASK_NAMES]) {
-    const outcome = await deleteTaskIfOwned(opts.schtasks, name, sid);
+    const outcome = await deleteTaskIfOwned(opts.schtasks, name, owner);
+    if (LEGACY_TASK_NAMES.includes(name as (typeof LEGACY_TASK_NAMES)[number])) {
+      legacyOutcomes.push(outcome);
+    }
     if (outcome === "deleted") {
       opts.out.write(`removed scheduled task: ${name}\n`);
     } else if (outcome === "kept-foreign") {
@@ -1178,10 +1233,15 @@ export async function uninstallPhantombotTasks(
     }
     // "absent" → nothing to report.
   }
-  // Best-effort removal of the shared launcher script and the persisted
-  // logon choice (the tasks are gone, so nothing references them any more).
-  // Missing files are fine.
-  await unlink(launcherVbsPath()).catch(() => {});
+  // Remove THIS persona's launcher script — other personas have their own
+  // (persona-scoped since the launcher rename), so this can't strand them.
+  await unlink(launcherVbsPath(persona)).catch(() => {});
+  // The legacy SHARED launcher is referenced only by the legacy pre-rename
+  // tasks. Remove it only when none of those survived: a foreign-owned
+  // legacy task we were not allowed to delete still needs the file.
+  if (legacyOutcomes.every((o) => o === "absent" || o === "deleted")) {
+    await unlink(legacyLauncherVbsPath()).catch(() => {});
+  }
   await unlink(logonMarkerPath(persona)).catch(() => {});
   return { removed: true };
 }
@@ -1326,6 +1386,7 @@ export async function ensureTasksCurrent(
         specArgsForLabel(spec.label),
         outLog,
         errLog,
+        launcherVbsPath(persona),
       );
       const patch = opts.patchAction ?? defaultPatchAction;
       const pr = await patch(spec.name, newArgs);
@@ -1348,7 +1409,7 @@ export async function ensureTasksCurrent(
     if (!ensuredDirs) {
       await mkdir(logsDir(), { recursive: true });
       await mkdir(xmlDir, { recursive: true });
-      await writeLauncherVbs();
+      await writeLauncherVbs(persona);
       ensuredDirs = true;
     }
     const r = await importTaskSpec(spec, xmlDir, opts.schtasks, logon);

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -10,24 +10,27 @@
  * Design constraints (from issue #201):
  *   - NO admin. Registering a task in the CURRENT user's own tree via
  *     `schtasks /Create` needs no elevation, unlike a true Windows Service
- *     (a real SCM registration, which is what WinSW does). The trade-off is that a
- *     user-scoped scheduled task with an InteractiveToken principal only runs
- *     while that user is logged in — exactly the macOS/launchd model Andrew
- *     accepted. Someone wanting true headless-without-login should install a
- *     real service (e.g. WinSW); the README documents that.
- *   - Runs as the current user, only when logged in:
- *       <LogonType>InteractiveToken</LogonType> + <UserId> = current SID.
- *     InteractiveToken means Task Scheduler needs no stored password.
+ *     (a real SCM registration, which is what WinSW does).
+ *   - Two logon modes, chosen at `phantombot install` time and persisted in
+ *     windows-logon.json beside the launcher script:
+ *       · "interactive" (default): InteractiveToken principal, no stored
+ *         password — but the tasks only run while the user is LOGGED ON
+ *         (the launchd-like model from #201).
+ *       · "password": LogonType Password with the credential stored by
+ *         Task Scheduler — the always-on task gains a BootTrigger and runs
+ *         whether or not anyone is logged on (headless VMs, WUS reboots).
  *   - Grant/identify the principal by SID, never by name — a workgroup box has
  *     %USERDOMAIN%=WORKGROUP which does not resolve (same lesson as the Phase 2
  *     identity.json ACL). `currentUserSid()` is reused from filePermissions.ts.
+ *     (Password mode additionally needs the `COMPUTER\user` name for /RU.)
  *
- * Task layout (all under a \Phantombot\ folder so they group in taskschd.msc):
+ * Task layout (all under a \Phantombot\ folder so they group in taskschd.msc,
+ * persona-suffixed so multi-persona boxes stay greppable):
  *
- *   \Phantombot\phantombot   — always-on `phantombot run`   (keep-alive)
- *   \Phantombot\heartbeat    — `phantombot heartbeat`       (every 30 min)
- *   \Phantombot\nightly      — `phantombot nightly`         (daily 02:00)
- *   \Phantombot\tick         — `phantombot tick`            (every 60 s)
+ *   \Phantombot\phantombot-<persona>   — always-on `phantombot run`   (keep-alive)
+ *   \Phantombot\heartbeat-<persona>    — `phantombot heartbeat`       (every 30 min)
+ *   \Phantombot\nightly-<persona>      — `phantombot nightly`         (daily 02:00)
+ *   \Phantombot\tick-<persona>         — `phantombot tick`            (every 60 s)
  *
  * Keep-alive without a supervisor: Task Scheduler has no true "restart on
  * clean exit" like launchd's KeepAlive. We emulate it for the always-on task
@@ -57,7 +60,7 @@
  * moved binary by inspecting the registered task XML.
  */
 
-import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -68,10 +71,96 @@ import type { WriteSink } from "./io.ts";
 import { log } from "./logger.ts";
 
 export const TASK_FOLDER = "\\Phantombot";
-export const PHANTOMBOT_TASK = "\\Phantombot\\phantombot";
-export const HEARTBEAT_TASK = "\\Phantombot\\heartbeat";
-export const NIGHTLY_TASK = "\\Phantombot\\nightly";
-export const TICK_TASK = "\\Phantombot\\tick";
+
+/**
+ * Legacy task names (pre persona-scoping). Installations registered before
+ * the `phantombot-<persona>` rename use these; install/heal/uninstall delete
+ * them best-effort so an upgrade never leaves a stale duplicate daemon task
+ * behind.
+ */
+export const LEGACY_TASK_NAMES = [
+  "\\Phantombot\\phantombot",
+  "\\Phantombot\\heartbeat",
+  "\\Phantombot\\nightly",
+  "\\Phantombot\\tick",
+] as const;
+
+/**
+ * Persona-scoped task names — `phantombot-<persona>` etc. — so a box running
+ * several personas has one identifiable task set per persona, and so the set
+ * is greppable in taskschd.msc / `schtasks /Query`.
+ */
+export interface TaskNames {
+  main: string;
+  heartbeat: string;
+  nightly: string;
+  tick: string;
+  all: readonly string[];
+}
+
+export function taskNames(persona: string): TaskNames {
+  const main = `${TASK_FOLDER}\\phantombot-${persona}`;
+  const heartbeat = `${TASK_FOLDER}\\heartbeat-${persona}`;
+  const nightly = `${TASK_FOLDER}\\nightly-${persona}`;
+  const tick = `${TASK_FOLDER}\\tick-${persona}`;
+  return { main, heartbeat, nightly, tick, all: [main, heartbeat, nightly, tick] };
+}
+
+/**
+ * Resolve the persona this process belongs to: an explicit
+ * PHANTOMBOT_PERSONA (set for channel-spawned children) wins, otherwise the
+ * configured default persona. The task names must match the persona whose
+ * daemon they supervise.
+ */
+export async function currentPersonaName(): Promise<string> {
+  const fromEnv = process.env.PHANTOMBOT_PERSONA?.trim();
+  if (fromEnv) return fromEnv;
+  const { loadConfig } = await import("../config.ts");
+  return (await loadConfig()).defaultPersona;
+}
+
+/**
+ * How the tasks authenticate with Task Scheduler.
+ *   - "interactive": InteractiveToken — no stored password, runs ONLY while
+ *     the user has an interactive session (the launchd-like default).
+ *   - "password": stored credential — Task Scheduler can start the task at
+ *     boot with NOBODY logged on. This is the headless/WUS-reboot-resilient
+ *     mode; the trade-off is the Windows password is stored (encrypted,
+ *     admin-retrievable) with the task.
+ */
+export type TaskLogonMode = "interactive" | "password";
+
+export interface TaskLogon {
+  mode: TaskLogonMode;
+  /** `COMPUTER\user` (or `DOMAIN\user`) — the /RU account. */
+  username?: string;
+}
+
+/** Persisted install-time logon choice, so the heartbeat self-heal can
+ * regenerate XML that matches instead of silently downgrading a
+ * password-mode install back to interactive (which would strip the stored
+ * credential and re-break boot-without-logon). */
+function logonMarkerPath(): string {
+  return join(launcherDir(), "windows-logon.json");
+}
+
+export async function writeTaskLogon(logon: TaskLogon): Promise<void> {
+  await mkdir(launcherDir(), { recursive: true });
+  await writeFile(logonMarkerPath(), JSON.stringify(logon, null, 2), "utf8");
+}
+
+/** Read the persisted logon choice; defaults to interactive when absent. */
+export async function readTaskLogon(): Promise<TaskLogon> {
+  try {
+    const raw = JSON.parse(await readFile(logonMarkerPath(), "utf8"));
+    if (raw && raw.mode === "password" && typeof raw.username === "string") {
+      return { mode: "password", username: raw.username };
+    }
+  } catch {
+    // Missing/corrupt marker → interactive default.
+  }
+  return { mode: "interactive" };
+}
 
 /** Short label used for the per-task log filenames. */
 type TaskLabel = "phantombot" | "heartbeat" | "nightly" | "tick";
@@ -185,6 +274,8 @@ interface TaskXmlOptions {
   executionTimeLimit: string;
   /** Emit a <RestartOnFailure> safety net (the always-on task only). */
   restartOnFailure?: boolean;
+  /** Authentication mode. "password" runs whether or not anyone is logged on. */
+  logon?: TaskLogon;
 }
 
 function generateTaskXml(opts: TaskXmlOptions): string {
@@ -204,6 +295,24 @@ function generateTaskXml(opts: TaskXmlOptions): string {
       "    </RestartOnFailure>\n"
     : "";
 
+  // Password mode: the principal carries the `COMPUTER\user` account and
+  // LogonType Password so Task Scheduler can build a non-interactive session
+  // at boot. The credential itself is supplied at registration time
+  // (schtasks /RP) — it never goes into the XML.
+  const logon = opts.logon ?? { mode: "interactive" as const };
+  const principal =
+    logon.mode === "password"
+      ? '    <Principal id="Author">\n' +
+        `      <UserId>${xmlEscape(logon.username ?? opts.sid)}</UserId>\n` +
+        "      <LogonType>Password</LogonType>\n" +
+        "      <RunLevel>LeastPrivilege</RunLevel>\n" +
+        "    </Principal>\n"
+      : '    <Principal id="Author">\n' +
+        `      <UserId>${xmlEscape(opts.sid)}</UserId>\n` +
+        "      <LogonType>InteractiveToken</LogonType>\n" +
+        "      <RunLevel>LeastPrivilege</RunLevel>\n" +
+        "    </Principal>\n";
+
   return (
     '<?xml version="1.0" encoding="UTF-16"?>\n' +
     '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n' +
@@ -215,11 +324,7 @@ function generateTaskXml(opts: TaskXmlOptions): string {
     opts.triggersXml +
     "  </Triggers>\n" +
     "  <Principals>\n" +
-    '    <Principal id="Author">\n' +
-    `      <UserId>${xmlEscape(opts.sid)}</UserId>\n` +
-    "      <LogonType>InteractiveToken</LogonType>\n" +
-    "      <RunLevel>LeastPrivilege</RunLevel>\n" +
-    "    </Principal>\n" +
+    principal +
     "  </Principals>\n" +
     "  <Settings>\n" +
     "    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>\n" +
@@ -273,19 +378,34 @@ function repeatingTimeTrigger(interval: string): string {
   );
 }
 
+/** Boot trigger — fires when the machine boots, nobody logged on. Only
+ * meaningful with a Password-logon principal (an InteractiveToken task has
+ * no session to start in at boot and would be skipped). */
+function bootTrigger(): string {
+  return "    <BootTrigger>\n" + "      <Enabled>true</Enabled>\n" + "    </BootTrigger>\n";
+}
+
 /** Generate the always-on phantombot agent task XML (keep-alive). */
-export function generatePhantombotTaskXml(sid: string, binPath: string): string {
+export function generatePhantombotTaskXml(
+  sid: string,
+  binPath: string,
+  persona: string,
+  logon: TaskLogon = { mode: "interactive" },
+): string {
   // LogonTrigger starts it at logon; the 1-minute TimeTrigger + IgnoreNew
-  // restarts it if it ever dies. Together: keep-alive while logged in.
+  // restarts it if it ever dies. In password mode a BootTrigger is added so
+  // the daemon also comes up straight after a reboot with nobody logged on
+  // (the WUS-update scenario). Together: keep-alive in the mode's scope.
   const triggers =
+    (logon.mode === "password" ? bootTrigger() : "") +
     "    <LogonTrigger>\n" +
     "      <Enabled>true</Enabled>\n" +
     `      <UserId>${xmlEscape(sid)}</UserId>\n` +
     "    </LogonTrigger>\n" +
     repeatingTimeTrigger("PT1M");
   return generateTaskXml({
-    uri: PHANTOMBOT_TASK,
-    description: "phantombot always-on agent (phantombot run)",
+    uri: taskNames(persona).main,
+    description: `phantombot always-on agent (phantombot run) [${persona}]`,
     sid,
     label: "phantombot",
     binPath,
@@ -293,25 +413,37 @@ export function generatePhantombotTaskXml(sid: string, binPath: string): string 
     triggersXml: triggers,
     executionTimeLimit: "PT0S", // unlimited — long-running daemon
     restartOnFailure: true,
+    logon,
   });
 }
 
 /** Generate the heartbeat task XML — fires every 30 minutes. */
-export function generateHeartbeatTaskXml(sid: string, binPath: string): string {
+export function generateHeartbeatTaskXml(
+  sid: string,
+  binPath: string,
+  persona: string,
+  logon: TaskLogon = { mode: "interactive" },
+): string {
   return generateTaskXml({
-    uri: HEARTBEAT_TASK,
-    description: "phantombot heartbeat (every 30 minutes)",
+    uri: taskNames(persona).heartbeat,
+    description: `phantombot heartbeat (every 30 minutes) [${persona}]`,
     sid,
     label: "heartbeat",
     binPath,
     args: ["heartbeat"],
     triggersXml: repeatingTimeTrigger("PT30M"),
     executionTimeLimit: "PT1H",
+    logon,
   });
 }
 
 /** Generate the nightly task XML — fires daily at 02:00. */
-export function generateNightlyTaskXml(sid: string, binPath: string): string {
+export function generateNightlyTaskXml(
+  sid: string,
+  binPath: string,
+  persona: string,
+  logon: TaskLogon = { mode: "interactive" },
+): string {
   const triggers =
     "    <CalendarTrigger>\n" +
     "      <Enabled>true</Enabled>\n" +
@@ -321,28 +453,35 @@ export function generateNightlyTaskXml(sid: string, binPath: string): string {
     "      </ScheduleByDay>\n" +
     "    </CalendarTrigger>\n";
   return generateTaskXml({
-    uri: NIGHTLY_TASK,
-    description: "phantombot nightly (daily at 02:00)",
+    uri: taskNames(persona).nightly,
+    description: `phantombot nightly (daily at 02:00) [${persona}]`,
     sid,
     label: "nightly",
     binPath,
     args: ["nightly"],
     triggersXml: triggers,
     executionTimeLimit: "PT1H",
+    logon,
   });
 }
 
 /** Generate the tick task XML — fires every 60 seconds. */
-export function generateTickTaskXml(sid: string, binPath: string): string {
+export function generateTickTaskXml(
+  sid: string,
+  binPath: string,
+  persona: string,
+  logon: TaskLogon = { mode: "interactive" },
+): string {
   return generateTaskXml({
-    uri: TICK_TASK,
-    description: "phantombot tick (every 60 seconds)",
+    uri: taskNames(persona).tick,
+    description: `phantombot tick (every 60 seconds) [${persona}]`,
     sid,
     label: "tick",
     binPath,
     args: ["tick"],
     triggersXml: repeatingTimeTrigger("PT1M"),
     executionTimeLimit: "PT1H",
+    logon,
   });
 }
 
@@ -779,54 +918,94 @@ interface TaskSpec {
  * `schtasks /Create /XML … /F` (idempotent — /F overwrites an existing task
  * of the same name), then delete the transient file. Shared by the full
  * install and the heartbeat self-heal so both encode/quote identically.
+ *
+ * In password mode the credential rides along as `/RU <user> /RP <pass>`:
+ * schtasks applies them on top of the XML principal and stores the password
+ * (encrypted) with the task. NOTE the password transits the schtasks command
+ * line — briefly visible to same-user process inspection; unavoidable with
+ * schtasks, and the reason the marker file stores only the username.
  */
 async function importTaskSpec(
   spec: TaskSpec,
   xmlDir: string,
   schtasks: SchtasksRunner,
+  logon?: TaskLogon & { password?: string },
 ): Promise<SchtasksResult> {
   const xmlPath = join(xmlDir, `phantombot-task-${spec.label}.xml`);
   await writeTaskXml(xmlPath, spec.xml);
-  const r = await schtasks.run([
-    "/Create",
-    "/TN",
-    spec.name,
-    "/XML",
-    xmlPath,
-    "/F",
-  ]);
+  const args = ["/Create", "/TN", spec.name, "/XML", xmlPath];
+  if (logon?.mode === "password" && logon.username && logon.password) {
+    args.push("/RU", logon.username, "/RP", logon.password);
+  }
+  args.push("/F");
+  const r = await schtasks.run(args);
   // Best-effort cleanup of the transient import file.
   await unlink(xmlPath).catch(() => {});
   return r;
 }
 
-function allTaskSpecs(sid: string, binPath: string): TaskSpec[] {
+function allTaskSpecs(
+  sid: string,
+  binPath: string,
+  persona: string,
+  logon: TaskLogon = { mode: "interactive" },
+): TaskSpec[] {
   return [
     {
-      name: PHANTOMBOT_TASK,
+      name: taskNames(persona).main,
       label: "phantombot",
-      xml: generatePhantombotTaskXml(sid, binPath),
+      xml: generatePhantombotTaskXml(sid, binPath, persona, logon),
     },
     {
-      name: HEARTBEAT_TASK,
+      name: taskNames(persona).heartbeat,
       label: "heartbeat",
-      xml: generateHeartbeatTaskXml(sid, binPath),
+      xml: generateHeartbeatTaskXml(sid, binPath, persona, logon),
     },
     {
-      name: NIGHTLY_TASK,
+      name: taskNames(persona).nightly,
       label: "nightly",
-      xml: generateNightlyTaskXml(sid, binPath),
+      xml: generateNightlyTaskXml(sid, binPath, persona, logon),
     },
-    { name: TICK_TASK, label: "tick", xml: generateTickTaskXml(sid, binPath) },
+    {
+      name: taskNames(persona).tick,
+      label: "tick",
+      xml: generateTickTaskXml(sid, binPath, persona, logon),
+    },
   ];
+}
+
+/**
+ * Delete the pre-persona-rename task names (best-effort; missing tasks are
+ * fine). Without this an upgraded install would leave the old
+ * `\Phantombot\phantombot` keep-alive running alongside the new
+ * `phantombot-<persona>` one — two supervisors fighting over one run-lock.
+ */
+export async function deleteLegacyTasks(
+  schtasks: SchtasksRunner,
+  keep: readonly string[],
+): Promise<string[]> {
+  const removed: string[] = [];
+  for (const name of LEGACY_TASK_NAMES) {
+    if (keep.includes(name)) continue;
+    const r = await schtasks.run(["/Delete", "/TN", name, "/F"]);
+    if (r.exitCode === 0) removed.push(name);
+  }
+  return removed;
 }
 
 export interface InstallTaskSchedulerOptions {
   binPath: string;
+  /** Persona the tasks supervise — names become `phantombot-<persona>` etc. */
+  persona: string;
   /** Override the current user's SID (tests). Production resolves it live. */
   sid?: string;
   /** Directory for the transient XML import files (tests). Defaults to %TEMP%. */
   xmlDir?: string;
+  /**
+   * Logon mode chosen at install. "password" requires `username` + `password`;
+   * the password is handed to schtasks at registration and NOT persisted by us.
+   */
+  logon?: TaskLogon & { password?: string };
   schtasks: SchtasksRunner;
   out: WriteSink;
   err: WriteSink;
@@ -837,18 +1016,32 @@ export interface InstallTaskSchedulerOptions {
  * installation. Missing tasks, or tasks that point at an old binary path, are
  * imported from the current templates; tasks that already point at `binPath`
  * retain their existing triggers, principal, settings, and action shape.
+ *
+ * The chosen logon mode is persisted (WITHOUT the password) so the heartbeat
+ * self-heal regenerates matching XML instead of silently downgrading a
+ * password-mode install back to interactive.
  */
 export async function installPhantombotTasks(
   opts: InstallTaskSchedulerOptions,
 ): Promise<{ installed: boolean }> {
   const sid = opts.sid ?? currentUserSid();
   const xmlDir = opts.xmlDir ?? tmpdir();
+  const logon = opts.logon ?? { mode: "interactive" as const };
+
+  // Persist the logon choice BEFORE registering, so a later heal sees it even
+  // if a registration below fails halfway.
+  await writeTaskLogon({ mode: logon.mode, username: logon.username });
 
   const r = await ensureTasksCurrent({
     binPath: opts.binPath,
+    persona: opts.persona,
     sid,
     xmlDir,
     schtasks: opts.schtasks,
+    // A (re)install must apply the chosen mode + credential even when the
+    // existing tasks already reference this binary — force re-import.
+    force: true,
+    logon,
   });
 
   for (const name of r.rewrote) opts.out.write(`registered scheduled task: ${name}\n`);
@@ -856,29 +1049,44 @@ export async function installPhantombotTasks(
     opts.err.write(`could not register scheduled task(s): ${r.failed.join(", ")}\n`);
     return { installed: false };
   }
+
+  // Remove pre-rename legacy task names so an upgrade never double-supervises.
+  const removedLegacy = await deleteLegacyTasks(
+    opts.schtasks,
+    taskNames(opts.persona).all,
+  );
+  for (const name of removedLegacy) {
+    opts.out.write(`removed legacy scheduled task: ${name}\n`);
+  }
+
   opts.out.write(
-    `registered ${PHANTOMBOT_TASK} + heartbeat + nightly + tick\n`,
+    `registered ${taskNames(opts.persona).main} + heartbeat + nightly + tick\n`,
   );
   return { installed: true };
 }
 
 export interface UninstallTaskSchedulerOptions {
+  /** Persona whose tasks to remove. Defaults to the current persona. */
+  persona?: string;
   schtasks: SchtasksRunner;
   out: WriteSink;
   err: WriteSink;
 }
 
 /**
- * Delete all four scheduled tasks (best-effort). A missing task returns
- * non-zero from schtasks — logged and skipped, never fatal. The empty
- * \Phantombot folder is harmless and left in place (schtasks has no reliable
- * folder-delete verb across Windows versions).
+ * Delete this persona's four scheduled tasks (best-effort), plus any legacy
+ * pre-rename names still around. A missing task returns non-zero from
+ * schtasks — logged and skipped, never fatal. The empty \Phantombot folder
+ * is harmless and left in place (schtasks has no reliable folder-delete verb
+ * across Windows versions).
  */
 export async function uninstallPhantombotTasks(
   opts: UninstallTaskSchedulerOptions,
 ): Promise<{ removed: boolean }> {
-  const names = [TICK_TASK, NIGHTLY_TASK, HEARTBEAT_TASK, PHANTOMBOT_TASK];
-  for (const name of names) {
+  const persona = opts.persona ?? (await currentPersonaName());
+  const names = taskNames(persona);
+  const ordered = [names.tick, names.nightly, names.heartbeat, names.main];
+  for (const name of [...ordered, ...LEGACY_TASK_NAMES]) {
     const r = await opts.schtasks.run(["/Delete", "/TN", name, "/F"]);
     if (r.exitCode !== 0) {
       opts.out.write(
@@ -888,9 +1096,11 @@ export async function uninstallPhantombotTasks(
       opts.out.write(`removed scheduled task: ${name}\n`);
     }
   }
-  // Best-effort removal of the shared launcher script (the tasks are gone, so
-  // nothing references it any more). A missing file is fine.
+  // Best-effort removal of the shared launcher script and the persisted
+  // logon choice (the tasks are gone, so nothing references them any more).
+  // Missing files are fine.
   await unlink(launcherVbsPath()).catch(() => {});
+  await unlink(logonMarkerPath()).catch(() => {});
   return { removed: true };
 }
 
@@ -906,12 +1116,61 @@ function xmlReferencesBin(xml: string, binPath: string): boolean {
 
 export interface EnsureTasksCurrentOptions {
   binPath: string;
+  /** Persona whose tasks to heal. Defaults to the current persona. */
+  persona?: string;
   /** Override the current user's SID (tests). Production resolves it live. */
   sid?: string;
   /** Directory for the transient XML import files (tests). Defaults to %TEMP%. */
   xmlDir?: string;
+  /** Re-import even when the registered task already references `binPath`
+   * (install applies a fresh logon mode / credential). */
+  force?: boolean;
+  /**
+   * Logon mode to write. When omitted the persisted install-time choice is
+   * used, so the heal never downgrades a password-mode install. A password
+   * is only present on the install path; the heal path repairs password-mode
+   * drift via a PowerShell action patch (no credential re-entry needed).
+   */
+  logon?: TaskLogon & { password?: string };
   schtasks: SchtasksRunner;
+  /** Test seam for the password-mode action patcher. */
+  patchAction?: PatchActionFn;
 }
+
+/**
+ * Patch a registered task's action arguments in place via PowerShell
+ * (`Set-ScheduledTask`), preserving the stored credential. This is the ONLY
+ * way to repair binary-path drift on a password-mode task without asking
+ * for the Windows password again — `schtasks /Create` on a Password-logon
+ * task insists on /RP.
+ */
+export type PatchActionFn = (
+  taskName: string,
+  newArguments: string,
+) => Promise<{ ok: boolean; stderr?: string }>;
+
+const defaultPatchAction: PatchActionFn = async (taskName, newArguments) => {
+  // Split "\\Phantombot\\phantombot-megan" into folder + leaf for the
+  // ScheduledTasks cmdlets. Single-quote escaping for PowerShell.
+  const q = (s: string) => `'${s.replace(/'/g, "''")}'`;
+  const leaf = taskName.split("\\").pop() ?? taskName;
+  const folder = taskName.slice(0, taskName.length - leaf.length) || "\\";
+  const script =
+    `$t = Get-ScheduledTask -TaskName ${q(leaf)} -TaskPath ${q(folder)}; ` +
+    `$t.Actions[0].Arguments = ${q(newArguments)}; ` +
+    `Set-ScheduledTask -InputObject $t | Out-Null`;
+  const child = Bun.spawn(
+    ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+    { env: { ...process.env }, stdout: "pipe", stderr: "pipe", windowsHide: true },
+  );
+  const [stderr, exitCode] = await Promise.all([
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return exitCode === 0
+    ? { ok: true }
+    : { ok: false, stderr: stderr.trim() || `powershell exited ${exitCode}` };
+};
 
 export interface EnsureTasksCurrentResult {
   /**
@@ -946,15 +1205,59 @@ export async function ensureTasksCurrent(
 ): Promise<EnsureTasksCurrentResult> {
   const sid = opts.sid ?? currentUserSid();
   const xmlDir = opts.xmlDir ?? tmpdir();
+  const persona = opts.persona ?? (await currentPersonaName());
+  const logon: TaskLogon & { password?: string } =
+    opts.logon ??
+    (opts.force ? { mode: "interactive" as const } : await readTaskLogon());
   const rewrote: string[] = [];
   const failed: string[] = [];
   let ensuredDirs = false;
 
-  for (const spec of allTaskSpecs(sid, opts.binPath)) {
+  for (const spec of allTaskSpecs(sid, opts.binPath, persona, logon)) {
     const q = await opts.schtasks.run(["/Query", "/TN", spec.name, "/XML"]);
+    const registered = q.exitCode === 0;
     const current =
-      q.exitCode === 0 && xmlReferencesBin(q.stdout, opts.binPath);
-    if (current) continue; // registered and already points at this binary
+      registered && xmlReferencesBin(q.stdout, opts.binPath);
+    if (current && !opts.force) continue; // registered and points at this binary
+
+    // Password-mode heal without a credential: schtasks /Create would demand
+    // /RP interactively, so instead patch the registered task's action
+    // arguments in place (credential untouched). A MISSING task can't be
+    // patched — that needs a re-install with the password.
+    if (logon.mode === "password" && !logon.password) {
+      if (!registered) {
+        failed.push(spec.name);
+        log.warn("taskScheduler: password-mode task missing; re-run `phantombot install` to restore it", {
+          task: spec.name,
+        });
+        continue;
+      }
+      if (opts.force) {
+        // force implies install, which always carries the password — this
+        // branch is defensive only.
+        failed.push(spec.name);
+        continue;
+      }
+      const { out: outLog, err: errLog } = taskLogPaths(spec.label);
+      const newArgs = buildLauncherArguments(
+        opts.binPath,
+        specArgsForLabel(spec.label),
+        outLog,
+        errLog,
+      );
+      const patch = opts.patchAction ?? defaultPatchAction;
+      const pr = await patch(spec.name, newArgs);
+      if (pr.ok) {
+        rewrote.push(spec.name);
+      } else {
+        failed.push(spec.name);
+        log.warn("taskScheduler: could not patch password-mode task", {
+          task: spec.name,
+          error: pr.stderr,
+        });
+      }
+      continue;
+    }
 
     // Missing or drifted → re-import. Ensure the log + temp dirs and the hidden
     // launcher exist first (a fresh box healing a never-installed task needs
@@ -966,7 +1269,7 @@ export async function ensureTasksCurrent(
       await writeLauncherVbs();
       ensuredDirs = true;
     }
-    const r = await importTaskSpec(spec, xmlDir, opts.schtasks);
+    const r = await importTaskSpec(spec, xmlDir, opts.schtasks, logon);
     if (r.exitCode === 0) {
       rewrote.push(spec.name);
     } else {
@@ -980,6 +1283,11 @@ export async function ensureTasksCurrent(
   }
 
   return { rewrote, failed };
+}
+
+/** Subcommand line each task label runs — kept in sync with allTaskSpecs. */
+function specArgsForLabel(label: TaskLabel): string[] {
+  return [label === "phantombot" ? "run" : label];
 }
 
 export interface TaskSchedulerServiceControl {
@@ -1079,19 +1387,29 @@ export async function scheduleWindowsRelaunch(
   const binPath = opts.binPath ?? process.execPath;
   const { out, err } = taskLogPaths("phantombot");
 
+  // Password-mode installs relaunch via `schtasks /Run`: the scheduler (not
+  // our dying process tree) owns the new daemon, so nothing can be reaped
+  // when the old task instance ends. Interactive mode keeps the Start-Process
+  // watcher — /Run into the console session is exactly what historically
+  // wedged the scheduler's run-accounting.
+  const passwordMode = (await readTaskLogon()).mode === "password";
+
   // Inner watcher: wait for the current daemon to exit (Wait-Process returns
   // immediately if the pid is already gone; -Timeout caps a wedged shutdown so
   // we still relaunch), then launch the swapped binary detached. Encoded as
   // base64 UTF-16LE so the outer -Command layer needs no nested quoting.
-  const watcher = [
-    `Wait-Process -Id ${selfPid} -Timeout ${graceSeconds} -ErrorAction SilentlyContinue;`,
-    `Start-Process -FilePath ${powershellQuote(binPath)}`,
-    `-ArgumentList @('run')`,
-    `-WorkingDirectory ${powershellQuote(process.cwd())}`,
-    `-WindowStyle Hidden`,
-    `-RedirectStandardOutput ${powershellQuote(out)}`,
-    `-RedirectStandardError ${powershellQuote(err)}`,
-  ].join(" ");
+  const waitForExit = `Wait-Process -Id ${selfPid} -Timeout ${graceSeconds} -ErrorAction SilentlyContinue;`;
+  const watcher = passwordMode
+    ? `${waitForExit} schtasks /Run /TN "${taskNames(await currentPersonaName()).main}"`
+    : [
+        waitForExit,
+        `Start-Process -FilePath ${powershellQuote(binPath)}`,
+        `-ArgumentList @('run')`,
+        `-WorkingDirectory ${powershellQuote(process.cwd())}`,
+        `-WindowStyle Hidden`,
+        `-RedirectStandardOutput ${powershellQuote(out)}`,
+        `-RedirectStandardError ${powershellQuote(err)}`,
+      ].join(" ");
   const encoded = Buffer.from(watcher, "utf16le").toString("base64");
 
   // Outer layer: detach the watcher from our process tree so it survives our
@@ -1139,23 +1457,43 @@ export function defaultTaskSchedulerServiceControl(
   selfPid: number = process.pid,
   // Injectable so stop()/restart() are testable without real 10s waits.
   waitDeps: WaitDeps = defaultWaitDeps,
+  /** Persona whose tasks to control. Defaults to the current persona. */
+  persona?: string,
 ): TaskSchedulerServiceControl {
-  const launchDirectly =
-    process.platform === "win32" && runner instanceof BunSchtasksRunner;
+  // Resolve the persona-scoped main task name once, lazily — every method
+  // awaits the same promise.
+  const mainTaskPromise = (async () =>
+    taskNames(persona ?? (await currentPersonaName())).main)();
+
+  // Password-mode tasks are scheduler-owned: `schtasks /Run` launches them in
+  // session 0 under the stored credential, so the daemon survives the
+  // disconnect of whatever SSH/console session typed `start`. The direct
+  // Start-Process path is only for interactive mode, where a scheduler run
+  // would pop the daemon into the console session anyway — and where /Run
+  // historically wedged. Resolved lazily per call so an install that flips
+  // modes mid-session is picked up.
+  const useSchedulerRun = async (): Promise<boolean> => {
+    if (!(process.platform === "win32" && runner instanceof BunSchtasksRunner)) {
+      return true; // tests / non-Windows: the fake runner path
+    }
+    return (await readTaskLogon()).mode === "password";
+  };
+
   return {
     async isActive() {
       // `schtasks /Query /TN <name>` exits 0 when the task is registered —
       // the Task Scheduler analogue of a launchd unit being loaded.
-      const r = await runner.run(["/Query", "/TN", PHANTOMBOT_TASK]);
+      const r = await runner.run(["/Query", "/TN", await mainTaskPromise]);
       return r.exitCode === 0;
     },
     async start() {
       // The main task carries a 1-minute keep-alive TimeTrigger, which `stop()`
       // disables. Re-enable it first so the supervisor keeps the process up,
       // then kick off a run immediately rather than waiting up to 60s for the
-      await runner.run(["/Change", "/TN", PHANTOMBOT_TASK, "/ENABLE"]);
-      if (!launchDirectly) {
-        const r = await runner.run(["/Run", "/TN", PHANTOMBOT_TASK]);
+      const mainTask = await mainTaskPromise;
+      await runner.run(["/Change", "/TN", mainTask, "/ENABLE"]);
+      if (await useSchedulerRun()) {
+        const r = await runner.run(["/Run", "/TN", mainTask]);
         return r.exitCode === 0
           ? { ok: true }
           : { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
@@ -1177,8 +1515,9 @@ export function defaultTaskSchedulerServiceControl(
       // disable the trigger, /End the task, then kill any surviving `phantombot
       // run` daemon directly. /Disable on an already-disabled task is harmless;
       // /End on a stopped task is harmless.
-      const r = await runner.run(["/Change", "/TN", PHANTOMBOT_TASK, "/DISABLE"]);
-      await runner.run(["/End", "/TN", PHANTOMBOT_TASK]);
+      const mainTask = await mainTaskPromise;
+      const r = await runner.run(["/Change", "/TN", mainTask, "/DISABLE"]);
+      await runner.run(["/End", "/TN", mainTask]);
       const kill = await killDaemonProcesses(processManager, selfPid, waitDeps);
       if (r.exitCode !== 0) {
         return { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
@@ -1201,8 +1540,9 @@ export function defaultTaskSchedulerServiceControl(
       // 1-minute trigger relaunches the swapped binary within 60s regardless.
       // /End is best-effort; killDaemonProcesses guarantees the old process is
       // actually gone so /Run doesn't bounce off the single-instance lock.
-      await runner.run(["/Change", "/TN", PHANTOMBOT_TASK, "/ENABLE"]);
-      await runner.run(["/End", "/TN", PHANTOMBOT_TASK]);
+      const mainTask = await mainTaskPromise;
+      await runner.run(["/Change", "/TN", mainTask, "/ENABLE"]);
+      await runner.run(["/End", "/TN", mainTask]);
       const kill = await killDaemonProcesses(processManager, selfPid, waitDeps);
       // Fail closed. If we can't prove the old daemon is gone, `/Run` would
       // bounce off its still-held run-lock and silently no-op — leaving the old
@@ -1220,8 +1560,8 @@ export function defaultTaskSchedulerServiceControl(
             `skipped /Run — the keep-alive trigger will relaunch within 60s`,
         };
       }
-      if (!launchDirectly) {
-        const r = await runner.run(["/Run", "/TN", PHANTOMBOT_TASK]);
+      if (await useSchedulerRun()) {
+        const r = await runner.run(["/Run", "/TN", mainTask]);
         return r.exitCode === 0
           ? { ok: true }
           : { ok: false, stderr: r.stderr.trim() || `exit ${r.exitCode}` };
@@ -1247,7 +1587,7 @@ export function defaultTaskSchedulerServiceControl(
       if (!isPhantombotBinary(binPath)) {
         return { rerendered: false };
       }
-      const installed = await runner.run(["/Query", "/TN", PHANTOMBOT_TASK]);
+      const installed = await runner.run(["/Query", "/TN", await mainTaskPromise]);
       if (installed.exitCode !== 0) return { rerendered: false };
       let sid: string;
       try {
@@ -1255,7 +1595,12 @@ export function defaultTaskSchedulerServiceControl(
       } catch {
         return { rerendered: false };
       }
-      const r = await ensureTasksCurrent({ binPath, sid, schtasks: runner });
+      const r = await ensureTasksCurrent({
+        binPath,
+        sid,
+        persona: persona ?? (await currentPersonaName()),
+        schtasks: runner,
+      });
       return { rerendered: r.rewrote.length > 0 };
     },
   };

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -139,25 +139,48 @@ export interface TaskLogon {
 /** Persisted install-time logon choice, so the heartbeat self-heal can
  * regenerate XML that matches instead of silently downgrading a
  * password-mode install back to interactive (which would strip the stored
- * credential and re-break boot-without-logon). */
-function logonMarkerPath(): string {
+ * credential and re-break boot-without-logon). The marker is PER PERSONA —
+ * several personas can share one Windows account, and a single shared
+ * marker would let persona B's install overwrite persona A's mode, so A's
+ * heartbeat would then heal its tasks into the wrong logon mode. */
+function logonMarkerPath(persona: string): string {
+  return join(launcherDir(), `windows-logon-${persona}.json`);
+}
+
+/** Pre-persona-scoping marker location; kept only as a read fallback so
+ * installs made before the scoping still heal in their original mode until
+ * the next `phantombot install` rewrites the persona-scoped marker. */
+function legacyLogonMarkerPath(): string {
   return join(launcherDir(), "windows-logon.json");
 }
 
-export async function writeTaskLogon(logon: TaskLogon): Promise<void> {
+export async function writeTaskLogon(
+  persona: string,
+  logon: TaskLogon,
+): Promise<void> {
   await mkdir(launcherDir(), { recursive: true });
-  await writeFile(logonMarkerPath(), JSON.stringify(logon, null, 2), "utf8");
+  await writeFile(logonMarkerPath(persona), JSON.stringify(logon, null, 2), "utf8");
+  // Migrate away from the shared pre-scoping marker once any persona has a
+  // scoped one — leaving it would keep it authoritative for other personas'
+  // fallback reads.
+  await unlink(legacyLogonMarkerPath()).catch(() => {});
 }
 
-/** Read the persisted logon choice; defaults to interactive when absent. */
-export async function readTaskLogon(): Promise<TaskLogon> {
-  try {
-    const raw = JSON.parse(await readFile(logonMarkerPath(), "utf8"));
-    if (raw && raw.mode === "password" && typeof raw.username === "string") {
-      return { mode: "password", username: raw.username };
+/** Read the persisted logon choice for `persona`; defaults to interactive
+ * when absent. Falls back to the legacy shared marker (above) so a
+ * pre-scoping install isn't mis-healed as interactive before its next
+ * reinstall. */
+export async function readTaskLogon(persona: string): Promise<TaskLogon> {
+  for (const path of [logonMarkerPath(persona), legacyLogonMarkerPath()]) {
+    try {
+      const raw = JSON.parse(await readFile(path, "utf8"));
+      if (raw && raw.mode === "password" && typeof raw.username === "string") {
+        return { mode: "password", username: raw.username };
+      }
+      if (raw && raw.mode === "interactive") return { mode: "interactive" };
+    } catch {
+      // Missing/corrupt marker → try the next one.
     }
-  } catch {
-    // Missing/corrupt marker → interactive default.
   }
   return { mode: "interactive" };
 }
@@ -975,22 +998,66 @@ function allTaskSpecs(
 }
 
 /**
- * Delete the pre-persona-rename task names (best-effort; missing tasks are
- * fine). Without this an upgraded install would leave the old
- * `\Phantombot\phantombot` keep-alive running alongside the new
- * `phantombot-<persona>` one — two supervisors fighting over one run-lock.
+ * The Principal UserId from a task's exported XML. Real
+ * `schtasks /Query /XML` output carries the account SID here (e.g.
+ * `S-1-5-21-…-1008`), which compares cleanly across renamed accounts and
+ * localized principal names.
+ */
+export function taskPrincipalUserId(xml: string): string | undefined {
+  const m =
+    /<Principals>[\s\S]*?<Principal\b[^>]*>[\s\S]*?<UserId>\s*([^<]+?)\s*<\/UserId>/i.exec(
+      xml,
+    );
+  return m?.[1];
+}
+
+type OwnedDeleteOutcome = "deleted" | "absent" | "kept-foreign" | "failed";
+
+/**
+ * Delete a scheduled task ONLY when it provably belongs to this Windows
+ * account. Task Scheduler folders are machine-global — every local user's
+ * tasks live in the same `\Phantombot\` namespace — so a blind `/Delete`
+ * from persona A's install could kill persona B's (or another Windows
+ * user's) still-active daemon task. Ownership is proven by the principal
+ * SID in the task's exported XML; when the task is missing, the XML won't
+ * parse, or the SID belongs to someone else, the task is left untouched.
+ */
+async function deleteTaskIfOwned(
+  schtasks: SchtasksRunner,
+  name: string,
+  ownerSid: string,
+): Promise<OwnedDeleteOutcome> {
+  const q = await schtasks.run(["/Query", "/TN", name, "/XML"]);
+  if (q.exitCode !== 0) return "absent";
+  const principal = taskPrincipalUserId(q.stdout);
+  if (principal === undefined || principal.toLowerCase() !== ownerSid.toLowerCase()) {
+    return "kept-foreign";
+  }
+  const r = await schtasks.run(["/Delete", "/TN", name, "/F"]);
+  return r.exitCode === 0 ? "deleted" : "failed";
+}
+
+/**
+ * Delete the pre-persona-rename task names, but only those owned by the
+ * installing Windows account (see deleteTaskIfOwned). Without this an
+ * upgraded install would leave the old `\Phantombot\phantombot` keep-alive
+ * running alongside the new `phantombot-<persona>` one — two supervisors
+ * fighting over one run-lock.
  */
 export async function deleteLegacyTasks(
   schtasks: SchtasksRunner,
   keep: readonly string[],
-): Promise<string[]> {
+  ownerSid: string,
+): Promise<{ removed: string[]; keptForeign: string[] }> {
   const removed: string[] = [];
+  const keptForeign: string[] = [];
   for (const name of LEGACY_TASK_NAMES) {
     if (keep.includes(name)) continue;
-    const r = await schtasks.run(["/Delete", "/TN", name, "/F"]);
-    if (r.exitCode === 0) removed.push(name);
+    const outcome = await deleteTaskIfOwned(schtasks, name, ownerSid);
+    if (outcome === "deleted") removed.push(name);
+    else if (outcome === "kept-foreign") keptForeign.push(name);
   }
-  return removed;
+  return { removed, keptForeign };
 }
 
 export interface InstallTaskSchedulerOptions {
@@ -1030,7 +1097,7 @@ export async function installPhantombotTasks(
 
   // Persist the logon choice BEFORE registering, so a later heal sees it even
   // if a registration below fails halfway.
-  await writeTaskLogon({ mode: logon.mode, username: logon.username });
+  await writeTaskLogon(opts.persona, { mode: logon.mode, username: logon.username });
 
   const r = await ensureTasksCurrent({
     binPath: opts.binPath,
@@ -1051,12 +1118,19 @@ export async function installPhantombotTasks(
   }
 
   // Remove pre-rename legacy task names so an upgrade never double-supervises.
-  const removedLegacy = await deleteLegacyTasks(
+  // Only tasks provably owned by THIS Windows account are touched.
+  const legacy = await deleteLegacyTasks(
     opts.schtasks,
     taskNames(opts.persona).all,
+    sid,
   );
-  for (const name of removedLegacy) {
+  for (const name of legacy.removed) {
     opts.out.write(`removed legacy scheduled task: ${name}\n`);
+  }
+  for (const name of legacy.keptForeign) {
+    opts.out.write(
+      `left ${name} untouched (owned by another Windows account)\n`,
+    );
   }
 
   opts.out.write(
@@ -1068,39 +1142,47 @@ export async function installPhantombotTasks(
 export interface UninstallTaskSchedulerOptions {
   /** Persona whose tasks to remove. Defaults to the current persona. */
   persona?: string;
+  /** Override the current user's SID (tests). Production resolves it live. */
+  sid?: string;
   schtasks: SchtasksRunner;
   out: WriteSink;
   err: WriteSink;
 }
 
 /**
- * Delete this persona's four scheduled tasks (best-effort), plus any legacy
- * pre-rename names still around. A missing task returns non-zero from
- * schtasks — logged and skipped, never fatal. The empty \Phantombot folder
- * is harmless and left in place (schtasks has no reliable folder-delete verb
+ * Delete this persona's four scheduled tasks, plus any legacy pre-rename
+ * names still around — but ONLY tasks provably owned by this Windows
+ * account (Task Scheduler folders are machine-global, so another user's
+ * same-named tasks are left untouched). A missing task is skipped quietly;
+ * a failed delete is logged, never fatal. The empty \Phantombot folder is
+ * harmless and left in place (schtasks has no reliable folder-delete verb
  * across Windows versions).
  */
 export async function uninstallPhantombotTasks(
   opts: UninstallTaskSchedulerOptions,
 ): Promise<{ removed: boolean }> {
   const persona = opts.persona ?? (await currentPersonaName());
+  const sid = opts.sid ?? currentUserSid();
   const names = taskNames(persona);
   const ordered = [names.tick, names.nightly, names.heartbeat, names.main];
   for (const name of [...ordered, ...LEGACY_TASK_NAMES]) {
-    const r = await opts.schtasks.run(["/Delete", "/TN", name, "/F"]);
-    if (r.exitCode !== 0) {
-      opts.out.write(
-        `schtasks /Delete ${name} returned ${r.exitCode} (continuing)\n`,
-      );
-    } else {
+    const outcome = await deleteTaskIfOwned(opts.schtasks, name, sid);
+    if (outcome === "deleted") {
       opts.out.write(`removed scheduled task: ${name}\n`);
+    } else if (outcome === "kept-foreign") {
+      opts.out.write(
+        `left ${name} untouched (owned by another Windows account)\n`,
+      );
+    } else if (outcome === "failed") {
+      opts.out.write(`schtasks /Delete ${name} failed (continuing)\n`);
     }
+    // "absent" → nothing to report.
   }
   // Best-effort removal of the shared launcher script and the persisted
   // logon choice (the tasks are gone, so nothing references them any more).
   // Missing files are fine.
   await unlink(launcherVbsPath()).catch(() => {});
-  await unlink(logonMarkerPath()).catch(() => {});
+  await unlink(logonMarkerPath(persona)).catch(() => {});
   return { removed: true };
 }
 
@@ -1208,7 +1290,7 @@ export async function ensureTasksCurrent(
   const persona = opts.persona ?? (await currentPersonaName());
   const logon: TaskLogon & { password?: string } =
     opts.logon ??
-    (opts.force ? { mode: "interactive" as const } : await readTaskLogon());
+    (opts.force ? { mode: "interactive" as const } : await readTaskLogon(persona));
   const rewrote: string[] = [];
   const failed: string[] = [];
   let ensuredDirs = false;
@@ -1352,6 +1434,8 @@ export interface ScheduleWindowsRelaunchOpts {
   graceSeconds?: number;
   /** Defaults to process.execPath — the on-disk (freshly-swapped) binary. */
   binPath?: string;
+  /** Persona whose task/marker to use (tests). Defaults to the current persona. */
+  persona?: string;
   /** Test seam. Defaults to a detached Bun.spawn of powershell. */
   spawnImpl?: RelaunchSpawn;
 }
@@ -1392,7 +1476,8 @@ export async function scheduleWindowsRelaunch(
   // when the old task instance ends. Interactive mode keeps the Start-Process
   // watcher — /Run into the console session is exactly what historically
   // wedged the scheduler's run-accounting.
-  const passwordMode = (await readTaskLogon()).mode === "password";
+  const persona = opts.persona ?? (await currentPersonaName());
+  const passwordMode = (await readTaskLogon(persona)).mode === "password";
 
   // Inner watcher: wait for the current daemon to exit (Wait-Process returns
   // immediately if the pid is already gone; -Timeout caps a wedged shutdown so
@@ -1400,7 +1485,7 @@ export async function scheduleWindowsRelaunch(
   // base64 UTF-16LE so the outer -Command layer needs no nested quoting.
   const waitForExit = `Wait-Process -Id ${selfPid} -Timeout ${graceSeconds} -ErrorAction SilentlyContinue;`;
   const watcher = passwordMode
-    ? `${waitForExit} schtasks /Run /TN "${taskNames(await currentPersonaName()).main}"`
+    ? `${waitForExit} schtasks /Run /TN "${taskNames(persona).main}"`
     : [
         waitForExit,
         `Start-Process -FilePath ${powershellQuote(binPath)}`,
@@ -1460,10 +1545,10 @@ export function defaultTaskSchedulerServiceControl(
   /** Persona whose tasks to control. Defaults to the current persona. */
   persona?: string,
 ): TaskSchedulerServiceControl {
-  // Resolve the persona-scoped main task name once, lazily — every method
-  // awaits the same promise.
-  const mainTaskPromise = (async () =>
-    taskNames(persona ?? (await currentPersonaName())).main)();
+  // Resolve the persona once, lazily — the task names and the logon marker
+  // are both persona-scoped, and every method awaits the same promise.
+  const personaPromise = (async () => persona ?? (await currentPersonaName()))();
+  const mainTaskPromise = (async () => taskNames(await personaPromise).main)();
 
   // Password-mode tasks are scheduler-owned: `schtasks /Run` launches them in
   // session 0 under the stored credential, so the daemon survives the
@@ -1476,7 +1561,7 @@ export function defaultTaskSchedulerServiceControl(
     if (!(process.platform === "win32" && runner instanceof BunSchtasksRunner)) {
       return true; // tests / non-Windows: the fake runner path
     }
-    return (await readTaskLogon()).mode === "password";
+    return (await readTaskLogon(await personaPromise)).mode === "password";
   };
 
   return {

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -44,10 +44,37 @@ class FakeLaunchctl implements LaunchctlRunner {
 class FakeSchtasks implements SchtasksRunner {
   calls: string[][] = [];
   responses: SchtasksResult[] = [];
+  /** Per-task registered XML; /Query answers from this (missing → exit 1). */
+  registry: Record<string, string | undefined> = {};
   async run(args: readonly string[]): Promise<SchtasksResult> {
     this.calls.push([...args]);
-    return this.responses.shift() ?? { exitCode: 0, stdout: "", stderr: "" };
+    if (this.responses.length > 0) return this.responses.shift()!;
+    if (args[0] === "/Query") {
+      const tn = args[args.indexOf("/TN") + 1]!;
+      const xml = this.registry[tn];
+      return xml === undefined
+        ? { exitCode: 1, stdout: "", stderr: "cannot find" }
+        : { exitCode: 0, stdout: xml, stderr: "" };
+    }
+    if (args[0] === "/Delete") {
+      const tn = args[args.indexOf("/TN") + 1]!;
+      if (this.registry[tn] === undefined) {
+        return { exitCode: 1, stdout: "", stderr: "cannot find" };
+      }
+      this.registry[tn] = undefined;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
   }
+}
+
+/** Minimal task XML carrying a Principal with the given SID (ownership check). */
+function principalXml(sid: string): string {
+  return (
+    `<Task xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">` +
+    `<Principals><Principal id="Author"><UserId>${sid}</UserId>` +
+    `<LogonType>InteractiveToken</LogonType></Principal></Principals></Task>`
+  );
 }
 
 class CaptureStream {
@@ -372,18 +399,50 @@ describe("runUninstall (windows/schtasks)", () => {
   test("deletes all four tasks and reports complete", async () => {
     const out = new CaptureStream();
     const st = new FakeSchtasks();
+    const sid = "S-1-5-21-1-2-3-1001";
+    // 4 persona-scoped tasks + 4 legacy pre-rename names, all owned by us.
+    const names = [
+      "phantombot-testbot",
+      "heartbeat-testbot",
+      "nightly-testbot",
+      "tick-testbot",
+      "phantombot",
+      "heartbeat",
+      "nightly",
+      "tick",
+    ];
+    for (const n of names) st.registry[`\\Phantombot\\${n}`] = principalXml(sid);
     const code = await runUninstall({
       persona: "testbot",
+      sid,
       schtasks: st,
       out,
       err: new CaptureStream(),
       platform: "windows",
     });
     expect(code).toBe(0);
-    // 4 persona-scoped tasks + 4 legacy pre-rename names.
     const deletes = st.calls.filter((c) => c[0] === "/Delete");
     expect(deletes.length).toBe(8);
     expect(out.text).toContain("uninstall complete");
+  });
+
+  test("leaves another Windows account's tasks alone", async () => {
+    const out = new CaptureStream();
+    const st = new FakeSchtasks();
+    const foreign = "S-1-5-21-9-9-9-1005";
+    st.registry["\\Phantombot\\phantombot-testbot"] = principalXml(foreign);
+    const code = await runUninstall({
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+      platform: "windows",
+    });
+    expect(code).toBe(0);
+    expect(st.calls.filter((c) => c[0] === "/Delete")).toEqual([]);
+    expect(st.registry["\\Phantombot\\phantombot-testbot"]).toBeDefined();
+    expect(out.text).toContain("owned by another Windows account");
   });
 });
 

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -280,6 +280,9 @@ describe("runInstall (darwin/launchd)", () => {
   });
 });
 
+const WIN_BIN2 =
+  "C:\\Users\\megan\\AppData\\Local\\phantombot\\bin\\phantombot.exe";
+
 describe("runInstall (windows/schtasks)", () => {
   const WIN_BIN =
     "C:\\Users\\andrew\\AppData\\Local\\phantombot\\bin\\phantombot.exe";
@@ -290,6 +293,7 @@ describe("runInstall (windows/schtasks)", () => {
     const st = new FakeSchtasks();
     const code = await runInstall({
       binPath: WIN_BIN,
+      persona: "testbot",
       sid: "S-1-5-21-1-2-3-1001",
       xmlDir: workdir,
       schtasks: st,
@@ -311,6 +315,7 @@ describe("runInstall (windows/schtasks)", () => {
     const st = new FakeSchtasks();
     const code = await runInstall({
       binPath: WIN_BIN,
+      persona: "testbot",
       sid: "S-1-5-21-1-2-3-1001",
       xmlDir: workdir,
       systemctl: sys,
@@ -334,6 +339,7 @@ describe("runInstall (windows/schtasks)", () => {
     ];
     const code = await runInstall({
       binPath: WIN_BIN,
+      persona: "testbot",
       sid: "S-1-5-21-1-2-3-1001",
       xmlDir: workdir,
       schtasks: st,
@@ -367,14 +373,16 @@ describe("runUninstall (windows/schtasks)", () => {
     const out = new CaptureStream();
     const st = new FakeSchtasks();
     const code = await runUninstall({
+      persona: "testbot",
       schtasks: st,
       out,
       err: new CaptureStream(),
       platform: "windows",
     });
     expect(code).toBe(0);
+    // 4 persona-scoped tasks + 4 legacy pre-rename names.
     const deletes = st.calls.filter((c) => c[0] === "/Delete");
-    expect(deletes.length).toBe(4);
+    expect(deletes.length).toBe(8);
     expect(out.text).toContain("uninstall complete");
   });
 });
@@ -449,3 +457,136 @@ describe("runUninstall (darwin/launchd)", () => {
     expect(out.text).toContain("uninstall complete");
   });
 });
+
+describe("runInstall (windows) logged-off prompt flow", () => {
+
+  test("answering no keeps interactive mode (no /RU, no password)", async () => {
+    const st = new FakeSchtasks();
+    const out = new CaptureStream();
+    const code = await runInstall({
+      binPath: WIN_BIN2,
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+      platform: "windows",
+      promptRunLoggedOff: async () => false,
+    });
+    expect(code).toBe(0);
+    const creates = st.calls.filter((c) => c[0] === "/Create");
+    expect(creates.length).toBe(4);
+    for (const c of creates) {
+      expect(c).not.toContain("/RU");
+      expect(c).not.toContain("/RP");
+    }
+    expect(out.text).toContain("while logged in");
+  });
+
+  test("answering yes asks for the password and registers with /RU + /RP", async () => {
+    const st = new FakeSchtasks();
+    const out = new CaptureStream();
+    let askedPassword = false;
+    const code = await runInstall({
+      binPath: WIN_BIN2,
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+      platform: "windows",
+      promptRunLoggedOff: async () => true,
+      promptPassword: async () => {
+        askedPassword = true;
+        return "s3cret!";
+      },
+      whoami: async () => "MEGAN-PC\\megan",
+    });
+    expect(code).toBe(0);
+    expect(askedPassword).toBe(true);
+    const creates = st.calls.filter((c) => c[0] === "/Create");
+    expect(creates.length).toBe(4);
+    for (const c of creates) {
+      expect(c).toContain("/RU");
+      expect(c).toContain("MEGAN-PC\\megan");
+      expect(c).toContain("/RP");
+    }
+    expect(out.text).toContain("whether or not anyone is logged on");
+  });
+
+  test("cancelling the prompt aborts the install with exit 2", async () => {
+    const st = new FakeSchtasks();
+    const err = new CaptureStream();
+    const code = await runInstall({
+      binPath: WIN_BIN2,
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err,
+      platform: "windows",
+      promptRunLoggedOff: async () => null,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("cancelled");
+    expect(st.calls).toEqual([]);
+  });
+});
+
+  test("scripted mode: runLoggedOff + password flag skips all prompts", async () => {
+    const st = new FakeSchtasks();
+    const out = new CaptureStream();
+    let prompted = false;
+    const code = await runInstall({
+      binPath: WIN_BIN2,
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+      platform: "windows",
+      runLoggedOff: true,
+      windowsPassword: "s3cret!",
+      whoami: async () => "MEGAN-PC\\megan",
+      promptRunLoggedOff: async () => {
+        prompted = true;
+        return false;
+      },
+    });
+    expect(code).toBe(0);
+    expect(prompted).toBe(false);
+    const creates = st.calls.filter((c) => c[0] === "/Create");
+    expect(creates.length).toBe(4);
+    for (const c of creates) expect(c).toContain("/RP");
+    expect(out.text).toContain("whether or not anyone is logged on");
+  });
+
+  test("scripted mode: runLoggedOff without a password fails clearly", async () => {
+    const st = new FakeSchtasks();
+    const err = new CaptureStream();
+    const prev = process.env.PHANTOMBOT_WINDOWS_PASSWORD;
+    delete process.env.PHANTOMBOT_WINDOWS_PASSWORD;
+    try {
+      const code = await runInstall({
+        binPath: WIN_BIN2,
+        persona: "testbot",
+        sid: "S-1-5-21-1-2-3-1001",
+        xmlDir: workdir,
+        schtasks: st,
+        out: new CaptureStream(),
+        err,
+        platform: "windows",
+        runLoggedOff: true,
+        whoami: async () => "MEGAN-PC\\megan",
+      });
+      expect(code).toBe(2);
+      expect(err.text).toContain("needs the Windows password");
+      expect(st.calls).toEqual([]);
+    } finally {
+      if (prev !== undefined) process.env.PHANTOMBOT_WINDOWS_PASSWORD = prev;
+    }
+  });

--- a/tests/lib-platform.test.ts
+++ b/tests/lib-platform.test.ts
@@ -35,47 +35,88 @@ describe("currentPlatform", () => {
 });
 
 describe("hint commands shape per platform", () => {
-  test("on linux: systemctl/journalctl strings", () => {
+  test("on linux: systemctl/journalctl strings", async () => {
     if (process.platform !== "linux") return; // guard for CI on darwin
-    expect(restartCommand()).toContain("systemctl --user restart phantombot");
-    expect(statusCommand()).toContain("systemctl --user status phantombot");
+    expect(await restartCommand()).toContain("systemctl --user restart phantombot");
+    expect(await statusCommand()).toContain("systemctl --user status phantombot");
     expect(logsCommand()).toContain("journalctl --user -u phantombot");
   });
 
-  test("on darwin: launchctl strings", () => {
+  test("on darwin: launchctl strings", async () => {
     if (process.platform !== "darwin") return;
-    expect(restartCommand()).toContain("launchctl kickstart -k");
-    expect(restartCommand()).toContain("dev.phantombot.phantombot");
-    expect(statusCommand()).toContain("launchctl print");
+    expect(await restartCommand()).toContain("launchctl kickstart -k");
+    expect(await restartCommand()).toContain("dev.phantombot.phantombot");
+    expect(await statusCommand()).toContain("launchctl print");
     expect(logsCommand()).toContain("Library/Logs/phantombot");
   });
 
-  test("on windows: Task Scheduler strings", () => {
+  test("on windows: Task Scheduler strings", async () => {
     if (process.platform !== "win32") return;
-    expect(restartCommand()).toContain("schtasks /End");
-    expect(statusCommand()).toContain("schtasks /Query");
+    expect(await restartCommand()).toContain("schtasks /End");
+    expect(await statusCommand()).toContain("schtasks /Query");
     expect(logsCommand()).toContain("phantombot\\logs\\phantombot.out.log");
   });
 });
 
 describe("start/stop hint commands per platform", () => {
-  test("on linux: systemctl start/stop", () => {
+  test("on linux: systemctl start/stop", async () => {
     if (process.platform !== "linux") return;
-    expect(startCommand()).toBe("systemctl --user start phantombot");
-    expect(stopCommand()).toBe("systemctl --user stop phantombot");
+    expect(await startCommand()).toBe("systemctl --user start phantombot");
+    expect(await stopCommand()).toBe("systemctl --user stop phantombot");
   });
 
-  test("on darwin: launchctl bootstrap/bootout", () => {
+  test("on darwin: launchctl bootstrap/bootout", async () => {
     if (process.platform !== "darwin") return;
-    expect(startCommand()).toContain("launchctl bootstrap");
-    expect(startCommand()).toContain("dev.phantombot.phantombot");
-    expect(stopCommand()).toContain("launchctl bootout");
+    expect(await startCommand()).toContain("launchctl bootstrap");
+    expect(await startCommand()).toContain("dev.phantombot.phantombot");
+    expect(await stopCommand()).toContain("launchctl bootout");
   });
 
-  test("on windows: Task Scheduler start/stop", () => {
+  test("on windows: Task Scheduler start/stop", async () => {
     if (process.platform !== "win32") return;
-    expect(startCommand()).toContain("schtasks /Change");
-    expect(stopCommand()).toContain("schtasks /Change");
+    expect(await startCommand()).toContain("schtasks /Change");
+    expect(await stopCommand()).toContain("schtasks /Change");
+  });
+});
+
+describe("windows hints name the persona-scoped task", () => {
+  // The whole point of the persona-suffixed rename: every hint the CLI
+  // prints must address `\Phantombot\phantombot-<persona>` — the legacy
+  // unsuffixed task no longer exists after install, so a hint that names
+  // it is a copy-pasteable command that fails.
+  const win = { platform: "windows" as const, persona: "megan" };
+  const task = "\\Phantombot\\phantombot-megan";
+
+  test("restart", async () => {
+    const cmd = await restartCommand(win);
+    expect(cmd).toBe(`schtasks /End /TN "${task}" & schtasks /Run /TN "${task}"`);
+  });
+
+  test("start", async () => {
+    const cmd = await startCommand(win);
+    expect(cmd).toBe(`schtasks /Change /TN "${task}" /ENABLE & schtasks /Run /TN "${task}"`);
+  });
+
+  test("stop", async () => {
+    const cmd = await stopCommand(win);
+    expect(cmd).toBe(`schtasks /Change /TN "${task}" /DISABLE & schtasks /End /TN "${task}"`);
+  });
+
+  test("status", async () => {
+    const cmd = await statusCommand(win);
+    expect(cmd).toBe(`schtasks /Query /TN "${task}" /V /FO LIST`);
+  });
+
+  test("no hint contains the legacy unsuffixed task name", async () => {
+    for (const cmd of [
+      await restartCommand(win),
+      await startCommand(win),
+      await stopCommand(win),
+      await statusCommand(win),
+    ]) {
+      expect(cmd).not.toContain('"\\Phantombot\\phantombot"');
+      expect(cmd).toContain("phantombot-megan");
+    }
   });
 });
 

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -37,14 +37,16 @@ import {
   type SchtasksRunner,
   taskLogPaths,
   uninstallPhantombotTasks,
-  HEARTBEAT_TASK,
-  NIGHTLY_TASK,
-  PHANTOMBOT_TASK,
-  TICK_TASK,
+  taskNames,
+  readTaskLogon,
+  writeTaskLogon,
+  LEGACY_TASK_NAMES,
 } from "../src/lib/taskScheduler.ts";
 
 const SID = "S-1-5-21-1111111111-2222222222-3333333333-1001";
 const BIN = "C:\\Users\\andrew\\AppData\\Local\\phantombot\\bin\\phantombot.exe";
+const PERSONA = "megan";
+const NAMES = taskNames(PERSONA);
 
 class FakeSchtasks implements SchtasksRunner {
   calls: string[][] = [];
@@ -67,12 +69,18 @@ class CaptureStream {
 }
 
 let workdir: string;
+let prevXdg: string | undefined;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-schtasks-"));
+  // Keep marker-file and launcher writes inside the tmpdir.
+  prevXdg = process.env.XDG_DATA_HOME;
+  process.env.XDG_DATA_HOME = workdir;
 });
 
 afterEach(async () => {
+  if (prevXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = prevXdg;
   await rmrf(workdir);
 });
 
@@ -130,14 +138,19 @@ describe("LAUNCHER_VBS", () => {
 });
 
 describe("generatePhantombotTaskXml", () => {
-  const xml = generatePhantombotTaskXml(SID, BIN);
+  // Generated lazily: the launcher path resolves through XDG_DATA_HOME,
+  // which the outer beforeEach only points at the tmpdir per-test.
+  let xml: string;
+  beforeEach(() => {
+    xml = generatePhantombotTaskXml(SID, BIN, PERSONA);
+  });
 
   test("is a Task Scheduler 1.2 document with the right URI", () => {
     expect(xml).toContain('<?xml version="1.0" encoding="UTF-16"?>');
     expect(xml).toContain(
       '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">',
     );
-    expect(xml).toContain(`<URI>${PHANTOMBOT_TASK}</URI>`);
+    expect(xml).toContain(`<URI>${NAMES.main}</URI>`);
   });
 
   test("runs as the current user by SID, only while logged in, no elevation", () => {
@@ -177,16 +190,16 @@ describe("generatePhantombotTaskXml", () => {
 
 describe("companion task schedules", () => {
   test("heartbeat repeats every 30 minutes", () => {
-    const xml = generateHeartbeatTaskXml(SID, BIN);
-    expect(xml).toContain(`<URI>${HEARTBEAT_TASK}</URI>`);
+    const xml = generateHeartbeatTaskXml(SID, BIN, PERSONA);
+    expect(xml).toContain(`<URI>${NAMES.heartbeat}</URI>`);
     expect(xml).toContain("<Interval>PT30M</Interval>");
     expect(xml).toContain("heartbeat.out.log");
     expect(xml).not.toContain("<RestartOnFailure>");
   });
 
   test("nightly fires daily at 02:00 (calendar trigger)", () => {
-    const xml = generateNightlyTaskXml(SID, BIN);
-    expect(xml).toContain(`<URI>${NIGHTLY_TASK}</URI>`);
+    const xml = generateNightlyTaskXml(SID, BIN, PERSONA);
+    expect(xml).toContain(`<URI>${NAMES.nightly}</URI>`);
     expect(xml).toContain("<CalendarTrigger>");
     expect(xml).toContain("<ScheduleByDay>");
     expect(xml).toContain("<DaysInterval>1</DaysInterval>");
@@ -194,8 +207,8 @@ describe("companion task schedules", () => {
   });
 
   test("tick repeats every minute", () => {
-    const xml = generateTickTaskXml(SID, BIN);
-    expect(xml).toContain(`<URI>${TICK_TASK}</URI>`);
+    const xml = generateTickTaskXml(SID, BIN, PERSONA);
+    expect(xml).toContain(`<URI>${NAMES.tick}</URI>`);
     expect(xml).toContain("<Interval>PT1M</Interval>");
     expect(xml).toContain("tick.out.log");
   });
@@ -203,7 +216,7 @@ describe("companion task schedules", () => {
 
 describe("XML escaping", () => {
   test("ampersands and angle brackets in the bin path become entities", () => {
-    const xml = generatePhantombotTaskXml(SID, "C:\\odd&path\\<bot>.exe");
+    const xml = generatePhantombotTaskXml(SID, "C:\\odd&path\\<bot>.exe", PERSONA);
     expect(xml).toContain("C:\\odd&amp;path\\&lt;bot&gt;.exe");
   });
 });
@@ -215,6 +228,7 @@ describe("installPhantombotTasks", () => {
     const st = new FakeSchtasks();
     const result = await installPhantombotTasks({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
@@ -225,14 +239,20 @@ describe("installPhantombotTasks", () => {
 
     const seq = st.calls.map((c) => c.join(" "));
     expect(seq).toEqual([
-      `/Query /TN ${PHANTOMBOT_TASK} /XML`,
-      `/Create /TN ${PHANTOMBOT_TASK} /XML ${join(workdir, "phantombot-task-phantombot.xml")} /F`,
-      `/Query /TN ${HEARTBEAT_TASK} /XML`,
-      `/Create /TN ${HEARTBEAT_TASK} /XML ${join(workdir, "phantombot-task-heartbeat.xml")} /F`,
-      `/Query /TN ${NIGHTLY_TASK} /XML`,
-      `/Create /TN ${NIGHTLY_TASK} /XML ${join(workdir, "phantombot-task-nightly.xml")} /F`,
-      `/Query /TN ${TICK_TASK} /XML`,
-      `/Create /TN ${TICK_TASK} /XML ${join(workdir, "phantombot-task-tick.xml")} /F`,
+      `/Query /TN ${NAMES.main} /XML`,
+      `/Create /TN ${NAMES.main} /XML ${join(workdir, "phantombot-task-phantombot.xml")} /F`,
+      `/Query /TN ${NAMES.heartbeat} /XML`,
+      `/Create /TN ${NAMES.heartbeat} /XML ${join(workdir, "phantombot-task-heartbeat.xml")} /F`,
+      `/Query /TN ${NAMES.nightly} /XML`,
+      `/Create /TN ${NAMES.nightly} /XML ${join(workdir, "phantombot-task-nightly.xml")} /F`,
+      `/Query /TN ${NAMES.tick} /XML`,
+      `/Create /TN ${NAMES.tick} /XML ${join(workdir, "phantombot-task-tick.xml")} /F`,
+      // Pre-rename legacy tasks are cleaned up so an upgrade never
+      // double-supervises the daemon.
+      `/Delete /TN ${LEGACY_TASK_NAMES[0]} /F`,
+      `/Delete /TN ${LEGACY_TASK_NAMES[1]} /F`,
+      `/Delete /TN ${LEGACY_TASK_NAMES[2]} /F`,
+      `/Delete /TN ${LEGACY_TASK_NAMES[3]} /F`,
     ]);
     expect(out.text).toContain("registered");
   });
@@ -241,6 +261,7 @@ describe("installPhantombotTasks", () => {
     const { existsSync, readFileSync } = await import("node:fs");
     await installPhantombotTasks({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: new FakeSchtasks(),
@@ -258,6 +279,7 @@ describe("installPhantombotTasks", () => {
     const st = new FakeSchtasks();
     await installPhantombotTasks({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
@@ -286,6 +308,7 @@ describe("installPhantombotTasks", () => {
     };
     await installPhantombotTasks({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
@@ -308,6 +331,7 @@ describe("installPhantombotTasks", () => {
     };
     const result = await installPhantombotTasks({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
@@ -318,16 +342,21 @@ describe("installPhantombotTasks", () => {
     expect(err.text).toContain("could not register scheduled task");
   });
 
-  test("preserves healthy existing task definitions", async () => {
-    const xml = generatePhantombotTaskXml(SID, BIN);
+  test("re-imports even healthy existing tasks (applies the chosen template + logon mode)", async () => {
+    const xml = generatePhantombotTaskXml(SID, BIN, PERSONA);
+    const created: string[] = [];
     const st: SchtasksRunner = {
       async run(args: readonly string[]): Promise<SchtasksResult> {
         if (args[0] === "/Query") return { exitCode: 0, stdout: xml, stderr: "" };
-        throw new Error("healthy tasks must not be rewritten");
+        if (args[0] === "/Create") {
+          created.push(args[args.indexOf("/TN") + 1]!);
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
       },
     };
     const result = await installPhantombotTasks({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
@@ -335,6 +364,15 @@ describe("installPhantombotTasks", () => {
       err: new CaptureStream(),
     });
     expect(result.installed).toBe(true);
+    // Install is not the heal: a re-install must apply the current template
+    // (and any fresh credential) even when the registered XML already points
+    // at this binary. Drift-only preservation is ensureTasksCurrent's job.
+    expect(created).toEqual([
+      NAMES.main,
+      NAMES.heartbeat,
+      NAMES.nightly,
+      NAMES.tick,
+    ]);
   });
 });
 
@@ -343,13 +381,17 @@ describe("uninstallPhantombotTasks", () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     const st = new FakeSchtasks();
-    const result = await uninstallPhantombotTasks({ schtasks: st, out, err });
+    const result = await uninstallPhantombotTasks({ persona: PERSONA, schtasks: st, out, err });
     expect(result.removed).toBe(true);
     expect(st.calls.map((c) => c.join(" "))).toEqual([
-      `/Delete /TN ${TICK_TASK} /F`,
-      `/Delete /TN ${NIGHTLY_TASK} /F`,
-      `/Delete /TN ${HEARTBEAT_TASK} /F`,
-      `/Delete /TN ${PHANTOMBOT_TASK} /F`,
+      `/Delete /TN ${NAMES.tick} /F`,
+      `/Delete /TN ${NAMES.nightly} /F`,
+      `/Delete /TN ${NAMES.heartbeat} /F`,
+      `/Delete /TN ${NAMES.main} /F`,
+      `/Delete /TN ${LEGACY_TASK_NAMES[0]} /F`,
+      `/Delete /TN ${LEGACY_TASK_NAMES[1]} /F`,
+      `/Delete /TN ${LEGACY_TASK_NAMES[2]} /F`,
+      `/Delete /TN ${LEGACY_TASK_NAMES[3]} /F`,
     ]);
     expect(out.text).toContain("removed scheduled task");
   });
@@ -359,6 +401,7 @@ describe("uninstallPhantombotTasks", () => {
     // Put the launcher in place first (install writes it), then uninstall.
     await installPhantombotTasks({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: new FakeSchtasks(),
@@ -367,6 +410,7 @@ describe("uninstallPhantombotTasks", () => {
     });
     expect(existsSync(launcherVbsPath())).toBe(true);
     await uninstallPhantombotTasks({
+      persona: PERSONA,
       schtasks: new FakeSchtasks(),
       out: new CaptureStream(),
       err: new CaptureStream(),
@@ -384,7 +428,7 @@ describe("uninstallPhantombotTasks", () => {
       { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
       { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
     ];
-    const result = await uninstallPhantombotTasks({ schtasks: st, out, err });
+    const result = await uninstallPhantombotTasks({ persona: PERSONA, schtasks: st, out, err });
     expect(result.removed).toBe(true);
     expect(out.text).toContain("returned 1 (continuing)");
   });
@@ -397,10 +441,10 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
   /** The registered XML each task's `/Query /XML` should return, keyed by name. */
   function registeredXml(bin: string): Record<string, string> {
     return {
-      [PHANTOMBOT_TASK]: generatePhantombotTaskXml(SID, bin),
-      [HEARTBEAT_TASK]: generateHeartbeatTaskXml(SID, bin),
-      [NIGHTLY_TASK]: generateNightlyTaskXml(SID, bin),
-      [TICK_TASK]: generateTickTaskXml(SID, bin),
+      [NAMES.main]: generatePhantombotTaskXml(SID, bin, PERSONA),
+      [NAMES.heartbeat]: generateHeartbeatTaskXml(SID, bin, PERSONA),
+      [NAMES.nightly]: generateNightlyTaskXml(SID, bin, PERSONA),
+      [NAMES.tick]: generateTickTaskXml(SID, bin, PERSONA),
     };
   }
 
@@ -436,6 +480,7 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
     const st = new HealFake(registeredXml(BIN));
     const r = await ensureTasksCurrent({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
@@ -451,36 +496,38 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
     const st = new HealFake(registeredXml(OLD_BIN));
     const r = await ensureTasksCurrent({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
     });
     expect(r.rewrote).toEqual([
-      PHANTOMBOT_TASK,
-      HEARTBEAT_TASK,
-      NIGHTLY_TASK,
-      TICK_TASK,
+      NAMES.main,
+      NAMES.heartbeat,
+      NAMES.nightly,
+      NAMES.tick,
     ]);
     expect(st.created()).toEqual([
-      PHANTOMBOT_TASK,
-      HEARTBEAT_TASK,
-      NIGHTLY_TASK,
-      TICK_TASK,
+      NAMES.main,
+      NAMES.heartbeat,
+      NAMES.nightly,
+      NAMES.tick,
     ]);
   });
 
   test("a single missing task is re-registered; the current ones are left alone", async () => {
     const xml = registeredXml(BIN);
-    xml[TICK_TASK] = undefined as unknown as string; // tick was deleted
+    xml[NAMES.tick] = undefined as unknown as string; // tick was deleted
     const st = new HealFake(xml);
     const r = await ensureTasksCurrent({
       binPath: BIN,
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
     });
-    expect(r.rewrote).toEqual([TICK_TASK]);
-    expect(st.created()).toEqual([TICK_TASK]);
+    expect(r.rewrote).toEqual([NAMES.tick]);
+    expect(st.created()).toEqual([NAMES.tick]);
   });
 
   test("path casing differences alone are not treated as drift", async () => {
@@ -489,6 +536,7 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
     const st = new HealFake(registeredXml(BIN.toUpperCase()));
     const r = await ensureTasksCurrent({
       binPath: BIN.toLowerCase(),
+      persona: PERSONA,
       sid: SID,
       xmlDir: workdir,
       schtasks: st,
@@ -750,7 +798,7 @@ describe("service control stop/restart kill the stray daemon", () => {
   test("stop(): disable + end + kill daemon (not the CLI invoker)", async () => {
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run"), pb(555, "stop")]);
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait, PERSONA);
     const r = await svc.stop();
     expect(r.ok).toBe(true);
     const verbs = st.calls.map((c) => c[0]);
@@ -762,7 +810,7 @@ describe("service control stop/restart kill the stray daemon", () => {
   test("restart(): enable + end + kill daemon + run", async () => {
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run")]);
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait, PERSONA);
     const r = await svc.restart();
     expect(r.ok).toBe(true);
     const verbs = st.calls.map((c) => c[0]);
@@ -775,7 +823,7 @@ describe("service control stop/restart kill the stray daemon", () => {
     // still held the single-instance lock, so the new daemon refused to start.
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run")]);
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait, PERSONA);
     await svc.restart();
     const runIdx = st.calls.findIndex((c) => c[0] === "/Run");
     expect(runIdx).toBeGreaterThanOrEqual(0);
@@ -790,7 +838,7 @@ describe("service control stop/restart kill the stray daemon", () => {
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run")]);
     pm.alwaysFailList = true;
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait, PERSONA);
     const r = await svc.restart();
     expect(r.ok).toBe(false);
     expect(st.calls.map((c) => c[0])).not.toContain("/Run");
@@ -803,7 +851,7 @@ describe("service control stop/restart kill the stray daemon", () => {
   test("restart(): an unkillable daemon must NOT fire /Run", async () => {
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run")], [100]);
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait, PERSONA);
     const r = await svc.restart();
     expect(r.ok).toBe(false);
     expect(st.calls.map((c) => c[0])).not.toContain("/Run");
@@ -813,7 +861,7 @@ describe("service control stop/restart kill the stray daemon", () => {
     const st = new FakeSchtasks();
     const pm = new FakeProcessManager([pb(100, "run")]);
     pm.alwaysFailList = true;
-    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait);
+    const svc = defaultTaskSchedulerServiceControl(st, pm, 555, fastWait, PERSONA);
     const r = await svc.stop();
     expect(r.ok).toBe(false);
     expect(r.stderr ?? "").toContain("could not confirm");
@@ -861,5 +909,156 @@ describe("scheduleWindowsRelaunch", () => {
     });
     expect(r.ok).toBe(false);
     expect(r.stderr).toContain("powershell exited 1");
+  });
+});
+
+describe("password logon mode (run when logged off)", () => {
+  const ACCOUNT = "MEGAN-PC\\megan";
+
+  test("task XML carries LogonType Password, the account name, and a boot trigger", () => {
+    const xml = generatePhantombotTaskXml(SID, BIN, PERSONA, {
+      mode: "password",
+      username: ACCOUNT,
+    });
+    expect(xml).toContain("<LogonType>Password</LogonType>");
+    expect(xml).toContain(`<UserId>${ACCOUNT}</UserId>`);
+    expect(xml).toContain("<BootTrigger>");
+    // The credential itself never goes into the XML.
+    expect(xml).not.toContain("s3cret");
+  });
+
+  test("companion tasks are password-mode too, but only the daemon gets a boot trigger", () => {
+    const hb = generateHeartbeatTaskXml(SID, BIN, PERSONA, {
+      mode: "password",
+      username: ACCOUNT,
+    });
+    expect(hb).toContain("<LogonType>Password</LogonType>");
+    expect(hb).not.toContain("<BootTrigger>");
+  });
+
+  test("install registers with /RU + /RP and persists the mode (without the password)", async () => {
+    const st = new FakeSchtasks();
+    const result = await installPhantombotTasks({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      logon: { mode: "password", username: ACCOUNT, password: "s3cret" },
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(result.installed).toBe(true);
+    const creates = st.calls.filter((c) => c[0] === "/Create");
+    expect(creates.length).toBe(4);
+    for (const c of creates) {
+      expect(c).toContain("/RU");
+      expect(c).toContain(ACCOUNT);
+      expect(c).toContain("/RP");
+      expect(c).toContain("s3cret");
+    }
+    // The marker remembers the mode + account for the heal path, but the
+    // password stays with Task Scheduler — never on our disk.
+    expect(await readTaskLogon()).toEqual({
+      mode: "password",
+      username: ACCOUNT,
+    });
+  });
+
+  test("heal patches a drifted password-mode task's action in place (no credential needed)", async () => {
+    await writeTaskLogon({ mode: "password", username: ACCOUNT });
+    const OLD_BIN = "C:\\old\\phantombot.exe";
+    const registered: Record<string, string | undefined> = {
+      [NAMES.main]: generatePhantombotTaskXml(SID, OLD_BIN, PERSONA, {
+        mode: "password",
+        username: ACCOUNT,
+      }),
+      [NAMES.heartbeat]: generateHeartbeatTaskXml(SID, BIN, PERSONA, {
+        mode: "password",
+        username: ACCOUNT,
+      }),
+      [NAMES.nightly]: generateNightlyTaskXml(SID, BIN, PERSONA, {
+        mode: "password",
+        username: ACCOUNT,
+      }),
+      [NAMES.tick]: generateTickTaskXml(SID, BIN, PERSONA, {
+        mode: "password",
+        username: ACCOUNT,
+      }),
+    };
+    const st: SchtasksRunner = {
+      async run(args: readonly string[]): Promise<SchtasksResult> {
+        if (args[0] === "/Query") {
+          const xml = registered[args[args.indexOf("/TN") + 1]!];
+          return xml === undefined
+            ? { exitCode: 1, stdout: "", stderr: "cannot find" }
+            : { exitCode: 0, stdout: xml, stderr: "" };
+        }
+        throw new Error("password-mode heal must NOT re-import via schtasks");
+      },
+    };
+    const patched: Array<[string, string]> = [];
+    const r = await ensureTasksCurrent({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      patchAction: async (name, args) => {
+        patched.push([name, args]);
+        return { ok: true };
+      },
+    });
+    // Only the drifted daemon task was patched, with the new binary path in
+    // the launcher arguments.
+    expect(r.rewrote).toEqual([NAMES.main]);
+    expect(r.failed).toEqual([]);
+    expect(patched.length).toBe(1);
+    expect(patched[0]![0]).toBe(NAMES.main);
+    expect(patched[0]![1]).toContain(BIN);
+    expect(patched[0]![1]).not.toContain(OLD_BIN);
+  });
+
+  test("heal cannot recreate a MISSING password-mode task — it says to re-install", async () => {
+    await writeTaskLogon({ mode: "password", username: ACCOUNT });
+    const st: SchtasksRunner = {
+      async run(): Promise<SchtasksResult> {
+        return { exitCode: 1, stdout: "", stderr: "cannot find" };
+      },
+    };
+    const r = await ensureTasksCurrent({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      patchAction: async () => ({ ok: true }),
+    });
+    expect(r.rewrote).toEqual([]);
+    expect(r.failed).toEqual([
+      NAMES.main,
+      NAMES.heartbeat,
+      NAMES.nightly,
+      NAMES.tick,
+    ]);
+  });
+
+  test("legacy (pre persona-rename) tasks are removed on install", async () => {
+    const st = new FakeSchtasks();
+    await installPhantombotTasks({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    const deletes = st.calls
+      .filter((c) => c[0] === "/Delete")
+      .map((c) => c[c.indexOf("/TN") + 1]);
+    for (const legacy of LEGACY_TASK_NAMES) {
+      expect(deletes).toContain(legacy);
+    }
   });
 });

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -26,6 +26,7 @@ import {
   isDaemonCommandLine,
   killDaemonProcesses,
   launcherVbsPath,
+  legacyLauncherVbsPath,
   LAUNCHER_VBS,
   scheduleWindowsRelaunch,
   ProcessEnumerationError,
@@ -44,6 +45,7 @@ import {
 } from "../src/lib/taskScheduler.ts";
 
 const SID = "S-1-5-21-1111111111-2222222222-3333333333-1001";
+const FOREIGN_SID = "S-1-5-21-9999999999-8888888888-7777777777-1005";
 const BIN = "C:\\Users\\andrew\\AppData\\Local\\phantombot\\bin\\phantombot.exe";
 const PERSONA = "megan";
 const NAMES = taskNames(PERSONA);
@@ -87,6 +89,16 @@ function principalXml(sid: string): string {
     `<Task xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">` +
     `<Principals><Principal id="Author"><UserId>${sid}</UserId>` +
     `<LogonType>InteractiveToken</LogonType></Principal></Principals></Task>`
+  );
+}
+
+/** Password-mode task XML: the Principal UserId is the `COMPUTER\\user`
+ * account name (what was passed as /RU), NOT a SID. */
+function passwordPrincipalXml(account: string): string {
+  return (
+    `<Task xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">` +
+    `<Principals><Principal id="Author"><UserId>${account}</UserId>` +
+    `<LogonType>Password</LogonType></Principal></Principals></Task>`
   );
 }
 
@@ -145,12 +157,13 @@ describe("buildLauncherArguments", () => {
       ["run"],
       "C:\\logs\\phantombot.out.log",
       "C:\\logs\\phantombot.err.log",
+      launcherVbsPath(PERSONA),
     );
     // //B (batch mode) suppresses any runtime script-error dialog. Each value
     // is its own quoted token so a spaced path survives arg parsing, and the
     // binary path stays visible (drift detection reads it back).
     expect(args).toBe(
-      `//B "${launcherVbsPath()}" "${BIN}" "run" "C:\\logs\\phantombot.out.log" "C:\\logs\\phantombot.err.log"`,
+      `//B "${launcherVbsPath(PERSONA)}" "${BIN}" "run" "C:\\logs\\phantombot.out.log" "C:\\logs\\phantombot.err.log"`,
     );
   });
 });
@@ -210,7 +223,7 @@ describe("generatePhantombotTaskXml", () => {
     // wscript runs in batch mode so a script error never pops its own dialog.
     expect(xml).toContain("//B");
     // The launcher path and the binary path are both quoted args…
-    expect(xml).toContain(`"${launcherVbsPath()}"`);
+    expect(xml).toContain(`"${launcherVbsPath(PERSONA)}"`);
     expect(xml).toContain(`"${BIN}"`);
     // …and the per-task log paths are handed to the launcher.
     expect(xml).toContain("phantombot.out.log");
@@ -298,7 +311,7 @@ describe("installPhantombotTasks", () => {
     expect(out.text).toContain("registered");
   });
 
-  test("writes the shared hidden launcher so wscript.exe has a script to run", async () => {
+  test("writes the persona-scoped hidden launcher so wscript.exe has a script to run", async () => {
     const { existsSync, readFileSync } = await import("node:fs");
     await installPhantombotTasks({
       binPath: BIN,
@@ -309,8 +322,8 @@ describe("installPhantombotTasks", () => {
       out: new CaptureStream(),
       err: new CaptureStream(),
     });
-    expect(existsSync(launcherVbsPath())).toBe(true);
-    expect(readFileSync(launcherVbsPath(), "utf8")).toBe(LAUNCHER_VBS);
+    expect(existsSync(launcherVbsPath(PERSONA))).toBe(true);
+    expect(readFileSync(launcherVbsPath(PERSONA), "utf8")).toBe(LAUNCHER_VBS);
   });
 
   test("transient XML import files are cleaned up after import", async () => {
@@ -451,7 +464,6 @@ describe("uninstallPhantombotTasks", () => {
   test("tasks owned by ANOTHER Windows account are left untouched", async () => {
     // Task Scheduler folders are machine-global: another local user's
     // same-named tasks must survive our uninstall.
-    const FOREIGN_SID = "S-1-5-21-9999999999-8888888888-7777777777-1005";
     const out = new CaptureStream();
     const st = new FakeSchtasks();
     for (const name of [...NAMES.all, ...LEGACY_TASK_NAMES]) {
@@ -473,9 +485,9 @@ describe("uninstallPhantombotTasks", () => {
     }
   });
 
-  test("removes the shared launcher script when the tasks are torn down", async () => {
-    const { existsSync } = await import("node:fs");
-    // Put the launcher in place first (install writes it), then uninstall.
+  test("removes THIS persona's launcher script — other personas' launchers survive", async () => {
+    const { existsSync, writeFileSync } = await import("node:fs");
+    // Install persona A (writes A's launcher), and fake persona B's launcher.
     await installPhantombotTasks({
       binPath: BIN,
       persona: PERSONA,
@@ -485,7 +497,8 @@ describe("uninstallPhantombotTasks", () => {
       out: new CaptureStream(),
       err: new CaptureStream(),
     });
-    expect(existsSync(launcherVbsPath())).toBe(true);
+    writeFileSync(launcherVbsPath("beta"), LAUNCHER_VBS, "utf8");
+    expect(existsSync(launcherVbsPath(PERSONA))).toBe(true);
     await uninstallPhantombotTasks({
       persona: PERSONA,
       sid: SID,
@@ -493,7 +506,64 @@ describe("uninstallPhantombotTasks", () => {
       out: new CaptureStream(),
       err: new CaptureStream(),
     });
-    expect(existsSync(launcherVbsPath())).toBe(false);
+    expect(existsSync(launcherVbsPath(PERSONA))).toBe(false);
+    // Persona B's tasks point at B's launcher — uninstalling A must not
+    // strand them.
+    expect(existsSync(launcherVbsPath("beta"))).toBe(true);
+  });
+
+  test("legacy shared launcher is removed only when no legacy task survives", async () => {
+    const { existsSync, writeFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(join(workdir, "phantombot"), { recursive: true });
+    const legacy = legacyLauncherVbsPath();
+    writeFileSync(legacy, LAUNCHER_VBS, "utf8");
+    // Case 1: all legacy tasks owned by us → deleted → shared launcher goes.
+    const st1 = new FakeSchtasks();
+    for (const name of LEGACY_TASK_NAMES) st1.registry[name] = principalXml(SID);
+    await uninstallPhantombotTasks({
+      persona: PERSONA,
+      sid: SID,
+      schtasks: st1,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(existsSync(legacy)).toBe(false);
+    // Case 2: a FOREIGN-owned legacy task survives → it still references the
+    // shared launcher, so the file must stay.
+    writeFileSync(legacy, LAUNCHER_VBS, "utf8");
+    const st2 = new FakeSchtasks();
+    st2.registry[LEGACY_TASK_NAMES[0]!] = principalXml(FOREIGN_SID);
+    await uninstallPhantombotTasks({
+      persona: PERSONA,
+      sid: SID,
+      schtasks: st2,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(existsSync(legacy)).toBe(true);
+  });
+
+  test("password-mode tasks (principal = account name, not SID) are still owned", async () => {
+    // Password-mode task XML carries `<UserId>MEGAN\megan</UserId>` with
+    // LogonType Password — no SID. Ownership must match the current account
+    // NAME or uninstall would strand every password-mode task while still
+    // deleting the persona marker.
+    const out = new CaptureStream();
+    const st = new FakeSchtasks();
+    for (const name of NAMES.all) {
+      st.registry[name] = passwordPrincipalXml("MEGAN\\megan");
+    }
+    const result = await uninstallPhantombotTasks({
+      persona: PERSONA,
+      sid: SID,
+      accountName: "megan\\megan", // whoami — case differs, must still match
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(result.removed).toBe(true);
+    expect(st.calls.filter((c) => c[0] === "/Delete").length).toBe(4);
+    for (const name of NAMES.all) expect(st.registry[name]).toBeUndefined();
   });
 
   test("missing tasks are skipped quietly — no deletes, not fatal", async () => {
@@ -1138,7 +1208,6 @@ describe("password logon mode (run when logged off)", () => {
   });
 
   test("legacy tasks owned by ANOTHER Windows account are kept on install", async () => {
-    const FOREIGN_SID = "S-1-5-21-9999999999-8888888888-7777777777-1005";
     const out = new CaptureStream();
     const st = new FakeSchtasks();
     for (const legacy of LEGACY_TASK_NAMES) st.registry[legacy] = principalXml(FOREIGN_SID);
@@ -1173,21 +1242,25 @@ describe("per-persona logon marker", () => {
     expect(await readTaskLogon("gamma")).toEqual({ mode: "interactive" });
   });
 
-  test("falls back to the pre-scoping shared marker, and a write migrates it", async () => {
+  test("falls back to the pre-scoping shared marker, and a write PRESERVES it", async () => {
     const { writeFileSync, existsSync } = await import("node:fs");
     const legacy = join(workdir, "phantombot", "windows-logon.json");
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(workdir, "phantombot"), { recursive: true });
     writeFileSync(legacy, JSON.stringify({ mode: "password", username: "PC\\old" }));
     // A persona installed before the scoping still heals in password mode.
-    expect(await readTaskLogon("newbot")).toEqual({
+    expect(await readTaskLogon("oldbot")).toEqual({
       mode: "password",
       username: "PC\\old",
     });
-    // The next install writes the scoped marker and removes the shared one.
-    await writeTaskLogon("newbot", { mode: "password", username: "PC\\old" });
-    expect(existsSync(legacy)).toBe(false);
-    expect(await readTaskLogon("newbot")).toEqual({
+    // A SECOND persona installing must NOT delete the shared marker: doing so
+    // would silently downgrade oldbot's heal/relaunch to interactive and
+    // re-break headless operation. Scoped markers win reads, so the stale
+    // file is inert for the persona that just installed.
+    await writeTaskLogon("newbot", { mode: "interactive" });
+    expect(existsSync(legacy)).toBe(true);
+    expect(await readTaskLogon("newbot")).toEqual({ mode: "interactive" });
+    expect(await readTaskLogon("oldbot")).toEqual({
       mode: "password",
       username: "PC\\old",
     });

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -51,10 +51,43 @@ const NAMES = taskNames(PERSONA);
 class FakeSchtasks implements SchtasksRunner {
   calls: string[][] = [];
   responses: SchtasksResult[] = [];
+  /**
+   * Per-task registered XML — `/Query /XML` answers from this map (missing
+   * entry → exit 1 "cannot find", like a real unregistered task), and
+   * `/Delete` only succeeds for registered tasks. Seed it with
+   * `principalXml(SID)` entries when a test needs tasks to exist.
+   */
+  registry: Record<string, string | undefined> = {};
   async run(args: readonly string[]): Promise<SchtasksResult> {
     this.calls.push([...args]);
-    return this.responses.shift() ?? { exitCode: 0, stdout: "", stderr: "" };
+    if (this.responses.length > 0) return this.responses.shift()!;
+    if (args[0] === "/Query") {
+      const tn = args[args.indexOf("/TN") + 1]!;
+      const xml = this.registry[tn];
+      return xml === undefined
+        ? { exitCode: 1, stdout: "", stderr: "cannot find" }
+        : { exitCode: 0, stdout: xml, stderr: "" };
+    }
+    if (args[0] === "/Delete") {
+      const tn = args[args.indexOf("/TN") + 1]!;
+      if (this.registry[tn] === undefined) {
+        return { exitCode: 1, stdout: "", stderr: "cannot find" };
+      }
+      this.registry[tn] = undefined;
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
   }
+}
+
+/** Minimal task XML carrying a Principal with the given SID — enough for
+ * the ownership check (taskPrincipalUserId) to match on. */
+function principalXml(sid: string): string {
+  return (
+    `<Task xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">` +
+    `<Principals><Principal id="Author"><UserId>${sid}</UserId>` +
+    `<LogonType>InteractiveToken</LogonType></Principal></Principals></Task>`
+  );
 }
 
 class CaptureStream {
@@ -226,6 +259,9 @@ describe("installPhantombotTasks", () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     const st = new FakeSchtasks();
+    // Seed legacy pre-rename tasks owned by this account so the upgrade
+    // cleanup has something to remove.
+    for (const legacy of LEGACY_TASK_NAMES) st.registry[legacy] = principalXml(SID);
     const result = await installPhantombotTasks({
       binPath: BIN,
       persona: PERSONA,
@@ -248,10 +284,15 @@ describe("installPhantombotTasks", () => {
       `/Query /TN ${NAMES.tick} /XML`,
       `/Create /TN ${NAMES.tick} /XML ${join(workdir, "phantombot-task-tick.xml")} /F`,
       // Pre-rename legacy tasks are cleaned up so an upgrade never
-      // double-supervises the daemon.
+      // double-supervises the daemon — each is ownership-checked via its
+      // exported XML before the delete.
+      `/Query /TN ${LEGACY_TASK_NAMES[0]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[0]} /F`,
+      `/Query /TN ${LEGACY_TASK_NAMES[1]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[1]} /F`,
+      `/Query /TN ${LEGACY_TASK_NAMES[2]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[2]} /F`,
+      `/Query /TN ${LEGACY_TASK_NAMES[3]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[3]} /F`,
     ]);
     expect(out.text).toContain("registered");
@@ -377,23 +418,59 @@ describe("installPhantombotTasks", () => {
 });
 
 describe("uninstallPhantombotTasks", () => {
-  test("deletes each task with /F in reverse (companions→main) order", async () => {
+  test("deletes each owned task with /F in reverse (companions→main) order", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     const st = new FakeSchtasks();
-    const result = await uninstallPhantombotTasks({ persona: PERSONA, schtasks: st, out, err });
+    for (const name of [...NAMES.all, ...LEGACY_TASK_NAMES]) {
+      st.registry[name] = principalXml(SID);
+    }
+    const result = await uninstallPhantombotTasks({ persona: PERSONA, sid: SID, schtasks: st, out, err });
     expect(result.removed).toBe(true);
     expect(st.calls.map((c) => c.join(" "))).toEqual([
+      `/Query /TN ${NAMES.tick} /XML`,
       `/Delete /TN ${NAMES.tick} /F`,
+      `/Query /TN ${NAMES.nightly} /XML`,
       `/Delete /TN ${NAMES.nightly} /F`,
+      `/Query /TN ${NAMES.heartbeat} /XML`,
       `/Delete /TN ${NAMES.heartbeat} /F`,
+      `/Query /TN ${NAMES.main} /XML`,
       `/Delete /TN ${NAMES.main} /F`,
+      `/Query /TN ${LEGACY_TASK_NAMES[0]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[0]} /F`,
+      `/Query /TN ${LEGACY_TASK_NAMES[1]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[1]} /F`,
+      `/Query /TN ${LEGACY_TASK_NAMES[2]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[2]} /F`,
+      `/Query /TN ${LEGACY_TASK_NAMES[3]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[3]} /F`,
     ]);
     expect(out.text).toContain("removed scheduled task");
+  });
+
+  test("tasks owned by ANOTHER Windows account are left untouched", async () => {
+    // Task Scheduler folders are machine-global: another local user's
+    // same-named tasks must survive our uninstall.
+    const FOREIGN_SID = "S-1-5-21-9999999999-8888888888-7777777777-1005";
+    const out = new CaptureStream();
+    const st = new FakeSchtasks();
+    for (const name of [...NAMES.all, ...LEGACY_TASK_NAMES]) {
+      st.registry[name] = principalXml(FOREIGN_SID);
+    }
+    const result = await uninstallPhantombotTasks({
+      persona: PERSONA,
+      sid: SID,
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(result.removed).toBe(true);
+    expect(st.calls.filter((c) => c[0] === "/Delete")).toEqual([]);
+    expect(out.text).toContain("owned by another Windows account");
+    // All eight tasks are still registered.
+    for (const name of [...NAMES.all, ...LEGACY_TASK_NAMES]) {
+      expect(st.registry[name]).toBeDefined();
+    }
   });
 
   test("removes the shared launcher script when the tasks are torn down", async () => {
@@ -411,6 +488,7 @@ describe("uninstallPhantombotTasks", () => {
     expect(existsSync(launcherVbsPath())).toBe(true);
     await uninstallPhantombotTasks({
       persona: PERSONA,
+      sid: SID,
       schtasks: new FakeSchtasks(),
       out: new CaptureStream(),
       err: new CaptureStream(),
@@ -418,19 +496,15 @@ describe("uninstallPhantombotTasks", () => {
     expect(existsSync(launcherVbsPath())).toBe(false);
   });
 
-  test("a missing task (non-zero delete) is logged, not fatal", async () => {
+  test("missing tasks are skipped quietly — no deletes, not fatal", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
-    const st = new FakeSchtasks();
-    st.responses = [
-      { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
-      { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
-      { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
-      { exitCode: 1, stdout: "", stderr: "cannot find the file specified" },
-    ];
-    const result = await uninstallPhantombotTasks({ persona: PERSONA, schtasks: st, out, err });
+    const st = new FakeSchtasks(); // empty registry: nothing registered
+    const result = await uninstallPhantombotTasks({ persona: PERSONA, sid: SID, schtasks: st, out, err });
     expect(result.removed).toBe(true);
-    expect(out.text).toContain("returned 1 (continuing)");
+    expect(st.calls.filter((c) => c[0] === "/Delete")).toEqual([]);
+    expect(st.calls.filter((c) => c[0] === "/Query").length).toBe(8);
+    expect(out.text).not.toContain("removed scheduled task");
   });
 });
 
@@ -959,14 +1033,14 @@ describe("password logon mode (run when logged off)", () => {
     }
     // The marker remembers the mode + account for the heal path, but the
     // password stays with Task Scheduler — never on our disk.
-    expect(await readTaskLogon()).toEqual({
+    expect(await readTaskLogon(PERSONA)).toEqual({
       mode: "password",
       username: ACCOUNT,
     });
   });
 
   test("heal patches a drifted password-mode task's action in place (no credential needed)", async () => {
-    await writeTaskLogon({ mode: "password", username: ACCOUNT });
+    await writeTaskLogon(PERSONA, { mode: "password", username: ACCOUNT });
     const OLD_BIN = "C:\\old\\phantombot.exe";
     const registered: Record<string, string | undefined> = {
       [NAMES.main]: generatePhantombotTaskXml(SID, OLD_BIN, PERSONA, {
@@ -1020,7 +1094,7 @@ describe("password logon mode (run when logged off)", () => {
   });
 
   test("heal cannot recreate a MISSING password-mode task — it says to re-install", async () => {
-    await writeTaskLogon({ mode: "password", username: ACCOUNT });
+    await writeTaskLogon(PERSONA, { mode: "password", username: ACCOUNT });
     const st: SchtasksRunner = {
       async run(): Promise<SchtasksResult> {
         return { exitCode: 1, stdout: "", stderr: "cannot find" };
@@ -1045,6 +1119,7 @@ describe("password logon mode (run when logged off)", () => {
 
   test("legacy (pre persona-rename) tasks are removed on install", async () => {
     const st = new FakeSchtasks();
+    for (const legacy of LEGACY_TASK_NAMES) st.registry[legacy] = principalXml(SID);
     await installPhantombotTasks({
       binPath: BIN,
       persona: PERSONA,
@@ -1060,5 +1135,74 @@ describe("password logon mode (run when logged off)", () => {
     for (const legacy of LEGACY_TASK_NAMES) {
       expect(deletes).toContain(legacy);
     }
+  });
+
+  test("legacy tasks owned by ANOTHER Windows account are kept on install", async () => {
+    const FOREIGN_SID = "S-1-5-21-9999999999-8888888888-7777777777-1005";
+    const out = new CaptureStream();
+    const st = new FakeSchtasks();
+    for (const legacy of LEGACY_TASK_NAMES) st.registry[legacy] = principalXml(FOREIGN_SID);
+    await installPhantombotTasks({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+    });
+    expect(st.calls.filter((c) => c[0] === "/Delete")).toEqual([]);
+    for (const legacy of LEGACY_TASK_NAMES) {
+      expect(st.registry[legacy]).toBeDefined();
+      expect(out.text).toContain(`left ${legacy} untouched`);
+    }
+  });
+});
+
+describe("per-persona logon marker", () => {
+  test("two personas on one Windows account keep independent modes", async () => {
+    await writeTaskLogon("alpha", { mode: "password", username: "PC\\alpha" });
+    await writeTaskLogon("beta", { mode: "interactive" });
+    // Persona B's install must not overwrite persona A's persisted mode —
+    // A's heartbeat heals from its own marker.
+    expect(await readTaskLogon("alpha")).toEqual({
+      mode: "password",
+      username: "PC\\alpha",
+    });
+    expect(await readTaskLogon("beta")).toEqual({ mode: "interactive" });
+    expect(await readTaskLogon("gamma")).toEqual({ mode: "interactive" });
+  });
+
+  test("falls back to the pre-scoping shared marker, and a write migrates it", async () => {
+    const { writeFileSync, existsSync } = await import("node:fs");
+    const legacy = join(workdir, "phantombot", "windows-logon.json");
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(workdir, "phantombot"), { recursive: true });
+    writeFileSync(legacy, JSON.stringify({ mode: "password", username: "PC\\old" }));
+    // A persona installed before the scoping still heals in password mode.
+    expect(await readTaskLogon("newbot")).toEqual({
+      mode: "password",
+      username: "PC\\old",
+    });
+    // The next install writes the scoped marker and removes the shared one.
+    await writeTaskLogon("newbot", { mode: "password", username: "PC\\old" });
+    expect(existsSync(legacy)).toBe(false);
+    expect(await readTaskLogon("newbot")).toEqual({
+      mode: "password",
+      username: "PC\\old",
+    });
+  });
+
+  test("a persona-scoped interactive marker beats a legacy password marker", async () => {
+    const { writeFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(join(workdir, "phantombot"), { recursive: true });
+    await writeTaskLogon("newbot", { mode: "interactive" });
+    // A stale shared marker left behind by an older build must NOT override
+    // this persona's scoped choice.
+    writeFileSync(
+      join(workdir, "phantombot", "windows-logon.json"),
+      JSON.stringify({ mode: "password", username: "PC\\old" }),
+    );
+    expect(await readTaskLogon("newbot")).toEqual({ mode: "interactive" });
   });
 });


### PR DESCRIPTION
## What

`phantombot install` on Windows now asks: **"Run phantombot when you are logged off?"** (default: **no**). Answering yes prompts for the Windows password and registers the four tasks with `LogonType Password` + a `BootTrigger`, so the daemon starts at boot with **no interactive session** — the headless-VM / Windows-update-reboot scenario that left Megan dark for 36h (see #308/#309 context).

Tasks are renamed to `phantombot-<persona>` (plus `heartbeat-<persona>` etc.) so multi-persona boxes stay identifiable in taskschd.msc.

## How

- **Persisted choice**: `windows-logon.json` (mode + username, never the password) so the heartbeat self-heal regenerates matching XML instead of silently downgrading a password-mode install to interactive.
- **Password-mode heal**: drift is repaired by patching the task's action arguments in place via `Set-ScheduledTask` — `schtasks /Create` on a Password task would demand the credential interactively. A *missing* password-mode task fails the heal with a clear "re-run install" message.
- **Scheduler-owned launches in password mode**: `start`/`restart` and the deferred self-update relaunch watcher use `schtasks /Run`, so the daemon runs in session 0 owned by the scheduler and is never reaped when the launching SSH/console session ends (the ad-hoc-Start-Process death from the Megan incident).
- **Scripted mode**: `--run-logged-off` / `--interactive` / `--windows-password` (or `PHANTOMBOT_WINDOWS_PASSWORD`) skip the prompts; non-TTY installs keep the safe interactive default.
- **Legacy migration**: install/heal/uninstall delete the pre-rename `\Phantombot\phantombot`-style names so an upgrade never double-supervises.

## Validation (on the Megan VM, kw-windows-11)

| Test | Result |
|---|---|
| `install --run-logged-off` | 4 persona tasks, `LogonType Password`, `BootTrigger` on main |
| Legacy tasks | removed (`heartbeat`, `nightly`, `tick`) |
| `start` from SSH, then disconnect | daemon survives, **session 0**, scheduler-owned |
| `restart` | new daemon PID via scheduler, session 0 |
| **Full reboot, nobody logs on** | **daemon up 14s after boot** |

## Tests

77 pass across `cli-install` + `lib-taskScheduler` suites (XML shape, /RU+/RP registration, marker persistence, in-place patch heal, missing-task failure, legacy cleanup, prompt flow incl. cancel, scripted mode). Full repo suite: 2336 pass; the 2 PiHarness failures reproduce on `main` (env-dependent, unrelated).

Refs #308 #309