### PR TITLE
harnesses: hard-disable background agents and subagents (claude + codex)

### DIFF
--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -518,8 +518,9 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   // policy (CLAUDE_CODE_DISABLE_BACKGROUND_TASKS in the env + Task in
   // --disallowedTools), so the CLI should never emit subagent activity. If a
   // future CLI version routes around those guards, any envelope carrying
-  // subagent lineage becomes a RECOVERABLE error: the orchestrator kills
-  // this harness and falls through to the next one instead of letting an
+  // subagent lineage becomes a RECOVERABLE, TERMINAL error: the runner kills
+  // the subprocess immediately and suppresses every line after this one, and
+  // the orchestrator falls through to the next harness instead of letting an
   // unmonitored agent run loose. Fail-safe direction, same as the API-error
   // gate below.
   if (isSubagentActivity(obj)) {
@@ -527,6 +528,7 @@ export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
       type: "error",
       error: "claude emitted subagent activity (disabled by phantombot policy)",
       recoverable: true,
+      terminal: true,
     };
   }
 

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -148,7 +148,19 @@ export class ClaudeHarness implements Harness {
     // routing var into the subprocess env (reloadEnvFiles just re-sourced
     // ~/.env), so claude resolves credentials from ~/.claude/.credentials.json.
     const env = withPersonaEnv(
-      filterAuthEnv(process.env),
+      {
+        ...filterAuthEnv(process.env),
+        // Background agents are disabled by product policy. This flag makes
+        // the CLI strip `run_in_background` from the Bash and Task tool
+        // SCHEMAS entirely (verified against claude 2.1.170), so the model
+        // cannot background anything — the capability is never advertised.
+        // It must be set HERE, after filterAuthEnv: the filter strips the
+        // whole CLAUDE_CODE_* namespace from the inherited env, so exporting
+        // it in ~/.env or the shell would silently NOT reach the subprocess
+        // (and a stray CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=0 out there must
+        // not be able to re-enable backgrounding).
+        CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1",
+      },
       req.persona,
       req.conversation,
     );
@@ -205,13 +217,20 @@ export class ClaudeHarness implements Harness {
       "--model", this.config.model,
       // Pre-prompting trim (phantombot supplies persona / memory / scheduling
       // itself, so Claude Code's daily-driver scaffolding is pure noise here):
-      //   --disallowedTools Workflow
-      //     Drops the Workflow tool from the available set. The "you typed
-      //     'workflow', use the Workflow tool" system nudge ONLY fires because
-      //     that tool is loaded — removing the tool kills the nudge at source.
-      //     (We deny by name rather than via the --settings deny-list because
-      //     disallowedTools removes it from the advertised surface, which is
-      //     what actually suppresses the injected reminder.)
+      //   --disallowedTools Workflow,Task
+      //     Workflow: drops the Workflow tool from the available set. The
+      //     "you typed 'workflow', use the Workflow tool" system nudge ONLY
+      //     fires because that tool is loaded — removing the tool kills the
+      //     nudge at source. (We deny by name rather than via the --settings
+      //     deny-list because disallowedTools removes it from the advertised
+      //     surface, which is what actually suppresses the injected reminder.)
+      //     Task: removes the subagent tool entirely — foreground AND
+      //     background. Subagents are disabled by product policy (the owner's
+      //     standing rule is "no subagents, ever"); combined with
+      //     CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 in the env (strips
+      //     run_in_background from the remaining tool schemas) and the
+      //     subagent tripwire in parseStreamJson, background/side agents are
+      //     structurally impossible rather than merely discouraged.
       //   --disable-slash-commands
       //     Suppresses the entire injected "available skills" block
       //     (deep-research / loop / schedule / verify / code-review / …).
@@ -220,7 +239,7 @@ export class ClaudeHarness implements Harness {
       //     already drops most of it; this is the canonical belt-and-suspenders.
       // NB: MCP connectors (Gmail / Calendar / Drive) are tools, not skills or
       // Workflow, so they are UNAFFECTED — Andrew uses those and they stay.
-      "--disallowedTools", "Workflow",
+      "--disallowedTools", "Workflow,Task",
       "--disable-slash-commands",
       "--exclude-dynamic-system-prompt-sections",
     ];
@@ -444,6 +463,32 @@ export function renderStdinPayload(req: HarnessRequest): string {
 const NON_ERROR_API_STATUSES = new Set(["max_output_tokens"]);
 
 /**
+ * Does this stream-json envelope carry subagent lineage? Three markers,
+ * all verified against claude 2.1.170:
+ *   - `subagent_type` on the envelope — stamped on messages belonging to a
+ *     Task-spawned subagent.
+ *   - `isSidechain: true` — the CLI's own sidechain (subagent) flag.
+ *   - a `tool_use` block named `Task` — the spawn call itself.
+ * Exported for testing.
+ */
+export function isSubagentActivity(obj: Record<string, unknown>): boolean {
+  if (typeof obj.subagent_type === "string" && obj.subagent_type.length > 0) {
+    return true;
+  }
+  if (obj.isSidechain === true) return true;
+  const message = obj.message as Record<string, unknown> | undefined;
+  const content = message?.content;
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (typeof part !== "object" || part === null) continue;
+      const p = part as Record<string, unknown>;
+      if (p.type === "tool_use" && p.name === "Task") return true;
+    }
+  }
+  return false;
+}
+
+/**
  * The API-error status stamped on a stream-json envelope, if any.
  *
  * NOTE: this is exit-code independent, and that matters. Observed on the wire
@@ -468,6 +513,22 @@ export function apiErrorStatus(obj: Record<string, unknown>): string | undefined
 export function parseStreamJson(parsed: unknown): HarnessChunk | undefined {
   if (typeof parsed !== "object" || parsed === null) return undefined;
   const obj = parsed as Record<string, unknown>;
+
+  // Subagent tripwire. Background agents and the Task tool are disabled by
+  // policy (CLAUDE_CODE_DISABLE_BACKGROUND_TASKS in the env + Task in
+  // --disallowedTools), so the CLI should never emit subagent activity. If a
+  // future CLI version routes around those guards, any envelope carrying
+  // subagent lineage becomes a RECOVERABLE error: the orchestrator kills
+  // this harness and falls through to the next one instead of letting an
+  // unmonitored agent run loose. Fail-safe direction, same as the API-error
+  // gate below.
+  if (isSubagentActivity(obj)) {
+    return {
+      type: "error",
+      error: "claude emitted subagent activity (disabled by phantombot policy)",
+      recoverable: true,
+    };
+  }
 
   // API-error gate. Checked BEFORE content, and before the `message`/`content`
   // shape guards, so not one byte of a CLI-authored error message can stream to

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -138,6 +138,18 @@ export const PHANTOMBOT_INJECTED_CODEX_FLAGS = [
   // `--ignore-rules` below so Codex's local AGENTS.md / project rules / memory
   // do NOT leak into behavior — phantombot's persona stays authoritative.
   "--ignore-rules",
+  // Subagents are disabled by product policy (the owner's standing rule is
+  // "no subagents, ever"). Codex ships real subagent tools (spawn_agent /
+  // resume_agent / close_agent / wait_agent) behind the multi_agent feature,
+  // which is STABLE and ON BY DEFAULT (verified against codex 0.145.0
+  // `features list`). multi_agent_v2 is off by default but a user config
+  // could enable it — so both are explicitly disabled here. `-c` overrides
+  // beat ~/.codex/config.toml, which matters on normal turns where user
+  // config intentionally loads (connectors, above). Belt: the parser
+  // tripwire in parseCodexEvent kills any turn that still emits subagent
+  // activity.
+  "-c", "features.multi_agent=false",
+  "-c", "features.multi_agent_v2=false",
 ] as const;
 
 /**
@@ -153,12 +165,61 @@ export const PHANTOMBOT_JUDGE_CODEX_FLAGS = [
   "--ephemeral",
   "--ignore-user-config",
   "--ignore-rules",
+  // Same subagent lockdown as normal turns — see PHANTOMBOT_INJECTED_CODEX_FLAGS.
+  "-c", "features.multi_agent=false",
+  "-c", "features.multi_agent_v2=false",
 ] as const;
+
+/** Codex's subagent tool names (verified against codex 0.145.0). */
+const CODEX_AGENT_TOOL_NAMES = new Set([
+  "spawn_agent",
+  "resume_agent",
+  "close_agent",
+  "wait_agent",
+]);
+
+/**
+ * Does this item represent subagent activity? Item types verified against
+ * codex 0.145.0: collab_agent_spawn_begin/end, collab_agent_interaction_
+ * begin/end, collab_agent_tool_call, collab_waiting_*, collab_close_*,
+ * collab_resume_*, sub_agent_activity — plus the agent tool names above.
+ * Exported for testing.
+ */
+export function isCodexSubagentActivity(
+  itemType: unknown,
+  itemName: unknown,
+): boolean {
+  if (typeof itemName === "string" && CODEX_AGENT_TOOL_NAMES.has(itemName)) {
+    return true;
+  }
+  if (typeof itemType !== "string") return false;
+  return itemType.startsWith("collab_") || itemType === "sub_agent_activity";
+}
 
 export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
   if (typeof parsed !== "object" || parsed === null) return undefined;
   const obj = parsed as Record<string, unknown>;
   const type = obj.type;
+
+  // Subagent tripwire. multi_agent is disabled via -c flags on every spawn,
+  // so codex should never emit collab/sub-agent items. If a future version
+  // routes around that (or a config layer we don't control re-enables it),
+  // the turn becomes a RECOVERABLE error: the orchestrator kills this
+  // harness and falls through instead of letting an unmonitored agent run.
+  if (type === "item.started" || type === "item.completed") {
+    const item = obj.item;
+    if (typeof item === "object" && item !== null) {
+      const it = item as Record<string, unknown>;
+      if (isCodexSubagentActivity(it.type, it.name)) {
+        return {
+          type: "error",
+          error: `codex emitted subagent activity (disabled by phantombot policy): ${String(it.type ?? it.name)}`,
+          recoverable: true,
+        };
+      }
+    }
+  }
+
   if (type === "item.started") {
     const item = obj.item;
     if (typeof item !== "object" || item === null) return undefined;

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -204,8 +204,9 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
   // Subagent tripwire. multi_agent is disabled via -c flags on every spawn,
   // so codex should never emit collab/sub-agent items. If a future version
   // routes around that (or a config layer we don't control re-enables it),
-  // the turn becomes a RECOVERABLE error: the orchestrator kills this
-  // harness and falls through instead of letting an unmonitored agent run.
+  // the turn becomes a RECOVERABLE, TERMINAL error: the runner kills the
+  // subprocess immediately and suppresses every line after this one, and the
+  // orchestrator falls through instead of letting an unmonitored agent run.
   if (type === "item.started" || type === "item.completed") {
     const item = obj.item;
     if (typeof item === "object" && item !== null) {
@@ -215,6 +216,7 @@ export function parseCodexEvent(parsed: unknown): HarnessChunk | undefined {
           type: "error",
           error: `codex emitted subagent activity (disabled by phantombot policy): ${String(it.type ?? it.name)}`,
           recoverable: true,
+          terminal: true,
         };
       }
     }

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -133,8 +133,22 @@ export type HarnessChunk =
    * means "this CLI's auth/quota/model state is bad" rather than a transient
    * blip a retry would fix. 5XX is just logged; we don't treat server-side
    * blips as a reason to cool the harness off.
+   *
+   * `terminal: true` marks a terminal POLICY violation (e.g. the subagent
+   * tripwires): the harness runner kills the subprocess immediately and
+   * suppresses ALL further output from the stream — no later text/tool
+   * chunks reach the user and no terminal `done` is synthesized. Without
+   * this a compromised/future CLI could emit the tripwire envelope and then
+   * ordinary output that would still stream to the user before fallback.
+   * Orchestrator handling is unchanged (`recoverable` → next harness).
    */
-  | { type: "error"; error: string; recoverable: boolean; httpStatus?: number };
+  | {
+      type: "error";
+      error: string;
+      recoverable: boolean;
+      httpStatus?: number;
+      terminal?: true;
+    };
 
 /**
  * Snapshot of the harness's configured model(s), for `/status` and `/model`

--- a/src/lib/harnessRunner.ts
+++ b/src/lib/harnessRunner.ts
@@ -39,7 +39,7 @@ type HarnessSubprocess = Subprocess<
   SpawnOptions.Readable
 >;
 
-export type KillCause = "timeout" | "idle" | "aborted" | undefined;
+export type KillCause = "timeout" | "idle" | "aborted" | "policy" | undefined;
 export type HarnessActivity = "model" | "tool" | "productive";
 
 export interface KillCoordinatorOpts {
@@ -68,6 +68,13 @@ export interface KillCoordinator {
   touch(activity?: HarnessActivity): void;
   /** Stop all timers and detach signal listener. Idempotent. */
   dispose(): Promise<void>;
+  /**
+   * Kill the process group immediately as a POLICY violation (terminal
+   * tripwire fired). Same SIGTERM → grace → SIGKILL path as the timers;
+   * idempotent and a no-op once a cause is set or the coordinator is
+   * disposed.
+   */
+  terminate(): void;
   /** Why the process was killed, if it was. undefined = exited normally. */
   killCause(): KillCause;
 }
@@ -126,6 +133,9 @@ export function createKillCoordinator(
         opts.idleTimeoutMs,
       );
     },
+    terminate(): void {
+      triggerKill("policy");
+    },
     async dispose(): Promise<void> {
       if (disposed) return;
       disposed = true;
@@ -148,6 +158,9 @@ export function createKillCoordinator(
  *   - "timeout"  → recoverable (orchestrator advances to next harness)
  *   - "idle"     → recoverable (same — wedged subprocess, try a different one)
  *   - "aborted"  → non-recoverable (user said /stop and meant it)
+ *   - "policy"   → recoverable (terminal tripwire; normally unreachable here
+ *     because the tripwire's own error chunk was already yielded and the
+ *     generator returned — this is the belt-and-suspenders fallback)
  */
 export function killCauseToErrorChunk(
   cause: KillCause,
@@ -173,6 +186,13 @@ export function killCauseToErrorChunk(
   }
   if (cause === "aborted") {
     return { type: "error", error: "stopped", recoverable: false };
+  }
+  if (cause === "policy") {
+    return {
+      type: "error",
+      error: `${harnessId} killed by policy tripwire`,
+      recoverable: true,
+    };
   }
   return undefined;
 }
@@ -308,6 +328,11 @@ export async function* runHarnessProcess(
   let buffer = "";
   let finalText = "";
   let captured: Record<string, unknown> | undefined;
+  // Set when a parser returns a terminal policy error (e.g. the subagent
+  // tripwire). The error chunk is yielded, the subprocess is killed NOW,
+  // and every line after it — same batch or later — is dropped: nothing a
+  // process says after violating policy may reach the user.
+  let terminalError: HarnessChunk | undefined;
   const decoder = new TextDecoder();
 
   // Translate one parsed line, feed the idle timer, fold text/done. Yields the
@@ -316,6 +341,12 @@ export async function* runHarnessProcess(
   function* consume(parsed: unknown): Generator<HarnessChunk> {
     const c = spec.parseEvent(parsed);
     if (!c) return;
+    if (c.type === "error" && c.terminal) {
+      terminalError = c;
+      killer.terminate(); // SIGTERM → grace → SIGKILL the whole group
+      yield c;
+      return;
+    }
     killer.touch(spec.activity(parsed, c));
     if (c.type === "text") finalText += c.text;
     if (c.type === "done") {
@@ -351,9 +382,11 @@ export async function* runHarnessProcess(
           continue;
         }
         yield* consume(parsed);
+        if (terminalError) break; // policy violation: drop the rest of the batch
       }
+      if (terminalError) break; // ...and stop reading stdout entirely
     }
-    if (spec.flushTail) {
+    if (spec.flushTail && !terminalError) {
       buffer += decoder.decode();
       const tail = buffer.trim();
       if (tail) {
@@ -368,8 +401,15 @@ export async function* runHarnessProcess(
     await killer.dispose();
   }
 
-  // Priority order matches the old hand-written loops: a harness-specific
-  // early provider error wins over kill-cause, which wins over exit code.
+  // Priority order matches the old hand-written loops: a terminal policy
+  // error wins over everything (its chunk was already yielded mid-loop; the
+  // orchestrator has it, so just stop), then a harness-specific early
+  // provider error wins over kill-cause, which wins over exit code.
+  if (terminalError) {
+    await proc.exited;
+    return;
+  }
+
   const early = spec.earlyError?.();
   if (early) {
     await proc.exited;

--- a/tests/fixtures/fake-claude.sh
+++ b/tests/fixtures/fake-claude.sh
@@ -12,6 +12,8 @@
 #   hang     — sleep forever (used for the timeout test)
 #   argv     — emit argv as a single assistant text event (so the test can
 #              inspect what flags the harness passed), then exit 0
+#   env      — emit select env vars as a text event (so the test can inspect
+#              the env the harness spawned us with), then exit 0
 #   posttool_thinking — tool_use -> user tool_result -> spaced thinking
 #              heartbeats -> final text. Proves user-side tool_result clears
 #              the tool-running idle latch.
@@ -51,6 +53,15 @@ case "$mode" in
     payload="${payload//\\/\\\\}"
     payload="${payload//\"/\\\"}"
     printf '%s\n' "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"${payload}\"}]}}"
+    printf '%s\n' '{"type":"result"}'
+    exit 0
+    ;;
+  env)
+    # Echo the background-tasks flag the harness is expected to inject, so
+    # tests can prove it reaches the subprocess env (and that an inherited
+    # CLAUDE_CODE_* value can't smuggle a different one through filterAuthEnv).
+    v="${CLAUDE_CODE_DISABLE_BACKGROUND_TASKS:-<unset>}"
+    printf '%s\n' "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"BGTASKS=${v}\"}]}}"
     printf '%s\n' '{"type":"result"}'
     exit 0
     ;;

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -17,6 +17,7 @@ import {
   PHANTOMBOT_INJECTED_CLAUDE_SETTINGS,
   filterAuthEnv,
   apiErrorStatus,
+  isSubagentActivity,
   parseStreamJson,
   renderStdinPayload,
 } from "../src/harnesses/claude.ts";
@@ -649,5 +650,137 @@ describe("ClaudeHarness.available", () => {
       fallbackModel: "",
     });
     expect(await h.available()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Background-agent lockdown. Product policy: no subagents, ever. Three layers
+// are tested here: the env flag that strips run_in_background from the tool
+// schemas, Task in --disallowedTools, and the parser tripwire that turns any
+// subagent-stamped envelope into a recoverable error.
+// ---------------------------------------------------------------------------
+
+describe("isSubagentActivity", () => {
+  test("flags an envelope stamped with subagent_type", () => {
+    expect(
+      isSubagentActivity({
+        type: "assistant",
+        subagent_type: "Explore",
+        message: { content: [{ type: "text", text: "hi" }] },
+      }),
+    ).toBe(true);
+  });
+
+  test("flags a sidechain envelope", () => {
+    expect(
+      isSubagentActivity({
+        type: "assistant",
+        isSidechain: true,
+        message: { content: [{ type: "text", text: "hi" }] },
+      }),
+    ).toBe(true);
+  });
+
+  test("flags a Task tool_use block", () => {
+    expect(
+      isSubagentActivity({
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_use", name: "Task", input: {} }],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test("ignores ordinary main-chain messages", () => {
+    expect(
+      isSubagentActivity({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "hello" }] },
+      }),
+    ).toBe(false);
+    expect(
+      isSubagentActivity({
+        type: "assistant",
+        isSidechain: false,
+        message: {
+          content: [{ type: "tool_use", name: "Bash", input: {} }],
+        },
+      }),
+    ).toBe(false);
+    expect(isSubagentActivity({ type: "result" })).toBe(false);
+  });
+});
+
+describe("parseStreamJson subagent tripwire", () => {
+  test("subagent-stamped text becomes a recoverable error, never user text", () => {
+    const chunk = parseStreamJson({
+      type: "assistant",
+      subagent_type: "Explore",
+      message: { content: [{ type: "text", text: "secret sidechain reply" }] },
+    });
+    expect(chunk).toEqual({
+      type: "error",
+      error: "claude emitted subagent activity (disabled by phantombot policy)",
+      recoverable: true,
+    });
+  });
+
+  test("a Task tool_use becomes a recoverable error, not progress", () => {
+    const chunk = parseStreamJson({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", name: "Task", input: { prompt: "x" } }],
+      },
+    });
+    expect(chunk?.type).toBe("error");
+    if (chunk?.type === "error") expect(chunk.recoverable).toBe(true);
+  });
+});
+
+describe("ClaudeHarness background-agent lockdown", () => {
+  test("--disallowedTools removes Task as well as Workflow", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });
+    const chunks = await collect(h.invoke(newRequest()));
+    const texts = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    expect(texts).toContain("--disallowedTools");
+    expect(texts).toContain("Workflow,Task");
+  });
+
+  test("CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1 reaches the subprocess env", async () => {
+    process.env.FAKE_CLAUDE_MODE = "env";
+    const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });
+    const chunks = await collect(h.invoke(newRequest()));
+    const texts = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    expect(texts).toContain("BGTASKS=1");
+  });
+
+  test("an inherited CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=0 cannot re-enable backgrounding", async () => {
+    // The whole CLAUDE_CODE_* namespace is stripped from the inherited env
+    // (auth filter) and the flag is re-injected as 1 afterwards — so a stray
+    // =0 in ~/.env or the daemon's shell must not survive to the subprocess.
+    const prev = process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
+    process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = "0";
+    try {
+      process.env.FAKE_CLAUDE_MODE = "env";
+      const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });
+      const chunks = await collect(h.invoke(newRequest()));
+      const texts = chunks
+        .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+        .map((c) => c.text)
+        .join("");
+      expect(texts).toContain("BGTASKS=1");
+      expect(texts).not.toContain("BGTASKS=0");
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS;
+      else process.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = prev;
+    }
   });
 });

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -723,6 +723,7 @@ describe("parseStreamJson subagent tripwire", () => {
       type: "error",
       error: "claude emitted subagent activity (disabled by phantombot policy)",
       recoverable: true,
+      terminal: true,
     });
   });
 
@@ -734,7 +735,10 @@ describe("parseStreamJson subagent tripwire", () => {
       },
     });
     expect(chunk?.type).toBe("error");
-    if (chunk?.type === "error") expect(chunk.recoverable).toBe(true);
+    if (chunk?.type === "error") {
+      expect(chunk.recoverable).toBe(true);
+      expect(chunk.terminal).toBe(true);
+    }
   });
 });
 

--- a/tests/harnesses-codex.test.ts
+++ b/tests/harnesses-codex.test.ts
@@ -309,6 +309,7 @@ describe("parseCodexEvent subagent tripwire", () => {
     expect(chunk?.type).toBe("error");
     if (chunk?.type === "error") {
       expect(chunk.recoverable).toBe(true);
+      expect(chunk.terminal).toBe(true);
       expect(chunk.error).toContain("subagent activity");
     }
   });
@@ -319,7 +320,10 @@ describe("parseCodexEvent subagent tripwire", () => {
       item: { type: "tool_call", name: "spawn_agent" },
     });
     expect(chunk?.type).toBe("error");
-    if (chunk?.type === "error") expect(chunk.recoverable).toBe(true);
+    if (chunk?.type === "error") {
+      expect(chunk.recoverable).toBe(true);
+      expect(chunk.terminal).toBe(true);
+    }
   });
 
   test("a completed sub_agent_activity item is caught too", () => {

--- a/tests/harnesses-codex.test.ts
+++ b/tests/harnesses-codex.test.ts
@@ -3,8 +3,10 @@ import { chmod } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
   CodexHarness,
+  isCodexSubagentActivity,
   parseCodexEvent,
   PHANTOMBOT_INJECTED_CODEX_FLAGS,
+  PHANTOMBOT_JUDGE_CODEX_FLAGS,
   renderStdinPayload,
 } from "../src/harnesses/codex.ts";
 import type { HarnessChunk, HarnessRequest } from "../src/harnesses/types.ts";
@@ -247,5 +249,94 @@ describe("CodexHarness.invoke", () => {
       expect(text).toContain(flag);
     }
     expect(text).toContain("-m gpt-5.3-codex");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subagent lockdown. Product policy: no subagents, ever. codex's multi_agent
+// feature is stable and ON by default, so every spawn disables it via -c
+// overrides, and the parser tripwire turns any collab/sub-agent item into a
+// recoverable error.
+// ---------------------------------------------------------------------------
+
+describe("codex subagent lockdown flags", () => {
+  test("normal-turn flags disable multi_agent and multi_agent_v2", () => {
+    const flags = PHANTOMBOT_INJECTED_CODEX_FLAGS.join(" ");
+    expect(flags).toContain("-c features.multi_agent=false");
+    expect(flags).toContain("-c features.multi_agent_v2=false");
+  });
+
+  test("judge flags disable multi_agent and multi_agent_v2 too", () => {
+    const flags = PHANTOMBOT_JUDGE_CODEX_FLAGS.join(" ");
+    expect(flags).toContain("-c features.multi_agent=false");
+    expect(flags).toContain("-c features.multi_agent_v2=false");
+  });
+});
+
+describe("isCodexSubagentActivity", () => {
+  test("flags collab_* item types", () => {
+    for (const t of [
+      "collab_agent_spawn_begin",
+      "collab_agent_spawn_end",
+      "collab_agent_interaction_begin",
+      "collab_agent_tool_call",
+      "collab_waiting_begin",
+    ]) {
+      expect(isCodexSubagentActivity(t, undefined)).toBe(true);
+    }
+    expect(isCodexSubagentActivity("sub_agent_activity", undefined)).toBe(true);
+  });
+
+  test("flags the agent tool names regardless of item type", () => {
+    for (const n of ["spawn_agent", "resume_agent", "close_agent", "wait_agent"]) {
+      expect(isCodexSubagentActivity("tool_call", n)).toBe(true);
+    }
+  });
+
+  test("ignores ordinary items", () => {
+    expect(isCodexSubagentActivity("agent_message", undefined)).toBe(false);
+    expect(isCodexSubagentActivity("command_execution", "bash")).toBe(false);
+    expect(isCodexSubagentActivity(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("parseCodexEvent subagent tripwire", () => {
+  test("a collab_agent_spawn item becomes a recoverable error", () => {
+    const chunk = parseCodexEvent({
+      type: "item.started",
+      item: { type: "collab_agent_spawn_begin", name: "spawn_agent" },
+    });
+    expect(chunk?.type).toBe("error");
+    if (chunk?.type === "error") {
+      expect(chunk.recoverable).toBe(true);
+      expect(chunk.error).toContain("subagent activity");
+    }
+  });
+
+  test("a spawn_agent tool call becomes a recoverable error, not progress", () => {
+    const chunk = parseCodexEvent({
+      type: "item.started",
+      item: { type: "tool_call", name: "spawn_agent" },
+    });
+    expect(chunk?.type).toBe("error");
+    if (chunk?.type === "error") expect(chunk.recoverable).toBe(true);
+  });
+
+  test("a completed sub_agent_activity item is caught too", () => {
+    const chunk = parseCodexEvent({
+      type: "item.completed",
+      item: { type: "sub_agent_activity" },
+    });
+    expect(chunk?.type).toBe("error");
+  });
+
+  test("ordinary items are unaffected by the tripwire", () => {
+    const msg = parseCodexEvent({
+      type: "item.completed",
+      item: { type: "agent_message", text: "hello" },
+    });
+    expect(msg).toEqual({ type: "text", text: "hello" });
+    const hb = parseCodexEvent({ type: "turn.started" });
+    expect(hb).toEqual({ type: "heartbeat" });
   });
 });

--- a/tests/lib-harnessRunner.test.ts
+++ b/tests/lib-harnessRunner.test.ts
@@ -266,3 +266,124 @@ describe("runHarnessProcess — regression: stdin blocking hang", () => {
     expect(errorChunk.recoverable).toBe(true);
   });
 });
+
+describe("runHarnessProcess — terminal policy tripwire", () => {
+  test("kills the child and suppresses ALL post-tripwire output", async () => {
+    // Regression for the PR #321 review: pre-fix, a parser's recoverable
+    // tripwire error was yielded but the runner kept consuming stdout, so a
+    // CLI emitting [text, tripwire, more text] would stream "more text" to
+    // the user before fallback. Now the terminal error must end the stream:
+    // the child is killed and no chunk after the error is yielded — not even
+    // lines that arrived in the SAME stdout batch.
+    const proc = spawnInNewSession(
+      [
+        "sh",
+        "-c",
+        'echo \'{"kind":"text","v":"before "}\'; ' +
+          'echo \'{"kind":"tripwire"}\'; ' +
+          'echo \'{"kind":"text","v":"after"}\'; ' +
+          "sleep 30",
+      ],
+      { stdin: "ignore", stdout: "pipe", stderr: "ignore" },
+    );
+    trackedPids.push(proc.pid!);
+
+    const start = Date.now();
+    const chunks: unknown[] = [];
+    for await (const chunk of runHarnessProcess({
+      proc,
+      harnessId: "test-harness",
+      req: {
+        idleTimeoutMs: 10_000,
+        hardTimeoutMs: 20_000,
+        workingDir: process.cwd(),
+        persona: "test",
+        conversation: "test",
+        userMessage: "test",
+      } as never,
+      parseEvent: (parsed: unknown) => {
+        const p = parsed as { kind?: string; v?: string };
+        if (p.kind === "tripwire") {
+          return {
+            type: "error",
+            error: "policy violation",
+            recoverable: true,
+            terminal: true,
+          } as const;
+        }
+        if (p.kind === "text") return { type: "text", text: p.v ?? "" } as const;
+        return undefined;
+      },
+      activity: () => "productive",
+      buildDoneMeta: () => ({}),
+    })) {
+      chunks.push(chunk);
+    }
+
+    // Exactly two chunks: pre-tripwire text, then the terminal error. The
+    // post-tripwire "after" line must NOT appear, and no `done` is
+    // synthesized on top of a policy violation.
+    expect(chunks).toEqual([
+      { type: "text", text: "before " },
+      {
+        type: "error",
+        error: "policy violation",
+        recoverable: true,
+        terminal: true,
+      },
+    ]);
+
+    // The child was killed promptly — not left to run out its sleep 30 and
+    // the 10s idle timer.
+    const code = await proc.exited;
+    expect(Date.now() - start).toBeLessThan(10_000);
+    expect(code).not.toBe(0);
+  });
+
+  test("a non-terminal recoverable error still streams like before", async () => {
+    // Guard the other direction: ordinary recoverable parser errors (API
+    // gate, mid-stream 4XX-style) do NOT kill the child or truncate the
+    // stream — only `terminal: true` gets the new semantics.
+    const proc = spawnInNewSession(
+      [
+        "sh",
+        "-c",
+        'echo \'{"kind":"err"}\'; echo \'{"kind":"text","v":"still here"}\'',
+      ],
+      { stdin: "ignore", stdout: "pipe", stderr: "ignore" },
+    );
+    trackedPids.push(proc.pid!);
+
+    const chunks: unknown[] = [];
+    for await (const chunk of runHarnessProcess({
+      proc,
+      harnessId: "test-harness",
+      req: {
+        idleTimeoutMs: 5_000,
+        workingDir: process.cwd(),
+        persona: "test",
+        conversation: "test",
+        userMessage: "test",
+      } as never,
+      parseEvent: (parsed: unknown) => {
+        const p = parsed as { kind?: string; v?: string };
+        if (p.kind === "err") {
+          return { type: "error", error: "transient", recoverable: true } as const;
+        }
+        if (p.kind === "text") return { type: "text", text: p.v ?? "" } as const;
+        return undefined;
+      },
+      activity: () => "productive",
+      buildDoneMeta: () => ({}),
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([
+      { type: "error", error: "transient", recoverable: true },
+      { type: "text", text: "still here" },
+      { type: "done", finalText: "still here", meta: {} },
+    ]);
+    expect(await proc.exited).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

Andrew's standing rule is **no subagents, ever** — but both harnesses could background work or spawn subagents today:

- **claude**: `run_in_background` was fully available on the Bash and Task tools, and the Task subagent tool sat on the advertised surface.
- **codex**: `multi_agent` (spawn_agent / resume_agent / close_agent / wait_agent) is a **stable feature, ON by default** — verified against codex 0.145.0 (`codex features list`).

## What — three layers, each verified against the real binaries

**1. claude env — `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`**
Injected into the subprocess env *after* `filterAuthEnv`. Verified against claude 2.1.170: the flag strips `run_in_background` from the tool **schemas**, so the capability is never advertised to the model (also kills Ctrl+B and the "use run_in_background" prompt nudges). It must be set here explicitly: `filterAuthEnv` strips the whole `CLAUDE_CODE_*` namespace, so exporting it in `~/.env` would silently never arrive — and an inherited `=0` can no longer re-enable backgrounding (regression-tested).

**2. Tool/feature surface removal**
- claude: `Task` added to `--disallowedTools` — subagents gone foreground *and* background.
- codex: `-c features.multi_agent=false -c features.multi_agent_v2=false` on both the normal and judge flag sets. `-c` overrides beat `~/.codex/config.toml`, which matters because normal turns intentionally load user config (connectors).

**3. Parser tripwire (fail-safe)**
Any subagent-stamped event becomes a **recoverable error** → the orchestrator kills the harness and falls through instead of letting an unmonitored agent run:
- claude: `subagent_type` envelope stamp, `isSidechain: true`, or a `Task` tool_use
- codex: `collab_*` items, `sub_agent_activity`, or the four agent tool names

Guards against a future CLI update renaming or bypassing layers 1–2. Same fail-safe direction as the existing API-error gate.

## Tests

13 new: marker classifiers, tripwire parsing (both harnesses), env injection including the inherited-`=0` override, `--disallowedTools` argv, codex flag-set contents. New `env` mode in fake-claude.sh.

Suite: **2426 pass, 0 new fails** (the 2 failures are the pre-existing PiHarness env issues on main). Typecheck clean.

## Out of scope

pi harness: no equivalent subagent/background surface identified — flag if one turns up and it'll get the same treatment.