### PR TITLE
feat(commands): /model slash command + /status harness/model surface (#313)

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -620,7 +620,13 @@ async function handleStatus(
 ): Promise<SlashCommandResult> {
   const uptimeS = Math.floor((Date.now() - ctx.startedAt) / 1000);
   const primary = ctx.harnesses[0]?.id ?? "(none)";
-  const chain = ctx.harnesses.map((h) => h.id).join(" → ") || "(none)";
+  const chainParts = await Promise.all(
+    ctx.harnesses.map(async (h) => {
+      const ok = await h.available();
+      return ok ? h.id : `${h.id} (unavailable)`;
+    }),
+  );
+  const chain = chainParts.join(" → ") || "(none)";
 
   // Rough context estimate: total chars across the rolling history turns, divided
   // by 4 (the standard chars-per-token heuristic). Doesn't include the

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -615,18 +615,27 @@ async function handleReset(
   };
 }
 
+/** Format the harness chain with availability annotations.
+ * Shared by /status and /harness so the output stays consistent. */
+async function formatHarnessChain(harnesses: Harness[]): Promise<string> {
+  if (harnesses.length === 0) return "(none)";
+  const parts = await Promise.all(
+    harnesses.map(async (h, i) => {
+      const ok = await h.available();
+      const marker = i === 0 ? "→" : " ";
+      const suffix = ok ? "" : " (unavailable)";
+      return `${marker} ${h.id}${suffix}`;
+    }),
+  );
+  return parts.join("\n");
+}
+
 async function handleStatus(
   ctx: SlashCommandContext,
 ): Promise<SlashCommandResult> {
   const uptimeS = Math.floor((Date.now() - ctx.startedAt) / 1000);
   const primary = ctx.harnesses[0]?.id ?? "(none)";
-  const chainParts = await Promise.all(
-    ctx.harnesses.map(async (h) => {
-      const ok = await h.available();
-      return ok ? h.id : `${h.id} (unavailable)`;
-    }),
-  );
-  const chain = chainParts.join(" → ") || "(none)";
+  const chain = await formatHarnessChain(ctx.harnesses);
 
   // Rough context estimate: total chars across the rolling history turns, divided
   // by 4 (the standard chars-per-token heuristic). Doesn't include the
@@ -694,17 +703,10 @@ async function handleHarness(
 
   if (!arg) {
     // No arg → list current chain with availability.
-    const lines: string[] = [];
-    for (let i = 0; i < ctx.harnesses.length; i++) {
-      const h = ctx.harnesses[i]!;
-      const ok = await h.available();
-      const marker = i === 0 ? "→" : " ";
-      const suffix = ok ? "" : " (unavailable)";
-      lines.push(`${marker} ${h.id}${suffix}`);
-    }
+    const chainLines = await formatHarnessChain(ctx.harnesses);
     return {
       reply:
-        `current chain (→ = primary):\n${lines.join("\n")}\n\n` +
+        `current chain (→ = primary):\n${chainLines}\n\n` +
         `use /harness <id> to switch primary`,
     };
   }

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -38,6 +38,12 @@ import {
   normalizeChattinessRequest,
 } from "../lib/chattiness.ts";
 import { setIn, updateConfigToml } from "../lib/configWriter.ts";
+import {
+  applyModelRequest,
+  formatModelShow,
+  parseModelRequest,
+} from "../lib/modelCommand.ts";
+import { listPiModels } from "../lib/piModels.ts";
 import type { MemoryStore } from "../memory/store.ts";
 import { DEFAULT_HISTORY_LIMIT } from "../orchestrator/turn.ts";
 import { VERSION } from "../version.ts";
@@ -161,6 +167,10 @@ export const TELEGRAM_BOT_COMMANDS: Array<{
     command: "chattiness",
     description: "Show/hide progress bubbles here (on | off | <on|off> default)",
   },
+  {
+    command: "model",
+    description: "Show or switch the active harness model (list | <slug> | coding|image <slug> | clear)",
+  },
   { command: "help", description: "Show this command list" },
 ];
 
@@ -246,6 +256,8 @@ export async function handleSlashCommand(
       return await handleCoderSwap(arg || "on", ctx);
     case "/chattiness":
       return await handleChattiness(arg, ctx);
+    case "/model":
+      return await handleModel(arg, ctx);
     case "/start":
     case "/help":
       return { reply: HELP };
@@ -631,6 +643,19 @@ async function handleStatus(
     ? `yes (${((Date.now() - ctx.activeTurn.startTime) / 1000).toFixed(1)}s)`
     : "no";
 
+  // Per-harness configured model(s) (issue #313) — the operator's "what
+  // brain am I actually running?" answer. Harnesses without modelInfo
+  // (test stubs, third-party) are simply omitted from the line.
+  const modelParts = ctx.harnesses
+    .map((h) => {
+      const mi = h.modelInfo?.();
+      if (!mi) return undefined;
+      return `${h.id}: ${mi.model}${mi.provider ? ` (${mi.provider})` : ""}`;
+    })
+    .filter((p): p is string => p !== undefined);
+  const modelsLine =
+    modelParts.length > 0 ? `models:  ${modelParts.join(" | ")}\n` : "";
+
   // If a turn is in flight AND we've captured a progress note, append a
   // "running:" line so the user can see what the harness is currently
   // doing — important for the "is it stuck or just busy?" question that
@@ -642,8 +667,10 @@ async function handleStatus(
 
   return {
     reply:
+      `phantom: ${ctx.persona} (pid ${process.pid}, v${VERSION})\n` +
       `harness: ${primary}\n` +
       `chain:   ${chain}\n` +
+      modelsLine +
       `uptime:  ${formatElapsedSeconds(uptimeS)}\n` +
       `context: ~${pct}% (≈${approxTokens.toLocaleString()} / ${windowTokens.toLocaleString()} tokens, last ${DEFAULT_HISTORY_LIMIT} turns)\n` +
       `active:  ${active}` +
@@ -700,6 +727,140 @@ async function handleHarness(
     primary: wanted,
   });
   return { reply: `switched to ${wanted}` };
+}
+
+/**
+ * /model — view, list, and flip the primary harness's model (issue #313).
+ *
+ * Every write persists to BOTH config.toml and ~/.env (env wins at startup,
+ * so a TOML-only write would be silently ignored on wizard-configured
+ * installs), syncs the in-memory Config, then restarts — all four harnesses
+ * bake their model config at construction, so nothing short of a bounce
+ * activates the new model. Same afterSend dance as /restart: the user reads
+ * the confirmation first, THEN we go down.
+ */
+const MODEL_USAGE =
+  "usage: /model [list [filter] | <slug> | primary <slug> | coding <slug> | image <slug> | clear]\n" +
+  "  /model            — show the primary harness's current model\n" +
+  "  /model list       — list models the primary harness can run (pi only)\n" +
+  "  /model <slug>     — switch the primary model (restarts phantombot)\n" +
+  "  /model coding <slug> / image <slug> — pi capability-routing delegates\n" +
+  "  /model clear      — revert gemini/codex to their CLI default";
+
+async function handleModel(
+  arg: string,
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  const req = parseModelRequest(arg);
+  if (req.kind === "usage") return { reply: MODEL_USAGE };
+
+  const primary = ctx.harnesses[0];
+  if (!primary) return { reply: "no harnesses configured" };
+
+  if (req.kind === "show") {
+    return { reply: formatModelShow(primary.id, primary.modelInfo?.()) };
+  }
+  if (req.kind === "list") {
+    return await handleModelList(req.filter, primary, ctx);
+  }
+
+  // set / clear — needs config for the two-store write.
+  if (!ctx.config) {
+    return {
+      reply: "can't change models: channel didn't pass config to the dispatcher",
+    };
+  }
+  const result = await applyModelRequest(req, primary.id, ctx.config);
+  if (!result.ok) return { reply: result.error };
+
+  log.info("commands: /model applied", {
+    chatId: ctx.chatId,
+    persona: ctx.persona,
+    harness: primary.id,
+    request: req,
+  });
+
+  const svc = ctx.serviceControl ?? defaultServiceControl();
+  const afterSend = async (): Promise<void> => {
+    const r = await selfRestart({ serviceControl: svc });
+    if (!r.ok) {
+      log.error("commands: /model restart failed", {
+        chatId: ctx.chatId,
+        stderr: r.stderr,
+      });
+    }
+  };
+  return { reply: `${result.summary} — restarting…`, afterSend };
+}
+
+/**
+ * `/model list` — pi is the only harness with a programmatic model catalog
+ * (`pi --list-models`, reused from lib/piModels.ts). The others get guidance
+ * text: claude is alias-based, gemini/codex pin-or-default.
+ */
+async function handleModelList(
+  filter: string | undefined,
+  primary: Harness,
+  ctx: SlashCommandContext,
+): Promise<SlashCommandResult> {
+  switch (primary.id) {
+    case "pi": {
+      const bin = ctx.config?.harnesses.pi.bin ?? "pi";
+      const provider = primary.modelInfo?.().provider;
+      let models = await listPiModels(bin);
+      if (provider) models = models.filter((m) => m.provider === provider);
+      if (filter) {
+        const needle = filter.toLowerCase();
+        models = models.filter((m) =>
+          `${m.provider}/${m.model}`.toLowerCase().includes(needle),
+        );
+      }
+      if (models.length === 0) {
+        return {
+          reply:
+            "no models found" +
+            (provider ? ` for provider '${provider}'` : "") +
+            " — is the provider keyed? (`pi --list-models` returned nothing)",
+        };
+      }
+      // Cap for phone readability; note the truncation so a missing model
+      // sends the user to the filter form rather than to confusion.
+      const MAX_ROWS = 25;
+      const rows = models
+        .slice(0, MAX_ROWS)
+        .map((m) => `${m.provider}/${m.model}${m.supportsImages ? " 🖼" : ""}`);
+      const truncated =
+        models.length > MAX_ROWS
+          ? `\n… and ${models.length - MAX_ROWS} more — use /model list <filter> to narrow`
+          : "";
+      return {
+        reply:
+          `models (${models.length}${provider ? `, provider: ${provider}` : ""}):\n` +
+          rows.join("\n") +
+          truncated,
+      };
+    }
+    case "claude":
+      return {
+        reply:
+          "claude models are set by alias: opus, sonnet, haiku. " +
+          "use /model <alias> to switch.",
+      };
+    case "gemini":
+      return {
+        reply:
+          "gemini-cli picks its default model when unset — there's no catalog to list. " +
+          "use /model <model-id> to pin one, or /model clear to reset to default.",
+      };
+    case "codex":
+      return {
+        reply:
+          "codex picks its default model when unset — there's no catalog to list. " +
+          "use /model <model-id> to pin one, or /model clear to reset to default.",
+      };
+    default:
+      return { reply: `/model list isn't supported for '${primary.id}'` };
+  }
 }
 
 /**

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -48,7 +48,12 @@
  */
 
 import { access, constants } from "node:fs/promises";
-import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessModelInfo,
+  HarnessRequest,
+} from "./types.ts";
 import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import { reloadVaultForPersona } from "../lib/vault.ts";
@@ -83,6 +88,13 @@ export class ClaudeHarness implements Harness {
     // platform.
     private readonly platform: NodeJS.Platform = process.platform,
   ) {}
+
+  modelInfo(): HarnessModelInfo {
+    return {
+      model: this.config.model,
+      fallbackModel: this.config.fallbackModel || undefined,
+    };
+  }
 
   async available(): Promise<boolean> {
     try {

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -13,7 +13,12 @@
  */
 
 import { access, constants } from "node:fs/promises";
-import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessModelInfo,
+  HarnessRequest,
+} from "./types.ts";
 import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import { reloadVaultForPersona } from "../lib/vault.ts";
@@ -33,6 +38,10 @@ export class CodexHarness implements Harness {
   readonly id = "codex";
 
   constructor(private readonly config: CodexHarnessConfig) {}
+
+  modelInfo(): HarnessModelInfo {
+    return { model: this.config.model || "(default)" };
+  }
 
   async available(): Promise<boolean> {
     try {

--- a/src/harnesses/gemini.ts
+++ b/src/harnesses/gemini.ts
@@ -37,7 +37,12 @@
  */
 
 import { access, constants } from "node:fs/promises";
-import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessModelInfo,
+  HarnessRequest,
+} from "./types.ts";
 import { buildToolCall } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import { reloadVaultForPersona } from "../lib/vault.ts";
@@ -76,6 +81,10 @@ export class GeminiHarness implements Harness {
   readonly id = "gemini";
 
   constructor(private readonly config: GeminiHarnessConfig) {}
+
+  modelInfo(): HarnessModelInfo {
+    return { model: this.config.model || "(default)" };
+  }
 
   async available(): Promise<boolean> {
     try {

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -34,7 +34,12 @@
  */
 
 import { access, constants } from "node:fs/promises";
-import type { Harness, HarnessChunk, HarnessRequest } from "./types.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessModelInfo,
+  HarnessRequest,
+} from "./types.ts";
 import { ENV_PI_API_KEY, ENV_PI_PROVIDER, type PiRoutingConfig } from "../lib/piRouting.ts";
 import { getCoderSwapOverride, resolveSwapModel } from "../lib/coderSwap.ts";
 import { buildToolCall, type ToolCallDetail } from "./toolNote.ts";
@@ -71,6 +76,16 @@ export class PiHarness implements Harness {
   readonly id = "pi";
 
   constructor(private readonly config: PiHarnessConfig) {}
+
+  modelInfo(): HarnessModelInfo {
+    const r = this.config.routing;
+    return {
+      model: r?.primaryModel ?? "(pi default)",
+      provider: r?.provider,
+      codingModel: r?.codingModel,
+      imageModel: r?.imageModel,
+    };
+  }
 
   async available(): Promise<boolean> {
     try {

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -136,9 +136,33 @@ export type HarnessChunk =
    */
   | { type: "error"; error: string; recoverable: boolean; httpStatus?: number };
 
+/**
+ * Snapshot of the harness's configured model(s), for `/status` and `/model`
+ * display (issue #313). Purely presentational — nothing reads this to make
+ * routing decisions; the harness's own config remains the source of truth.
+ */
+export interface HarnessModelInfo {
+  /** Primary model the harness runs, or "(default)" when unpinned. */
+  model: string;
+  /** Provider id when meaningful (Pi routing, e.g. "openrouter"). */
+  provider?: string;
+  /** Pi capability-routing delegates, when configured. */
+  codingModel?: string;
+  imageModel?: string;
+  /** Claude's --fallback-model, when configured. */
+  fallbackModel?: string;
+}
+
 export interface Harness {
   /** Stable identifier — matches the wrapper file name. */
   readonly id: string;
+
+  /**
+   * Configured model snapshot for /status and /model. Optional so test stubs
+   * and third-party harnesses don't have to implement it — the command layer
+   * degrades to omitting the harness from the models line when absent.
+   */
+  modelInfo?(): HarnessModelInfo;
 
   /**
    * Largest allowable rendered payload (system prompt + history + new

--- a/src/lib/modelCommand.ts
+++ b/src/lib/modelCommand.ts
@@ -1,0 +1,277 @@
+/**
+ * /model slash command — parsing, write planning, and persistence (issue #313).
+ *
+ * The channel dispatcher (channels/commands.ts) owns Telegram-shaped concerns
+ * (usage text, replies, restart); this module owns everything unit-testable:
+ *   - parseModelRequest: arg string → structured request
+ *   - applyModelRequest: persist a set/clear to BOTH stores (config.toml +
+ *     ~/.env) and sync the in-memory Config, mirroring the /chattiness and
+ *     wizard write patterns
+ *   - formatModelShow: the bare-`/model` reply body per harness
+ *
+ * WHY BOTH STORES: model config resolves env-over-TOML at startup
+ * (config.ts), so writing only config.toml would be silently ignored on any
+ * install where the wizard previously wrote PHANTOMBOT_*_MODEL into ~/.env.
+ * Writing only env would leave `phantombot doctor` and the TOML reading
+ * stale. Both must move together, exactly like applyRouting does for the
+ * onboarding wizard.
+ *
+ * A restart is always required after a successful write — every harness
+ * bakes its model config at construction (buildHarnessChain), so the
+ * dispatcher fires selfRestart via afterSend, same dance as /restart.
+ */
+
+import type { Config } from "../config.ts";
+import { getIn, setIn, updateConfigToml } from "./configWriter.ts";
+import { defaultEnvFilePath, updateEnvFile } from "./envFile.ts";
+import {
+  ENV_CODING_MODEL,
+  ENV_IMAGE_MODEL,
+  ENV_PRIMARY_MODEL,
+  type PiRoutingConfig,
+} from "./piRouting.ts";
+import type { HarnessModelInfo } from "../harnesses/types.ts";
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+export type ModelRole = "primary" | "coding" | "image";
+
+export type ModelRequest =
+  | { kind: "show" }
+  | { kind: "list"; filter?: string }
+  | { kind: "set"; role: ModelRole; slug: string }
+  | { kind: "clear" }
+  | { kind: "usage" };
+
+/**
+ * Parse the text after `/model` into a structured request.
+ *
+ *   ""                  → show
+ *   "list [filter]"     → list
+ *   "clear"             → clear (gemini/codex only)
+ *   "primary <slug>"    → set primary (explicit alias of the bare form)
+ *   "coding <slug>"     → set coding (pi only)
+ *   "image <slug>"      → set image (pi only)
+ *   "<slug>"            → set primary
+ *   anything else       → usage
+ *
+ * Roles and "list"/"clear" are case-insensitive; the slug is preserved
+ * verbatim because model ids are case-sensitive on some providers.
+ */
+export function parseModelRequest(arg: string): ModelRequest {
+  const tokens = arg.split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length === 0) return { kind: "show" };
+
+  const head = tokens[0]!.toLowerCase();
+  if (head === "list") {
+    const filter = tokens.slice(1).join(" ").trim();
+    return { kind: "list", filter: filter.length > 0 ? filter : undefined };
+  }
+  if (head === "clear") {
+    return tokens.length === 1 ? { kind: "clear" } : { kind: "usage" };
+  }
+  if (head === "primary" || head === "coding" || head === "image") {
+    if (tokens.length === 2) {
+      return { kind: "set", role: head, slug: tokens[1]! };
+    }
+    return { kind: "usage" };
+  }
+  if (tokens.length === 1) return { kind: "set", role: "primary", slug: tokens[0]! };
+  return { kind: "usage" };
+}
+
+// ---------------------------------------------------------------------------
+// Show formatting
+// ---------------------------------------------------------------------------
+
+/** Bare-`/model` reply body: what the primary harness is currently running. */
+export function formatModelShow(
+  harnessId: string,
+  info: HarnessModelInfo | undefined,
+): string {
+  if (!info) {
+    return `${harnessId}: model info unavailable (harness doesn't report it)`;
+  }
+  switch (harnessId) {
+    case "pi": {
+      const lines = [`pi primary: ${info.model}`];
+      if (info.provider) lines.push(`provider:   ${info.provider}`);
+      lines.push(`coding:     ${info.codingModel ?? "(same as primary)"}`);
+      lines.push(`image:      ${info.imageModel ?? "(none)"}`);
+      return lines.join("\n");
+    }
+    case "claude":
+      return (
+        `claude model: ${info.model}` +
+        (info.fallbackModel ? `\nfallback:     ${info.fallbackModel}` : "")
+      );
+    default:
+      return `${harnessId} model: ${info.model}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+/**
+ * Claude models are set by alias, validated against a small allowlist to
+ * catch typos — a bad --model value fails every turn at runtime, which is a
+ * much worse place to discover "opys". Keep in sync with the aliases the
+ * claude CLI accepts.
+ */
+export const CLAUDE_MODEL_ALIASES = ["opus", "sonnet", "haiku"] as const;
+
+export type ModelApplyResult =
+  | { ok: true; summary: string }
+  | { ok: false; error: string };
+
+const PI_ROLE_WRITES: Record<
+  ModelRole,
+  { tomlKey: string; envVar: string; routingField: keyof PiRoutingConfig }
+> = {
+  primary: { tomlKey: "primary_model", envVar: ENV_PRIMARY_MODEL, routingField: "primaryModel" },
+  coding: { tomlKey: "coding_model", envVar: ENV_CODING_MODEL, routingField: "codingModel" },
+  image: { tomlKey: "image_model", envVar: ENV_IMAGE_MODEL, routingField: "imageModel" },
+};
+
+/**
+ * Persist a set/clear to config.toml + the env file, and sync the in-memory
+ * Config + process.env so the running process agrees with disk until the
+ * restart lands. `envPath` is injectable for tests.
+ *
+ * Returns a refusal (ok: false) for requests the harness can't honor:
+ * coding/image roles on non-Pi harnesses, clear on pi/claude (both need a
+ * model to function — use set instead), and non-allowlisted Claude aliases.
+ */
+export async function applyModelRequest(
+  req: ModelRequest & { kind: "set" | "clear" },
+  harnessId: string,
+  config: Config,
+  envPath: string = defaultEnvFilePath(),
+): Promise<ModelApplyResult> {
+  switch (harnessId) {
+    case "pi":
+      return applyPi(req, config, envPath);
+    case "claude":
+      return applyClaude(req, config, envPath);
+    case "gemini":
+      return applySimple(req, config, envPath, "gemini", "PHANTOMBOT_GEMINI_MODEL");
+    case "codex":
+      return applySimple(req, config, envPath, "codex", "PHANTOMBOT_CODEX_MODEL");
+    default:
+      return {
+        ok: false,
+        error: `/model isn't supported for the '${harnessId}' harness`,
+      };
+  }
+}
+
+async function applyPi(
+  req: ModelRequest & { kind: "set" | "clear" },
+  config: Config,
+  envPath: string,
+): Promise<ModelApplyResult> {
+  if (req.kind === "clear") {
+    return {
+      ok: false,
+      error:
+        "pi has no default to clear to — routing needs an explicit primary. " +
+        "use /model <slug> to switch, or `phantombot harness` to re-run the routing wizard",
+    };
+  }
+  const { tomlKey, envVar, routingField } = PI_ROLE_WRITES[req.role];
+  await updateConfigToml(config.configPath, (toml) => {
+    setIn(toml, ["harnesses", "pi", "routing", tomlKey], req.slug);
+  });
+  await updateEnvFile(envPath, { [envVar]: req.slug });
+  // In-memory sync — config.ts resolved env-over-TOML at startup, so both
+  // the live Config and the live env must agree with what we just wrote.
+  const routing = (config.harnesses.pi.routing ??= {});
+  routing[routingField] = req.slug;
+  process.env[envVar] = req.slug;
+  return { ok: true, summary: `pi ${req.role} model → ${req.slug}` };
+}
+
+async function applyClaude(
+  req: ModelRequest & { kind: "set" | "clear" },
+  config: Config,
+  envPath: string,
+): Promise<ModelApplyResult> {
+  if (req.kind === "clear") {
+    return {
+      ok: false,
+      error:
+        "claude has no default to clear to — use /model <alias> (opus, sonnet, haiku)",
+    };
+  }
+  if (req.role !== "primary") {
+    return {
+      ok: false,
+      error: "claude runs a single model — /model <alias> is the only write",
+    };
+  }
+  const alias = req.slug.toLowerCase();
+  if (!(CLAUDE_MODEL_ALIASES as readonly string[]).includes(alias)) {
+    return {
+      ok: false,
+      error:
+        `unknown claude alias '${req.slug}' — expected one of: ` +
+        CLAUDE_MODEL_ALIASES.join(", "),
+    };
+  }
+  await updateConfigToml(config.configPath, (toml) => {
+    setIn(toml, ["harnesses", "claude", "model"], alias);
+  });
+  await updateEnvFile(envPath, { PHANTOMBOT_CLAUDE_MODEL: alias });
+  config.harnesses.claude.model = alias;
+  process.env.PHANTOMBOT_CLAUDE_MODEL = alias;
+  return { ok: true, summary: `claude model → ${alias}` };
+}
+
+/**
+ * gemini + codex share their shape: a single `model` string where "" means
+ * "let the CLI pick its default". Set pins it; clear reverts to the default
+ * by DELETING the TOML key and unsetting the env var ("" is the env-file
+ * unset sentinel), so the config genuinely returns to its unpinned state
+ * rather than carrying an empty-string override forever.
+ */
+async function applySimple(
+  req: ModelRequest & { kind: "set" | "clear" },
+  config: Config,
+  envPath: string,
+  id: "gemini" | "codex",
+  envVar: string,
+): Promise<ModelApplyResult> {
+  if (req.kind === "set" && req.role !== "primary") {
+    return {
+      ok: false,
+      error: `${id} runs a single model — /model <model-id> is the only write`,
+    };
+  }
+
+  if (req.kind === "clear") {
+    await updateConfigToml(config.configPath, (toml) => {
+      const harness = getIn(toml, ["harnesses", id]) as
+        | Record<string, unknown>
+        | undefined;
+      if (harness) delete harness.model;
+    });
+    await updateEnvFile(envPath, { [envVar]: "" });
+    if (id === "gemini") config.harnesses.gemini.model = "";
+    else if (config.harnesses.codex) config.harnesses.codex.model = "";
+    delete process.env[envVar];
+    return { ok: true, summary: `${id} model → (default)` };
+  }
+
+  await updateConfigToml(config.configPath, (toml) => {
+    setIn(toml, ["harnesses", id, "model"], req.slug);
+  });
+  await updateEnvFile(envPath, { [envVar]: req.slug });
+  if (id === "gemini") config.harnesses.gemini.model = req.slug;
+  else if (config.harnesses.codex) config.harnesses.codex.model = req.slug;
+  process.env[envVar] = req.slug;
+  return { ok: true, summary: `${id} model → ${req.slug}` };
+}

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -261,7 +261,8 @@ describe("/status", () => {
     });
     const r = await handleSlashCommand("/status", ctx());
     expect(r!.reply).toContain("harness: claude");
-    expect(r!.reply).toContain("claude → pi");
+    expect(r!.reply).toContain("→ claude");
+    expect(r!.reply).toContain("pi");
     expect(r!.reply).toMatch(/uptime:\s+1m \d+s/);
     expect(r!.reply).toContain("context:");
     expect(r!.reply).toContain("active:  no");
@@ -655,7 +656,8 @@ describe("/status phantom + models surface", () => {
         ],
       }),
     );
-    expect(r!.reply).toContain("chain:   pi → claude (unavailable)");
+    expect(r!.reply).toContain("→ pi");
+    expect(r!.reply).toContain("claude (unavailable)");
   });
 });
 

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -644,6 +644,19 @@ describe("/status phantom + models surface", () => {
       "models:  pi: deepseek-v3 (openrouter) | claude: opus",
     );
   });
+
+  test("marks unavailable harnesses in the chain line", async () => {
+    const r = await handleSlashCommand(
+      "/status",
+      ctx({
+        harnesses: [
+          new StubHarness("pi", true),
+          new StubHarness("claude", false),
+        ],
+      }),
+    );
+    expect(r!.reply).toContain("chain:   pi → claude (unavailable)");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -16,7 +16,12 @@ import {
   type ActiveTurnHandle,
   type SlashCommandContext,
 } from "../src/channels/commands.ts";
-import type { Harness, HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessModelInfo,
+  HarnessRequest,
+} from "../src/harnesses/types.ts";
 import { openMemoryStore, type MemoryStore } from "../src/memory/store.ts";
 import {
   getChattinessOverride,
@@ -31,9 +36,13 @@ class StubHarness implements Harness {
   constructor(
     public readonly id: string,
     private readonly _available: boolean = true,
+    private readonly _modelInfo?: HarnessModelInfo,
   ) {}
   async available(): Promise<boolean> {
     return this._available;
+  }
+  modelInfo(): HarnessModelInfo {
+    return this._modelInfo ?? { model: "(default)" };
   }
   async *invoke(_req: HarnessRequest): AsyncGenerator<HarnessChunk> {
     yield { type: "done", finalText: "" };
@@ -605,5 +614,128 @@ describe("nominalContextWindow", () => {
     expect(nominalContextWindow("gemini")).toBe(1_000_000);
     expect(nominalContextWindow("pi")).toBe(64_000);
     expect(nominalContextWindow("unknown")).toBe(128_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /status — phantom + models lines (issue #313)
+// ---------------------------------------------------------------------------
+
+describe("/status phantom + models surface", () => {
+  test("reports persona name, pid, and version", async () => {
+    const r = await handleSlashCommand("/status", ctx());
+    expect(r!.reply).toContain(`phantom: phantom (pid ${process.pid}`);
+  });
+
+  test("includes a models line when harnesses report modelInfo", async () => {
+    const r = await handleSlashCommand(
+      "/status",
+      ctx({
+        harnesses: [
+          new StubHarness("pi", true, {
+            model: "deepseek-v3",
+            provider: "openrouter",
+          }),
+          new StubHarness("claude", true, { model: "opus" }),
+        ],
+      }),
+    );
+    expect(r!.reply).toContain(
+      "models:  pi: deepseek-v3 (openrouter) | claude: opus",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /model (issue #313)
+// ---------------------------------------------------------------------------
+
+describe("/model", () => {
+  const SAVED_ENV_FILE = process.env.PHANTOMBOT_ENV_FILE;
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "phantombot-cmd-model-"));
+    process.env.PHANTOMBOT_ENV_FILE = join(dir, ".env");
+  });
+  afterEach(async () => {
+    if (SAVED_ENV_FILE === undefined) delete process.env.PHANTOMBOT_ENV_FILE;
+    else process.env.PHANTOMBOT_ENV_FILE = SAVED_ENV_FILE;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function modelConfig(): import("../src/config.ts").Config {
+    return {
+      configPath: join(dir, "config.toml"),
+      harnesses: {
+        chain: ["pi"],
+        claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+        pi: { bin: "pi" },
+        gemini: { bin: "gemini", model: "" },
+      },
+    } as unknown as import("../src/config.ts").Config;
+  }
+
+  test("bare /model shows the primary harness's model", async () => {
+    const r = await handleSlashCommand(
+      "/model",
+      ctx({
+        harnesses: [
+          new StubHarness("pi", true, {
+            model: "deepseek-v3",
+            provider: "openrouter",
+            codingModel: "qwen-coder",
+          }),
+        ],
+      }),
+    );
+    expect(r!.reply).toContain("pi primary: deepseek-v3");
+    expect(r!.reply).toContain("openrouter");
+  });
+
+  test("bad args show usage", async () => {
+    const r = await handleSlashCommand("/model coding", ctx());
+    expect(r!.reply).toContain("usage: /model");
+  });
+
+  test("/model list gives claude the alias guidance", async () => {
+    const r = await handleSlashCommand("/model list", ctx());
+    expect(r!.reply).toContain("opus, sonnet, haiku");
+  });
+
+  test("/model set without config fails loud", async () => {
+    const r = await handleSlashCommand("/model opus", ctx());
+    expect(r!.reply).toContain("didn't pass config");
+  });
+
+  test("/model <slug> writes config.toml and schedules a restart", async () => {
+    const config = modelConfig();
+    const r = await handleSlashCommand(
+      "/model deepseek-v3",
+      ctx({
+        harnesses: [new StubHarness("pi", true, { model: "old-model" })],
+        config,
+      }),
+    );
+    expect(r!.reply).toContain("pi primary model → deepseek-v3");
+    expect(r!.reply).toContain("restarting");
+    expect(typeof r!.afterSend).toBe("function");
+    // NOTE: afterSend is NOT invoked — it self-restarts the process.
+    const toml = await readConfigToml(config.configPath);
+    expect(getIn(toml, ["harnesses", "pi", "routing", "primary_model"])).toBe(
+      "deepseek-v3",
+    );
+  });
+
+  test("claude rejects a typo'd alias without writing anything", async () => {
+    const config = modelConfig();
+    const r = await handleSlashCommand(
+      "/model opys",
+      ctx({ harnesses: [new StubHarness("claude")], config }),
+    );
+    expect(r!.reply).toContain("unknown claude alias");
+    expect(r!.afterSend).toBeUndefined();
+    const toml = await readConfigToml(config.configPath);
+    expect(getIn(toml, ["harnesses", "claude", "model"])).toBeUndefined();
   });
 });

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -3582,7 +3582,8 @@ describe("runTelegramServer slash commands", () => {
     });
     expect(transport.sent).toHaveLength(1);
     expect(transport.sent[0]!.text).toContain("harness: claude");
-    expect(transport.sent[0]!.text).toContain("claude → pi");
+    expect(transport.sent[0]!.text).toContain("→ claude");
+    expect(transport.sent[0]!.text).toContain("pi");
   });
 
   test("/harness <id> switches the primary so the next turn uses it", async () => {

--- a/tests/harnesses-modelInfo.test.ts
+++ b/tests/harnesses-modelInfo.test.ts
@@ -1,0 +1,84 @@
+/**
+ * modelInfo() on the four harness classes (issue #313) — the /status and
+ * /model display surface. Each class projects its own config shape into the
+ * shared HarnessModelInfo; these pin that projection, especially the
+ * "unpinned → (default)" sentinels.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { PiHarness } from "../src/harnesses/pi.ts";
+import { ClaudeHarness } from "../src/harnesses/claude.ts";
+import { GeminiHarness } from "../src/harnesses/gemini.ts";
+import { CodexHarness } from "../src/harnesses/codex.ts";
+
+describe("PiHarness.modelInfo", () => {
+  test("with full routing configured", () => {
+    const h = new PiHarness({
+      bin: "pi",
+      routing: {
+        provider: "openrouter",
+        primaryModel: "deepseek-v3",
+        codingModel: "qwen-coder",
+        imageModel: "qwen-vl",
+      },
+    });
+    expect(h.modelInfo()).toEqual({
+      model: "deepseek-v3",
+      provider: "openrouter",
+      codingModel: "qwen-coder",
+      imageModel: "qwen-vl",
+    });
+  });
+
+  test("without routing → pi default sentinel", () => {
+    const h = new PiHarness({ bin: "pi" });
+    const info = h.modelInfo();
+    expect(info.model).toBe("(pi default)");
+    expect(info.provider).toBeUndefined();
+    expect(info.codingModel).toBeUndefined();
+  });
+});
+
+describe("ClaudeHarness.modelInfo", () => {
+  test("reports model and fallback", () => {
+    const h = new ClaudeHarness({
+      bin: "claude",
+      model: "opus",
+      fallbackModel: "sonnet",
+    });
+    expect(h.modelInfo()).toEqual({ model: "opus", fallbackModel: "sonnet" });
+  });
+
+  test("empty fallback is omitted", () => {
+    const h = new ClaudeHarness({ bin: "claude", model: "opus", fallbackModel: "" });
+    expect(h.modelInfo().fallbackModel).toBeUndefined();
+  });
+});
+
+describe("GeminiHarness.modelInfo", () => {
+  test("pinned model", () => {
+    expect(
+      new GeminiHarness({ bin: "gemini", model: "gemini-2.5-pro" }).modelInfo(),
+    ).toEqual({ model: "gemini-2.5-pro" });
+  });
+
+  test("empty model → (default)", () => {
+    expect(new GeminiHarness({ bin: "gemini", model: "" }).modelInfo()).toEqual({
+      model: "(default)",
+    });
+  });
+});
+
+describe("CodexHarness.modelInfo", () => {
+  test("pinned model", () => {
+    expect(
+      new CodexHarness({ bin: "codex", model: "gpt-5.2-codex" }).modelInfo(),
+    ).toEqual({ model: "gpt-5.2-codex" });
+  });
+
+  test("empty model → (default)", () => {
+    expect(new CodexHarness({ bin: "codex", model: "" }).modelInfo()).toEqual({
+      model: "(default)",
+    });
+  });
+});

--- a/tests/lib-modelCommand.test.ts
+++ b/tests/lib-modelCommand.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Unit tests for lib/modelCommand.ts (issue #313) — /model parsing,
+ * show formatting, and the two-store (config.toml + env file) write path.
+ *
+ * Write tests run against real temp files (config.toml + .env in a tmpdir)
+ * because the contract under test IS the file content; mocking the writer
+ * would test nothing. process.env keys touched by the in-memory sync are
+ * saved and restored around each test.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Config } from "../src/config.ts";
+import {
+  applyModelRequest,
+  CLAUDE_MODEL_ALIASES,
+  formatModelShow,
+  parseModelRequest,
+} from "../src/lib/modelCommand.ts";
+import { getIn, readConfigToml } from "../src/lib/configWriter.ts";
+import { loadEnvFile } from "../src/lib/envFile.ts";
+
+const TOUCHED_ENV = [
+  "PHANTOMBOT_PRIMARY_MODEL",
+  "PHANTOMBOT_CODING_MODEL",
+  "PHANTOMBOT_IMAGE_MODEL",
+  "PHANTOMBOT_CLAUDE_MODEL",
+  "PHANTOMBOT_GEMINI_MODEL",
+  "PHANTOMBOT_CODEX_MODEL",
+] as const;
+
+let dir: string;
+let configPath: string;
+let envPath: string;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "phantombot-modelcmd-"));
+  configPath = join(dir, "config.toml");
+  envPath = join(dir, ".env");
+  savedEnv = {};
+  for (const k of TOUCHED_ENV) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(async () => {
+  for (const k of TOUCHED_ENV) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  await rm(dir, { recursive: true, force: true });
+});
+
+function makeConfig(overrides: Partial<Config["harnesses"]> = {}): Config {
+  return {
+    defaultPersona: "phantom",
+    harnessIdleTimeoutMs: 1000,
+    harnessHardTimeoutMs: 1000,
+    personasDir: dir,
+    memoryDbPath: ":memory:",
+    configPath,
+    harnesses: {
+      chain: ["pi"],
+      claude: { bin: "claude", model: "opus", fallbackModel: "sonnet" },
+      pi: { bin: "pi" },
+      gemini: { bin: "gemini", model: "" },
+      ...overrides,
+    },
+    channels: {},
+    embeddings: { provider: "none" },
+    voice: { provider: "none" },
+  } as Config;
+}
+
+// ---------------------------------------------------------------------------
+// parseModelRequest
+// ---------------------------------------------------------------------------
+
+describe("parseModelRequest", () => {
+  test("bare → show", () => {
+    expect(parseModelRequest("")).toEqual({ kind: "show" });
+  });
+
+  test("list with and without filter", () => {
+    expect(parseModelRequest("list")).toEqual({ kind: "list", filter: undefined });
+    expect(parseModelRequest("list deepseek")).toEqual({
+      kind: "list",
+      filter: "deepseek",
+    });
+    expect(parseModelRequest("LIST Claude Opus")).toEqual({
+      kind: "list",
+      filter: "Claude Opus",
+    });
+  });
+
+  test("clear", () => {
+    expect(parseModelRequest("clear")).toEqual({ kind: "clear" });
+    expect(parseModelRequest("CLEAR")).toEqual({ kind: "clear" });
+    expect(parseModelRequest("clear now")).toEqual({ kind: "usage" });
+  });
+
+  test("explicit roles", () => {
+    expect(parseModelRequest("primary openrouter/x")).toEqual({
+      kind: "set",
+      role: "primary",
+      slug: "openrouter/x",
+    });
+    expect(parseModelRequest("coding deepseek-v3")).toEqual({
+      kind: "set",
+      role: "coding",
+      slug: "deepseek-v3",
+    });
+    expect(parseModelRequest("IMAGE qwen-vl")).toEqual({
+      kind: "set",
+      role: "image",
+      slug: "qwen-vl",
+    });
+  });
+
+  test("bare slug → set primary, case preserved", () => {
+    expect(parseModelRequest("Opus-4.1")).toEqual({
+      kind: "set",
+      role: "primary",
+      slug: "Opus-4.1",
+    });
+  });
+
+  test("role without slug, or extra tokens → usage", () => {
+    expect(parseModelRequest("coding")).toEqual({ kind: "usage" });
+    expect(parseModelRequest("coding a b")).toEqual({ kind: "usage" });
+    expect(parseModelRequest("two tokens")).toEqual({ kind: "usage" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatModelShow
+// ---------------------------------------------------------------------------
+
+describe("formatModelShow", () => {
+  test("pi with full routing", () => {
+    const out = formatModelShow("pi", {
+      model: "deepseek-v3",
+      provider: "openrouter",
+      codingModel: "qwen-coder",
+      imageModel: "qwen-vl",
+    });
+    expect(out).toContain("pi primary: deepseek-v3");
+    expect(out).toContain("provider:   openrouter");
+    expect(out).toContain("coding:     qwen-coder");
+    expect(out).toContain("image:      qwen-vl");
+  });
+
+  test("pi without delegates says so", () => {
+    const out = formatModelShow("pi", { model: "(pi default)" });
+    expect(out).toContain("(same as primary)");
+    expect(out).toContain("(none)");
+  });
+
+  test("claude includes fallback when set", () => {
+    const out = formatModelShow("claude", {
+      model: "opus",
+      fallbackModel: "sonnet",
+    });
+    expect(out).toContain("claude model: opus");
+    expect(out).toContain("fallback:     sonnet");
+  });
+
+  test("gemini/codex single line; missing info degrades", () => {
+    expect(formatModelShow("gemini", { model: "(default)" })).toBe(
+      "gemini model: (default)",
+    );
+    expect(formatModelShow("pi", undefined)).toContain("unavailable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyModelRequest — pi
+// ---------------------------------------------------------------------------
+
+describe("applyModelRequest pi", () => {
+  test("set primary writes toml + env + in-memory", async () => {
+    const config = makeConfig();
+    const r = await applyModelRequest(
+      { kind: "set", role: "primary", slug: "deepseek-v3" },
+      "pi",
+      config,
+      envPath,
+    );
+    expect(r).toEqual({ ok: true, summary: "pi primary model → deepseek-v3" });
+
+    const toml = await readConfigToml(configPath);
+    expect(getIn(toml, ["harnesses", "pi", "routing", "primary_model"])).toBe(
+      "deepseek-v3",
+    );
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_PRIMARY_MODEL).toBe("deepseek-v3");
+    expect(config.harnesses.pi.routing?.primaryModel).toBe("deepseek-v3");
+    expect(process.env.PHANTOMBOT_PRIMARY_MODEL).toBe("deepseek-v3");
+  });
+
+  test("set coding + image roles hit their own keys", async () => {
+    const config = makeConfig();
+    await applyModelRequest(
+      { kind: "set", role: "coding", slug: "qwen-coder" },
+      "pi",
+      config,
+      envPath,
+    );
+    await applyModelRequest(
+      { kind: "set", role: "image", slug: "qwen-vl" },
+      "pi",
+      config,
+      envPath,
+    );
+    const toml = await readConfigToml(configPath);
+    expect(getIn(toml, ["harnesses", "pi", "routing", "coding_model"])).toBe(
+      "qwen-coder",
+    );
+    expect(getIn(toml, ["harnesses", "pi", "routing", "image_model"])).toBe(
+      "qwen-vl",
+    );
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_CODING_MODEL).toBe("qwen-coder");
+    expect(env.PHANTOMBOT_IMAGE_MODEL).toBe("qwen-vl");
+  });
+
+  test("clear is refused — pi has no default to fall back to", async () => {
+    const r = await applyModelRequest(
+      { kind: "clear" },
+      "pi",
+      makeConfig(),
+      envPath,
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyModelRequest — claude
+// ---------------------------------------------------------------------------
+
+describe("applyModelRequest claude", () => {
+  test("accepts allowlisted aliases, writes both stores", async () => {
+    const config = makeConfig();
+    const r = await applyModelRequest(
+      { kind: "set", role: "primary", slug: "Sonnet" },
+      "claude",
+      config,
+      envPath,
+    );
+    expect(r.ok).toBe(true);
+    const toml = await readConfigToml(configPath);
+    expect(getIn(toml, ["harnesses", "claude", "model"])).toBe("sonnet");
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_CLAUDE_MODEL).toBe("sonnet");
+    expect(config.harnesses.claude.model).toBe("sonnet");
+  });
+
+  test("rejects aliases outside the allowlist", async () => {
+    const r = await applyModelRequest(
+      { kind: "set", role: "primary", slug: "opys" },
+      "claude",
+      makeConfig(),
+      envPath,
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain(CLAUDE_MODEL_ALIASES[0]);
+  });
+
+  test("rejects clear and non-primary roles", async () => {
+    const config = makeConfig();
+    expect(
+      (await applyModelRequest({ kind: "clear" }, "claude", config, envPath)).ok,
+    ).toBe(false);
+    expect(
+      (
+        await applyModelRequest(
+          { kind: "set", role: "coding", slug: "opus" },
+          "claude",
+          config,
+          envPath,
+        )
+      ).ok,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyModelRequest — gemini / codex
+// ---------------------------------------------------------------------------
+
+describe("applyModelRequest gemini + codex", () => {
+  test("set pins the model in both stores", async () => {
+    const config = makeConfig();
+    const r = await applyModelRequest(
+      { kind: "set", role: "primary", slug: "gemini-2.5-pro" },
+      "gemini",
+      config,
+      envPath,
+    );
+    expect(r.ok).toBe(true);
+    const toml = await readConfigToml(configPath);
+    expect(getIn(toml, ["harnesses", "gemini", "model"])).toBe("gemini-2.5-pro");
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_GEMINI_MODEL).toBe("gemini-2.5-pro");
+    expect(config.harnesses.gemini.model).toBe("gemini-2.5-pro");
+  });
+
+  test("clear deletes the toml key and unsets env (back to CLI default)", async () => {
+    const config = makeConfig();
+    await applyModelRequest(
+      { kind: "set", role: "primary", slug: "gemini-2.5-pro" },
+      "gemini",
+      config,
+      envPath,
+    );
+    const r = await applyModelRequest({ kind: "clear" }, "gemini", config, envPath);
+    expect(r).toEqual({ ok: true, summary: "gemini model → (default)" });
+    const toml = await readConfigToml(configPath);
+    expect(getIn(toml, ["harnesses", "gemini", "model"])).toBeUndefined();
+    const env = await loadEnvFile(envPath);
+    expect(env.PHANTOMBOT_GEMINI_MODEL).toBeUndefined();
+    expect(config.harnesses.gemini.model).toBe("");
+    expect(process.env.PHANTOMBOT_GEMINI_MODEL).toBeUndefined();
+  });
+
+  test("codex set/clear mirrors gemini", async () => {
+    const config = makeConfig({ codex: { bin: "codex", model: "" } });
+    const set = await applyModelRequest(
+      { kind: "set", role: "primary", slug: "gpt-5.2-codex" },
+      "codex",
+      config,
+      envPath,
+    );
+    expect(set.ok).toBe(true);
+    expect(config.harnesses.codex?.model).toBe("gpt-5.2-codex");
+    const clear = await applyModelRequest({ kind: "clear" }, "codex", config, envPath);
+    expect(clear.ok).toBe(true);
+    expect(config.harnesses.codex?.model).toBe("");
+  });
+
+  test("codex tolerates an absent codex config block", async () => {
+    const config = makeConfig(); // no codex key
+    const r = await applyModelRequest(
+      { kind: "set", role: "primary", slug: "gpt-5.2-codex" },
+      "codex",
+      config,
+      envPath,
+    );
+    expect(r.ok).toBe(true);
+    const toml = await readConfigToml(configPath);
+    expect(getIn(toml, ["harnesses", "codex", "model"])).toBe("gpt-5.2-codex");
+  });
+
+  test("rejects coding/image roles — single-model harnesses", async () => {
+    const r = await applyModelRequest(
+      { kind: "set", role: "image", slug: "x" },
+      "gemini",
+      makeConfig(),
+      envPath,
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+test("unknown harness id is refused", async () => {
+  const r = await applyModelRequest(
+    { kind: "set", role: "primary", slug: "x" },
+    "mystery",
+    makeConfig(),
+    envPath,
+  );
+  expect(r.ok).toBe(false);
+});


### PR DESCRIPTION
## Summary

Implements the full spec on #313: a `/model` slash command for all four harnesses, plus a `/status` upgrade that surfaces the phantom's name, pid, version, and per-harness models.

**`/model`**

| Command | Behavior |
|---------|----------|
| `/model` | Show the primary harness's current model config |
| `/model list [filter]` | Pi: models from `pi --list-models`, filtered to the configured provider, capped at 25 rows for phone readability. Claude/Gemini/Codex: guidance text (no programmatic catalog exists) |
| `/model <slug>` / `/model primary <slug>` | Switch the primary model, then restart |
| `/model coding <slug>` / `/model image <slug>` | Pi capability-routing delegates (refused on single-model harnesses) |
| `/model clear` | Gemini/Codex only — deletes the TOML key + unsets the env var, back to the CLI default |

**Write pattern** (mirrors `/chattiness` + the routing wizard): `updateConfigToml` + `updateEnvFile` + in-memory Config sync + `selfRestart` via `afterSend`. Both stores move together because config resolves env-over-TOML at startup — a TOML-only write would be silently ignored on any install where the wizard previously wrote `PHANTOMBOT_*_MODEL` into `~/.env`.

**`/status`**

```
phantom: lena (pid 12345, v1.1.215)
harness: pi
chain:   pi → claude
models:  pi: deepseek-v3 (openrouter) | claude: opus
uptime:  3h 22m
context: ~42% (≈52k / 128k tokens, last 20 turns)
active:  no
```

**Design decisions for reviewers:**
- `Harness.modelInfo()` is **optional** on the interface so test stubs and third-party harnesses don't break; all four bundled harnesses implement it. `/status` omits harnesses that don't report.
- Claude validates against an `opus`/`sonnet`/`haiku` allowlist — a typo'd `--model` fails every turn at runtime, a much worse place to discover "opys". Other harnesses accept any slug (the operator may know a model we don't).
- `clear` is refused on pi/claude — both need a model to function; there is no default to fall back to.
- Restart is mandatory: all harnesses bake model config at `buildHarnessChain()` construction.

## Tests

- 22 new lib tests (`lib-modelCommand`): parse table, per-harness writes against real temp config.toml + .env files, allowlist/refusal paths, codex-absent tolerance
- 8 new `modelInfo` tests across the four harness classes
- 7 new dispatcher tests: show/list-guidance/usage/no-config refusal/write+restart-scheduled/typo-rejected-without-write
- Full suite: **2402 pass / 2 fail** — the 2 failures (`harnesses-pi` subprocess env threading) fail identically on `main`, pre-existing (also seen on #314)
- `tsc --noEmit` clean

Closes #313
