### PR TITLE
feat(memory): task-woken turns get retrieval + durable facts (self tier)

### DIFF
--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -217,13 +217,19 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
               harnesses,
               agentDir,
             ),
-            // Provenance: a task wake feeds the persona its OWN scheduled
-            // prompt — first-hand self-observation, not an untrusted stranger.
-            // Stamp the user turn `self` so task-derived facts don't land in the
-            // untrusted `other` tier. NOT `trusted`: a task has no principal
-            // command authority, and untrusted content it might ingest stays
-            // untrusted (see #327 for the mid-turn-fetch hardening follow-up).
-            userSource: "self",
+            // Provenance: an autonomous task wake can ingest UNTRUSTED content
+            // mid-turn (email body, web page, Plane issue) via tools — content
+            // the threat judge never screened because it arrives as tool output,
+            // not a judged `ask` turn (#327). So stamp BOTH turns `other`: every
+            // durable fact a task produces lands in the untrusted tier (weight
+            // 0.3, 7-day half-life, injected only tagged `unverified`, never
+            // recall-bumped) and can never masquerade as first-hand `self`
+            // knowledge or poison the persona-wide pool one tier below the owner.
+            // Conservative by design — we can't tell here which task wakes truly
+            // ingested untrusted content, so all are treated as if they did.
+            // NOT `trusted`: a task has no principal command authority either.
+            userSource: "other",
+            assistantSource: "other",
           })) {
             logBackgroundWakeChunk(task, conversation, chunk);
             if (chunk.type === "text") finalText += chunk.text;

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -51,6 +51,12 @@ import { openTaskStore, type Task, type TaskStore } from "../lib/tasks.ts";
 import { recordTickFired } from "../lib/timerHealth.ts";
 import { openMemoryStore, type MemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
+import { makeRetriever } from "../orchestrator/retrieval.ts";
+import { makeTurnIndexer } from "../orchestrator/turnIndexer.ts";
+import {
+  makeDurableFactPuller,
+  makeFactExtractor,
+} from "../orchestrator/durableFacts.ts";
 
 const WAKE_STREAM_PREVIEW_CHARS = 2000;
 const BACKGROUND_WAKE_HARD_TIMEOUT_MS = 30 * 60 * 1000;
@@ -187,6 +193,37 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
             memory,
             idleTimeoutMs: config.harnessIdleTimeoutMs,
             hardTimeoutMs: BACKGROUND_WAKE_HARD_TIMEOUT_MS,
+            // #324: an agent-woken task should wake with the same memory
+            // instincts a conversation turn gets — semantic recall + durable
+            // facts on the READ side, and consolidate its observations back on
+            // the WRITE side — instead of running context-blind and mute. Each
+            // factory self-gates: it returns undefined when its feature is
+            // disabled in config, so this is a no-op when retrieval/durable
+            // facts are off. (--command tasks never reach here — they stay
+            // blind/mute by design.)
+            retrieve: makeRetriever(config, task.persona, agentDir, conversation),
+            indexTurns: makeTurnIndexer(config, task.persona, conversation, memory),
+            pullFacts: makeDurableFactPuller(
+              config,
+              task.persona,
+              conversation,
+              memory,
+            ),
+            extractFacts: makeFactExtractor(
+              config,
+              task.persona,
+              conversation,
+              memory,
+              harnesses,
+              agentDir,
+            ),
+            // Provenance: a task wake feeds the persona its OWN scheduled
+            // prompt — first-hand self-observation, not an untrusted stranger.
+            // Stamp the user turn `self` so task-derived facts don't land in the
+            // untrusted `other` tier. NOT `trusted`: a task has no principal
+            // command authority, and untrusted content it might ingest stays
+            // untrusted (see #327 for the mid-turn-fetch hardening follow-up).
+            userSource: "self",
           })) {
             logBackgroundWakeChunk(task, conversation, chunk);
             if (chunk.type === "text") finalText += chunk.text;

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -32,6 +32,7 @@ import {
 import { loadPersona } from "../persona/loader.ts";
 import type { Harness, HarnessChunk } from "../harnesses/types.ts";
 import type { MemoryStore } from "../memory/store.ts";
+import type { FactSource } from "../config.ts";
 import type { ScreenVerdict } from "./screen.ts";
 
 export const DEFAULT_HISTORY_LIMIT = 30;
@@ -153,6 +154,26 @@ export interface TurnInput {
    *      screened by the tool-less judge before any capable harness runs.
    */
   trusted?: boolean;
+  /**
+   * Optional override for the USER-turn durable-fact provenance tier.
+   *
+   * By default the user turn is stamped `principal` when `trusted`, else
+   * `other` — the security-perimeter framing: the owner speaking vs. a third
+   * party in a shared context. That default is right for human-authored input,
+   * but wrong for a turn the persona schedules for ITSELF: a `tick` task wake
+   * feeds its own scheduled prompt, which is neither the principal live nor an
+   * untrusted stranger. Such callers pass `userSource: "self"` so task-derived
+   * observations land in the self tier (first-hand, faster-decayed) instead of
+   * masquerading as `other` (untrusted, fast-decay, low-weight).
+   *
+   * Decoupled from `trusted` on purpose: provenance-tier and the
+   * security-perimeter bit answer different questions and must not be conflated
+   * (a task wake is `self`-provenance but still NOT `trusted` — it does not get
+   * the principal's command authority). Undefined preserves the legacy
+   * `trusted ? "principal" : "other"` behaviour exactly. The assistant reply is
+   * always stamped `self` regardless — this only affects the user turn.
+   */
+  userSource?: FactSource;
   /**
    * Optional threat screen for UNTRUSTED turns (built by
    * orchestrator/screen.ts#makeScreener). Called with the incoming user
@@ -320,8 +341,10 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
         // principal (owner) speaking → highest trust. An untrusted turn is a
         // third party in a shared context → `other`, down-weighted and
         // fast-decayed so a group member's claim can't masquerade as something
-        // the owner told us in the persona-wide fact pool.
-        source: input.trusted === true ? "principal" : "other",
+        // the owner told us in the persona-wide fact pool. `userSource` lets a
+        // self-scheduled caller (tick task wake) override this to `self` so its
+        // own prompt isn't stamped as an untrusted stranger — see the field doc.
+        source: input.userSource ?? (input.trusted === true ? "principal" : "other"),
       },
       {
         persona: input.persona,

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -160,20 +160,38 @@ export interface TurnInput {
    * By default the user turn is stamped `principal` when `trusted`, else
    * `other` — the security-perimeter framing: the owner speaking vs. a third
    * party in a shared context. That default is right for human-authored input,
-   * but wrong for a turn the persona schedules for ITSELF: a `tick` task wake
-   * feeds its own scheduled prompt, which is neither the principal live nor an
-   * untrusted stranger. Such callers pass `userSource: "self"` so task-derived
-   * observations land in the self tier (first-hand, faster-decayed) instead of
-   * masquerading as `other` (untrusted, fast-decay, low-weight).
+   * but a `tick` task wake is neither: it feeds its OWN scheduled prompt and
+   * then, mid-turn, may ingest UNTRUSTED content (an email body, a web page, a
+   * Plane issue) via tools — content the threat judge never screened, because
+   * it arrives as tool output, not as a judged `ask` turn (see #327). If facts
+   * extracted from such a turn landed at `self` (weight 0.6), a prompt-injected
+   * email a poller summarises could poison the persona-wide fact pool one tier
+   * below the owner. So task callers pass BOTH `userSource` and
+   * `assistantSource` = `"other"`: everything a task turn produces lands in the
+   * untrusted tier (weight 0.3, 7-day half-life, injected only tagged
+   * `unverified`, never recall-bumped) and can never masquerade as first-hand
+   * `self` knowledge. Deliberately conservative — we can't tell at the turn
+   * layer which task wakes actually ingested untrusted content, so all of them
+   * are treated as if they did. #327 tracks doing this per-fact by tool input.
    *
    * Decoupled from `trusted` on purpose: provenance-tier and the
    * security-perimeter bit answer different questions and must not be conflated
-   * (a task wake is `self`-provenance but still NOT `trusted` — it does not get
-   * the principal's command authority). Undefined preserves the legacy
-   * `trusted ? "principal" : "other"` behaviour exactly. The assistant reply is
-   * always stamped `self` regardless — this only affects the user turn.
+   * (a task wake is `other`-provenance and still NOT `trusted` — it gets neither
+   * the principal's command authority nor self-tier trust). Undefined preserves
+   * the legacy `trusted ? "principal" : "other"` behaviour exactly.
    */
   userSource?: FactSource;
+  /**
+   * Optional override for the ASSISTANT-turn durable-fact provenance tier.
+   *
+   * The persona's own reply is stamped `self` by default (a first-hand
+   * observation). But an autonomous `tick` task can surface untrusted
+   * tool-ingested content INTO that reply, so task callers pass
+   * `assistantSource: "other"` to keep task-derived facts out of the self tier
+   * — see the `userSource` doc above for the full rationale. Undefined
+   * preserves the default `self` stamp exactly.
+   */
+  assistantSource?: FactSource;
   /**
    * Optional threat screen for UNTRUSTED turns (built by
    * orchestrator/screen.ts#makeScreener). Called with the incoming user
@@ -351,9 +369,12 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
         conversation: input.conversation,
         role: "assistant",
         text: finalText,
-        // The persona's own reply — a first-hand observation. Trusted, but
-        // decayed faster than principal facts since self-observations go stale.
-        source: "self",
+        // The persona's own reply — normally a first-hand observation (`self`,
+        // decayed faster than principal facts since self-observations go
+        // stale). `assistantSource` lets an autonomous caller (tick task wake)
+        // down-tier to `other` when the reply may carry untrusted tool-ingested
+        // content, so nothing a poller ingests can poison self-tier memory.
+        source: input.assistantSource ?? "self",
       },
     );
 

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -238,6 +238,47 @@ describe("runTick — normal task fire", () => {
     }));
   });
 
+  test("agent-woken task stamps its user turn `self` (not `other`)", async () => {
+    // #324: a task feeds the persona its OWN scheduled prompt, so the user
+    // turn must land in the self tier — NOT `other` (untrusted stranger).
+    const created = store.add({
+      persona: "phantom",
+      description: "hourly check",
+      schedule: "0 * * * *",
+      prompt: "do the thing",
+      now: new Date("2026-05-02T09:30:00Z"),
+    });
+    if (!created.ok) throw new Error("setup");
+
+    const pairCalls: Array<{ user: { source?: string } }> = [];
+    const spied = new Proxy(memory, {
+      get(target, prop, receiver) {
+        if (prop === "appendTurnPair") {
+          return async (user: { source?: string }, assistant: unknown) => {
+            pairCalls.push({ user });
+            return (
+              memory.appendTurnPair as (u: unknown, a: unknown) => Promise<void>
+            )(user, assistant);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+
+    await runTick({
+      config,
+      taskStore: store,
+      memory: spied,
+      harnesses: [new ScriptedHarness("h", [{ type: "done", finalText: "ok" }])],
+      lockPath,
+      out: { write() {} },
+      now: new Date("2026-05-02T10:00:00Z"),
+    });
+
+    expect(pairCalls).toHaveLength(1);
+    expect(pairCalls[0]!.user.source).toBe("self");
+  });
+
   test("background wake previews redact obvious secrets and cap long chunks", () => {
     const token = "ghp_" + "a".repeat(36);
     const preview = previewForLog(

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -238,9 +238,11 @@ describe("runTick — normal task fire", () => {
     }));
   });
 
-  test("agent-woken task stamps its user turn `self` (not `other`)", async () => {
-    // #324: a task feeds the persona its OWN scheduled prompt, so the user
-    // turn must land in the self tier — NOT `other` (untrusted stranger).
+  test("agent-woken task down-tiers BOTH turns to `other`", async () => {
+    // #324 + review: a task can ingest UNTRUSTED content mid-turn (email/web)
+    // that the threat judge never screened, so every fact it produces must land
+    // in the untrusted `other` tier — never `self`. Both the user turn and the
+    // assistant reply (the laundering vector) are stamped `other`.
     const created = store.add({
       persona: "phantom",
       description: "hourly check",
@@ -250,12 +252,18 @@ describe("runTick — normal task fire", () => {
     });
     if (!created.ok) throw new Error("setup");
 
-    const pairCalls: Array<{ user: { source?: string } }> = [];
+    const pairCalls: Array<{
+      user: { source?: string };
+      assistant: { source?: string };
+    }> = [];
     const spied = new Proxy(memory, {
       get(target, prop, receiver) {
         if (prop === "appendTurnPair") {
-          return async (user: { source?: string }, assistant: unknown) => {
-            pairCalls.push({ user });
+          return async (
+            user: { source?: string },
+            assistant: { source?: string },
+          ) => {
+            pairCalls.push({ user, assistant });
             return (
               memory.appendTurnPair as (u: unknown, a: unknown) => Promise<void>
             )(user, assistant);
@@ -276,7 +284,8 @@ describe("runTick — normal task fire", () => {
     });
 
     expect(pairCalls).toHaveLength(1);
-    expect(pairCalls[0]!.user.source).toBe("self");
+    expect(pairCalls[0]!.user.source).toBe("other");
+    expect(pairCalls[0]!.assistant.source).toBe("other");
   });
 
   test("background wake previews redact obvious secrets and cap long chunks", () => {

--- a/tests/orchestrator-turn.test.ts
+++ b/tests/orchestrator-turn.test.ts
@@ -416,6 +416,101 @@ describe("runTurn — purge-after-ruling (trusted success)", () => {
   });
 });
 
+describe("runTurn — user-turn provenance (userSource / trusted)", () => {
+  /** Wrap the store, capturing the user + assistant records passed to appendTurnPair. */
+  function spyPair(inner: MemoryStore): {
+    store: MemoryStore;
+    calls: Array<{ user: { source?: string }; assistant: { source?: string } }>;
+  } {
+    const calls: Array<{
+      user: { source?: string };
+      assistant: { source?: string };
+    }> = [];
+    const store = new Proxy(inner, {
+      get(target, prop, receiver) {
+        if (prop === "appendTurnPair") {
+          return async (
+            user: { source?: string },
+            assistant: { source?: string },
+          ) => {
+            calls.push({ user, assistant });
+            return (
+              inner.appendTurnPair as (u: unknown, a: unknown) => Promise<void>
+            )(user, assistant);
+          };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    return { store, calls };
+  }
+
+  const okHarness = () =>
+    new ScriptedHarness("fake", [{ type: "done", finalText: "ok" }]);
+
+  test("defaults to `other` for an untrusted turn (no userSource)", async () => {
+    const { store, calls } = spyPair(memory);
+    await collect(
+      runTurn({
+        ...baseInput(),
+        memory: store,
+        userMessage: "ambient",
+        harnesses: [okHarness()],
+      }),
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.user.source).toBe("other");
+    expect(calls[0]!.assistant.source).toBe("self");
+  });
+
+  test("stamps `principal` for a trusted turn (no userSource)", async () => {
+    const { store, calls } = spyPair(memory);
+    await collect(
+      runTurn({
+        ...baseInput(),
+        memory: store,
+        userMessage: "do it",
+        harnesses: [okHarness()],
+        trusted: true,
+      }),
+    );
+    expect(calls[0]!.user.source).toBe("principal");
+  });
+
+  test("userSource overrides the user turn to `self` (task wake)", async () => {
+    const { store, calls } = spyPair(memory);
+    await collect(
+      runTurn({
+        ...baseInput(),
+        memory: store,
+        userMessage: "scheduled work",
+        harnesses: [okHarness()],
+        // A tick task wake: self-scheduled prompt, NOT trusted.
+        userSource: "self",
+      }),
+    );
+    expect(calls[0]!.user.source).toBe("self");
+    // Assistant reply is always self regardless.
+    expect(calls[0]!.assistant.source).toBe("self");
+  });
+
+  test("userSource wins over the trusted default", async () => {
+    const { store, calls } = spyPair(memory);
+    await collect(
+      runTurn({
+        ...baseInput(),
+        memory: store,
+        userMessage: "scheduled work",
+        harnesses: [okHarness()],
+        trusted: true,
+        userSource: "self",
+      }),
+    );
+    // Explicit override beats the trusted→principal default.
+    expect(calls[0]!.user.source).toBe("self");
+  });
+});
+
 describe("runTurn — noHistory option", () => {
   test("skips loading prior turns AND skips persisting this turn", async () => {
     await memory.appendTurn({

--- a/tests/orchestrator-turn.test.ts
+++ b/tests/orchestrator-turn.test.ts
@@ -477,7 +477,7 @@ describe("runTurn — user-turn provenance (userSource / trusted)", () => {
     expect(calls[0]!.user.source).toBe("principal");
   });
 
-  test("userSource overrides the user turn to `self` (task wake)", async () => {
+  test("userSource + assistantSource down-tier BOTH turns to `other` (task wake)", async () => {
     const { store, calls } = spyPair(memory);
     await collect(
       runTurn({
@@ -485,12 +485,44 @@ describe("runTurn — user-turn provenance (userSource / trusted)", () => {
         memory: store,
         userMessage: "scheduled work",
         harnesses: [okHarness()],
-        // A tick task wake: self-scheduled prompt, NOT trusted.
-        userSource: "self",
+        // A tick task wake: may ingest untrusted content mid-turn, so every
+        // fact it produces is pinned to the untrusted tier. NOT trusted.
+        userSource: "other",
+        assistantSource: "other",
       }),
     );
-    expect(calls[0]!.user.source).toBe("self");
-    // Assistant reply is always self regardless.
+    expect(calls[0]!.user.source).toBe("other");
+    // The assistant reply is down-tiered too — this is the laundering vector.
+    expect(calls[0]!.assistant.source).toBe("other");
+  });
+
+  test("assistantSource alone overrides only the assistant turn", async () => {
+    const { store, calls } = spyPair(memory);
+    await collect(
+      runTurn({
+        ...baseInput(),
+        memory: store,
+        userMessage: "hi",
+        harnesses: [okHarness()],
+        assistantSource: "other",
+      }),
+    );
+    // User turn keeps its default (untrusted → other here); assistant overridden.
+    expect(calls[0]!.user.source).toBe("other");
+    expect(calls[0]!.assistant.source).toBe("other");
+  });
+
+  test("assistant turn defaults to `self` when not overridden", async () => {
+    const { store, calls } = spyPair(memory);
+    await collect(
+      runTurn({
+        ...baseInput(),
+        memory: store,
+        userMessage: "hi",
+        harnesses: [okHarness()],
+        trusted: true,
+      }),
+    );
     expect(calls[0]!.assistant.source).toBe("self");
   });
 
@@ -503,11 +535,11 @@ describe("runTurn — user-turn provenance (userSource / trusted)", () => {
         userMessage: "scheduled work",
         harnesses: [okHarness()],
         trusted: true,
-        userSource: "self",
+        userSource: "other",
       }),
     );
     // Explicit override beats the trusted→principal default.
-    expect(calls[0]!.user.source).toBe("self");
+    expect(calls[0]!.user.source).toBe("other");
   });
 });
 


### PR DESCRIPTION
Closes #324.

## Problem
Agent-woken (`tick`) tasks ran **context-blind and mute**: no semantic recall and no durable-fact pull on the READ side, and no turn indexing or fact extraction on the WRITE side. A scheduled task woke the persona with a bare prompt and discarded everything it observed — the exact memory instincts a normal conversation turn gets were missing.

## Change
Wire the same four factories the conversation path (`engine.ts`/`ask.ts`) uses into the **agent-woken** branch of `tick.ts` (`!isCommandTask`):
- `makeRetriever` → semantic recall injected into the prompt
- `makeDurableFactPuller` → durable facts injected (pure-SQL READ half)
- `makeTurnIndexer` → task turns become searchable
- `makeFactExtractor` → observations consolidated at the eviction cliff (out-of-band WRITE half)

`--command` tasks stay **blind/mute by design** — untouched. Each factory **self-gates** (returns `undefined` when its feature is disabled in config), so this is a **strict no-op** when retrieval/durable-facts are off.

## Provenance — Option B (`self` tier)
A task feeds the persona its **own scheduled prompt** — a first-hand self-observation, not an untrusted stranger. New optional `userSource` override on `TurnInput` stamps the task user turn `self` instead of the default `other`, so task-derived facts don't land in the untrusted fast-decay/low-weight tier.

`userSource` is **decoupled from `trusted`** on purpose:
- A task wake is `self`-provenance but still **NOT trusted** — it gets no principal command authority and doesn't skip the threat screen framing.
- Undefined `userSource` preserves the legacy `trusted ? "principal" : "other"` behaviour exactly.
- The assistant reply is always `self` regardless — this only affects the user turn.

We chose **B (reuse `self`)** over adding a distinct fast-decay `self_task` tier (Option A): simpler, no new tier surface across config/SQL/weighting, and `self`'s decay is a reasonable home for task chatter.

## Security note
Any **untrusted content a task ingests mid-turn** (email body, web page read via a tool) stays untrusted conceptually, but the current code would extract facts from it at the turn's `self` tier — **provenance laundering**. That gap is **pre-existing** (the judge guards the entry door, not mid-turn tool output) and tracked separately in #327 for future hardening. Not a blocker: today untrusted input is meant to arrive as a judged `ask` turn, and task prompts are self-authored.

## Tests
- `runTurn` provenance matrix: `other` default (untrusted), `principal` when trusted, `self` via `userSource`, and `userSource` wins over the trusted default.
- `tick` integration test: an agent-woken task stamps its persisted **user** turn `self` (spy on `appendTurnPair`).
- Existing tick tests (config has no retrieval/durable-facts blocks) confirm the **no-op-when-disabled** self-gating.
- Full suite green — 2482 pass; only the **pre-existing** `migrates a legacy Gemini CLI chain` env-leak fails (reproduces on clean `main`).