### PR TITLE
Windows boot-resilience: login-fallback task, credential validation, boot-schema migration (#311, #309)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,13 @@ phantombot install      # installs the per-user logon task and periodic tasks
 phantombot uninstall    # removes the service and tasks
 ```
 
-`install` first asks: **"Run phantombot when you are logged off?"** (default:
-**no**). It then ensures four tasks in the current user's `\Phantombot\`
-folder, named per persona so multi-persona boxes stay identifiable in
-taskschd.msc: the always-on daemon (`phantombot-<persona>`) and the periodic
-`heartbeat-<persona>`, `nightly-<persona>`, and `tick-<persona>` tasks.
+`install` first asks: **"Run phantombot when you are logged off?"** The prompt
+**defaults to whatever you chose last time** (a first-ever install defaults to
+**no** — interactive/login mode). It then ensures the tasks in the current
+user's `\Phantombot\` folder, named per persona so multi-persona boxes stay
+identifiable in taskschd.msc: the always-on daemon (`phantombot-<persona>`) and
+the periodic `heartbeat-<persona>`, `nightly-<persona>`, and `tick-<persona>`
+tasks.
 
 For example, a persona named `robbie` gets:
 
@@ -290,11 +292,46 @@ For example, a persona named `robbie` gets:
   in session 0 owned by the scheduler and is never reaped when the launching
   SSH/console session ends.
 
+  - **Password validation + reuse.** Before committing to logged-off mode the
+    entered password is validated (`ValidateCredentials`). A blank or wrong
+    password never registers a boot task that would fail on every reboot —
+    install falls back to interactive/login mode with a clear message instead.
+    A validated password is saved to the persona's encrypted **vault**
+    (`WINDOWS_PASSWORD` key), so the next `install` lets you **press Enter to
+    reuse it** — the same UX as harness API tokens.
+  - **Login-fallback task.** Logged-off mode also registers a fifth task,
+    `login-<persona>` — an interactive twin of the daemon that starts at logon.
+    If the stored password later goes stale (corporate password rotation) and
+    the boot task can no longer authenticate, this still brings the agent up
+    the next time you log in. It is a no-op when the boot task already started
+    the daemon (the single-instance run-lock dedupes them), and is removed
+    automatically if you reinstall in interactive mode.
+  - **Update-safe boot machinery.** Each install stamps a boot-schema version
+    into the marker. On every `phantombot run` startup the daemon compares it
+    against the version the running binary expects; if a self-update changed the
+    boot-task shape, it re-runs the idempotent install to migrate the tasks in
+    place — so an update that changes the boot method can't brick the box. A
+    password-mode migration reuses the saved vault password; if none is saved it
+    logs loudly and asks you to re-run `phantombot install`.
+
 For scripted installs, `--run-logged-off` / `--interactive` skip the prompt and
-`--windows-password` (or `PHANTOMBOT_WINDOWS_PASSWORD`) supplies the
-credential non-interactively. On an existing installation,
+`--windows-password` (or `PHANTOMBOT_WINDOWS_PASSWORD`, or a saved vault value)
+supplies the credential non-interactively. On an existing installation,
 `install` leaves healthy task definitions unchanged and only repairs missing
 tasks or paths pointing at an older binary.
+
+**Cold-start recovery.** `phantombot install` is idempotent and is *the*
+recovery path when the boot machinery is gone. If all of a persona's
+`\Phantombot\*` tasks disappear at once — an AV false-positive quarantining the
+launcher, a cleanup script or Windows feature update purging Task Scheduler
+entries — the box goes dark: no daemon, no heartbeat, no self-heal, nothing left
+to run. Because nothing survives to trigger an automatic repair, recovery is a
+deliberate manual step (mirroring the Linux/macOS `install` / `uninstall`
+lifecycle): log in and run `phantombot install` again. It re-registers the full
+task set from scratch, prompting for the password (Enter to reuse the saved
+vault value) only if you had logged-off mode. Partial damage — one task deleted,
+a moved binary, a deleted launcher script — is repaired automatically by the
+heartbeat self-heal without any manual step.
 
 **Self-update.** `phantombot update` and the `/update` chat command work on
 Windows. Because Windows locks a running `.exe` against overwrite, the updater

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -537,19 +537,25 @@ async function defaultValidateWindowsCredential(
   // Strip any DOMAIN\ or COMPUTER\ prefix — ValidateCredentials takes the bare
   // account name plus a context.
   const bare = username.includes("\\") ? username.split("\\").pop()! : username;
+  // Exit codes: 0 = valid, 1 = definitively invalid (a store answered "no"),
+  // 2 = couldn't verify (no store was reachable — e.g. no domain controller).
+  // Only a definitive "invalid" (exit 1) downgrades the install; an
+  // "unverifiable" result throws so the caller proceeds as requested rather
+  // than penalising a transient infrastructure outage.
   const script = `
 $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName System.DirectoryServices.AccountManagement
 $u = $env:PB_VC_USER
 $p = $env:PB_VC_PASS
+$definitive = $false
 foreach ($ctx in @('Machine','Domain')) {
   try {
     $pc = New-Object System.DirectoryServices.AccountManagement.PrincipalContext($ctx)
     if ($pc.ValidateCredentials($u, $p)) { Write-Output 'VALID'; exit 0 }
+    $definitive = $true
   } catch { }
 }
-Write-Output 'INVALID'
-exit 1
+if ($definitive) { Write-Output 'INVALID'; exit 1 } else { Write-Output 'UNKNOWN'; exit 2 }
 `;
   const child = Bun.spawn(
     ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
@@ -565,7 +571,11 @@ exit 1
     new Response(child.stdout).text(),
     child.exited,
   ]);
-  return exitCode === 0 && stdout.includes("VALID");
+  if (exitCode === 0 && stdout.includes("VALID")) return true;
+  if (exitCode === 1) return false;
+  // Couldn't verify (no reachable credential store, or powershell itself
+  // failed) — surface as an error so commitPassword proceeds with a warning.
+  throw new Error("could not verify the Windows credential (no reachable account store)");
 }
 
 /** `COMPUTER\user` (or `DOMAIN\user`) for schtasks /RU. */

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -42,10 +42,21 @@ import {
   BunSchtasksRunner,
   currentPersonaName,
   installPhantombotTasks,
+  readTaskLogon,
   type SchtasksRunner,
   type TaskLogon,
+  type TaskLogonMode,
 } from "../lib/taskScheduler.ts";
+import { openPersonaVault, vaultPath } from "../lib/vault.ts";
+import { resolveVaultPersonaDir } from "./vault.ts";
+import { existsSync } from "node:fs";
 import type { WriteSink } from "../lib/io.ts";
+
+/** Vault key under which the Windows account password is stored so a later
+ * reinstall / boot-schema migration can reuse it without re-prompting — the
+ * same "press Enter to reuse the saved value" UX the harness uses for API
+ * tokens. Per-persona, encrypted at rest with the persona's derived key. */
+export const WINDOWS_PASSWORD_VAULT_KEY = "WINDOWS_PASSWORD";
 
 /**
  * Trailing "here's how to manage it" block shown after a successful install,
@@ -118,6 +129,36 @@ export interface RunInstallInput {
   windowsPassword?: string;
   /** Directory for transient Task Scheduler XML import files (Windows tests). */
   xmlDir?: string;
+  /**
+   * Read the previously-saved Windows password from the vault (enables the
+   * "press Enter to reuse" flow). Test seam; the real impl opens the persona
+   * vault. Returns null when none is saved.
+   */
+  readVaultWindowsPassword?: () => Promise<string | null>;
+  /**
+   * Persist a validated Windows password to the vault after a successful
+   * install so future reinstalls / boot-schema migrations can reuse it. Test
+   * seam; the real impl writes the persona vault.
+   */
+  saveVaultWindowsPassword?: (password: string) => Promise<void>;
+  /**
+   * Validate that `username`+`password` actually authenticate BEFORE committing
+   * to password/boot mode. A blank or wrong password would otherwise register a
+   * boot task that fails every reboot; instead install falls back to
+   * interactive (login) mode. Test seam; the real impl runs a PowerShell
+   * ValidateCredentials probe. When absent, validation is skipped (assumed
+   * valid) — validation is a Windows-runtime concern.
+   */
+  validateWindowsCredential?: (
+    username: string,
+    password: string,
+  ) => Promise<boolean>;
+  /**
+   * The persona's persisted install-time logon mode, used to default the
+   * run-logged-off prompt to the previous choice (first-time installs default
+   * to interactive/login). Test seam; defaults to reading the logon marker.
+   */
+  readPersistedLogonMode?: () => Promise<TaskLogonMode>;
   /** Override systemd-env detection for testing. */
   ensureSystemdEnv?: () => UserSystemdEnv;
   /**
@@ -251,10 +292,13 @@ async function runInstallWindows(
 
   // Ask whether the daemon should also run when NOBODY is logged on
   // (headless VM, Windows-update reboots). That requires Task Scheduler to
-  // store the Windows password with the task; default stays the safer
-  // interactive-token mode. Prompts only run on a real TTY — scripted
-  // installs keep the default.
-  const logon = await resolveWindowsLogon(input, err);
+  // store the Windows password with the task. The prompt DEFAULT reflects the
+  // persona's previously-chosen mode (first-time installs default to the safer
+  // interactive/login mode). Prompts only run on a real TTY; an unattended
+  // reinstall honours the persisted choice (this is the boot-schema migration
+  // path). A blank or wrong password never registers a boot task — install
+  // falls back to interactive/login mode instead.
+  const logon = await resolveWindowsLogon(input, persona, out, err);
   if (!logon) return 2; // user cancelled the prompt
 
   const result = await installPhantombotTasks({
@@ -269,9 +313,26 @@ async function runInstallWindows(
   });
   if (!result.installed) return 1;
 
+  // Persist the validated password to the vault so a later reinstall or
+  // boot-schema migration can reuse it without prompting (Enter-to-reuse).
+  if (logon.mode === "password" && logon.password) {
+    const save =
+      input.saveVaultWindowsPassword ??
+      ((pw: string) => defaultSaveVaultWindowsPassword(persona, pw));
+    try {
+      await save(logon.password);
+      out.write(`saved ${WINDOWS_PASSWORD_VAULT_KEY} to the vault (press Enter to reuse it next install)\n`);
+    } catch (e) {
+      err.write(
+        `warning: could not save the Windows password to the vault: ${(e as Error).message}\n`,
+      );
+    }
+  }
+
   out.write(
     logon.mode === "password"
-      ? `\nThese tasks run as ${logon.username} whether or not anyone is logged on (starts at boot).\n` +
+      ? `\nThese tasks run as ${logon.username} whether or not anyone is logged on (starts at boot). ` +
+          `A login-fallback task also starts the agent at logon, so a later password change can't lock the agent out.\n` +
           manageHints()
       : `\nThese tasks run for the current Windows user while logged in.\n` +
           manageHints(),
@@ -283,29 +344,87 @@ type WindowsLogonChoice = TaskLogon & { password?: string };
 
 /**
  * The install-time "run when logged off?" flow. Returns the chosen logon
- * config, or null when the user cancels. Non-interactive invocations (no
- * TTY) skip the prompts and take the interactive default — a scripted
- * install must never block on a question nobody can answer.
+ * config, or null when the user cancels. Key behaviours:
+ *
+ *  - The run-logged-off prompt DEFAULTS to the persona's previously-chosen
+ *    mode; a first-time install defaults to interactive/login.
+ *  - When run-logged-off is chosen, the password can be typed OR reused from
+ *    the vault by pressing Enter (the harness API-token UX).
+ *  - The credential is VALIDATED before committing; a blank or wrong password
+ *    falls back to interactive/login mode with a loud message, rather than
+ *    registering a boot task that fails every reboot.
+ *  - An unattended invocation (no TTY, no flag) honours the persisted mode —
+ *    the path a boot-schema migration re-runs install through.
  */
 async function resolveWindowsLogon(
   input: RunInstallInput,
+  persona: string,
+  out: WriteSink,
   err: WriteSink,
 ): Promise<WindowsLogonChoice | null> {
-  // Scripted mode: flags/env decide, no prompts. Explicit false is the same
-  // interactive-token install as answering "no".
+  const readVault =
+    input.readVaultWindowsPassword ??
+    (() => defaultReadVaultWindowsPassword(persona));
+  const validate =
+    input.validateWindowsCredential ?? defaultValidateWindowsCredential;
+
+  // Validate the credential, then either commit to password mode or fall back
+  // to interactive/login with a loud message. A validation ERROR (the probe
+  // couldn't run) is not proof the password is wrong, so it proceeds as
+  // requested with a warning; only an explicit "invalid" downgrades.
+  const commitPassword = async (
+    username: string,
+    password: string,
+  ): Promise<WindowsLogonChoice> => {
+    if (!password) {
+      out.write(
+        "no Windows password provided — installing interactive/login mode instead (runs while you are logged in)\n",
+      );
+      return { mode: "interactive" };
+    }
+    let valid: boolean;
+    try {
+      valid = await validate(username, password);
+    } catch (e) {
+      out.write(
+        `warning: could not verify the Windows password (${(e as Error).message}); proceeding with run-logged-off as requested\n`,
+      );
+      return { mode: "password", username, password };
+    }
+    if (!valid) {
+      out.write(
+        `the Windows password for ${username} did not validate — installing interactive/login mode instead ` +
+          `(the agent will start when you log in, not at boot). Re-run \`phantombot install\` with the correct password to enable boot start.\n`,
+      );
+      return { mode: "interactive" };
+    }
+    return { mode: "password", username, password };
+  };
+
+  // Scripted mode: flags/env/vault decide, no prompts. Explicit false is the
+  // same interactive-token install as answering "no".
   if (input.runLoggedOff !== undefined) {
     if (!input.runLoggedOff) return { mode: "interactive" };
     const username = await (input.whoami ?? defaultWhoami)();
     const password =
-      input.windowsPassword ?? process.env.PHANTOMBOT_WINDOWS_PASSWORD;
+      input.windowsPassword ??
+      process.env.PHANTOMBOT_WINDOWS_PASSWORD ??
+      (await readVault()) ??
+      undefined;
     if (!password) {
       err.write(
-        "--run-logged-off needs the Windows password via --windows-password or PHANTOMBOT_WINDOWS_PASSWORD\n",
+        "--run-logged-off needs the Windows password via --windows-password, PHANTOMBOT_WINDOWS_PASSWORD, or a saved vault value\n",
       );
       return null;
     }
-    return { mode: "password", username, password };
+    return await commitPassword(username, password);
   }
+
+  const persistedMode = await (
+    input.readPersistedLogonMode ??
+    (async () => (await readTaskLogon(persona)).mode)
+  )();
+  const defaultLoggedOff = persistedMode === "password";
 
   const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
   const askLoggedOff =
@@ -315,13 +434,28 @@ async function resolveWindowsLogon(
           const answer = await p.confirm({
             message:
               "Run phantombot when you are logged off? (survives reboots without login; requires your Windows password)",
-            initialValue: false,
+            initialValue: defaultLoggedOff,
           });
           if (p.isCancel(answer)) return null;
           return answer;
         }
       : undefined);
-  if (!askLoggedOff) return { mode: "interactive" };
+
+  // Unattended (no TTY, no prompt seam): honour the persisted choice. This is
+  // the boot-schema migration / silent-reinstall path — it must not silently
+  // downgrade a password-mode box to interactive.
+  if (!askLoggedOff) {
+    if (!defaultLoggedOff) return { mode: "interactive" };
+    const username = await (input.whoami ?? defaultWhoami)();
+    const password = (await readVault()) ?? undefined;
+    if (!password) {
+      out.write(
+        "run-logged-off was previously configured but no saved password is available; installing interactive/login mode instead\n",
+      );
+      return { mode: "interactive" };
+    }
+    return await commitPassword(username, password);
+  }
 
   const wantsLoggedOff = await askLoggedOff();
   if (wantsLoggedOff === null) {
@@ -331,23 +465,106 @@ async function resolveWindowsLogon(
   if (!wantsLoggedOff) return { mode: "interactive" };
 
   const username = await (input.whoami ?? defaultWhoami)();
+  const saved = (await readVault()) ?? undefined;
   const askPassword =
     input.promptPassword ??
     (async () => {
       const answer = await p.password({
-        message: `Windows password for ${username} (stored encrypted with the scheduled task):`,
+        message: saved
+          ? `Windows password for ${username} (press Enter to reuse the saved password):`
+          : `Windows password for ${username} (stored encrypted with the scheduled task):`,
         validate: (v) =>
-          !v || v.length === 0 ? "password may not be empty" : undefined,
+          !v && !saved ? "password may not be empty" : undefined,
       });
       if (p.isCancel(answer)) return null;
       return answer;
     });
-  const password = await askPassword();
-  if (password === null) {
+  const typed = await askPassword();
+  if (typed === null) {
     err.write("install cancelled\n");
     return null;
   }
-  return { mode: "password", username, password };
+  // Empty input + a saved value → reuse the saved password (Enter-to-reuse).
+  const password = typed === "" && saved ? saved : typed;
+  return await commitPassword(username, password);
+}
+
+/** Read the saved Windows password from the persona vault, or null. Never
+ * creates a vault: if none exists yet there's nothing to reuse. */
+async function defaultReadVaultWindowsPassword(
+  persona: string,
+): Promise<string | null> {
+  try {
+    const dir = await resolveVaultPersonaDir(persona);
+    if (!existsSync(vaultPath(dir))) return null;
+    const vault = await openPersonaVault(dir);
+    try {
+      return vault.get(WINDOWS_PASSWORD_VAULT_KEY) ?? null;
+    } finally {
+      vault.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the Windows password into the persona vault (encrypted at rest). */
+async function defaultSaveVaultWindowsPassword(
+  persona: string,
+  password: string,
+): Promise<void> {
+  const dir = await resolveVaultPersonaDir(persona);
+  const vault = await openPersonaVault(dir);
+  try {
+    vault.set(WINDOWS_PASSWORD_VAULT_KEY, password);
+  } finally {
+    vault.close();
+  }
+}
+
+/**
+ * Validate a Windows credential via a PowerShell ValidateCredentials probe,
+ * so a blank/wrong password never registers a boot task that fails on every
+ * reboot. The password is passed through the environment (not the command
+ * line) to keep it out of process listings. Tries the local machine account
+ * store first, then the domain — returns true if either authenticates.
+ */
+async function defaultValidateWindowsCredential(
+  username: string,
+  password: string,
+): Promise<boolean> {
+  // Strip any DOMAIN\ or COMPUTER\ prefix — ValidateCredentials takes the bare
+  // account name plus a context.
+  const bare = username.includes("\\") ? username.split("\\").pop()! : username;
+  const script = `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+$u = $env:PB_VC_USER
+$p = $env:PB_VC_PASS
+foreach ($ctx in @('Machine','Domain')) {
+  try {
+    $pc = New-Object System.DirectoryServices.AccountManagement.PrincipalContext($ctx)
+    if ($pc.ValidateCredentials($u, $p)) { Write-Output 'VALID'; exit 0 }
+  } catch { }
+}
+Write-Output 'INVALID'
+exit 1
+`;
+  const child = Bun.spawn(
+    ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      windowsHide: true,
+      env: { ...process.env, PB_VC_USER: bare, PB_VC_PASS: password },
+    },
+  );
+  const [stdout, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    child.exited,
+  ]);
+  return exitCode === 0 && stdout.includes("VALID");
 }
 
 /** `COMPUTER\user` (or `DOMAIN\user`) for schtasks /RU. */

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -490,8 +490,9 @@ async function resolveWindowsLogon(
 }
 
 /** Read the saved Windows password from the persona vault, or null. Never
- * creates a vault: if none exists yet there's nothing to reuse. */
-async function defaultReadVaultWindowsPassword(
+ * creates a vault: if none exists yet there's nothing to reuse. Exported so
+ * the boot-schema migration path (run.ts) can reuse the same reader. */
+export async function defaultReadVaultWindowsPassword(
   persona: string,
 ): Promise<string | null> {
   try {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -55,7 +55,13 @@ import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import { healDefaultPersonaIfBroken } from "../lib/personaDefault.ts";
 import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
-import { logsCommand, statusCommand } from "../lib/platform.ts";
+import { currentPlatform, logsCommand, statusCommand } from "../lib/platform.ts";
+import {
+  BunSchtasksRunner,
+  currentPersonaName,
+  migrateBootSchemaIfNeeded,
+} from "../lib/taskScheduler.ts";
+import { defaultReadVaultWindowsPassword } from "./install.ts";
 import {
   acquireRunLock,
   defaultLockPath,
@@ -327,6 +333,36 @@ export async function runRun(input: RunInput = {}): Promise<number> {
       }
     } catch (e) {
       log.warn("run: self-update artifact cleanup threw", {
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Windows only: reconcile the installed boot machinery with the version this
+  // binary expects. If a self-update changed the boot-task shape, re-run the
+  // idempotent install to migrate the tasks in place — so an update that
+  // changes the boot method can't leave a box with stale, broken boot tasks.
+  // Best-effort: a migration failure never blocks startup (the daemon is
+  // already up; the heartbeat self-heal keeps patching drift meanwhile).
+  if (isPhantombotBinary() && currentPlatform() === "windows") {
+    try {
+      const persona = await currentPersonaName();
+      const result = await migrateBootSchemaIfNeeded({
+        binPath: process.execPath,
+        persona,
+        schtasks: new BunSchtasksRunner(),
+        out: { write: () => true },
+        err: { write: () => true },
+        readWindowsPassword: () => defaultReadVaultWindowsPassword(persona),
+      });
+      if (result.migrated) {
+        log.info("run: migrated Windows boot schema", {
+          from: result.from,
+          to: result.to,
+        });
+      }
+    } catch (e) {
+      log.warn("run: boot-schema reconcile threw", {
         error: (e as Error).message,
       });
     }

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -60,6 +60,7 @@
  * moved binary by inspecting the registered task XML.
  */
 
+import { existsSync } from "node:fs";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1355,12 +1356,19 @@ export async function ensureTasksCurrent(
   const failed: string[] = [];
   let ensuredDirs = false;
 
+  // A registered task whose XML is healthy is still broken if the hidden
+  // launcher it invokes (wscript.exe //B "<launcher>.vbs" ...) has been
+  // deleted from disk — the task fires and immediately fails because
+  // wscript.exe can't find the script. The task XML alone can't reveal this,
+  // so probe the file too and treat a missing launcher as drift (#311).
+  const launcherPresent = existsSync(launcherVbsPath(persona));
+
   for (const spec of allTaskSpecs(sid, opts.binPath, persona, logon)) {
     const q = await opts.schtasks.run(["/Query", "/TN", spec.name, "/XML"]);
     const registered = q.exitCode === 0;
     const current =
-      registered && xmlReferencesBin(q.stdout, opts.binPath);
-    if (current && !opts.force) continue; // registered and points at this binary
+      registered && xmlReferencesBin(q.stdout, opts.binPath) && launcherPresent;
+    if (current && !opts.force) continue; // registered, points at this binary, launcher on disk
 
     // Password-mode heal without a credential: schtasks /Create would demand
     // /RP interactively, so instead patch the registered task's action
@@ -1379,6 +1387,13 @@ export async function ensureTasksCurrent(
         // branch is defensive only.
         failed.push(spec.name);
         continue;
+      }
+      // The task XML may be healthy and only the launcher file missing
+      // (#311). Patching the action alone would leave the task pointing at a
+      // .vbs that isn't there, so restore the launcher before patching.
+      if (!launcherPresent) {
+        await mkdir(logsDir(), { recursive: true });
+        await writeLauncherVbs(persona);
       }
       const { out: outLog, err: errLog } = taskLogPaths(spec.label);
       const newArgs = buildLauncherArguments(

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -1281,9 +1281,18 @@ export async function installPhantombotTasks(
   const xmlDir = opts.xmlDir ?? tmpdir();
   const logon = opts.logon ?? { mode: "interactive" as const };
 
-  // Persist the logon choice BEFORE registering, so a later heal sees it even
-  // if a registration below fails halfway.
-  await writeTaskLogon(opts.persona, { mode: logon.mode, username: logon.username });
+  // Persist the logon MODE before registering, so a later heal sees it even if
+  // a registration below fails halfway. But do NOT advance the boot-schema
+  // version yet: keep the prior version until every task registers. Otherwise a
+  // partial `/Create` failure would leave the marker stamped current while the
+  // tasks are still the old shape, and `migrateBootSchemaIfNeeded` would see
+  // `current` and permanently skip the retry — bricking the boot path.
+  const priorSchemaVersion = (await readTaskLogonRecord(opts.persona)).schemaVersion;
+  await writeTaskLogon(
+    opts.persona,
+    { mode: logon.mode, username: logon.username },
+    priorSchemaVersion,
+  );
 
   const r = await ensureTasksCurrent({
     binPath: opts.binPath,
@@ -1302,6 +1311,16 @@ export async function installPhantombotTasks(
     opts.err.write(`could not register scheduled task(s): ${r.failed.join(", ")}\n`);
     return { installed: false };
   }
+
+  // Every task registered — only now is it safe to advance the schema marker to
+  // the current version (transactional with successful registration, so a
+  // failed install above leaves the marker at its prior version and the next
+  // `phantombot run` retries the migration instead of skipping it forever).
+  await writeTaskLogon(
+    opts.persona,
+    { mode: logon.mode, username: logon.username },
+    BOOT_SCHEMA_VERSION,
+  );
 
   // Remove pre-rename legacy task names so an upgrade never double-supervises.
   // Only tasks provably owned by THIS Windows account are touched.

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -74,6 +74,27 @@ import { log } from "./logger.ts";
 export const TASK_FOLDER = "\\Phantombot";
 
 /**
+ * Boot-machinery schema version. Bumped whenever the SHAPE of the installed
+ * tasks changes in a way a running box can't detect from the binary path
+ * alone — new triggers, a new companion task (e.g. the login-fallback task),
+ * a changed principal/logon layout, a launcher rewrite that needs matching
+ * task args, etc.
+ *
+ * The version is stamped into the per-persona logon marker at install time.
+ * On every `phantombot run` start, {@link bootSchemaNeedsMigration} compares
+ * the stamped version against this constant; a mismatch means an update
+ * changed the boot machinery, so the daemon re-runs the idempotent install to
+ * migrate its own tasks in place. This is what stops an update that changes
+ * the boot method from bricking a box whose tasks were written by the old
+ * scheme.
+ *
+ * History:
+ *   0 — implicit; pre-versioning installs (no schemaVersion in the marker).
+ *   1 — adds the interactive login-fallback task in password mode.
+ */
+export const BOOT_SCHEMA_VERSION = 1;
+
+/**
  * Legacy task names (pre persona-scoping). Installations registered before
  * the `phantombot-<persona>` rename use these; install/heal/uninstall delete
  * them best-effort so an upgrade never leaves a stale duplicate daemon task
@@ -96,6 +117,15 @@ export interface TaskNames {
   heartbeat: string;
   nightly: string;
   tick: string;
+  /**
+   * Interactive login-fallback task. Registered ONLY in password mode: an
+   * InteractiveToken twin of the always-on daemon that starts at logon, so if
+   * the stored Windows password later goes stale (corporate rotation) and the
+   * Password-principal boot task can no longer authenticate, the daemon still
+   * comes up the next time the user logs in. The single-instance run-lock
+   * makes it a no-op when the boot task already started the daemon.
+   */
+  login: string;
   all: readonly string[];
 }
 
@@ -104,7 +134,18 @@ export function taskNames(persona: string): TaskNames {
   const heartbeat = `${TASK_FOLDER}\\heartbeat-${persona}`;
   const nightly = `${TASK_FOLDER}\\nightly-${persona}`;
   const tick = `${TASK_FOLDER}\\tick-${persona}`;
-  return { main, heartbeat, nightly, tick, all: [main, heartbeat, nightly, tick] };
+  const login = `${TASK_FOLDER}\\login-${persona}`;
+  return {
+    main,
+    heartbeat,
+    nightly,
+    tick,
+    login,
+    // `all` intentionally omits the login task: it is conditionally
+    // registered (password mode only), so heal/ownership sweeps address it
+    // explicitly rather than assuming it always exists.
+    all: [main, heartbeat, nightly, tick],
+  };
 }
 
 /**
@@ -158,9 +199,14 @@ function legacyLogonMarkerPath(): string {
 export async function writeTaskLogon(
   persona: string,
   logon: TaskLogon,
+  schemaVersion: number = BOOT_SCHEMA_VERSION,
 ): Promise<void> {
   await mkdir(launcherDir(), { recursive: true });
-  await writeFile(logonMarkerPath(persona), JSON.stringify(logon, null, 2), "utf8");
+  await writeFile(
+    logonMarkerPath(persona),
+    JSON.stringify({ ...logon, schemaVersion }, null, 2),
+    "utf8",
+  );
   // The legacy shared marker is deliberately LEFT IN PLACE: it is the only
   // record of the logon mode for personas installed before the scoping, and
   // deleting it here (when persona B installs) would silently downgrade
@@ -174,22 +220,55 @@ export async function writeTaskLogon(
  * pre-scoping install isn't mis-healed as interactive before its next
  * reinstall. */
 export async function readTaskLogon(persona: string): Promise<TaskLogon> {
+  return (await readTaskLogonRecord(persona)).logon;
+}
+
+/** Persisted marker contents: the logon choice plus the boot-schema version
+ * the tasks were last written under (absent/`0` for pre-versioning installs). */
+export interface TaskLogonRecord {
+  logon: TaskLogon;
+  schemaVersion: number;
+}
+
+/** Read the full persisted marker (logon + schema version), trying the
+ * persona-scoped marker first and falling back to the legacy shared one. */
+export async function readTaskLogonRecord(
+  persona: string,
+): Promise<TaskLogonRecord> {
   for (const path of [logonMarkerPath(persona), legacyLogonMarkerPath()]) {
     try {
       const raw = JSON.parse(await readFile(path, "utf8"));
+      const schemaVersion =
+        typeof raw?.schemaVersion === "number" ? raw.schemaVersion : 0;
       if (raw && raw.mode === "password" && typeof raw.username === "string") {
-        return { mode: "password", username: raw.username };
+        return { logon: { mode: "password", username: raw.username }, schemaVersion };
       }
-      if (raw && raw.mode === "interactive") return { mode: "interactive" };
+      if (raw && raw.mode === "interactive") {
+        return { logon: { mode: "interactive" }, schemaVersion };
+      }
     } catch {
       // Missing/corrupt marker → try the next one.
     }
   }
-  return { mode: "interactive" };
+  return { logon: { mode: "interactive" }, schemaVersion: 0 };
+}
+
+/**
+ * Does the box need a boot-schema migration? True when the tasks on disk were
+ * written under a different schema version than the running binary expects —
+ * i.e. an update changed the boot machinery. The caller responds by re-running
+ * the idempotent install so the tasks are rewritten to the current shape.
+ *
+ * Only meaningful once tasks are actually installed: a box that never ran
+ * `phantombot install` has no marker (schemaVersion 0) but also no tasks to
+ * migrate, so callers gate this on "tasks exist" separately.
+ */
+export function bootSchemaNeedsMigration(installedVersion: number): boolean {
+  return installedVersion !== BOOT_SCHEMA_VERSION;
 }
 
 /** Short label used for the per-task log filenames. */
-type TaskLabel = "phantombot" | "heartbeat" | "nightly" | "tick";
+type TaskLabel = "phantombot" | "heartbeat" | "nightly" | "tick" | "login";
 
 function logsDir(): string {
   return join(xdgDataHome(), "phantombot", "logs");
@@ -454,6 +533,42 @@ export function generatePhantombotTaskXml(
     executionTimeLimit: "PT0S", // unlimited — long-running daemon
     restartOnFailure: true,
     logon,
+  });
+}
+
+/**
+ * Generate the interactive login-fallback task XML. This is the InteractiveToken
+ * twin of the always-on daemon, registered ONLY in password mode. It carries a
+ * LogonTrigger + 1-minute keep-alive but NO BootTrigger and NO stored password,
+ * so it always authenticates as the interactive user. Its job: if the stored
+ * Windows password later goes stale and the Password-principal boot task can no
+ * longer start, this still brings the daemon up at the next logon. The
+ * single-instance run-lock makes it a no-op whenever the boot task already
+ * started the daemon.
+ */
+export function generateLoginFallbackTaskXml(
+  sid: string,
+  binPath: string,
+  persona: string,
+): string {
+  const triggers =
+    "    <LogonTrigger>\n" +
+    "      <Enabled>true</Enabled>\n" +
+    `      <UserId>${xmlEscape(sid)}</UserId>\n` +
+    "    </LogonTrigger>\n" +
+    repeatingTimeTrigger("PT1M");
+  return generateTaskXml({
+    uri: taskNames(persona).login,
+    description: `phantombot login-fallback daemon (interactive; recovers from a stale stored password) [${persona}]`,
+    sid,
+    persona,
+    label: "login",
+    binPath,
+    args: ["run"],
+    triggersXml: triggers,
+    executionTimeLimit: "PT0S", // unlimited — long-running daemon
+    restartOnFailure: true,
+    logon: { mode: "interactive" },
   });
 }
 
@@ -954,6 +1069,13 @@ interface TaskSpec {
   name: string;
   label: TaskLabel;
   xml: string;
+  /**
+   * Effective logon for THIS task. Usually the install-wide choice, but the
+   * login-fallback task is always interactive even inside a password-mode
+   * install — so heal/import must decide per-task whether a credential is
+   * needed rather than assuming the whole set shares one mode.
+   */
+  logon: TaskLogon & { password?: string };
 }
 
 /**
@@ -972,8 +1094,8 @@ async function importTaskSpec(
   spec: TaskSpec,
   xmlDir: string,
   schtasks: SchtasksRunner,
-  logon?: TaskLogon & { password?: string },
 ): Promise<SchtasksResult> {
+  const logon = spec.logon;
   const xmlPath = join(xmlDir, `phantombot-task-${spec.label}.xml`);
   await writeTaskXml(xmlPath, spec.xml);
   const args = ["/Create", "/TN", spec.name, "/XML", xmlPath];
@@ -998,22 +1120,40 @@ function allTaskSpecs(
       name: taskNames(persona).main,
       label: "phantombot",
       xml: generatePhantombotTaskXml(sid, binPath, persona, logon),
+      logon,
     },
     {
       name: taskNames(persona).heartbeat,
       label: "heartbeat",
       xml: generateHeartbeatTaskXml(sid, binPath, persona, logon),
+      logon,
     },
     {
       name: taskNames(persona).nightly,
       label: "nightly",
       xml: generateNightlyTaskXml(sid, binPath, persona, logon),
+      logon,
     },
     {
       name: taskNames(persona).tick,
       label: "tick",
       xml: generateTickTaskXml(sid, binPath, persona, logon),
+      logon,
     },
+    // Password mode only: the interactive login-fallback twin of the daemon,
+    // so a later stale password can't leave the box with no way back in. It is
+    // itself INTERACTIVE (no stored credential), so heal/import never treats it
+    // as needing the Windows password.
+    ...(logon.mode === "password"
+      ? [
+          {
+            name: taskNames(persona).login,
+            label: "login" as const,
+            xml: generateLoginFallbackTaskXml(sid, binPath, persona),
+            logon: { mode: "interactive" as const },
+          },
+        ]
+      : []),
   ];
 }
 
@@ -1179,8 +1319,27 @@ export async function installPhantombotTasks(
     );
   }
 
+  // The login-fallback task belongs to password mode only. Reinstalling in
+  // interactive mode over a previous password install must remove it, or an
+  // orphaned interactive daemon task would linger (ownership-guarded so a
+  // concurrent persona's task is never touched).
+  if (logon.mode !== "password") {
+    const outcome = await deleteTaskIfOwned(
+      opts.schtasks,
+      taskNames(opts.persona).login,
+      owner,
+    );
+    if (outcome === "deleted") {
+      opts.out.write(
+        `removed login-fallback task ${taskNames(opts.persona).login} (interactive mode)\n`,
+      );
+    }
+  }
+
   opts.out.write(
-    `registered ${taskNames(opts.persona).main} + heartbeat + nightly + tick\n`,
+    logon.mode === "password"
+      ? `registered ${taskNames(opts.persona).main} + heartbeat + nightly + tick + login-fallback\n`
+      : `registered ${taskNames(opts.persona).main} + heartbeat + nightly + tick\n`,
   );
   return { installed: true };
 }
@@ -1216,7 +1375,16 @@ export async function uninstallPhantombotTasks(
     username: opts.accountName ?? currentUserName(),
   };
   const names = taskNames(persona);
-  const ordered = [names.tick, names.nightly, names.heartbeat, names.main];
+  // Includes the login-fallback task: it only exists after a password-mode
+  // install, but deleting an absent task is a quiet no-op, so listing it
+  // unconditionally is safe and keeps uninstall total.
+  const ordered = [
+    names.login,
+    names.tick,
+    names.nightly,
+    names.heartbeat,
+    names.main,
+  ];
   const legacyOutcomes: OwnedDeleteOutcome[] = [];
   for (const name of [...ordered, ...LEGACY_TASK_NAMES]) {
     const outcome = await deleteTaskIfOwned(opts.schtasks, name, owner);
@@ -1373,8 +1541,10 @@ export async function ensureTasksCurrent(
     // Password-mode heal without a credential: schtasks /Create would demand
     // /RP interactively, so instead patch the registered task's action
     // arguments in place (credential untouched). A MISSING task can't be
-    // patched — that needs a re-install with the password.
-    if (logon.mode === "password" && !logon.password) {
+    // patched — that needs a re-install with the password. Keyed off THIS
+    // task's logon: the interactive login-fallback task carries no password
+    // and re-imports normally even inside a password-mode install.
+    if (spec.logon.mode === "password" && !spec.logon.password) {
       if (!registered) {
         failed.push(spec.name);
         log.warn("taskScheduler: password-mode task missing; re-run `phantombot install` to restore it", {
@@ -1427,7 +1597,7 @@ export async function ensureTasksCurrent(
       await writeLauncherVbs(persona);
       ensuredDirs = true;
     }
-    const r = await importTaskSpec(spec, xmlDir, opts.schtasks, logon);
+    const r = await importTaskSpec(spec, xmlDir, opts.schtasks);
     if (r.exitCode === 0) {
       rewrote.push(spec.name);
     } else {
@@ -1445,7 +1615,8 @@ export async function ensureTasksCurrent(
 
 /** Subcommand line each task label runs — kept in sync with allTaskSpecs. */
 function specArgsForLabel(label: TaskLabel): string[] {
-  return [label === "phantombot" ? "run" : label];
+  // Both the always-on daemon and its login-fallback twin run `phantombot run`.
+  return [label === "phantombot" || label === "login" ? "run" : label];
 }
 
 export interface TaskSchedulerServiceControl {

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -1344,6 +1344,97 @@ export async function installPhantombotTasks(
   return { installed: true };
 }
 
+export interface MigrateBootSchemaOptions {
+  binPath: string;
+  /** Persona whose tasks to migrate. Defaults to the current persona. */
+  persona?: string;
+  sid?: string;
+  xmlDir?: string;
+  schtasks: SchtasksRunner;
+  out: WriteSink;
+  err: WriteSink;
+  /**
+   * Supplies the saved Windows password for a password-mode migration (a
+   * schema change may add a task that needs re-registration, which schtasks
+   * can't do without the credential). Returns null when none is available —
+   * then the migration is skipped loudly rather than half-registering.
+   */
+  readWindowsPassword?: () => Promise<string | null>;
+}
+
+export interface MigrateBootSchemaResult {
+  migrated: boolean;
+  reason:
+    | "migrated"
+    | "not-installed"
+    | "current"
+    | "password-unavailable"
+    | "failed";
+  from?: number;
+  to?: number;
+}
+
+/**
+ * Reconcile the installed boot machinery with the version the running binary
+ * expects. Called once at `phantombot run` startup (Windows only): if an update
+ * changed the boot-task shape (BOOT_SCHEMA_VERSION bumped), re-run the
+ * idempotent install so the tasks are migrated in place — the thing that stops
+ * an update that changes the boot method from bricking a box whose tasks were
+ * written by the old scheme.
+ *
+ * Only an already-installed box migrates (a never-installed box has nothing to
+ * migrate, and `run` must never silently install itself). A password-mode
+ * migration needs the saved Windows password; when none is available the
+ * migration is skipped with a loud log rather than half-registering.
+ */
+export async function migrateBootSchemaIfNeeded(
+  opts: MigrateBootSchemaOptions,
+): Promise<MigrateBootSchemaResult> {
+  const persona = opts.persona ?? (await currentPersonaName());
+  const record = await readTaskLogonRecord(persona);
+
+  const mainQ = await opts.schtasks.run([
+    "/Query",
+    "/TN",
+    taskNames(persona).main,
+    "/XML",
+  ]);
+  if (mainQ.exitCode !== 0) return { migrated: false, reason: "not-installed" };
+
+  const from = record.schemaVersion;
+  const to = BOOT_SCHEMA_VERSION;
+  if (!bootSchemaNeedsMigration(from)) {
+    return { migrated: false, reason: "current", from, to };
+  }
+
+  let logon: TaskLogon & { password?: string } = record.logon;
+  if (logon.mode === "password") {
+    const pw = opts.readWindowsPassword ? await opts.readWindowsPassword() : null;
+    if (!pw) {
+      log.warn(
+        "taskScheduler: boot-schema migration needs the saved Windows password but none is available — run `phantombot install` to migrate the boot tasks",
+        { persona, from, to },
+      );
+      return { migrated: false, reason: "password-unavailable", from, to };
+    }
+    logon = { ...logon, password: pw };
+  }
+
+  const r = await installPhantombotTasks({
+    binPath: opts.binPath,
+    persona,
+    sid: opts.sid,
+    xmlDir: opts.xmlDir,
+    logon,
+    schtasks: opts.schtasks,
+    out: opts.out,
+    err: opts.err,
+  });
+  if (!r.installed) return { migrated: false, reason: "failed", from, to };
+  log.info("taskScheduler: migrated boot schema", { persona, from, to });
+  return { migrated: true, reason: "migrated", from, to };
+}
+
 export interface UninstallTaskSchedulerOptions {
   /** Persona whose tasks to remove. Defaults to the current persona. */
   persona?: string;

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -566,8 +566,9 @@ describe("runInstall (windows) logged-off prompt flow", () => {
     expect(code).toBe(0);
     expect(askedPassword).toBe(true);
     const creates = st.calls.filter((c) => c[0] === "/Create");
-    expect(creates.length).toBe(4);
-    for (const c of creates) {
+    // 4 password tasks + the interactive login-fallback twin.
+    expect(creates.length).toBe(5);
+    for (const c of creates.filter((c) => !c.some((a) => a.includes("login-testbot")))) {
       expect(c).toContain("/RU");
       expect(c).toContain("MEGAN-PC\\megan");
       expect(c).toContain("/RP");
@@ -619,8 +620,11 @@ describe("runInstall (windows) logged-off prompt flow", () => {
     expect(code).toBe(0);
     expect(prompted).toBe(false);
     const creates = st.calls.filter((c) => c[0] === "/Create");
-    expect(creates.length).toBe(4);
-    for (const c of creates) expect(c).toContain("/RP");
+    // 4 password tasks + the interactive login-fallback twin.
+    expect(creates.length).toBe(5);
+    for (const c of creates.filter((c) => !c.some((a) => a.includes("login-testbot")))) {
+      expect(c).toContain("/RP");
+    }
     expect(out.text).toContain("whether or not anyone is logged on");
   });
 

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -562,6 +562,9 @@ describe("runInstall (windows) logged-off prompt flow", () => {
         return "s3cret!";
       },
       whoami: async () => "MEGAN-PC\\megan",
+      readVaultWindowsPassword: async () => null,
+      validateWindowsCredential: async () => true,
+      saveVaultWindowsPassword: async () => {},
     });
     expect(code).toBe(0);
     expect(askedPassword).toBe(true);
@@ -616,6 +619,9 @@ describe("runInstall (windows) logged-off prompt flow", () => {
         prompted = true;
         return false;
       },
+      readVaultWindowsPassword: async () => null,
+      validateWindowsCredential: async () => true,
+      saveVaultWindowsPassword: async () => {},
     });
     expect(code).toBe(0);
     expect(prompted).toBe(false);
@@ -645,6 +651,7 @@ describe("runInstall (windows) logged-off prompt flow", () => {
         platform: "windows",
         runLoggedOff: true,
         whoami: async () => "MEGAN-PC\\megan",
+        readVaultWindowsPassword: async () => null,
       });
       expect(code).toBe(2);
       expect(err.text).toContain("needs the Windows password");
@@ -652,4 +659,123 @@ describe("runInstall (windows) logged-off prompt flow", () => {
     } finally {
       if (prev !== undefined) process.env.PHANTOMBOT_WINDOWS_PASSWORD = prev;
     }
+  });
+
+  test("Enter reuses the saved vault password", async () => {
+    const st = new FakeSchtasks();
+    const code = await runInstall({
+      binPath: WIN_BIN2,
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      platform: "windows",
+      whoami: async () => "MEGAN-PC\\megan",
+      promptRunLoggedOff: async () => true,
+      // User pressed Enter (empty) at the password prompt.
+      promptPassword: async () => "",
+      readVaultWindowsPassword: async () => "vault-pw",
+      validateWindowsCredential: async () => true,
+      saveVaultWindowsPassword: async () => {},
+    });
+    expect(code).toBe(0);
+    const pwCreates = st.calls.filter(
+      (c) => c[0] === "/Create" && !c.some((a) => a.includes("login-testbot")),
+    );
+    expect(pwCreates.length).toBe(4);
+    // The reused vault password was applied via /RP.
+    for (const c of pwCreates) {
+      expect(c).toContain("/RP");
+      expect(c).toContain("vault-pw");
+    }
+  });
+
+  test("a wrong password falls back to interactive/login mode (no boot task)", async () => {
+    const st = new FakeSchtasks();
+    const out = new CaptureStream();
+    let saved = false;
+    const code = await runInstall({
+      binPath: WIN_BIN2,
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+      platform: "windows",
+      whoami: async () => "MEGAN-PC\\megan",
+      promptRunLoggedOff: async () => true,
+      promptPassword: async () => "wrong-pw",
+      readVaultWindowsPassword: async () => null,
+      validateWindowsCredential: async () => false,
+      saveVaultWindowsPassword: async () => {
+        saved = true;
+      },
+    });
+    expect(code).toBe(0);
+    // No password-mode registration: no /RP anywhere, and no login-fallback
+    // task is CREATED (interactive install still probes it for cleanup).
+    expect(st.calls.some((c) => c.includes("/RP"))).toBe(false);
+    expect(
+      st.calls.some(
+        (c) => c[0] === "/Create" && c.some((a) => a.includes("login-testbot")),
+      ),
+    ).toBe(false);
+    // A wrong password is never persisted to the vault.
+    expect(saved).toBe(false);
+    expect(out.text).toContain("did not validate");
+  });
+
+  test("unattended reinstall honours a persisted password mode (boot-schema migration path)", async () => {
+    const st = new FakeSchtasks();
+    const code = await runInstall({
+      binPath: WIN_BIN2,
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      platform: "windows",
+      whoami: async () => "MEGAN-PC\\megan",
+      // No prompt seam + no runLoggedOff flag = unattended. Persisted mode +
+      // saved password drive it, exactly like a silent boot-schema migration.
+      readPersistedLogonMode: async () => "password",
+      readVaultWindowsPassword: async () => "migrated-pw",
+      validateWindowsCredential: async () => true,
+      saveVaultWindowsPassword: async () => {},
+    });
+    expect(code).toBe(0);
+    const pwCreates = st.calls.filter(
+      (c) => c[0] === "/Create" && !c.some((a) => a.includes("login-testbot")),
+    );
+    expect(pwCreates.length).toBe(4);
+    for (const c of pwCreates) expect(c).toContain("migrated-pw");
+    // The interactive login-fallback twin is registered too.
+    expect(st.calls.some((c) => c.some((a) => a.includes("login-testbot")))).toBe(
+      true,
+    );
+  });
+
+  test("unattended reinstall with no saved password downgrades to interactive, loudly", async () => {
+    const st = new FakeSchtasks();
+    const out = new CaptureStream();
+    const code = await runInstall({
+      binPath: WIN_BIN2,
+      persona: "testbot",
+      sid: "S-1-5-21-1-2-3-1001",
+      xmlDir: workdir,
+      schtasks: st,
+      out,
+      err: new CaptureStream(),
+      platform: "windows",
+      whoami: async () => "MEGAN-PC\\megan",
+      readPersistedLogonMode: async () => "password",
+      readVaultWindowsPassword: async () => null,
+    });
+    expect(code).toBe(0);
+    expect(st.calls.some((c) => c.includes("/RP"))).toBe(false);
+    expect(out.text).toContain("no saved password is available");
   });

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -592,6 +592,16 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
     };
   }
 
+  /** Model a genuinely healthy box: the hidden launcher exists on disk.
+   * Without this a "healthy" registry is still treated as drift, because a
+   * task pointing at a missing .vbs is broken (#311). */
+  async function primeLauncher(persona = PERSONA): Promise<void> {
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    mkdirSync(dirname(launcherVbsPath(persona)), { recursive: true });
+    writeFileSync(launcherVbsPath(persona), LAUNCHER_VBS, "utf8");
+  }
+
   /**
    * A schtasks fake whose `/Query /XML` answers come from a per-task map
    * (undefined => task not installed, exit 1) and whose `/Create` always
@@ -621,6 +631,7 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
   }
 
   test("healthy box: every task already points at the binary → no re-import", async () => {
+    await primeLauncher();
     const st = new HealFake(registeredXml(BIN));
     const r = await ensureTasksCurrent({
       binPath: BIN,
@@ -660,6 +671,7 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
   });
 
   test("a single missing task is re-registered; the current ones are left alone", async () => {
+    await primeLauncher();
     const xml = registeredXml(BIN);
     xml[NAMES.tick] = undefined as unknown as string; // tick was deleted
     const st = new HealFake(xml);
@@ -677,6 +689,7 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
   test("path casing differences alone are not treated as drift", async () => {
     // schtasks may echo the command line back with different casing; a mere
     // case difference must not trigger a needless re-import.
+    await primeLauncher();
     const st = new HealFake(registeredXml(BIN.toUpperCase()));
     const r = await ensureTasksCurrent({
       binPath: BIN.toLowerCase(),
@@ -687,6 +700,31 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
     });
     expect(r.rewrote).toEqual([]);
     expect(st.created()).toEqual([]);
+  });
+
+  test("healthy XML but launcher .vbs deleted → all tasks re-registered and launcher restored (#311)", async () => {
+    // Every task's XML is healthy and points at the current binary, but the
+    // hidden launcher the actions invoke has been deleted from disk (AV
+    // quarantine, cleanup script). The tasks are live but broken — heal must
+    // catch this even though the XML alone looks current.
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(launcherVbsPath(PERSONA))).toBe(false);
+    const st = new HealFake(registeredXml(BIN));
+    const r = await ensureTasksCurrent({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+    });
+    expect(r.rewrote).toEqual([
+      NAMES.main,
+      NAMES.heartbeat,
+      NAMES.nightly,
+      NAMES.tick,
+    ]);
+    // The launcher is written back so the re-registered tasks can actually run.
+    expect(existsSync(launcherVbsPath(PERSONA))).toBe(true);
   });
 });
 
@@ -1111,6 +1149,14 @@ describe("password logon mode (run when logged off)", () => {
 
   test("heal patches a drifted password-mode task's action in place (no credential needed)", async () => {
     await writeTaskLogon(PERSONA, { mode: "password", username: ACCOUNT });
+    // Launcher present on disk so only the binary-path drift is healed, not a
+    // launcher-missing (#311) rewrite of every task.
+    {
+      const { mkdirSync, writeFileSync } = await import("node:fs");
+      const { dirname } = await import("node:path");
+      mkdirSync(dirname(launcherVbsPath(PERSONA)), { recursive: true });
+      writeFileSync(launcherVbsPath(PERSONA), LAUNCHER_VBS, "utf8");
+    }
     const OLD_BIN = "C:\\old\\phantombot.exe";
     const registered: Record<string, string | undefined> = {
       [NAMES.main]: generatePhantombotTaskXml(SID, OLD_BIN, PERSONA, {

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -1510,6 +1510,71 @@ describe("boot-schema versioning + migration", () => {
     });
     expect(st.created()).toEqual([]);
   });
+
+  test("a partial registration failure does NOT advance the marker, so the next run retries", async () => {
+    // Old-schema interactive box: installed but stale, so a migration is due.
+    await writeTaskLogon(PERSONA, { mode: "interactive" }, 0);
+
+    // A runner whose main task exists (migration proceeds) but that fails the
+    // tick /Create the first time through, then heals.
+    class FlakyMigrateFake implements SchtasksRunner {
+      calls: string[][] = [];
+      failCreate = true;
+      constructor(private registry: Record<string, string | undefined>) {}
+      async run(args: readonly string[]): Promise<SchtasksResult> {
+        this.calls.push([...args]);
+        if (args[0] === "/Query") {
+          const xml = this.registry[args[args.indexOf("/TN") + 1]!];
+          return xml === undefined
+            ? { exitCode: 1, stdout: "", stderr: "cannot find" }
+            : { exitCode: 0, stdout: xml, stderr: "" };
+        }
+        if (args[0] === "/Create" && this.failCreate && args.includes(NAMES.tick)) {
+          return { exitCode: 1, stdout: "", stderr: "access denied" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+    }
+
+    const st = new FlakyMigrateFake({ [NAMES.main]: principalXml(SID) });
+
+    // First attempt: the tick /Create fails → migration reports failure and the
+    // marker MUST stay at the prior schema (0), not jump to current.
+    const first = await migrateBootSchemaIfNeeded({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(first).toEqual({
+      migrated: false,
+      reason: "failed",
+      from: 0,
+      to: BOOT_SCHEMA_VERSION,
+    });
+    // The critical assertion: a half-migrated box is still marked stale, so the
+    // migration is retried rather than permanently skipped.
+    expect((await readTaskLogonRecord(PERSONA)).schemaVersion).toBe(0);
+
+    // The transient fault clears; the next `phantombot run` retries and completes.
+    st.failCreate = false;
+    const second = await migrateBootSchemaIfNeeded({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(second.migrated).toBe(true);
+    expect((await readTaskLogonRecord(PERSONA)).schemaVersion).toBe(
+      BOOT_SCHEMA_VERSION,
+    );
+  });
 });
 
 describe("#309 cold-start recovery: `phantombot install` restores a fully-wiped set", () => {

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -40,8 +40,12 @@ import {
   uninstallPhantombotTasks,
   taskNames,
   readTaskLogon,
+  readTaskLogonRecord,
   writeTaskLogon,
   LEGACY_TASK_NAMES,
+  BOOT_SCHEMA_VERSION,
+  bootSchemaNeedsMigration,
+  migrateBootSchemaIfNeeded,
 } from "../src/lib/taskScheduler.ts";
 
 const SID = "S-1-5-21-1111111111-2222222222-3333333333-1001";
@@ -1358,5 +1362,152 @@ describe("per-persona logon marker", () => {
       JSON.stringify({ mode: "password", username: "PC\\old" }),
     );
     expect(await readTaskLogon("newbot")).toEqual({ mode: "interactive" });
+  });
+});
+
+describe("boot-schema versioning + migration", () => {
+  /** A schtasks fake: /Query answers from a registry (missing → exit 1),
+   * /Create + everything else succeed and are recorded. */
+  class MigrateFake implements SchtasksRunner {
+    calls: string[][] = [];
+    constructor(private registry: Record<string, string | undefined> = {}) {}
+    async run(args: readonly string[]): Promise<SchtasksResult> {
+      this.calls.push([...args]);
+      if (args[0] === "/Query") {
+        const xml = this.registry[args[args.indexOf("/TN") + 1]!];
+        return xml === undefined
+          ? { exitCode: 1, stdout: "", stderr: "cannot find" }
+          : { exitCode: 0, stdout: xml, stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    created(): string[] {
+      return this.calls
+        .filter((c) => c[0] === "/Create")
+        .map((c) => c[c.indexOf("/TN") + 1]!);
+    }
+  }
+
+  test("bootSchemaNeedsMigration: 0 (pre-versioning) needs it, current does not", () => {
+    expect(bootSchemaNeedsMigration(0)).toBe(true);
+    expect(bootSchemaNeedsMigration(BOOT_SCHEMA_VERSION)).toBe(false);
+  });
+
+  test("writeTaskLogon stamps the schema version; readTaskLogonRecord returns it", async () => {
+    await writeTaskLogon(PERSONA, { mode: "interactive" });
+    const rec = await readTaskLogonRecord(PERSONA);
+    expect(rec.logon).toEqual({ mode: "interactive" });
+    expect(rec.schemaVersion).toBe(BOOT_SCHEMA_VERSION);
+  });
+
+  test("a marker written without a version reads back as schemaVersion 0", async () => {
+    const { writeFileSync, mkdirSync } = await import("node:fs");
+    mkdirSync(join(workdir, "phantombot"), { recursive: true });
+    writeFileSync(
+      join(workdir, "phantombot", `windows-logon-${PERSONA}.json`),
+      JSON.stringify({ mode: "interactive" }), // no schemaVersion
+    );
+    expect((await readTaskLogonRecord(PERSONA)).schemaVersion).toBe(0);
+  });
+
+  test("a never-installed box does not migrate (and never self-installs)", async () => {
+    const st = new MigrateFake({}); // main task not registered
+    const r = await migrateBootSchemaIfNeeded({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(r).toEqual({ migrated: false, reason: "not-installed" });
+    expect(st.created()).toEqual([]);
+  });
+
+  test("an up-to-date box does not migrate", async () => {
+    await writeTaskLogon(PERSONA, { mode: "interactive" }); // stamps current version
+    const st = new MigrateFake({ [NAMES.main]: principalXml(SID) });
+    const r = await migrateBootSchemaIfNeeded({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(r.reason).toBe("current");
+    expect(r.migrated).toBe(false);
+    expect(st.created()).toEqual([]);
+  });
+
+  test("an interactive box on an old schema migrates by re-installing", async () => {
+    // Old-schema marker (version 0) + a registered main task = installed but stale.
+    await writeTaskLogon(PERSONA, { mode: "interactive" }, 0);
+    const st = new MigrateFake({ [NAMES.main]: principalXml(SID) });
+    const r = await migrateBootSchemaIfNeeded({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(r.migrated).toBe(true);
+    expect(r.from).toBe(0);
+    expect(r.to).toBe(BOOT_SCHEMA_VERSION);
+    // Re-registered the four interactive tasks (no login task in interactive mode).
+    expect(st.created()).toContain(NAMES.main);
+    // The marker is stamped current, so a second start does not re-migrate.
+    expect((await readTaskLogonRecord(PERSONA)).schemaVersion).toBe(
+      BOOT_SCHEMA_VERSION,
+    );
+  });
+
+  test("a password box migrates using the saved vault password (adds the login task)", async () => {
+    await writeTaskLogon(PERSONA, { mode: "password", username: "PC\\me" }, 0);
+    const st = new MigrateFake({ [NAMES.main]: passwordPrincipalXml("PC\\me") });
+    const r = await migrateBootSchemaIfNeeded({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      readWindowsPassword: async () => "saved-pw",
+    });
+    expect(r.migrated).toBe(true);
+    // The login-fallback task is now part of the set.
+    expect(st.created()).toContain(NAMES.login);
+    // The saved password was applied via /RP on the password tasks.
+    const mainCreate = st.calls.find(
+      (c) => c[0] === "/Create" && c.includes(NAMES.main),
+    )!;
+    expect(mainCreate).toContain("saved-pw");
+  });
+
+  test("a password box with no saved password is skipped loudly, not half-migrated", async () => {
+    await writeTaskLogon(PERSONA, { mode: "password", username: "PC\\me" }, 0);
+    const st = new MigrateFake({ [NAMES.main]: passwordPrincipalXml("PC\\me") });
+    const r = await migrateBootSchemaIfNeeded({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      readWindowsPassword: async () => null,
+    });
+    expect(r).toEqual({
+      migrated: false,
+      reason: "password-unavailable",
+      from: 0,
+      to: BOOT_SCHEMA_VERSION,
+    });
+    expect(st.created()).toEqual([]);
   });
 });

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -1511,3 +1511,65 @@ describe("boot-schema versioning + migration", () => {
     expect(st.created()).toEqual([]);
   });
 });
+
+describe("#309 cold-start recovery: `phantombot install` restores a fully-wiped set", () => {
+  /** Records /Create names; /Query always misses (every task deleted). */
+  class ColdStartFake implements SchtasksRunner {
+    calls: string[][] = [];
+    async run(args: readonly string[]): Promise<SchtasksResult> {
+      this.calls.push([...args]);
+      if (args[0] === "/Query") {
+        return { exitCode: 1, stdout: "", stderr: "cannot find" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    created(): string[] {
+      return this.calls
+        .filter((c) => c[0] === "/Create")
+        .map((c) => c[c.indexOf("/TN") + 1]!);
+    }
+  }
+
+  test("all tasks deleted → interactive install re-registers the four-task set", async () => {
+    const st = new ColdStartFake();
+    const result = await installPhantombotTasks({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      xmlDir: workdir,
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(result.installed).toBe(true);
+    expect(st.created()).toEqual([
+      NAMES.main,
+      NAMES.heartbeat,
+      NAMES.nightly,
+      NAMES.tick,
+    ]);
+  });
+
+  test("all tasks deleted → logged-off install re-registers all five (incl. login-fallback)", async () => {
+    const st = new ColdStartFake();
+    const result = await installPhantombotTasks({
+      binPath: BIN,
+      persona: PERSONA,
+      sid: SID,
+      accountName: "PC\\me",
+      xmlDir: workdir,
+      logon: { mode: "password", username: "PC\\me", password: "pw" },
+      schtasks: st,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(result.installed).toBe(true);
+    expect(st.created()).toEqual([
+      NAMES.main,
+      NAMES.heartbeat,
+      NAMES.nightly,
+      NAMES.tick,
+      NAMES.login,
+    ]);
+  });
+});

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -307,6 +307,9 @@ describe("installPhantombotTasks", () => {
       `/Delete /TN ${LEGACY_TASK_NAMES[2]} /F`,
       `/Query /TN ${LEGACY_TASK_NAMES[3]} /XML`,
       `/Delete /TN ${LEGACY_TASK_NAMES[3]} /F`,
+      // Interactive install also sweeps a stale password-mode login-fallback
+      // task (absent here, so just the ownership probe, no delete).
+      `/Query /TN ${NAMES.login} /XML`,
     ]);
     expect(out.text).toContain("registered");
   });
@@ -441,6 +444,9 @@ describe("uninstallPhantombotTasks", () => {
     const result = await uninstallPhantombotTasks({ persona: PERSONA, sid: SID, schtasks: st, out, err });
     expect(result.removed).toBe(true);
     expect(st.calls.map((c) => c.join(" "))).toEqual([
+      // Login-fallback task is swept first; absent here (only NAMES.all is
+      // registered), so just the ownership probe.
+      `/Query /TN ${NAMES.login} /XML`,
       `/Query /TN ${NAMES.tick} /XML`,
       `/Delete /TN ${NAMES.tick} /F`,
       `/Query /TN ${NAMES.nightly} /XML`,
@@ -573,7 +579,8 @@ describe("uninstallPhantombotTasks", () => {
     const result = await uninstallPhantombotTasks({ persona: PERSONA, sid: SID, schtasks: st, out, err });
     expect(result.removed).toBe(true);
     expect(st.calls.filter((c) => c[0] === "/Delete")).toEqual([]);
-    expect(st.calls.filter((c) => c[0] === "/Query").length).toBe(8);
+    // 4 persona tasks + the login-fallback probe + 4 legacy names = 9 queries.
+    expect(st.calls.filter((c) => c[0] === "/Query").length).toBe(9);
     expect(out.text).not.toContain("removed scheduled task");
   });
 });
@@ -1132,13 +1139,20 @@ describe("password logon mode (run when logged off)", () => {
     });
     expect(result.installed).toBe(true);
     const creates = st.calls.filter((c) => c[0] === "/Create");
-    expect(creates.length).toBe(4);
-    for (const c of creates) {
+    // 4 password tasks + the interactive login-fallback twin = 5 registrations.
+    expect(creates.length).toBe(5);
+    const loginCreate = creates.find((c) => c.includes(NAMES.login))!;
+    const passwordCreates = creates.filter((c) => !c.includes(NAMES.login));
+    expect(passwordCreates.length).toBe(4);
+    for (const c of passwordCreates) {
       expect(c).toContain("/RU");
       expect(c).toContain(ACCOUNT);
       expect(c).toContain("/RP");
       expect(c).toContain("s3cret");
     }
+    // The login-fallback task is INTERACTIVE — it never carries the credential.
+    expect(loginCreate).not.toContain("/RP");
+    expect(loginCreate).not.toContain("s3cret");
     // The marker remembers the mode + account for the heal path, but the
     // password stays with Task Scheduler — never on our disk.
     expect(await readTaskLogon(PERSONA)).toEqual({
@@ -1176,6 +1190,7 @@ describe("password logon mode (run when logged off)", () => {
         username: ACCOUNT,
       }),
     };
+    const creates: string[] = [];
     const st: SchtasksRunner = {
       async run(args: readonly string[]): Promise<SchtasksResult> {
         if (args[0] === "/Query") {
@@ -1184,7 +1199,19 @@ describe("password logon mode (run when logged off)", () => {
             ? { exitCode: 1, stdout: "", stderr: "cannot find" }
             : { exitCode: 0, stdout: xml, stderr: "" };
         }
-        throw new Error("password-mode heal must NOT re-import via schtasks");
+        // The interactive login-fallback task needs no credential, so a
+        // missing one IS re-imported by the heal. Any /Create of a
+        // PASSWORD-mode task without a credential would be the bug this test
+        // guards against.
+        if (args[0] === "/Create") {
+          const tn = args[args.indexOf("/TN") + 1]!;
+          if (tn !== NAMES.login) {
+            throw new Error(`password-mode heal must NOT re-import ${tn}`);
+          }
+          creates.push(tn);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
       },
     };
     const patched: Array<[string, string]> = [];
@@ -1199,21 +1226,27 @@ describe("password logon mode (run when logged off)", () => {
         return { ok: true };
       },
     });
-    // Only the drifted daemon task was patched, with the new binary path in
-    // the launcher arguments.
-    expect(r.rewrote).toEqual([NAMES.main]);
+    // The drifted daemon task was patched in place (credential preserved); the
+    // absent interactive login-fallback task was re-imported (no credential).
+    expect(r.rewrote).toEqual([NAMES.main, NAMES.login]);
     expect(r.failed).toEqual([]);
     expect(patched.length).toBe(1);
     expect(patched[0]![0]).toBe(NAMES.main);
     expect(patched[0]![1]).toContain(BIN);
     expect(patched[0]![1]).not.toContain(OLD_BIN);
+    expect(creates).toEqual([NAMES.login]);
   });
 
   test("heal cannot recreate a MISSING password-mode task — it says to re-install", async () => {
     await writeTaskLogon(PERSONA, { mode: "password", username: ACCOUNT });
     const st: SchtasksRunner = {
-      async run(): Promise<SchtasksResult> {
-        return { exitCode: 1, stdout: "", stderr: "cannot find" };
+      async run(args: readonly string[]): Promise<SchtasksResult> {
+        // Every task is missing (/Query fails); /Create succeeds — but the
+        // password tasks never reach /Create without a credential.
+        if (args[0] === "/Query") {
+          return { exitCode: 1, stdout: "", stderr: "cannot find" };
+        }
+        return { exitCode: 0, stdout: "", stderr: "" };
       },
     };
     const r = await ensureTasksCurrent({
@@ -1224,7 +1257,9 @@ describe("password logon mode (run when logged off)", () => {
       schtasks: st,
       patchAction: async () => ({ ok: true }),
     });
-    expect(r.rewrote).toEqual([]);
+    // The 4 password tasks can't be recreated without the credential; the
+    // interactive login-fallback twin needs none, so it IS restored.
+    expect(r.rewrote).toEqual([NAMES.login]);
     expect(r.failed).toEqual([
       NAMES.main,
       NAMES.heartbeat,


### PR DESCRIPTION
Closes #311. Closes #309.

Windows boot-resilience for the Task Scheduler service, per the design worked out with Andrew. One coherent PR because every piece touches the same file and the same boot machinery.

## What's in it

**1. `#311` — deleted launcher counts as drift.** `ensureTasksCurrent` only compared the registered task XML against the current binary path. A task whose XML is healthy but whose hidden launcher `.vbs` has been deleted (AV quarantine, cleanup script) fires and immediately fails, and self-heal never noticed. Now the launcher's on-disk presence is folded into the drift check, so a missing launcher triggers a rewrite (interactive) or a launcher-restore + action-patch (password mode).

**2. Password-by-preference install UX.**
- The "run when logged off?" prompt now **defaults to the persona's previously-chosen mode** (first-ever install → interactive/login).
- When logged-off is chosen, the Windows password can be **typed or reused from the vault by pressing Enter** (`WINDOWS_PASSWORD` key — the same UX as harness API tokens). A validated password is saved to the vault after a successful install.
- The credential is **validated before committing** (PowerShell `ValidateCredentials`, password passed via env not argv). A blank/wrong password **falls back to interactive/login mode with a loud message** instead of registering a boot task that fails on every reboot. An *unverifiable* probe (no reachable account store) proceeds as requested rather than penalising an infrastructure hiccup.

**3. Interactive login-fallback task.** Logged-off mode now also registers `login-<persona>` — an InteractiveToken twin of the daemon that starts at logon. If the stored password later goes **stale (corporate rotation)** and the Password-principal boot task can't authenticate, this still brings the agent up at the next logon. The single-instance run-lock makes it a no-op when the boot task already started the daemon; it's removed automatically when reinstalling in interactive mode.

**4. Update-safe boot schema.** Each install stamps `BOOT_SCHEMA_VERSION` into the per-persona marker. On every `phantombot run` start, `migrateBootSchemaIfNeeded` compares it against the version the running binary expects; if a self-update changed the boot-task shape, the daemon re-runs the idempotent install to migrate its tasks in place — so an update that changes the boot method can't brick the box. Password-mode migration reuses the saved vault password; with none saved it logs loudly and asks for a manual `phantombot install`. Best-effort — never blocks startup.

**5. `#309` — cold-start recovery documented.** `phantombot install` is idempotent and is *the* recovery path when all `\Phantombot\*` tasks are wiped at once. Because nothing survives a total wipe to trigger an automatic repair, recovery is a deliberate manual re-run — mirroring the Linux/macOS install/uninstall lifecycle. README updated; explicit all-tasks-deleted tests added (interactive restores 4, logged-off restores all 5).

## Tests
- `bun test` green except one **pre-existing** unrelated failure on `main` (`loadConfig … migrates a legacy Gemini CLI chain`) — not touched here.
- `bun tsc --noEmit` clean.
- ~30 new unit tests across `tests/lib-taskScheduler.test.ts` and `tests/cli-install.test.ts` covering the launcher-drift, login-fallback, schema round-trip/migration, install UX (vault reuse / validation fallback / unattended migration path), and cold-start recovery.

## Reviewer notes — validated on Linux CI only
Consistent with the existing Windows suite (fake `SchtasksRunner`, runs on Linux CI), everything here is unit-tested with fakes; I don't have a Windows box. Worth a real-Windows eye on:
- `ValidateCredentials` behaviour for **domain** accounts (Machine-vs-Domain context selection) and the 0/1/2 exit-code contract.
- The login-fallback task actually recovering after a deliberately-staled password, and the boot-schema migration re-running install cleanly at startup.
- Storing the Windows account password in the persona vault is a deliberate design choice (enables Enter-to-reuse + unattended schema migration); flagging it explicitly for security review.
