### PR TITLE
fix(onboarding): merge-write wizard API key into Pi's auth.json (#312)

### DIFF
--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -43,6 +43,7 @@ import {
   type RoutingChoices,
 } from "../lib/piRouting.ts";
 import { updateEnvFile } from "../lib/envFile.ts";
+import { writePiApiKey } from "../lib/piAuthStore.ts";
 import { userEnvPath } from "./env.ts";
 import { saveHarnessBins } from "../state.ts";
 
@@ -344,9 +345,11 @@ async function installPi(
  *        · "Configure models" ⇒ continue to 3.
  *   3. Pick the provider (from Pi's full static catalogue, NOT just what's
  *      already keyed), collect that provider's API key (stored in ~/.env as
- *      PHANTOMBOT_PI_API_KEY, threaded per-turn onto `--api-key`; NOT written
- *      into Pi's own store), refresh the model catalogue with it, then run the
- *      routing wizard for primary / image / coding (no "use defaults?" detour).
+ *      PHANTOMBOT_PI_API_KEY, threaded per-turn onto `--api-key`; AND
+ *      merge-written into Pi's own auth.json so `pi --list-models` sees it —
+ *      the env-injected refresh alone proved unreliable off-Linux, #312),
+ *      refresh the model catalogue with it, then run the routing wizard for
+ *      primary / image / coding (no "use defaults?" detour).
  *
  * `availability` is mutated in place when an install succeeds. Returns `true`
  * only when the operator cancelled outright (Esc), so the caller can abort.
@@ -455,18 +458,52 @@ async function configurePi(
     // Refresh the catalog with the key we just took. On a fresh install the
     // first listing was EMPTY (Pi had no key, so `--list-models` printed "No
     // models available"), which is what forced the model pickers into free-text.
-    // Now that we hold a key we can populate them — but only by injecting the
-    // provider's NATIVE env var: `--list-models` ignores `--api-key` and reads
-    // auth from its own store / native vars only (see PiProvider.envVar). No
-    // known var (or still empty ⇒ bad key, provider outage) leaves `models` as
-    // it was, and the pickers degrade to free-text rather than dead-ending.
-    const envVar = provider ? providerEnvVar(provider) : undefined;
-    if (availability.pi && envVar) {
-      const refreshed = await listPiModels(availability.pi, undefined, {
-        [envVar]: keyWrite.value,
-      });
-      if (refreshed.length > 0) models = refreshed;
+    //
+    // PRIMARY path (#312): merge-write the key into Pi's OWN auth store
+    // (~/.pi/agent/auth.json). `--list-models` reads auth from that file and
+    // the native env vars only — once the key is in the store a plain listing
+    // is populated, no env tricks needed. This is what keying Pi interactively
+    // does, and it fixed the macOS fresh-onboarding repro where the
+    // env-injected child never saw the var.
+    //
+    // FALLBACK: if the write is skipped (an oauth login already keys this
+    // provider — the listing is populated anyway) or fails (unparseable
+    // user-owned file we refuse to clobber), keep the pre-#312 behavior:
+    // inject the provider's NATIVE env var into the `--list-models` child (see
+    // PiProvider.envVar). No known var (or still empty ⇒ bad key, provider
+    // outage) leaves `models` as it was, and the pickers degrade to free-text
+    // rather than dead-ending.
+    let refreshed: PiModel[] = [];
+    if (provider) {
+      const authWrite = await writePiApiKey(provider, keyWrite.value);
+      if (authWrite.ok && !authWrite.skipped) {
+        p.note(
+          `also keyed Pi's own store (${authWrite.path}) so \`pi --list-models\` works`,
+          "Pi API key",
+        );
+      } else if (!authWrite.ok) {
+        p.note(
+          `couldn't write Pi's auth store: ${authWrite.reason}\n` +
+            `falling back to an env-injected model refresh`,
+          "Pi API key",
+        );
+      }
+      // Plain listing first whenever the store keys this provider — either we
+      // just wrote the key, or an oauth login already did (skipped ⇒ the
+      // provider is keyed, so a plain listing is populated).
+      if (authWrite.ok && availability.pi) {
+        refreshed = await listPiModels(availability.pi);
+      }
     }
+    if (refreshed.length === 0) {
+      const envVar = provider ? providerEnvVar(provider) : undefined;
+      if (availability.pi && envVar) {
+        refreshed = await listPiModels(availability.pi, undefined, {
+          [envVar]: keyWrite.value,
+        });
+      }
+    }
+    if (refreshed.length > 0) models = refreshed;
   } else if (keyWrite.action === "clear") {
     await updateEnvFile(userEnvPath(), { [ENV_PI_API_KEY]: "" });
     p.note(

--- a/src/lib/piAuthStore.ts
+++ b/src/lib/piAuthStore.ts
@@ -1,0 +1,141 @@
+/**
+ * Writer for Pi's own auth store: ~/.pi/agent/auth.json.
+ *
+ * WHY THIS EXISTS (issue #312): `pi --list-models` reads auth ONLY from this
+ * file and the providers' native env vars — it ignores `--api-key`. The
+ * onboarding wizard collects the provider key into phantombot's own env store
+ * (PHANTOMBOT_PI_API_KEY, threaded per-turn) and used to refresh the model
+ * catalog by injecting the native env var into the `--list-models` child.
+ * That works on Linux but proved unreliable elsewhere (macOS repro in #312),
+ * leaving fresh installs with an empty catalog and free-text model entry.
+ * Keying Pi directly fixes it because the first catalog fetch then succeeds —
+ * so the wizard now merge-writes the key into Pi's store too.
+ *
+ * SCOPE: this module is WRITE-ONLY. Phantombot never deletes from Pi's store:
+ * the "Use Pi's own config" path (clearPiRouting) delegates to the very login
+ * this file holds, so erasing it would break the mode it enables. Pi's store
+ * is shared user state (interactive `pi` logins included) — we add/replace an
+ * api_key entry for the provider the operator just keyed, and nothing else.
+ *
+ * GUARDS (Pi's auth.json is user-owned, so we are conservative):
+ *   - existing oauth entry for the same provider → left untouched (an
+ *     interactive `/login` beats a wizard key; the provider is already keyed)
+ *   - existing file is unparseable or not a JSON object → REFUSE to write
+ *     rather than clobber unknown state
+ *   - all other providers' entries are preserved verbatim
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export function piAuthJsonPath(home: string = homedir()): string {
+  return join(home, ".pi", "agent", "auth.json");
+}
+
+/** One entry in Pi's auth.json. OAuth entries carry more fields; we only read `type`. */
+interface PiAuthEntry {
+  type?: string;
+  key?: string;
+  [k: string]: unknown;
+}
+
+export type PiAuthMerge =
+  | { action: "write"; store: Record<string, PiAuthEntry> }
+  | { action: "skip-oauth" }
+  | { action: "refuse"; reason: string };
+
+/**
+ * Pure merge decision: given the raw existing file content (`undefined` when
+ * the file does not exist yet — fresh install ⇒ start from an empty object),
+ * decide what writing `provider`'s api_key should do. Exported for tests.
+ */
+export function mergePiApiKey(
+  existingText: string | undefined,
+  provider: string,
+  apiKey: string,
+): PiAuthMerge {
+  let store: Record<string, PiAuthEntry> = {};
+  if (existingText !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(existingText);
+    } catch {
+      return {
+        action: "refuse",
+        reason: "existing auth.json is not valid JSON — refusing to clobber it",
+      };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {
+        action: "refuse",
+        reason: "existing auth.json is not a JSON object — refusing to clobber it",
+      };
+    }
+    store = parsed as Record<string, PiAuthEntry>;
+    const current = store[provider];
+    if (current && typeof current === "object" && current.type === "oauth") {
+      return { action: "skip-oauth" };
+    }
+  }
+  store[provider] = { type: "api_key", key: apiKey };
+  return { action: "write", store };
+}
+
+export type PiAuthWriteResult =
+  | { ok: true; path: string; skipped?: "oauth-present" }
+  | { ok: false; path: string; reason: string };
+
+/**
+ * Merge-write an api_key for `provider` into Pi's auth.json, preserving every
+ * other entry. Atomic (tmp + rename), mode 0o600 — same discipline as
+ * envFile.ts. Never throws: failures are reported in the result so the wizard
+ * can fall back to the env-injected catalog refresh.
+ *
+ * `home` is injectable for tests.
+ */
+export async function writePiApiKey(
+  provider: string,
+  apiKey: string,
+  home?: string,
+): Promise<PiAuthWriteResult> {
+  const path = piAuthJsonPath(home);
+  try {
+    const existing = existsSync(path)
+      ? await readFile(path, "utf8")
+      : undefined;
+    const merge = mergePiApiKey(existing, provider, apiKey);
+    if (merge.action === "refuse") {
+      return { ok: false, path, reason: merge.reason };
+    }
+    if (merge.action === "skip-oauth") {
+      return { ok: true, path, skipped: "oauth-present" };
+    }
+    await mkdir(dirname(path), { recursive: true });
+    // Write to a tempfile at mode 0o600 then atomically rename over the target,
+    // so a fresh file is never briefly world-readable (mirrors saveEnvFile).
+    const tmp = `${path}.tmp`;
+    try {
+      await writeFile(tmp, JSON.stringify(merge.store, null, 2) + "\n", {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await rename(tmp, path);
+    } catch (e) {
+      try {
+        await unlink(tmp);
+      } catch {
+        /* best-effort cleanup */
+      }
+      throw e;
+    }
+    return { ok: true, path };
+  } catch (e) {
+    return {
+      ok: false,
+      path,
+      reason: e instanceof Error ? e.message : String(e),
+    };
+  }
+}

--- a/src/lib/piAuthStore.ts
+++ b/src/lib/piAuthStore.ts
@@ -26,9 +26,36 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+
+/**
+ * In-process serialization of writers, keyed by target path. Pi's auth.json
+ * is updated read→merge→rename, which is only safe if no two writers overlap:
+ * without this, two concurrent calls can both read the same old store and the
+ * later rename silently drops the other's provider entry. The chain makes
+ * each call's read+merge+rename atomic relative to other phantombot writers
+ * in this process. (Cross-process overlap — e.g. an interactive `pi /login`
+ * racing the wizard — is out of scope for a lock-free file; the oauth guard
+ * and refuse-to-clobber rules keep that case safe-by-refusal.)
+ */
+const writeChains = new Map<string, Promise<void>>();
+
+async function serialized<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const prev = writeChains.get(path) ?? Promise.resolve();
+  let result!: T;
+  const next = prev.then(async () => {
+    result = await fn();
+  });
+  writeChains.set(path, next);
+  try {
+    await next;
+  } finally {
+    if (writeChains.get(path) === next) writeChains.delete(path);
+  }
+  return result;
+}
 
 export function piAuthJsonPath(home: string = homedir()): string {
   return join(home, ".pi", "agent", "auth.json");
@@ -101,6 +128,14 @@ export async function writePiApiKey(
   home?: string,
 ): Promise<PiAuthWriteResult> {
   const path = piAuthJsonPath(home);
+  return serialized(path, () => writePiApiKeyInner(provider, apiKey, path));
+}
+
+async function writePiApiKeyInner(
+  provider: string,
+  apiKey: string,
+  path: string,
+): Promise<PiAuthWriteResult> {
   try {
     const existing = existsSync(path)
       ? await readFile(path, "utf8")
@@ -113,14 +148,20 @@ export async function writePiApiKey(
       return { ok: true, path, skipped: "oauth-present" };
     }
     await mkdir(dirname(path), { recursive: true });
-    // Write to a tempfile at mode 0o600 then atomically rename over the target,
-    // so a fresh file is never briefly world-readable (mirrors saveEnvFile).
-    const tmp = `${path}.tmp`;
+    // Write to a unique, exclusively-created tempfile at mode 0o600 then
+    // atomically rename over the target, so a fresh file is never briefly
+    // world-readable (mirrors saveEnvFile). The tempfile is unique per call
+    // and opened O_EXCL: a fixed `auth.json.tmp` would let overlapping
+    // writers clobber each other's tempfile (and one writer's cleanup unlink
+    // the other's pending rename) — see PR #314 review.
+    const tmp = `${path}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
     try {
-      await writeFile(tmp, JSON.stringify(merge.store, null, 2) + "\n", {
-        encoding: "utf8",
-        mode: 0o600,
-      });
+      const fh = await open(tmp, "wx", 0o600);
+      try {
+        await fh.writeFile(JSON.stringify(merge.store, null, 2) + "\n", "utf8");
+      } finally {
+        await fh.close();
+      }
       await rename(tmp, path);
     } catch (e) {
       try {

--- a/tests/lib-piAuthStore.test.ts
+++ b/tests/lib-piAuthStore.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  mergePiApiKey,
+  piAuthJsonPath,
+  writePiApiKey,
+} from "../src/lib/piAuthStore.ts";
+
+let home: string;
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "phantombot-piauth-"));
+});
+
+afterEach(async () => {
+  await rm(home, { recursive: true, force: true });
+});
+
+describe("piAuthJsonPath", () => {
+  test("points at ~/.pi/agent/auth.json under the given home", () => {
+    expect(piAuthJsonPath("/h")).toBe(join("/h", ".pi", "agent", "auth.json"));
+  });
+});
+
+describe("mergePiApiKey", () => {
+  test("fresh install (no file) starts from an empty store", () => {
+    const r = mergePiApiKey(undefined, "openrouter", "sk-or-1");
+    expect(r.action).toBe("write");
+    if (r.action === "write") {
+      expect(r.store).toEqual({
+        openrouter: { type: "api_key", key: "sk-or-1" },
+      });
+    }
+  });
+
+  test("preserves other providers' entries verbatim", () => {
+    const existing = JSON.stringify({
+      google: { type: "api_key", key: "gk" },
+      "google-gemini-cli": {
+        type: "oauth",
+        access: "a",
+        refresh: "r",
+        expires: 123,
+      },
+    });
+    const r = mergePiApiKey(existing, "openrouter", "sk-or-1");
+    expect(r.action).toBe("write");
+    if (r.action === "write") {
+      expect(r.store.google).toEqual({ type: "api_key", key: "gk" });
+      expect(r.store["google-gemini-cli"]).toEqual({
+        type: "oauth",
+        access: "a",
+        refresh: "r",
+        expires: 123,
+      });
+      expect(r.store.openrouter).toEqual({ type: "api_key", key: "sk-or-1" });
+    }
+  });
+
+  test("replaces an existing api_key entry for the same provider", () => {
+    const existing = JSON.stringify({
+      openrouter: { type: "api_key", key: "old" },
+    });
+    const r = mergePiApiKey(existing, "openrouter", "new");
+    expect(r.action).toBe("write");
+    if (r.action === "write") {
+      expect(r.store.openrouter).toEqual({ type: "api_key", key: "new" });
+    }
+  });
+
+  test("skips when the provider already has an oauth entry", () => {
+    const existing = JSON.stringify({
+      "google-gemini-cli": { type: "oauth", access: "a", refresh: "r" },
+    });
+    const r = mergePiApiKey(existing, "google-gemini-cli", "gk");
+    expect(r.action).toBe("skip-oauth");
+  });
+
+  test("refuses to clobber unparseable JSON", () => {
+    const r = mergePiApiKey("{not json", "openrouter", "sk-or-1");
+    expect(r.action).toBe("refuse");
+  });
+
+  test("refuses when the top level is not an object", () => {
+    for (const text of ['"str"', "[1,2]", "42", "null"]) {
+      expect(mergePiApiKey(text, "openrouter", "k").action).toBe("refuse");
+    }
+  });
+});
+
+describe("writePiApiKey", () => {
+  test("creates ~/.pi/agent/auth.json (and parents) at mode 600", async () => {
+    const r = await writePiApiKey("openrouter", "sk-or-1", home);
+    expect(r.ok).toBe(true);
+    const path = piAuthJsonPath(home);
+    expect(existsSync(path)).toBe(true);
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+      openrouter: { type: "api_key", key: "sk-or-1" },
+    });
+    expect(((await stat(path)).mode & 0o777).toString(8)).toBe("600");
+  });
+
+  test("merges into an existing store without touching other entries", async () => {
+    const path = piAuthJsonPath(home);
+    await writePiApiKey("google", "gk", home);
+    await writePiApiKey("openrouter", "sk-or-1", home);
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+      google: { type: "api_key", key: "gk" },
+      openrouter: { type: "api_key", key: "sk-or-1" },
+    });
+  });
+
+  test("oauth entry for the same provider is left untouched", async () => {
+    const path = piAuthJsonPath(home);
+    await mkdir(join(home, ".pi", "agent"), { recursive: true });
+    const oauth = {
+      "google-gemini-cli": { type: "oauth", access: "a", refresh: "r" },
+    };
+    await writeFile(path, JSON.stringify(oauth), { mode: 0o600 });
+    const before = await readFile(path, "utf8");
+    const r = await writePiApiKey("google-gemini-cli", "gk", home);
+    expect(r).toMatchObject({ ok: true, skipped: "oauth-present" });
+    expect(await readFile(path, "utf8")).toBe(before);
+  });
+
+  test("unparseable existing file: reports failure and does not clobber", async () => {
+    const path = piAuthJsonPath(home);
+    await mkdir(join(home, ".pi", "agent"), { recursive: true });
+    await writeFile(path, "{not json", { mode: 0o600 });
+    const r = await writePiApiKey("openrouter", "sk-or-1", home);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("refusing to clobber");
+    expect(await readFile(path, "utf8")).toBe("{not json");
+  });
+});

--- a/tests/lib-piAuthStore.test.ts
+++ b/tests/lib-piAuthStore.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -124,6 +124,31 @@ describe("writePiApiKey", () => {
     const r = await writePiApiKey("google-gemini-cli", "gk", home);
     expect(r).toMatchObject({ ok: true, skipped: "oauth-present" });
     expect(await readFile(path, "utf8")).toBe(before);
+  });
+
+  test("concurrent writers for different providers both land (no lost update)", async () => {
+    // Regression for PR #314 review: a shared fixed tempfile plus unserialized
+    // read→merge→rename let overlapping writers drop each other's entry.
+    const providers = Array.from({ length: 8 }, (_, i) => `provider-${i}`);
+    const results = await Promise.all(
+      providers.map((p) => writePiApiKey(p, `key-${p}`, home)),
+    );
+    for (const r of results) expect(r.ok).toBe(true);
+    const path = piAuthJsonPath(home);
+    const store = JSON.parse(await readFile(path, "utf8"));
+    for (const p of providers) {
+      expect(store[p]).toEqual({ type: "api_key", key: `key-${p}` });
+    }
+  });
+
+  test("concurrent writers leave no stray tempfiles behind", async () => {
+    await Promise.all([
+      writePiApiKey("a", "ka", home),
+      writePiApiKey("b", "kb", home),
+    ]);
+    const dir = join(home, ".pi", "agent");
+    const leftovers = (await readdir(dir)).filter((f) => f.includes(".tmp"));
+    expect(leftovers).toEqual([]);
   });
 
   test("unparseable existing file: reports failure and does not clobber", async () => {


### PR DESCRIPTION
## Problem

Fresh onboarding on macOS (post-v1.1.214): pick OpenRouter in the wizard, enter the API key, model pickers still fall back to free-text because the catalog refresh comes back empty. Keying Pi directly and re-running `phantombot harness` works — because `pi --list-models` reads auth **only** from `~/.pi/agent/auth.json` and the providers' native env vars; it ignores `--api-key`. The wizard's env-injected child refresh (#299) works on Linux (verified) but not reliably elsewhere.

## Fix

When the wizard takes a key (`keyWrite.action === "set"`, provider known), it now **merge-writes the key into Pi's own auth store** — exactly what an interactive `pi` login does — then refreshes the catalog with a plain `--list-models`. The env-injected refresh remains as the fallback when the write is refused.

Deliberate scoping decisions (please challenge in review):

- **Write-only.** `clearPiRouting` does NOT delete from `auth.json`: the "Use Pi's own config" mode delegates to exactly this store, so erasing it would break the mode it enables. Pi's store is shared user state; phantombot adds/replaces one api_key entry and nothing else.
- **oauth guard.** An existing oauth entry for the same provider is left untouched — an interactive `/login` beats a wizard key, and the provider is already keyed so the listing populates anyway.
- **Refuse to clobber.** Unparseable or non-object `auth.json` → report the failure, fall back to env-injection, never destroy unknown user state.
- **No `settings.json` default-model write.** Phantombot passes `--model` per turn and owns routing in `config.toml`; duplicating a default into Pi's settings adds coupling for zero behavioral gain.

## Implementation

- New `src/lib/piAuthStore.ts`: pure `mergePiApiKey` decision (write / skip-oauth / refuse) + `writePiApiKey` (atomic tmp+rename, mode 0600, mkdir -p — same discipline as `envFile.ts`).
- `configurePi` (shared by `init` and `harness`) wires it into the key-set branch with user-facing notes on write/fallback.

## Tests

- `tests/lib-piAuthStore.test.ts`: 11 tests — merge semantics (fresh, replace, preserve-others, oauth-skip, refuse-corrupt/non-object), file creation at mode 600, merge round-trip, no-clobber guarantees. All green; typecheck clean.
- Full suite: 2362 pass / 2 fail — the 2 failures (`harnesses-pi.test.ts` subprocess env tests) reproduce identically on `origin/main`, pre-existing and unrelated.

Closes #312