### PR TITLE
feat(memory): faster recall — turn-index every 3 turns, embed notes on heartbeat, search-before-you-act norm

### DIFF
--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -10,7 +10,9 @@ import { existsSync } from "node:fs";
 
 import { type Config, loadConfig, memoryIndexPath, personaDir } from "../config.ts";
 import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
+import { defaultEmbedder, runEmbedJob } from "../lib/embedJob.ts";
 import { runHeartbeat } from "../lib/heartbeat.ts";
+import { MemoryIndex } from "../lib/memoryIndex.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import { currentPlatform } from "../lib/platform.ts";
@@ -108,6 +110,41 @@ export async function runHeartbeatCli(
     });
   }
 
+  // Embed newly-written notes on the heartbeat's regular cadence so a
+  // `memory capture`, a fresh KB note, or a drawer promotion becomes
+  // *semantically* recallable within ~30 min instead of waiting for the
+  // nightly `memory index --rebuild` (a full day of lag). runHeartbeat has
+  // already refreshed the FTS index above, so the `files` table is current;
+  // this incremental pass embeds only chunks whose text_sha changed (new or
+  // edited notes) and skips everything else — no API call for unchanged
+  // content. The nightly rebuild still runs for full consistency (deletions,
+  // model/dim changes, drift repair). Wrapped in try/catch: an embed hiccup
+  // must never break the primary heartbeat work.
+  let noteEmbedLine = "";
+  try {
+    const embedder = defaultEmbedder(config);
+    if (embedder) {
+      const ix = await MemoryIndex.open(indexPath(persona));
+      try {
+        const e = await runEmbedJob({ personaDir: dir, index: ix, embedder });
+        if (e.embedded > 0 || e.failed > 0) {
+          noteEmbedLine = `, embedded ${e.embedded}`;
+          log.info("heartbeat: embedded fresh notes", {
+            embedded: e.embedded,
+            skipped: e.skipped,
+            failed: e.failed,
+          });
+        }
+      } finally {
+        ix.close();
+      }
+    }
+  } catch (e) {
+    log.warn("heartbeat: note-embed pass threw unexpectedly", {
+      error: (e as Error).message,
+    });
+  }
+
   // Self-heal the service-manager units on the heartbeat's regular cadence.
   // This is the long-uptime cure for the drifted-unit class of bug (a broken
   // symlink on Linux, a moved binary on Windows) — a box that never restarts
@@ -141,7 +178,7 @@ export async function runHeartbeatCli(
   out.write(
     `heartbeat ok: promoted ${r.promoted.length}, ` +
       `stale ${r.staleRecent.length}, ` +
-      `indexed ${r.indexedFiles}${updateLine}\n`,
+      `indexed ${r.indexedFiles}${noteEmbedLine}${updateLine}\n`,
   );
   return 0;
 }
@@ -205,7 +242,7 @@ export default defineCommand({
   meta: {
     name: "heartbeat",
     description:
-      "Mechanical 30-min maintenance: promote tagged daily-file lines to drawers, scan ## Recent for staleness, refresh FTS index. No LLM call.",
+      "Mechanical 30-min maintenance: promote tagged daily-file lines to drawers, scan ## Recent for staleness, refresh FTS index, flush due conversation-turn tails, and embed newly-written notes. No LLM call.",
   },
   args: {
     persona: {

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -52,6 +52,23 @@ export interface RunHeartbeatCliInput {
    * systemd bus and only run if available.
    */
   healSystemd?: false | (() => Promise<void>);
+  /**
+   * Test seam for the fresh-note embed pass. Pass `false` to skip it
+   * entirely (keeps the real Gemini embedder out of the path — this is
+   * effectively what a `provider: "none"` config already does, but the
+   * flag is explicit). Pass a function to substitute a fake that returns
+   * the embed counts the pass should have produced (or `null` to model
+   * "no embedder configured"). Production passes undefined → we build the
+   * real embedder from config and run runEmbedJob against the note index.
+   */
+  embedNotes?: false | (() => Promise<EmbedNotesResult | null>);
+}
+
+/** Outcome of the heartbeat's incremental note-embed pass. */
+export interface EmbedNotesResult {
+  embedded: number;
+  skipped: number;
+  failed: number;
 }
 
 export async function runHeartbeatCli(
@@ -121,28 +138,24 @@ export async function runHeartbeatCli(
   // model/dim changes, drift repair). Wrapped in try/catch: an embed hiccup
   // must never break the primary heartbeat work.
   let noteEmbedLine = "";
-  try {
-    const embedder = defaultEmbedder(config);
-    if (embedder) {
-      const ix = await MemoryIndex.open(indexPath(persona));
-      try {
-        const e = await runEmbedJob({ personaDir: dir, index: ix, embedder });
-        if (e.embedded > 0 || e.failed > 0) {
-          noteEmbedLine = `, embedded ${e.embedded}`;
-          log.info("heartbeat: embedded fresh notes", {
-            embedded: e.embedded,
-            skipped: e.skipped,
-            failed: e.failed,
-          });
-        }
-      } finally {
-        ix.close();
+  if (input.embedNotes !== false) {
+    try {
+      const e = input.embedNotes
+        ? await input.embedNotes()
+        : await defaultEmbedNotes(config, dir, persona);
+      if (e && (e.embedded > 0 || e.failed > 0)) {
+        noteEmbedLine = `, embedded ${e.embedded}`;
+        log.info("heartbeat: embedded fresh notes", {
+          embedded: e.embedded,
+          skipped: e.skipped,
+          failed: e.failed,
+        });
       }
+    } catch (e) {
+      log.warn("heartbeat: note-embed pass threw unexpectedly", {
+        error: (e as Error).message,
+      });
     }
-  } catch (e) {
-    log.warn("heartbeat: note-embed pass threw unexpectedly", {
-      error: (e as Error).message,
-    });
   }
 
   // Self-heal the service-manager units on the heartbeat's regular cadence.
@@ -181,6 +194,29 @@ export async function runHeartbeatCli(
       `indexed ${r.indexedFiles}${noteEmbedLine}${updateLine}\n`,
   );
   return 0;
+}
+
+/**
+ * Production note-embed pass: build the configured embedder and run an
+ * incremental embed job over the note index. Returns `null` when no
+ * embedder is configured (e.g. `embeddings.provider: "none"` or a missing
+ * Gemini key) so the caller prints no embed line. Owns the MemoryIndex
+ * handle it opens and closes it in a finally.
+ */
+async function defaultEmbedNotes(
+  config: Config,
+  dir: string,
+  persona: string,
+): Promise<EmbedNotesResult | null> {
+  const embedder = defaultEmbedder(config);
+  if (!embedder) return null;
+  const ix = await MemoryIndex.open(indexPath(persona));
+  try {
+    const e = await runEmbedJob({ personaDir: dir, index: ix, embedder });
+    return { embedded: e.embedded, skipped: e.skipped, failed: e.failed };
+  } finally {
+    ix.close();
+  }
 }
 
 /**

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -98,8 +98,8 @@ export async function runHeartbeatCli(
 
   // Drain sub-threshold conversation turn tails on the heartbeat's regular
   // cadence. The live service only flushes a conversation when a new message
-  // crosses the 20-turn batch, so a quiet conversation stuck below it (e.g.
-  // 19 turns) would stay unembedded for days — recent chat goes invisible to
+  // crosses the turn-index batch, so a quiet conversation stuck below it
+  // would stay unembedded for days — recent chat goes invisible to
   // recall. This time-based sweep (flushAfterHours) closes that gap for every
   // conversation, mechanically, with no LLM call. Wrapped in try/catch so a
   // turn-flush hiccup never breaks the primary heartbeat work.

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -236,7 +236,7 @@ export interface RunIndexInputV2 extends RunIndexInput {
    * Force-flush unindexed conversation turn tails across ALL conversations
    * instead of (re)building the notes/KB index. This is the operator
    * backfill path for the time-based turn flush — drains tails that are
-   * below the 20-turn batch and haven't aged into the heartbeat window yet.
+   * below the turn-index batch and haven't aged into the heartbeat window yet.
    */
   flushTurns?: boolean;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -153,9 +153,17 @@ export interface TurnIndexingSettings {
 
 export const DEFAULT_TURN_INDEXING: TurnIndexingSettings = {
   enabled: true,
-  interval: 20,
+  // Tight batch so an early-established fact (a procedure, a connection string)
+  // becomes semantically recallable within a few user turns instead of after
+  // 20 — the window where it has scrolled past the verbatim history but isn't
+  // yet indexed is the mechanical cause of "forgot mid-conversation, remembered
+  // when nudged". Cheap: each flush is sha-deduped, so only the growing tail
+  // costs an embed call.
+  interval: 3,
   batchSize: 200,
-  flushAfterHours: 2,
+  // Align the time-based safety net with the 30-min heartbeat cadence so a
+  // quiet sub-threshold tail is never more than ~30 min from being recallable.
+  flushAfterHours: 0.5,
   repairBatchSize: 32,
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -744,9 +744,11 @@ function buildTurnIndexingConfig(
     asInt(process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_BATCH_SIZE) ??
     asInt(tomlTurnIndexing.batch_size) ??
     DEFAULT_TURN_INDEXING.batchSize;
+  // Parsed as a float (not asInt): the default is fractional (0.5h) and
+  // Math.floor would round 0.5 down to 0, silently disabling the flush.
   const flushAfterHours =
-    asInt(process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS) ??
-    asInt(tomlTurnIndexing.flush_after_hours) ??
+    asNumber(process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS) ??
+    asNumber(tomlTurnIndexing.flush_after_hours) ??
     DEFAULT_TURN_INDEXING.flushAfterHours;
   const repairBatchSize =
     asInt(process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_REPAIR_BATCH_SIZE) ??
@@ -756,7 +758,7 @@ function buildTurnIndexingConfig(
     enabled,
     interval: Math.max(1, Math.min(10_000, interval)),
     batchSize: Math.max(1, Math.min(5_000, batchSize)),
-    // 0 disables the time-based flush; otherwise clamp to a sane 1h..1yr.
+    // 0 disables the time-based flush; otherwise clamp to a sane 0.5h..1yr.
     flushAfterHours: Math.max(0, Math.min(8_760, flushAfterHours)),
     // 0 disables the repair pass. Capped so one sweep can't fire off an
     // unbounded burst of embedding calls at a provider that may be rate-limiting.

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -155,9 +155,18 @@ Layout (relative to your working dir):
 
 Two hard rules — apply on every nontrivial task:
 
-1. SEARCH BEFORE DEBUGGING. Run \`phantombot memory search "<topic>"\`
-   first. If memory or KB has prior knowledge, use it. Investigate
-   from scratch only if neither found anything.
+1. SEARCH BEFORE YOU ACT. Before debugging, before running an infra
+   or connection procedure (SSH, deploy, cluster access, a service
+   restart), and before re-deriving anything you suspect you have hit
+   before, run \`phantombot memory search "<topic>"\` FIRST — make it
+   reflexive, not optional. Your live context only holds the last ~30
+   turns, so a fact established earlier in THIS same conversation may
+   have already scrolled out of view; the search index still has it.
+   If a search returns prior knowledge, use it instead of working it
+   out again. If you notice you are re-deriving the same fact a second
+   time in one session, that is the signal to search — and to
+   \`memory capture\` it so it is not lost a third time. Investigate
+   from scratch only when search genuinely comes up empty.
 
 2. CAPTURE AS YOU GO. When a decision, lesson, person fact,
    commitment, or norm comes up, record it with:

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -131,4 +131,95 @@ describe("runHeartbeatCli", () => {
     expect(code).toBe(0);
     expect(out.text).toContain("heartbeat ok");
   });
+
+  test("embedNotes seam result appends the embedded count to the summary", async () => {
+    await writeFile(
+      join(workdir, "personas", "phantom", "memory", "decisions.md"),
+      "# Decisions\n",
+    );
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: async () => ({ embedded: 3, skipped: 7, failed: 0 }),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("embedded 3");
+  });
+
+  test("embedNotes seam with nothing to embed prints no embed line", async () => {
+    await writeFile(
+      join(workdir, "personas", "phantom", "memory", "decisions.md"),
+      "# Decisions\n",
+    );
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: async () => ({ embedded: 0, skipped: 12, failed: 0 }),
+    });
+    expect(code).toBe(0);
+    expect(out.text).not.toContain("embedded");
+  });
+
+  test("embedNotes returning null (no embedder) prints no embed line", async () => {
+    await writeFile(
+      join(workdir, "personas", "phantom", "memory", "decisions.md"),
+      "# Decisions\n",
+    );
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: async () => null,
+    });
+    expect(code).toBe(0);
+    expect(out.text).not.toContain("embedded");
+  });
+
+  test("embedNotes throwing does not break the heartbeat", async () => {
+    await writeFile(
+      join(workdir, "personas", "phantom", "memory", "decisions.md"),
+      "# Decisions\n",
+    );
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: async () => {
+        throw new Error("gemini exploded");
+      },
+    });
+    // Embed failure is logged but swallowed; primary work still completes.
+    expect(code).toBe(0);
+    expect(out.text).toContain("heartbeat ok");
+  });
+
+  test("embedNotes: false skips the pass and still completes cleanly", async () => {
+    await writeFile(
+      join(workdir, "personas", "phantom", "memory", "decisions.md"),
+      "# Decisions\n",
+    );
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      // `false` short-circuits the pass entirely — the primary heartbeat
+      // work still runs and no embed line is printed.
+      embedNotes: false,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("heartbeat ok");
+    expect(out.text).not.toContain("embedded");
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -728,6 +728,33 @@ repair_batch_size = 8
     });
   });
 
+  test("flush_after_hours parses a fractional value (TOML and env)", async () => {
+    // Regression: flush_after_hours went through asInt (Math.floor), so the
+    // shipped fractional default 0.5 was silently floored to 0 — disabling the
+    // time-based flush. It must parse as a float now.
+    await writeToml(`
+[retrieval.turn_indexing]
+flush_after_hours = 0.5
+`);
+    expect((await loadConfig()).retrieval!.turnIndexing.flushAfterHours).toBe(
+      0.5,
+    );
+
+    process.env.PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS = "0.5";
+    expect((await loadConfig()).retrieval!.turnIndexing.flushAfterHours).toBe(
+      0.5,
+    );
+  });
+
+  test("turn-indexing defaults are the shipped fast-recall values", async () => {
+    // Guards the two levers this feature ships against accidental drift.
+    expect(DEFAULT_TURN_INDEXING.interval).toBe(3);
+    expect(DEFAULT_TURN_INDEXING.flushAfterHours).toBe(0.5);
+    const c = await loadConfig();
+    expect(c.retrieval!.turnIndexing.interval).toBe(3);
+    expect(c.retrieval!.turnIndexing.flushAfterHours).toBe(0.5);
+  });
+
   test("limit is clamped to 1..50", async () => {
     process.env.PHANTOMBOT_RETRIEVAL_LIMIT = "999";
     expect((await loadConfig()).retrieval!.limit).toBe(50);

--- a/tests/orchestrator-turnIndexer.test.ts
+++ b/tests/orchestrator-turnIndexer.test.ts
@@ -72,7 +72,10 @@ describe("indexConversationTurnsIfDue", () => {
       persona: "phantom",
       conversation: "telegram:1001",
       memory,
-      settings: DEFAULT_RETRIEVAL.turnIndexing,
+      // Pin interval explicitly so this mechanism test is decoupled from the
+      // shipped default (which is intentionally small); 19 < 20 → no count flush,
+      // and the tail is fresh so the age trigger stays quiet too.
+      settings: { ...DEFAULT_RETRIEVAL.turnIndexing, interval: 20 },
     });
 
     expect(result?.triggered).toBe(false);
@@ -221,7 +224,9 @@ describe("time-based and forced flush", () => {
       for (let i = 1; i <= 19; i++) await appendUserPair(store, "telegram:2002", i);
       backdateAllTurns(path, 3); // age the whole tail 3h into the past
 
-      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, flushAfterHours: 2 };
+      // interval pinned high so the 19-turn tail can't count-trigger; this test
+      // isolates the time-based (flushAfterHours) path.
+      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, interval: 20, flushAfterHours: 2 };
       const result = await indexConversationTurnsIfDue({
         config: baseConfig(),
         persona: "phantom",
@@ -247,7 +252,9 @@ describe("time-based and forced flush", () => {
     try {
       for (let i = 1; i <= 19; i++) await appendUserPair(store, "telegram:2003", i);
       // No backdating: the tail is brand new, so the 2h window hasn't elapsed.
-      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, flushAfterHours: 2 };
+      // interval pinned high so the 19-turn tail can't count-trigger; this test
+      // isolates the time-based (flushAfterHours) path.
+      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, interval: 20, flushAfterHours: 2 };
       const result = await indexConversationTurnsIfDue({
         config: baseConfig(),
         persona: "phantom",
@@ -267,7 +274,9 @@ describe("time-based and forced flush", () => {
     try {
       for (let i = 1; i <= 19; i++) await appendUserPair(store, "telegram:2004", i);
       backdateAllTurns(path, 100); // very old, but time flush is disabled
-      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, flushAfterHours: 0 };
+      // interval pinned high so the 19-turn tail can't count-trigger; this test
+      // isolates the "flushAfterHours = 0 disables the age flush" path.
+      const settings = { ...DEFAULT_RETRIEVAL.turnIndexing, interval: 20, flushAfterHours: 0 };
       const result = await indexConversationTurnsIfDue({
         config: baseConfig(),
         persona: "phantom",

--- a/tests/persona-builder-memory-tools.test.ts
+++ b/tests/persona-builder-memory-tools.test.ts
@@ -22,7 +22,7 @@ describe("buildSystemPrompt — memory tools section", () => {
     );
     expect(prompt).toContain("# Memory tools");
     expect(prompt).toContain("phantombot memory search");
-    expect(prompt).toContain("SEARCH BEFORE DEBUGGING");
+    expect(prompt).toContain("SEARCH BEFORE YOU ACT");
     expect(prompt).toContain("CAPTURE AS YOU GO");
   });
 


### PR DESCRIPTION
## Why

Phantombot forgets facts established mid-conversation and only remembers when nudged. Root cause (traced to source): the harness sees a fixed **30-turn verbatim window**, and earlier same-session turns only become searchable after a flush trigger fires — `interval = 20` user-turns or `flushAfterHours = 2`. In a fast debugging session, an SSH procedure established at turn 5 scrolls past the 30-turn window **before** either trigger fires, so it's in neither the live context nor the index — invisible until the user re-states it. Separately, notes written mid-day (`memory capture`, KB notes) aren't **semantically** searchable until the nightly `memory index --rebuild` — up to a full day of lag.

This PR ships the two low-risk levers we agreed. It does **not** include live durable-fact injection or the auto-scratchpad (deferred to follow-ups).

## What

**P1a — turn-index cadence** (`src/config.ts`)
- `interval` 20 → **3**: an early fact becomes semantically recallable within a few user-turns. Cheap — flushes are sha-deduped, only the growing tail costs an embed call.
- `flushAfterHours` 2 → **0.5**: aligns the age safety-net with the 30-min heartbeat.

**P1b — embed notes on write** (`src/cli/heartbeat.ts`)
- The 30-min heartbeat now runs an incremental note-embed pass (`runEmbedJob`, sha-skipped) after its FTS refresh. A fresh capture/KB note/drawer promotion is semantically recallable within ~30 min instead of ~24 h.
- Nightly `--rebuild` **still runs** for full consistency (deletions/renames GC, model/dim changes, drift repair). Incremental = freshness; rebuild = periodic consistency sweep.
- Guarded (only when a Gemini embedder is configured), try/catch-wrapped, no LLM call.

**P3 — search-before-you-act norm** (`src/persona/builder.ts`)
- Broadened `SEARCH BEFORE DEBUGGING` → `SEARCH BEFORE YOU ACT`: reflexively search memory before infra/connection procedures (SSH, deploy, cluster access, restarts) and before re-deriving a fact, because the live window only holds ~30 turns.

## Deferred (follow-up PRs)
- **P2** — live durable-fact injection (PhantomOps-style extract-on-save + inject-every-prompt). Net-new subsystem; writes to every prompt; needs its own design pass.
- **P4** — auto-scratchpad / working-memory note for active tasks.

## Testing
- `bun run typecheck` clean; full suite **2371 pass / 0 fail** (with the unrelated env-leak var cleared — see below).
- Turn-indexer mechanism tests updated to pin `interval` explicitly so they test the age/count mechanism decoupled from the shipped default.
- Builder test updated to the new norm heading.
- Note: `tests/config.test.ts > migrates a legacy Gemini CLI chain` fails **only** when `PHANTOMBOT_GEMINI_API_KEY` is present in the environment (it overrides the test fixture). Pre-existing on `main`, unrelated to this PR.

## Reviewer notes / known gaps
- The heartbeat note-embed pass reuses the already-tested `runEmbedJob` + `defaultEmbedder`, but has no dedicated unit test because the CLI path has no embedder injection seam. Happy to add a small seam + test if wanted.
- Draft — not for merge until reviewed.
