### PR TITLE
feat(memory): default assistant turns to `unverified`, promote on principal engagement (#327)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -291,19 +291,30 @@ export const DEFAULT_RETRIEVAL: RetrievalSettings = {
  * turn.ts) from the turn's role + trust bit, carried onto the fact:
  *   - `principal` — the owner said it in a trusted turn. Highest trust, slowest
  *     decay: a standing fact the owner gave us holds until they correct it.
- *   - `self`      — the persona's OWN assistant turn (a first-hand observation
- *     it made, e.g. running a task). Trust the sighting, but decay it fast:
- *     infra state churns, so a stale reading must not masquerade as current.
+ *   - `self`      — a first-hand observation the persona has EARNED trust in:
+ *     the default assistant turn no longer lands here (see `unverified`); a fact
+ *     reaches `self` only when it was promoted — e.g. re-asserted after the
+ *     principal engaged with it. Trust the sighting, but decay it fast: infra
+ *     state churns, so a stale reading must not masquerade as current.
+ *   - `unverified` — the persona's OWN assistant turn by default. The harness
+ *     reply is a mix of the persona's reasoning and whatever untrusted bytes a
+ *     tool (curl, gog, headless chrome, exec) pulled in mid-turn, and we cannot
+ *     tell them apart at the turn layer — so nothing the persona emits is
+ *     trusted first-hand until the principal engages with it. Low trust, short
+ *     life; promoted to `principal` when the owner discusses/confirms it, else
+ *     it decays and retires. This is the #327 fix: fail-closed by construction,
+ *     no allowlist, no fetch-detection, no self-declaring tools.
  *   - `other`     — anyone else in a shared/group conversation (another agent,
  *     a third party). Lowest trust, shortest life: heard in a room, not told to
  *     us one-on-one.
  */
-export type FactSource = "principal" | "self" | "other";
+export type FactSource = "principal" | "self" | "other" | "unverified";
 
 export const FACT_SOURCES: readonly FactSource[] = [
   "principal",
   "self",
   "other",
+  "unverified",
 ] as const;
 
 /**
@@ -392,6 +403,13 @@ export const DEFAULT_FACT_TIERS: FactSourceTiers = {
   principal: { weight: 1.0, halfLifeDays: 180, maxAgeDays: 365 },
   self: { weight: 0.6, halfLifeDays: 30, maxAgeDays: 90 },
   other: { weight: 0.3, halfLifeDays: 7, maxAgeDays: 30 },
+  // The persona's own default output. Weight sits at `other`'s level — untrusted
+  // until the principal engages — but with a slightly longer life (14d/60d vs
+  // 7d/30d): it is the persona's OWN work product, so a genuinely useful
+  // procedure gets a fair window to be confirmed and promoted before it retires,
+  // without ever masquerading as first-hand `self` (0.6) knowledge in the mean
+  // time. Injected tagged `unverified`, never recall-bumped (see durableFacts).
+  unverified: { weight: 0.3, halfLifeDays: 14, maxAgeDays: 60 },
 };
 
 export const DEFAULT_DURABLE_FACTS: DurableFactsSettings = {

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -32,17 +32,23 @@ export type Role = "user" | "assistant";
  * Numeric trust priority per fact source. Used both in SQL (the upsert conflict
  * clause, inlined) and in JS to decide which source wins when the same
  * normalized fact arrives from two conversations under the persona-wide key:
- * the higher-trust source is kept. principal > self > other.
+ * the higher-trust source is kept. principal > self > other > unverified. So
+ * when the SAME fact later arrives on a higher-trust turn — e.g. the principal
+ * confirms an `unverified` claim, making it `principal` — the upsert promotes
+ * it; a lower-trust re-sighting never demotes an already-earned tier.
  */
 export const FACT_SOURCE_PRIORITY: Record<FactSource, number> = {
   principal: 3,
   self: 2,
   other: 1,
+  unverified: 0,
 };
 
 /** Coerce a raw DB string to a known FactSource, defaulting to `principal`. */
 export function asFactSource(v: unknown): FactSource {
-  return v === "self" || v === "other" ? v : "principal";
+  return v === "self" || v === "other" || v === "unverified"
+    ? v
+    : "principal";
 }
 
 export interface Turn {
@@ -64,10 +70,13 @@ export interface Turn {
   embeddable: boolean;
   /**
    * Provenance of this turn's content, used by durable-fact extraction to
-   * stamp each fact's trust tier. `principal` (owner, trusted turn), `self`
-   * (the persona's own assistant turn), or `other` (a third party in a shared
+   * stamp each fact's trust tier. `principal` (owner, trusted turn),
+   * `unverified` (the persona's own assistant turn by default — unconfirmed,
+   * may carry untrusted tool-ingested bytes), `self` (a first-hand observation
+   * that has EARNED trust via promotion), or `other` (a third party in a shared
    * conversation). Legacy rows written before this column default to
-   * `principal`; the migration backfills assistant rows to `self`.
+   * `principal`; the pre-provenance migration backfilled assistant rows to
+   * `self`, but new assistant turns land `unverified`.
    */
   source: FactSource;
 }
@@ -79,8 +88,10 @@ export interface AppendTurnInput {
   text: string;
   /**
    * Provenance tier for durable-fact extraction (see Turn.source). Optional on
-   * input: when omitted it defaults to `self` for assistant turns and
-   * `principal` for user turns, matching the pre-provenance behaviour.
+   * input: when omitted it defaults to `unverified` for assistant turns and
+   * `principal` for user turns. (The assistant default was `self` before the
+   * #327 provenance tightening — an assistant turn is now untrusted until the
+   * principal engages with it.)
    */
   source?: FactSource;
   /**
@@ -444,8 +455,10 @@ CREATE TABLE IF NOT EXISTS turns (
   -- 1 = indexable (default), 0 = QUARANTINED untrusted payload that must
   -- replay in history but never reach the search index. See Turn.embeddable.
   embeddable   INTEGER NOT NULL DEFAULT 1,
-  -- Provenance tier for durable-fact extraction: 'principal' | 'self' | 'other'.
-  -- Legacy rows default to 'principal'; migration backfills assistant→'self'.
+  -- Provenance tier for durable-fact extraction:
+  -- 'principal' | 'self' | 'other' | 'unverified'. New assistant turns land
+  -- 'unverified' (own unconfirmed voice); legacy rows default to 'principal'
+  -- and the pre-provenance migration backfilled assistant rows to 'self'.
   source       TEXT NOT NULL DEFAULT 'principal'
 );
 CREATE INDEX IF NOT EXISTS idx_turns_persona_conv_time
@@ -476,8 +489,10 @@ CREATE TABLE IF NOT EXISTS durable_facts (
   fact           TEXT NOT NULL,
   fact_norm      TEXT NOT NULL,
   confidence     REAL NOT NULL DEFAULT 0.5,
-  -- Provenance tier: 'principal' | 'self' | 'other'. Drives read-path
-  -- weighting + decay and write-path retirement. Legacy rows → 'principal'.
+  -- Provenance tier: 'principal' | 'self' | 'other' | 'unverified'. Drives
+  -- read-path weighting + decay and write-path retirement. Legacy rows →
+  -- 'principal'. A fact promotes to a higher tier when re-asserted on a
+  -- higher-trust turn (unverified → principal when the owner confirms it).
   source         TEXT NOT NULL DEFAULT 'principal',
   source_turn_id INTEGER,
   created_at     TEXT NOT NULL,
@@ -758,8 +773,8 @@ class SqliteMemoryStore implements MemoryStore {
          source_turn_id = excluded.source_turn_id,
          conversation   = excluded.conversation,
          source = CASE
-           WHEN (CASE excluded.source WHEN 'principal' THEN 3 WHEN 'self' THEN 2 ELSE 1 END)
-              >  (CASE source          WHEN 'principal' THEN 3 WHEN 'self' THEN 2 ELSE 1 END)
+           WHEN (CASE excluded.source WHEN 'principal' THEN 3 WHEN 'self' THEN 2 WHEN 'other' THEN 1 ELSE 0 END)
+              >  (CASE source          WHEN 'principal' THEN 3 WHEN 'self' THEN 2 WHEN 'other' THEN 1 ELSE 0 END)
            THEN excluded.source ELSE source END`,
     );
     // Persona-wide candidate pull (no conversation filter). Returns the raw
@@ -784,9 +799,10 @@ class SqliteMemoryStore implements MemoryStore {
     this.pruneDurableFactsStmt = db.prepare(
       `DELETE FROM durable_facts
        WHERE persona = ?
-         AND ( (source = 'principal' AND last_seen_at < ?)
-            OR (source = 'self'      AND last_seen_at < ?)
-            OR (source = 'other'     AND last_seen_at < ?) )`,
+         AND ( (source = 'principal'  AND last_seen_at < ?)
+            OR (source = 'self'       AND last_seen_at < ?)
+            OR (source = 'other'      AND last_seen_at < ?)
+            OR (source = 'unverified' AND last_seen_at < ?) )`,
     );
     this.durableFactCursorStmt = db.prepare(
       `SELECT last_extracted_turn_id AS id FROM durable_fact_cursor
@@ -1246,6 +1262,7 @@ class SqliteMemoryStore implements MemoryStore {
       cutoffs.principal,
       cutoffs.self,
       cutoffs.other,
+      cutoffs.unverified,
     );
     return res.changes;
   }
@@ -1360,14 +1377,17 @@ function embeddableInt(embeddable: boolean | undefined): number {
 
 /**
  * Resolve a turn's stored provenance source. An explicit `source` wins;
- * otherwise default by role — assistant turns are the persona's own voice
- * (`self`), user turns default to `principal` (the pre-provenance behaviour).
- * Callers that know the trust bit (orchestrator/turn.ts) pass `source`
- * explicitly so a group third-party lands as `other`.
+ * otherwise default by role — assistant turns are the persona's own UNCONFIRMED
+ * voice (`unverified`: the harness reply may carry untrusted tool-ingested bytes
+ * we can't separate at this layer, so it is never first-hand `self` until the
+ * principal engages), user turns default to `principal` (the pre-provenance
+ * behaviour). Callers that know the trust bit (orchestrator/turn.ts) pass
+ * `source` explicitly so a group third-party lands as `other`. Fail-closed: a
+ * caller that forgets to stamp an assistant turn gets `unverified`, never `self`.
  */
 function defaultTurnSource(t: AppendTurnInput): FactSource {
   if (t.source) return t.source;
-  return t.role === "assistant" ? "self" : "principal";
+  return t.role === "assistant" ? "unverified" : "principal";
 }
 
 /**

--- a/src/orchestrator/durableFacts.ts
+++ b/src/orchestrator/durableFacts.ts
@@ -513,6 +513,7 @@ export function pruneCutoffs(
     principal: cut(tiers.principal.maxAgeDays),
     self: cut(tiers.self.maxAgeDays),
     other: cut(tiers.other.maxAgeDays),
+    unverified: cut(tiers.unverified.maxAgeDays),
   };
 }
 
@@ -578,12 +579,15 @@ export async function pullDurableFacts(
     // Recall bump — fire-and-forget so injection never blocks on a write.
     // Refreshing last_seen_at on the facts we actually surface is what keeps a
     // frequently-used fact fresh while unused ones decay and retire.
-    // EXCLUDE `other`-tier facts: they inject only tagged-as-unverified and must
-    // never have their clock reset, or a third-party claim would become immortal
-    // (bump → stays in top-N → bump again → never retires). They still decay and
-    // hit the retirement floor on schedule.
+    // Recall-bump ONLY the trusted tiers (principal, self). The untrusted tiers
+    // (`other` third-party claims, `unverified` own-unconfirmed output) inject
+    // tagged and must never have their clock reset, or an untrusted claim would
+    // become immortal (bump → stays in top-N → bump again → never retires). They
+    // still decay and hit the retirement floor on schedule — the ONLY way an
+    // `unverified` fact escapes that decay is genuine promotion to a trusted tier
+    // when the principal re-asserts it, not by being repeatedly surfaced.
     const touchIds = top
-      .filter((s) => s.fact.source !== "other")
+      .filter((s) => s.fact.source === "principal" || s.fact.source === "self")
       .map((s) => s.fact.id);
     if (touchIds.length > 0) {
       void input.memory.touchDurableFacts(touchIds).catch(() => {
@@ -620,20 +624,25 @@ export function formatDurableFacts(facts: DurableFact[]): string | undefined {
 
 /**
  * Render one fact as a bullet, QUALIFIED BY PROVENANCE. principal/self facts —
- * things the owner told us or the persona itself established — render as plain
- * background knowledge. An `other` fact came from a third party in a shared
- * conversation and only cleared the inject floor on a lower trust weight; it is
- * tagged inline as unverified so it can NEVER be presented to a principal turn
- * as the owner's own knowledge. Dropping this qualifier was the injection-side
- * half of the provenance hole PR #325 review flagged: an allowed untrusted turn
- * becoming a durable fact and then masquerading as owner knowledge. The tag is
- * per-line (not a section header) so it survives any slicing/reordering of the
- * bullet list.
+ * things the owner told us or the persona has EARNED first-hand trust in —
+ * render as plain background knowledge. The two untrusted tiers are tagged
+ * inline instead: an `other` fact came from a third party in a shared
+ * conversation, and an `unverified` fact is the persona's OWN assistant-turn
+ * note that the principal has not yet engaged with (the #327 default). Both only
+ * cleared the inject floor on a lower trust weight and are labelled so they can
+ * NEVER be presented to a principal turn as the owner's own knowledge. Dropping
+ * this qualifier was the injection-side half of the provenance hole PR #325
+ * review flagged: an untrusted claim becoming a durable fact and then
+ * masquerading as owner knowledge. The tag is per-line (not a section header) so
+ * it survives any slicing/reordering of the bullet list.
  */
 function formatFactLine(f: DurableFact): string {
   const fact = f.fact.trim();
   if (f.source === "other") {
     return `- [unverified — reported by a third party in a shared conversation] ${fact}`;
+  }
+  if (f.source === "unverified") {
+    return `- [unverified — the assistant's own note, not yet confirmed by the principal] ${fact}`;
   }
   return `- ${fact}`;
 }

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -184,12 +184,13 @@ export interface TurnInput {
   /**
    * Optional override for the ASSISTANT-turn durable-fact provenance tier.
    *
-   * The persona's own reply is stamped `self` by default (a first-hand
-   * observation). But an autonomous `tick` task can surface untrusted
-   * tool-ingested content INTO that reply, so task callers pass
-   * `assistantSource: "other"` to keep task-derived facts out of the self tier
-   * — see the `userSource` doc above for the full rationale. Undefined
-   * preserves the default `self` stamp exactly.
+   * The persona's own reply is stamped `unverified` by default (#327): the
+   * harness reply may carry untrusted tool-ingested content we can't separate
+   * from the persona's own reasoning, so it is not trusted first-hand until the
+   * principal engages with it. A `tick` task wake is even more clearly untrusted
+   * (it autonomously ingests emails/web/issues), so task callers still pass
+   * `assistantSource: "other"` to pin it to the third-party tier explicitly — see
+   * the `userSource` doc above. Undefined preserves the `unverified` default.
    */
   assistantSource?: FactSource;
   /**
@@ -369,12 +370,16 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
         conversation: input.conversation,
         role: "assistant",
         text: finalText,
-        // The persona's own reply — normally a first-hand observation (`self`,
-        // decayed faster than principal facts since self-observations go
-        // stale). `assistantSource` lets an autonomous caller (tick task wake)
-        // down-tier to `other` when the reply may carry untrusted tool-ingested
-        // content, so nothing a poller ingests can poison self-tier memory.
-        source: input.assistantSource ?? "self",
+        // The persona's own reply enters `unverified`, NOT `self` — this is the
+        // #327 fix. An assistant turn is a blend of the persona's reasoning and
+        // whatever untrusted bytes a tool (curl, gog, headless chrome, exec)
+        // pulled in mid-turn, and we cannot separate them at this layer, so
+        // nothing the persona emits is trusted first-hand until the principal
+        // engages with it (which re-asserts the claim on a `principal` turn and
+        // promotes the fact). Fail-closed: the default is untrusted, and it takes
+        // an interaction to earn trust, not a flag to lose it. `assistantSource`
+        // still lets an autonomous caller (tick task wake) pin `other` explicitly.
+        source: input.assistantSource ?? "unverified",
       },
     );
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -149,12 +149,14 @@ describe("loadConfig — defaults (no file)", () => {
       minConfidence: 0.5,
       maxExtractPerTurn: 4,
       // Provenance tiers: principal (owner) is highest-trust, slowest decay,
-      // ~1yr retention; self (own observations) rots in a quarter; other
-      // (overheard) fades fastest. These make persona-wide facts safe.
+      // ~1yr retention; self (EARNED first-hand) rots in a quarter; unverified
+      // (own default output, unconfirmed) and other (overheard) fade fastest.
+      // These make persona-wide facts safe.
       tiers: {
         principal: { weight: 1.0, halfLifeDays: 180, maxAgeDays: 365 },
         self: { weight: 0.6, halfLifeDays: 30, maxAgeDays: 90 },
         other: { weight: 0.3, halfLifeDays: 7, maxAgeDays: 30 },
+        unverified: { weight: 0.3, halfLifeDays: 14, maxAgeDays: 60 },
       },
       injectFloor: 0.05,
       debug: false,
@@ -531,6 +533,7 @@ max_extract_per_turn = 4
         principal: { weight: 1.0, halfLifeDays: 180, maxAgeDays: 365 },
         self: { weight: 0.6, halfLifeDays: 30, maxAgeDays: 90 },
         other: { weight: 0.3, halfLifeDays: 7, maxAgeDays: 30 },
+        unverified: { weight: 0.3, halfLifeDays: 14, maxAgeDays: 60 },
       },
       injectFloor: 0.05,
       debug: false,

--- a/tests/memory-durableFacts.test.ts
+++ b/tests/memory-durableFacts.test.ts
@@ -366,7 +366,7 @@ describe("touchDurableFacts (recall bump)", () => {
 describe("pruneExpiredDurableFacts (retirement floor)", () => {
   async function seed(
     fact: string,
-    source: "principal" | "self" | "other",
+    source: "principal" | "self" | "other" | "unverified",
   ): Promise<void> {
     await memory.upsertDurableFact({
       persona: PERSONA,
@@ -381,17 +381,20 @@ describe("pruneExpiredDurableFacts (retirement floor)", () => {
     await seed("fresh principal", "principal");
     await seed("fresh self", "self");
     await seed("fresh other", "other");
+    await seed("fresh unverified", "unverified");
 
-    // Cutoffs in the FUTURE for `other` (so it's expired) but in the PAST for
-    // principal/self (so they survive). ISO strings compare lexicographically.
+    // Cutoffs in the FUTURE for `other` + `unverified` (so they're expired) but
+    // in the PAST for principal/self (so they survive). ISO strings compare
+    // lexicographically.
     const now = Date.now();
     const iso = (msFromNow: number) => new Date(now + msFromNow).toISOString();
     const pruned = await memory.pruneExpiredDurableFacts(PERSONA, {
       principal: iso(-1000), // nothing older than 1s ago → survives
       self: iso(-1000),
       other: iso(60_000), // everything before 1min-from-now → other retires
+      unverified: iso(60_000), // ...and unverified retires on its own clock too
     });
-    expect(pruned).toBe(1);
+    expect(pruned).toBe(2);
     const remaining = (await memory.topDurableFacts(PERSONA, { limit: 10 })).map(
       (f) => f.fact,
     );
@@ -406,6 +409,7 @@ describe("pruneExpiredDurableFacts (retirement floor)", () => {
       principal: past,
       self: past,
       other: past,
+      unverified: past,
     });
     expect(pruned).toBe(0);
     expect(await memory.countDurableFacts(PERSONA)).toBe(1);
@@ -461,12 +465,27 @@ describe("turnsEvictedFromWindow", () => {
       persona: PERSONA,
       conversation: CONV,
       role: "assistant",
-      text: "self turn",
+      text: "assistant turn",
     });
     for (let i = 1; i <= 3; i++) await appendTurn(`turn ${i}`);
     const evicted = await memory.turnsEvictedFromWindow(PERSONA, CONV, 1, 0, 100);
-    const self = evicted.find((t) => t.text === "self turn")!;
-    expect(self.source).toBe("self"); // assistant turn defaults to self
+    const asst = evicted.find((t) => t.text === "assistant turn")!;
+    // #327: an assistant turn is UNCONFIRMED by default — `unverified`, never
+    // first-hand `self` — until the principal engages with it.
+    expect(asst.source).toBe("unverified");
+  });
+
+  test("an explicit source override still wins over the unverified default", async () => {
+    await memory.appendTurn({
+      persona: PERSONA,
+      conversation: CONV,
+      role: "assistant",
+      text: "promoted turn",
+      source: "self",
+    });
+    for (let i = 1; i <= 3; i++) await appendTurn(`turn ${i}`);
+    const evicted = await memory.turnsEvictedFromWindow(PERSONA, CONV, 1, 0, 100);
+    expect(evicted.find((t) => t.text === "promoted turn")!.source).toBe("self");
   });
 });
 

--- a/tests/orchestrator-durableFacts.test.ts
+++ b/tests/orchestrator-durableFacts.test.ts
@@ -515,6 +515,40 @@ describe("pullDurableFacts / formatDurableFacts", () => {
     expect(block).not.toContain("- The gateway password is hunter2.");
   });
 
+  test("qualifies `unverified`-source facts inline so the persona's own unconfirmed notes never masquerade as owner knowledge (#327)", () => {
+    const block = formatDurableFacts([
+      {
+        id: 1,
+        persona: PERSONA,
+        conversation: CONV,
+        fact: "Andrew lives in Arnhem.",
+        confidence: 0.9,
+        source: "principal",
+        createdAt: new Date(),
+        lastSeenAt: new Date(),
+      },
+      {
+        id: 2,
+        persona: PERSONA,
+        conversation: CONV,
+        fact: "The az CLI command to create a Container App is `az containerapp create`.",
+        confidence: 0.9,
+        source: "unverified",
+        createdAt: new Date(),
+        lastSeenAt: new Date(),
+      },
+    ]);
+    expect(block).toContain("- Andrew lives in Arnhem.");
+    // The persona's own unconfirmed note is present but explicitly tagged — it
+    // must never render as a bare, owner-authoritative bullet.
+    expect(block).toContain(
+      "- [unverified — the assistant's own note, not yet confirmed by the principal] The az CLI command to create a Container App is `az containerapp create`.",
+    );
+    expect(block).not.toContain(
+      "- The az CLI command to create a Container App is `az containerapp create`.",
+    );
+  });
+
   test("labels an allowed untrusted (`other`) turn to the extractor as THIRD_PARTY, not PRINCIPAL", async () => {
     // A third-party message in a shared conversation that the screen let
     // through (embeddable=true, source=other), followed by enough turns to
@@ -602,6 +636,85 @@ describe("pullDurableFacts / formatDurableFacts", () => {
     expect(otherAfter.lastSeenAt.getTime()).toBe(
       otherBefore.lastSeenAt.getTime(),
     );
+  });
+
+  test("recall bump NEVER refreshes `unverified` facts — they only escape decay via promotion (#327)", async () => {
+    // The persona's own unconfirmed note must decay on its own clock: repeatedly
+    // surfacing it must NOT reset last_seen_at, or an unverified claim would
+    // become immortal without the principal ever confirming it.
+    await memory.upsertDurableFact({
+      persona: PERSONA,
+      conversation: CONV,
+      fact: "Andrew lives in Arnhem.",
+      confidence: 0.9,
+      source: "principal",
+    });
+    await memory.upsertDurableFact({
+      persona: PERSONA,
+      conversation: CONV,
+      fact: "unconfirmed az recipe",
+      confidence: 0.9,
+      source: "unverified",
+    });
+    const before = await memory.topDurableFacts(PERSONA, { limit: 10 });
+    const principalBefore = before.find((f) => f.source === "principal")!;
+    const unverifiedBefore = before.find((f) => f.source === "unverified")!;
+
+    await new Promise((r) => setTimeout(r, 5));
+    const block = await pullDurableFacts({
+      persona: PERSONA,
+      conversation: CONV,
+      memory,
+      settings: SETTINGS,
+    });
+    expect(block).toContain("- Andrew lives in Arnhem.");
+    expect(block).toContain(
+      "- [unverified — the assistant's own note, not yet confirmed by the principal] unconfirmed az recipe",
+    );
+    await new Promise((r) => setTimeout(r, 20));
+
+    const after = await memory.topDurableFacts(PERSONA, { limit: 10 });
+    const principalAfter = after.find((f) => f.id === principalBefore.id)!;
+    const unverifiedAfter = after.find((f) => f.id === unverifiedBefore.id)!;
+    expect(principalAfter.lastSeenAt.getTime()).toBeGreaterThan(
+      principalBefore.lastSeenAt.getTime(),
+    );
+    expect(unverifiedAfter.lastSeenAt.getTime()).toBe(
+      unverifiedBefore.lastSeenAt.getTime(),
+    );
+  });
+
+  test("an `unverified` fact PROMOTES to `principal` when the owner re-asserts it (the trust-earning path, #327)", async () => {
+    // First the persona notes something itself (unverified). Then the principal
+    // confirms the same normalized fact on a trusted turn — the upsert's
+    // higher-trust-wins clause promotes the row to `principal`, and it now
+    // renders as plain owner knowledge instead of a tagged, decaying note.
+    await memory.upsertDurableFact({
+      persona: PERSONA,
+      conversation: CONV,
+      fact: "The deploy script lives at /opt/deploy.sh.",
+      confidence: 0.7,
+      source: "unverified",
+    });
+    let facts = await memory.topDurableFacts(PERSONA, { limit: 10 });
+    expect(facts.find((f) => f.fact.includes("/opt/deploy.sh"))!.source).toBe(
+      "unverified",
+    );
+
+    await memory.upsertDurableFact({
+      persona: PERSONA,
+      conversation: CONV,
+      fact: "The deploy script lives at /opt/deploy.sh.",
+      confidence: 0.9,
+      source: "principal",
+    });
+    facts = await memory.topDurableFacts(PERSONA, { limit: 10 });
+    const promoted = facts.find((f) => f.fact.includes("/opt/deploy.sh"))!;
+    expect(promoted.source).toBe("principal");
+
+    const block = formatDurableFacts([promoted])!;
+    expect(block).toContain("- The deploy script lives at /opt/deploy.sh.");
+    expect(block).not.toContain("[unverified");
   });
 
   test("formatDurableFacts returns undefined for an all-blank set", () => {

--- a/tests/orchestrator-turn.test.ts
+++ b/tests/orchestrator-turn.test.ts
@@ -460,7 +460,7 @@ describe("runTurn — user-turn provenance (userSource / trusted)", () => {
     );
     expect(calls).toHaveLength(1);
     expect(calls[0]!.user.source).toBe("other");
-    expect(calls[0]!.assistant.source).toBe("self");
+    expect(calls[0]!.assistant.source).toBe("unverified");
   });
 
   test("stamps `principal` for a trusted turn (no userSource)", async () => {
@@ -512,7 +512,7 @@ describe("runTurn — user-turn provenance (userSource / trusted)", () => {
     expect(calls[0]!.assistant.source).toBe("other");
   });
 
-  test("assistant turn defaults to `self` when not overridden", async () => {
+  test("assistant turn defaults to `unverified`, even on a trusted turn (#327)", async () => {
     const { store, calls } = spyPair(memory);
     await collect(
       runTurn({
@@ -523,7 +523,11 @@ describe("runTurn — user-turn provenance (userSource / trusted)", () => {
         trusted: true,
       }),
     );
-    expect(calls[0]!.assistant.source).toBe("self");
+    // The reply may relay untrusted tool-ingested bytes we can't separate from
+    // the persona's own reasoning, so it is NOT stamped first-hand `self` even
+    // when the principal drove the turn — trust is earned by engagement, not by
+    // the `trusted` bit. The principal's confirming turn is what promotes it.
+    expect(calls[0]!.assistant.source).toBe("unverified");
   });
 
   test("userSource wins over the trusted default", async () => {


### PR DESCRIPTION
## What & why

Closes the durable-fact laundering hole tracked in #327.

When the persona faithfully relays email / web / tool-ingested content in its reply, that **assistant turn was stamped `self`** (weight 0.6) at `turn.ts` — so facts extracted from it entered the persona-wide pool one tier below the owner. A prompt-injected email a poller summarises could quietly land as near-first-hand memory. The existing per-fact provenance machinery (#320/#325/#328) never plugged this specific default.

The turn layer **cannot** separate the persona's own reasoning from the untrusted bytes a tool (`curl`, `gog`, headless chrome, `exec`) pulled in mid-turn. So we stop trying to classify — everything the harness emits is untrusted until the principal engages with it.

## The change

New provenance tier **`unverified`** (weight `0.3`, half-life `14d`, retirement `60d`) sitting below `self`. Assistant turns now default to `unverified` instead of `self`. **Trust is earned, not assumed:**

- **Fail-closed** — an unstamped assistant turn is untrusted, never first-hand `self`. A caller that forgets to stamp gets the safe tier.
- **Promotion is free** — the existing higher-trust-wins upsert clause promotes a row to `principal` the moment the owner re-asserts the same normalised fact on a trusted turn. That's the whole trust-earning path: **no verified-by-doing, no allowlist, no fetch-detection, no self-declaring tools.**
- **Injected tagged** `[unverified — the assistant's own note, not yet confirmed by the principal]` so it can never masquerade as owner knowledge, and **never recall-bumped** — it decays and retires unless genuinely promoted.

Forward-going default change only; legacy `self` rows are untouched (the pre-provenance migration that backfilled assistant→`self` is left as-is).

## Files

- `config.ts` — `FactSource` gains `unverified`; `FACT_SOURCES`; `DEFAULT_FACT_TIERS`. TOML overrides auto-covered by `buildFactTiers`.
- `memory/store.ts` — priority map + SQL CASE, `asFactSource`, prune SQL + bind, schema/interface docs, and `defaultTurnSource` assistant fallback → `unverified`.
- `orchestrator/durableFacts.ts` — `pruneCutoffs`, inject tag, recall-bump restricted to trusted tiers.
- `orchestrator/turn.ts` — the actual flip: `assistantSource ?? "unverified"`.

## Tests

- Drift guards updated for the new tier (default + TOML-overlay configs).
- Per-source retirement prune covers `unverified` on its own clock.
- Assistant-turn default flips to `unverified` (even on a `trusted` turn); explicit override still wins.
- New: `unverified` inject tag; recall-bump never refreshes `unverified`; **`unverified` → `principal` promotion** when the owner re-asserts.

`bun tsc --noEmit` clean. All touched suites green. (One pre-existing unrelated failure on `main`: `config.test.ts` "migrates a legacy Gemini CLI chain" — fails identically before this branch.)

## Design note

Deliberately dropped *verified-by-doing* (exit-0 blessing a procedure) from the original design — it needs tool-exit plumbing the tool-less extractor has no access to, and would be fake if hand-waved. Promotion-by-engagement covers the competence-retention concern: a genuinely useful recipe gets a 14d/60d window to be confirmed before it decays.