### PR TITLE
feat(memory): time-decay raw conversation-turn hits in retrieval

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -200,6 +200,37 @@ export interface RetrievalSettings {
    * vector path is used instead, so Gemini users are unaffected).
    */
   graphExpansion: GraphExpansionSettings;
+  /**
+   * Time-decay on raw conversation-turn hits. Ranking has no clock of its own —
+   * BM25 + RRF are purely relevance-based, so a stale turn that lexically
+   * matches (e.g. a superseded infra note repeated in old chat) competes with a
+   * fresh correction on equal footing and can win forever. Decay multiplies a
+   * turn hit's score by `0.5^(ageDays/halfLifeDays)` (floored), so old turns
+   * sink no matter how strongly they match. Applies ONLY to `turns` scope —
+   * curated memory/ + kb/ notes are immune (factor 1.0) and never age out, so
+   * rarely-recalled-but-important runbooks survive for years. There is no
+   * refresh-on-recall by design: a ghost is recalled *because* it matches, so
+   * bumping it on recall would keep it alive — the opposite of the goal.
+   */
+  decay: RetrievalDecaySettings;
+}
+
+/** Time-decay knobs for raw conversation-turn hits (curated notes are immune). */
+export interface RetrievalDecaySettings {
+  /** Master switch. When false, turn hits are ranked without any time-decay. */
+  enabled: boolean;
+  /**
+   * Half-life in days for a turn hit's relevance score. After this many days a
+   * turn's score is halved; after 2× it is quartered; etc. Lower = turns age
+   * out faster. Only affects `turns` scope. `<= 0` disables decay (factor 1).
+   */
+  halfLifeDays: number;
+  /**
+   * Lower bound on the decay multiplier so a very old turn's score is damped
+   * but never driven to exactly 0 — it stays a tie-broken last resort rather
+   * than vanishing. 0..1; 0 lets ancient turns decay to nothing.
+   */
+  floor: number;
 }
 
 /** OKF link-graph expansion knobs (BM25-only retrieval path). */
@@ -218,6 +249,16 @@ export const DEFAULT_GRAPH_EXPANSION: GraphExpansionSettings = {
   maxAdd: 3,
 };
 
+export const DEFAULT_RETRIEVAL_DECAY: RetrievalDecaySettings = {
+  enabled: true,
+  // 30 days: raw chat history a month old is worth about half a fresh turn.
+  // Long enough that this-week's context is barely touched; short enough that
+  // a months-old ghost is effectively dead (180d → 0.5^6 ≈ 0.016 × floor).
+  halfLifeDays: 30,
+  // Keep a sliver so an ancient turn is a last-resort tie-break, not erased.
+  floor: 0.02,
+};
+
 export const DEFAULT_RETRIEVAL: RetrievalSettings = {
   enabled: true,
   limit: 5,
@@ -225,6 +266,7 @@ export const DEFAULT_RETRIEVAL: RetrievalSettings = {
   minScore: 0,
   turnIndexing: DEFAULT_TURN_INDEXING,
   graphExpansion: DEFAULT_GRAPH_EXPANSION,
+  decay: DEFAULT_RETRIEVAL_DECAY,
 };
 
 /**
@@ -862,6 +904,35 @@ function buildRetrievalConfig(
     graphExpansion: buildGraphExpansionConfig(
       (tomlRetrieval.graph_expansion ?? {}) as Record<string, unknown>,
     ),
+    decay: buildRetrievalDecayConfig(
+      (tomlRetrieval.decay ?? {}) as Record<string, unknown>,
+    ),
+  };
+}
+
+function buildRetrievalDecayConfig(
+  toml: Record<string, unknown>,
+): RetrievalDecaySettings {
+  const enabled =
+    asBool(process.env.PHANTOMBOT_RETRIEVAL_DECAY_ENABLED) ??
+    asBool(toml.enabled) ??
+    DEFAULT_RETRIEVAL_DECAY.enabled;
+  const halfLifeDays =
+    asNumber(process.env.PHANTOMBOT_RETRIEVAL_DECAY_HALF_LIFE_DAYS) ??
+    asNumber(toml.half_life_days) ??
+    DEFAULT_RETRIEVAL_DECAY.halfLifeDays;
+  const floor =
+    asNumber(process.env.PHANTOMBOT_RETRIEVAL_DECAY_FLOOR) ??
+    asNumber(toml.floor) ??
+    DEFAULT_RETRIEVAL_DECAY.floor;
+  return {
+    enabled,
+    // Floor at 0 (0 or below disables decay in the index). No hard ceiling —
+    // an operator wanting effectively-immortal turns can set this very large.
+    halfLifeDays: Math.max(0, halfLifeDays),
+    // Clamp to a valid multiplier range so a fat-fingered value can't invert
+    // ordering (floor > 1) or push scores negative.
+    floor: Math.max(0, Math.min(1, floor)),
   };
 }
 

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -31,6 +31,46 @@ import { parseOkf } from "./okf.ts";
 export type Scope = "memory" | "kb" | "turns";
 
 /**
+ * Time-decay parameters for raw conversation-turn ranking. Passed down from the
+ * retrieval settings; when omitted, ranking is purely relevance-based (the
+ * historical behaviour, still used by the CLI `memory search`). Decay applies
+ * ONLY to `turns` — curated memory/ + kb/ notes are never aged.
+ */
+export interface TurnDecay {
+  /** Half-life in days; `<= 0` disables (factor stays 1). */
+  halfLifeDays: number;
+  /** Lower bound on the multiplier so ancient turns damp but never hit 0. */
+  floor: number;
+  /** Injectable clock for tests; defaults to Date.now() at call time. */
+  nowMs?: number;
+}
+
+/**
+ * Multiplicative time-decay factor for a turn `ageDays` old: `0.5^(age/half)`,
+ * clamped to `[floor, 1]`. A half-life of 0 (or less) disables decay → 1.
+ * Exported for testing.
+ */
+export function turnDecayFactor(ageDays: number, decay: TurnDecay): number {
+  if (decay.halfLifeDays <= 0) return 1;
+  const f = Math.pow(0.5, Math.max(0, ageDays) / decay.halfLifeDays);
+  return Math.max(decay.floor, Math.min(1, f));
+}
+
+/**
+ * Extract the turn's creation time from an indexed `turn_docs.content` string.
+ * renderTurnForIndex writes `[<role> <ISO8601>]\n<text>`, so the ISO timestamp
+ * is the second whitespace-delimited token inside the leading bracket. Returns
+ * undefined if the prefix doesn't match (older/hand-written rows) — callers
+ * treat that as "no decay" rather than guessing an age. Exported for testing.
+ */
+export function parseTurnCreatedAtMs(content: string): number | undefined {
+  const m = /^\[\S+ (\S+)\]/.exec(content);
+  if (!m) return undefined;
+  const t = Date.parse(m[1]!);
+  return Number.isFinite(t) ? t : undefined;
+}
+
+/**
  * BM25F field weights for the `notes` table. A term hit in a concept's title,
  * tags, or aliases is worth far more than the same term buried in the body —
  * this is the lexical-precision half of the OKF superpowers, and it makes the
@@ -42,6 +82,14 @@ export const NOTE_FIELD_WEIGHTS = [0, 0, 8.0, 6.0, 6.0, 3.0, 1.0] as const;
 
 /** Column index of `body` in `notes` (for snippet()). */
 const NOTES_BODY_COL = 6;
+
+/**
+ * How many raw-BM25 turn candidates to pull before decay re-ranks them (per
+ * search when decay is active). Wider than the usual `limit` so a fresh turn
+ * that BM25 ranks just outside the top-N can climb in once older front-runners
+ * are damped. 25 matches hybridSearch's internal candidate pool.
+ */
+const DECAY_CANDIDATE_POOL = 25;
 
 export interface IndexedFile {
   path: string; // relative to personaDir
@@ -685,6 +733,13 @@ export class MemoryIndex {
        * never surfaces chat B's turns. (Kai's review on PR #132.)
        */
       conversation?: string;
+      /**
+       * Time-decay for turn hits (see TurnDecay). When set, turn scores are
+       * multiplied by a half-life factor before the final sort/slice, so a
+       * fresh turn beyond the raw-BM25 top-N can still surface over a stale
+       * ghost. Omitted → relevance-only ranking (CLI `memory search`).
+       */
+      decay?: TurnDecay;
     } = {},
   ): SearchHit[] {
     const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
@@ -692,6 +747,12 @@ export class MemoryIndex {
     if (!query.trim()) return [];
 
     const ftsQuery = sanitizeFtsQuery(query);
+
+    // When decay is active, pull a wider pool of turn candidates than `limit`
+    // before re-ranking: a fresh turn that BM25 puts just outside the top-N
+    // should be able to climb in once the stale front-runners are damped.
+    // Notes are unaffected (immune to decay), so their pool stays at `limit`.
+    const turnLimit = opts.decay ? Math.max(limit, DECAY_CANDIDATE_POOL) : limit;
 
     // BM25F: weight title/tags/aliases/headings above body. Weights are SQL
     // literals (bm25() doesn't bind them), sourced from NOTE_FIELD_WEIGHTS.
@@ -735,7 +796,7 @@ export class MemoryIndex {
                   "FROM turn_docs WHERE content MATCH ? AND conversation = ? " +
                   "ORDER BY rank LIMIT ?",
               )
-              .all(ftsQuery, opts.conversation, limit) as Array<{
+              .all(ftsQuery, opts.conversation, turnLimit) as Array<{
               path: string;
               rank: number;
               snip: string;
@@ -747,12 +808,21 @@ export class MemoryIndex {
                   "FROM turn_docs WHERE content MATCH ? " +
                   "ORDER BY rank LIMIT ?",
               )
-              .all(ftsQuery, limit) as Array<{
+              .all(ftsQuery, turnLimit) as Array<{
               path: string;
               rank: number;
               snip: string;
             }>)
         : [];
+
+    // Turn scores get time-decayed (curated notes are immune); look up each
+    // candidate turn's age once, in a single batched query.
+    const decayFactors = opts.decay
+      ? this.turnDecayFactors(
+          turnRows.map((r) => r.path),
+          opts.decay,
+        )
+      : undefined;
 
     return [
       ...noteRows.map((r) => ({
@@ -766,7 +836,9 @@ export class MemoryIndex {
       ...turnRows.map((r) => ({
         path: r.path,
         scope: "turns" as const,
-        ftsScore: -r.rank,
+        // Decay damps stale turns (factor in [floor,1]); default 1 when decay
+        // is off or the turn's age couldn't be parsed.
+        ftsScore: -r.rank * (decayFactors?.get(r.path) ?? 1),
         snippet: r.snip,
       })),
     ]
@@ -798,6 +870,8 @@ export class MemoryIndex {
       hops?: number;
       /** Max neighbours to fold in. Default 3. */
       maxAdd?: number;
+      /** Time-decay for turn hits (see TurnDecay); forwarded to search(). */
+      decay?: TurnDecay;
     } = {},
   ): SearchHit[] {
     const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
@@ -805,6 +879,7 @@ export class MemoryIndex {
       scope: opts.scope,
       limit,
       conversation: opts.conversation,
+      decay: opts.decay,
     });
     const maxAdd = Math.max(0, opts.maxAdd ?? 3);
     if (maxAdd === 0) return hits;
@@ -918,6 +993,13 @@ export class MemoryIndex {
       limit?: number;
       /** See `search()` — scopes conversation-turn rows to one conversation. */
       conversation?: string;
+      /**
+       * Time-decay for turn hits (see TurnDecay). Applied ONCE, to the final
+       * fused RRF scores of turn paths, before the top-`limit` slice. The inner
+       * FTS/vector candidate lists stay relevance-ordered so RRF fuses on merit
+       * and decay isn't double-counted.
+       */
+      decay?: TurnDecay;
     } = {},
   ): SearchHit[] {
     const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
@@ -927,7 +1009,23 @@ export class MemoryIndex {
       conversation: opts.conversation,
     });
 
-    if (!queryVec || queryVec.length === 0) return ftsHits.slice(0, limit);
+    // No vector → FTS-only fallback. Still honour decay here (the inner search
+    // above is left undecayed so the RRF path below fuses on raw relevance),
+    // otherwise a vector-less call would silently skip decay.
+    if (!queryVec || queryVec.length === 0) {
+      if (!opts.decay) return ftsHits.slice(0, limit);
+      const factors = this.turnDecayFactors(
+        ftsHits.map((h) => h.path),
+        opts.decay,
+      );
+      return [...ftsHits]
+        .sort(
+          (a, b) =>
+            (b.ftsScore ?? 0) * (factors.get(b.path) ?? 1) -
+            (a.ftsScore ?? 0) * (factors.get(a.path) ?? 1),
+        )
+        .slice(0, limit);
+    }
 
     // Vector search. Brute-force cosine over all embeddings.
     const all = this.allEmbeddings();
@@ -987,10 +1085,22 @@ export class MemoryIndex {
     const vecPaths = vecRanked.map(([path]) => path);
     const rrf = rrfMerge([ftsRanked, vecPaths]);
 
-    // Build the final hit list, ordered by rrf score, including both
-    // sub-scores when available.
+    // Time-decay the fused scores of turn paths (curated notes are immune), so
+    // a stale turn that fused high on raw relevance still sinks below a fresher
+    // one. Done here — after the merge, before the slice — so decay is applied
+    // exactly once and can reorder the whole candidate pool. `rrfScore` in the
+    // emitted hit stays the RAW fused score (what callers threshold on); only
+    // the ordering key carries the decay multiplier.
+    const decayFactors = opts.decay
+      ? this.turnDecayFactors([...rrf.keys()], opts.decay)
+      : undefined;
+    const orderKey = (path: string, rrfScore: number): number =>
+      rrfScore * (decayFactors?.get(path) ?? 1);
+
+    // Build the final hit list, ordered by decay-adjusted rrf score, including
+    // both sub-scores when available.
     const merged: SearchHit[] = [...rrf.entries()]
-      .sort((a, b) => b[1] - a[1])
+      .sort((a, b) => orderKey(b[0], b[1]) - orderKey(a[0], a[1]))
       .slice(0, limit)
       .map(([path, rrfScore]) => {
         const ftsHit = ftsHits.find((h) => h.path === path);
@@ -1008,6 +1118,37 @@ export class MemoryIndex {
         };
       });
     return merged;
+  }
+
+  /**
+   * Map each candidate `turns/…` path to its decay multiplier. Non-turn paths
+   * are skipped (they're immune → caller defaults them to 1). Ages come from
+   * the ISO timestamp renderTurnForIndex bakes into each turn's content, so no
+   * schema change or extra column is needed. A single batched query fetches all
+   * candidate contents; rows whose age can't be parsed are omitted (→ factor 1,
+   * i.e. no decay rather than a guessed age).
+   */
+  private turnDecayFactors(
+    paths: string[],
+    decay: TurnDecay,
+  ): Map<string, number> {
+    const factors = new Map<string, number>();
+    const turnPaths = paths.filter((p) => p.startsWith("turns/"));
+    if (turnPaths.length === 0) return factors;
+    const now = decay.nowMs ?? Date.now();
+    const placeholders = turnPaths.map(() => "?").join(", ");
+    const rows = this.db
+      .query(
+        `SELECT path, content FROM turn_docs WHERE path IN (${placeholders})`,
+      )
+      .all(...turnPaths) as Array<{ path: string; content: string }>;
+    for (const r of rows) {
+      const createdMs = parseTurnCreatedAtMs(r.content);
+      if (createdMs === undefined) continue;
+      const ageDays = (now - createdMs) / 86_400_000;
+      factors.set(r.path, turnDecayFactor(ageDays, decay));
+    }
+    return factors;
   }
 
   private lookupScope(path: string): Scope | undefined {

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -277,7 +277,10 @@ PHASE 3 — Feed the KB
   Re-read the daily file for durable knowledge (procedures, configs, runbooks, concepts, decisions worth keeping).
   For each candidate:
     a) phantombot memory search "<topic>" to check for existing coverage
-    b) If a note already covers the area: open and update it (add the new case, edge cases, links)
+    b) If a note already covers the area, open it and RECONCILE it against today's knowledge — don't just append:
+       - ADDS (new case, edge case, link): update in place.
+       - CONTRADICTS / INVALIDATES it (a fact changed, something was decommissioned, an old assumption proved wrong): do NOT silently overwrite, and do NOT leave the stale claim standing beside the new one. Rewrite the note so its body states the CURRENT truth, bump \`updated:\`, and append a dated line under a "## Changelog" section recording what was invalidated — "${today}: was X → now Y, because Z". The old belief survives as history; it just stops being served as current truth.
+       - The whole subject is DECOMMISSIONED / no longer real: set frontmatter \`status: obsolete\` with a dated one-line reason (and a [[wikilink]] to any replacement) instead of deleting — recall must know it's dead, not silently lose it.
     c) Otherwise create a new atomic note in the right kb/<category>/ subdir using one of kb/templates/ as a starting point. Frontmatter required: type, tags, created, updated. Link related notes with [[wikilinks]].
   Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
   Run \`phantombot memory index --rebuild\` at the end so new notes have embeddings.
@@ -332,10 +335,13 @@ Re-read the daily file (memory/${today}.md). For each promote-able item the hear
   - Mistakes and learnings   → memory/lessons.md
   - Deadlines / obligations  → memory/commitments.md
 Append under a "## ${today}" header. Do not duplicate items the heartbeat already promoted.`,
-  kb: () => `STAGE: FEED THE KB
+  kb: (today) => `STAGE: FEED THE KB
 Re-read today's daily file for durable knowledge (procedures, configs, runbooks, concepts, decisions worth keeping). For each candidate:
   a) phantombot memory search "<topic>" to check for existing coverage
-  b) If a note already covers the area, open and update it (new case, edge cases, links)
+  b) If a note already covers the area, open it and RECONCILE — don't just append:
+     - ADDS (new case, edge case, link): update in place.
+     - CONTRADICTS / INVALIDATES it (fact changed, thing decommissioned, old assumption wrong): rewrite the body to the CURRENT truth, bump \`updated:\`, and append a dated line under a "## Changelog" section — "${today}: was X → now Y, because Z". Don't leave the stale claim standing beside the new one; the old belief lives on only as changelog history.
+     - Whole subject DECOMMISSIONED: set frontmatter \`status: obsolete\` with a dated reason (+ [[wikilink]] to any replacement) instead of deleting.
   c) Otherwise create a new atomic note in the right kb/<category>/ subdir from a kb/templates/ scaffold. Frontmatter required: type, tags, created, updated. Link related notes with [[wikilinks]].
 Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
 Finish with \`phantombot memory index --rebuild\` so new notes get embeddings.`,

--- a/src/orchestrator/retrieval.ts
+++ b/src/orchestrator/retrieval.ts
@@ -100,15 +100,25 @@ export async function retrieveContext(
         });
     }
 
+    // Time-decay for raw conversation-turn hits (curated memory/kb immune).
+    // Off, or half-life <= 0, → undefined, and ranking stays relevance-only.
+    const dc = opts.settings.decay;
+    const decay =
+      dc?.enabled && dc.halfLifeDays > 0
+        ? { halfLifeDays: dc.halfLifeDays, floor: dc.floor }
+        : undefined;
+
     // Gemini path: hybrid (BM25 + vector via RRF), unchanged. No-embeddings
     // path: fielded BM25 plus OKF link-graph expansion (the superpower) when
     // enabled — so keyword-only personas get semantic-ish spread for free.
+    // Turn-decay rides along every path so stale turns sink regardless.
     const ge = opts.settings.graphExpansion;
     const hits = queryVec
       ? ix.hybridSearch(query, queryVec, {
           scope: "all",
           limit: opts.settings.limit,
           conversation: opts.conversation,
+          decay,
         })
       : ge?.enabled
         ? ix.searchExpanded(query, {
@@ -117,11 +127,13 @@ export async function retrieveContext(
             conversation: opts.conversation,
             hops: ge.hops,
             maxAdd: ge.maxAdd,
+            decay,
           })
         : ix.search(query, {
             scope: "all",
             limit: opts.settings.limit,
             conversation: opts.conversation,
+            decay,
           });
 
     return formatRetrieved(hits, opts.settings);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_DURABLE_FACTS,
   DEFAULT_GRAPH_EXPANSION,
   DEFAULT_RETRIEVAL,
+  DEFAULT_RETRIEVAL_DECAY,
   DEFAULT_TELEGRAM_STREAMING,
   DEFAULT_TURN_INDEXING,
   loadConfig,
@@ -50,6 +51,9 @@ const ENV_KEYS = [
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_BATCH_SIZE",
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_FLUSH_AFTER_HOURS",
   "PHANTOMBOT_RETRIEVAL_TURN_INDEXING_REPAIR_BATCH_SIZE",
+  "PHANTOMBOT_RETRIEVAL_DECAY_ENABLED",
+  "PHANTOMBOT_RETRIEVAL_DECAY_HALF_LIFE_DAYS",
+  "PHANTOMBOT_RETRIEVAL_DECAY_FLOOR",
   "PHANTOMBOT_DURABLE_FACTS_ENABLED",
   "PHANTOMBOT_DURABLE_FACTS_MAX_INJECTED",
   "PHANTOMBOT_DURABLE_FACTS_MIN_CONFIDENCE",
@@ -770,6 +774,7 @@ min_score = 0.25
       minScore: 0.25,
       turnIndexing: DEFAULT_TURN_INDEXING,
       graphExpansion: DEFAULT_GRAPH_EXPANSION,
+      decay: DEFAULT_RETRIEVAL_DECAY,
     });
   });
 
@@ -791,7 +796,52 @@ limit = 5
       minScore: 0.4,
       turnIndexing: DEFAULT_TURN_INDEXING,
       graphExpansion: DEFAULT_GRAPH_EXPANSION,
+      decay: DEFAULT_RETRIEVAL_DECAY,
     });
+  });
+
+  test("TOML [retrieval.decay] overrides defaults", async () => {
+    await writeToml(`
+[retrieval.decay]
+enabled = false
+half_life_days = 90
+floor = 0.1
+`);
+    const c = await loadConfig();
+    expect(c.retrieval!.decay).toEqual({
+      enabled: false,
+      halfLifeDays: 90,
+      floor: 0.1,
+    });
+  });
+
+  test("decay env vars override TOML and clamp the floor to [0,1]", async () => {
+    await writeToml(`
+[retrieval.decay]
+enabled = false
+half_life_days = 90
+floor = 0.1
+`);
+    process.env.PHANTOMBOT_RETRIEVAL_DECAY_ENABLED = "true";
+    process.env.PHANTOMBOT_RETRIEVAL_DECAY_HALF_LIFE_DAYS = "45";
+    process.env.PHANTOMBOT_RETRIEVAL_DECAY_FLOOR = "5"; // out of range → 1
+    const c = await loadConfig();
+    expect(c.retrieval!.decay).toEqual({
+      enabled: true,
+      halfLifeDays: 45,
+      floor: 1,
+    });
+  });
+
+  test("decay half_life_days parses a fractional value and floors at 0", async () => {
+    await writeToml(`
+[retrieval.decay]
+half_life_days = 0.5
+`);
+    expect((await loadConfig()).retrieval!.decay.halfLifeDays).toBe(0.5);
+
+    process.env.PHANTOMBOT_RETRIEVAL_DECAY_HALF_LIFE_DAYS = "-3";
+    expect((await loadConfig()).retrieval!.decay.halfLifeDays).toBe(0);
   });
 
   test("TOML [retrieval.turn_indexing] overrides defaults", async () => {

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -9,8 +9,10 @@ import { join } from "node:path";
 import {
   MemoryIndex,
   NOTES_SCHEMA_VERSION,
+  parseTurnCreatedAtMs,
   resolveMdLink,
   sanitizeFtsQuery,
+  turnDecayFactor,
   turnPath,
   walkMarkdown,
 } from "../src/lib/memoryIndex.ts";
@@ -556,5 +558,134 @@ describe("notes-schema self-heal", () => {
       healed.close();
       await rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("turnDecayFactor", () => {
+  test("halves the score at one half-life, quarters at two", () => {
+    const d = { halfLifeDays: 30, floor: 0 };
+    expect(turnDecayFactor(0, d)).toBeCloseTo(1, 6);
+    expect(turnDecayFactor(30, d)).toBeCloseTo(0.5, 6);
+    expect(turnDecayFactor(60, d)).toBeCloseTo(0.25, 6);
+  });
+
+  test("clamps to the floor for ancient turns", () => {
+    const d = { halfLifeDays: 30, floor: 0.02 };
+    // 300 days ≈ 10 half-lives → ~0.001, below the floor.
+    expect(turnDecayFactor(300, d)).toBe(0.02);
+  });
+
+  test("half-life <= 0 disables decay (factor 1)", () => {
+    expect(turnDecayFactor(9999, { halfLifeDays: 0, floor: 0 })).toBe(1);
+    expect(turnDecayFactor(9999, { halfLifeDays: -5, floor: 0 })).toBe(1);
+  });
+
+  test("negative age (future turn) never exceeds 1", () => {
+    expect(turnDecayFactor(-10, { halfLifeDays: 30, floor: 0 })).toBe(1);
+  });
+});
+
+describe("parseTurnCreatedAtMs", () => {
+  test("extracts the ISO timestamp from a rendered turn", () => {
+    const iso = "2026-05-28T06:00:00.000Z";
+    expect(parseTurnCreatedAtMs(`[user ${iso}]\nhello`)).toBe(Date.parse(iso));
+  });
+
+  test("returns undefined for a row without the bracketed prefix", () => {
+    expect(parseTurnCreatedAtMs("just some text")).toBeUndefined();
+    expect(parseTurnCreatedAtMs("[user not-a-date]\nx")).toBeUndefined();
+  });
+});
+
+describe("turn-hit time decay (search / hybridSearch)", () => {
+  const now = new Date("2026-06-01T00:00:00Z").getTime();
+  const daysAgo = (n: number) => new Date(now - n * 86_400_000);
+
+  function seedGhostAndFresh() {
+    // Stale turn is a STRONGER lexical match (term repeated) so raw BM25 ranks
+    // it first — the exact kw-openclaw ghost shape.
+    ix.upsertTurn({
+      id: 1,
+      persona: "phantom",
+      conversation: "telegram:1001",
+      role: "assistant",
+      text: "kw-openclaw kw-openclaw kw-openclaw is the runtime here",
+      createdAt: daysAgo(300),
+      embeddable: true,
+      source: "self",
+    });
+    ix.upsertTurn({
+      id: 2,
+      persona: "phantom",
+      conversation: "telegram:1001",
+      role: "user",
+      text: "kw-openclaw was replaced by phantombot",
+      createdAt: daysAgo(0),
+      embeddable: true,
+      source: "principal",
+    });
+  }
+
+  test("without decay the stale-but-stronger turn ranks first", () => {
+    seedGhostAndFresh();
+    const hits = ix.search("kw-openclaw", { scope: "turns" });
+    expect(hits[0]?.path).toContain("/1"); // the 300-day-old ghost wins
+  });
+
+  test("with decay the fresh turn overtakes the stale ghost", () => {
+    seedGhostAndFresh();
+    const hits = ix.search("kw-openclaw", {
+      scope: "turns",
+      decay: { halfLifeDays: 30, floor: 0.02, nowMs: now },
+    });
+    expect(hits[0]?.path).toContain("/2"); // fresh correction now on top
+    expect(hits[1]?.path).toContain("/1");
+  });
+
+  test("hybridSearch applies decay to fused turn scores", () => {
+    seedGhostAndFresh();
+    // No queryVec → hybridSearch falls back through search(); pass decay and
+    // confirm the fresh turn wins there too.
+    const hits = ix.hybridSearch("kw-openclaw", undefined, {
+      scope: "turns",
+      decay: { halfLifeDays: 30, floor: 0.02, nowMs: now },
+    });
+    expect(hits[0]?.path).toContain("/2");
+  });
+
+  test("curated notes are immune — a note's score is unchanged by decay", async () => {
+    await note("kb/infra/runtime.md", "kw-openclaw runtime backup procedure");
+    await ix.refreshStale(personaDir);
+    const plain = ix.search("kw-openclaw", { scope: "kb" });
+    const decayed = ix.search("kw-openclaw", {
+      scope: "kb",
+      decay: { halfLifeDays: 1, floor: 0.01, nowMs: now },
+    });
+    expect(decayed[0]?.path).toBe("kb/infra/runtime.md");
+    // Same score with and without decay → notes never aged.
+    expect(decayed[0]?.ftsScore).toBe(plain[0]?.ftsScore);
+  });
+
+  test("a turn with unparseable age is not decayed (factor 1)", () => {
+    // Manually insert a turn_docs row whose content lacks the ISO prefix.
+    const db = (ix as unknown as { db: import("bun:sqlite").Database }).db;
+    db.prepare(
+      "INSERT INTO turn_docs (path, persona, conversation, role, turn_id, content) " +
+        "VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(
+      "turns/phantom/telegram%3A1001/5",
+      "phantom",
+      "telegram:1001",
+      "user",
+      5,
+      "kw-openclaw with no timestamp prefix",
+    );
+    const withDecay = ix.search("kw-openclaw", {
+      scope: "turns",
+      decay: { halfLifeDays: 1, floor: 0.01, nowMs: now },
+    });
+    const without = ix.search("kw-openclaw", { scope: "turns" });
+    // Unparseable age → factor 1 → identical score.
+    expect(withDecay[0]?.ftsScore).toBe(without[0]?.ftsScore);
   });
 });

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -305,4 +305,18 @@ describe("buildNightlyStagePrompt", () => {
     // and still keeps the trim half
     expect(body).toContain("TRIM");
   });
+
+  // The KB stage used to be purely additive ("open and update it"), so a note
+  // that became WRONG (subject decommissioned / assumption invalidated) kept the
+  // stale claim standing next to the new one. It must now RECONCILE: rewrite to
+  // current truth, leave a dated changelog trail, and mark dead subjects obsolete.
+  test("the KB stage instructs supersession, not just append", () => {
+    const body = buildNightlyStagePrompt("robbie", "2026-05-18", "kb");
+    expect(body).toContain("RECONCILE");
+    expect(body).toMatch(/CONTRADICTS|INVALIDATES/);
+    expect(body).toContain("## Changelog");
+    expect(body).toContain("status: obsolete");
+    // the changelog instruction is dated with the run's date (today binding)
+    expect(body).toContain("2026-05-18: was X → now Y");
+  });
 });


### PR DESCRIPTION
Closes #323.

## Problem
Retrieval ranking has **no clock**. `hybridSearch` fuses BM25 (keyword) and cosine (vector) with **RRF** — a purely rank-based merge that discards raw scores and knows nothing about age. So a months-old turn and today's correction compete on relevance alone. That's the kw-openclaw ghost: a superseded fact keeps resurfacing because it still *lexically matches*, and relevance has no memory of being superseded.

## Approach — decay-only, per-kind (agreed with Andrew)
Multiplicative time-decay on **turn hits only**:

```
score *= 0.5 ^ (ageDays / halfLifeDays)   # clamped to [floor, 1]
```

- **Turns decay** (half-life default **30d**) → stale chatter sinks no matter how strongly it matches; fresh corrections naturally outrank it.
- **Curated `memory/` + `kb/` notes are immune** (factor 1.0, never aged). This is the deliberate "keep for years, maybe forever" tier — a backup runbook reviewed once a year must not be deleted *because* it's rarely recalled.
- **No refresh-on-recall, by design.** A ghost is recalled *because* it matches; bumping its clock on recall would keep it alive — the opposite of the goal. Pure age-decay only.

### Consequence (explicit)
Decay-only ages raw turns; it does **not** touch curated files. Stale text hand-written into `CLAUDE.md` / auto-memory can still resurface until those files are edited — that's plain manual housekeeping, no PR needed, and out of scope here.

## Mechanics
- **Age source:** parsed from the ISO timestamp `renderTurnForIndex` already bakes into every `turn_docs.content` (`[role ISO]…`). **No schema change, no migration** to the fragile turn/embedding tables.
- `search()`: decay applied before the final sort+slice, with a **widened turn candidate pool** (25) so a fresh turn just outside the raw-BM25 top-N can climb in once ghosts are damped.
- `hybridSearch()`: decay applied **once**, to the fused RRF scores of turn paths, before the slice (inner candidate lists stay relevance-ordered so RRF fuses on merit and decay isn't double-counted). The no-vector fallback path honours decay too.
- `searchExpanded()` forwards decay to `search()`; graph neighbours are notes → immune.
- **Config:** new `[retrieval.decay]` block (`enabled`, `half_life_days`, `floor`) with `PHANTOMBOT_RETRIEVAL_DECAY_*` env overrides and clamping. **Disabled = zero behaviour change.** The CLI `memory search` path doesn't pass `decay`, so raw relevance ranking there is unchanged.

## Tests
- `turnDecayFactor` math (half-life, floor clamp, disabled, future-turn).
- `parseTurnCreatedAtMs` (extract + graceful undefined).
- Integration: a 300-day-old turn that BM25-outranks a fresh one **wins without decay, loses with it**; same for `hybridSearch`.
- Curated note score **identical** with/without decay (immunity proven).
- Unparseable age → factor 1 (no-op).
- Config override / clamp / fractional parse.

`bun test` green — 2476 pass. The one failure (`migrates a legacy Gemini CLI chain`) is a **pre-existing env leak on this box** (a real `PHANTOMBOT_GEMINI_API_KEY` overrides the test's TOML); it reproduces on clean `main`, unrelated to this PR.
---

## Follow-on in this PR — nightly KB supersession (65c930e)
Decay handles *old* raw turns, but not curated notes that became **wrong** (subject decommissioned, or an assumption later invalidated). Those are immune to decay by design, so they need a *correction* path, not an age one.

The nightly `kb` stage was **purely additive** ("open and update it"), so a note that became wrong kept the stale claim standing next to the new one — nothing recorded that the old belief was no longer valid.

Now the stage **reconciles**:
- **ADDS** (new case/edge/link) → update in place, as before.
- **CONTRADICTS / INVALIDATES** → rewrite the body to current truth, bump `updated:`, and append a dated line under a `## Changelog` section (`YYYY-MM-DD: was X → now Y, because Z`). The old belief survives as history but stops being served as current truth.
- **Whole subject DECOMMISSIONED** → set frontmatter `status: obsolete` with a dated reason + `[[wikilink]]` to any replacement, instead of deleting — recall knows it is dead rather than silently losing it.

Applied to both prompt variants (`buildNightlyPrompt` PHASE 3 and the checkpointed `NIGHTLY_STAGE_BODY.kb`; bound `today` into the compact `kb` arrow). Regression test asserts the supersession language + the dated changelog binding. Full suite still green (2477 pass; same lone pre-existing Gemini env-leak).