### PR TITLE
fix(coder-swap): decay manual /coder overrides on a 10-min idle TTL

### DIFF
--- a/src/lib/coderSwap.ts
+++ b/src/lib/coderSwap.ts
@@ -38,13 +38,17 @@
  *
  * MANUAL OVERRIDE: `/coder` forces the coding brain on for a conversation,
  * `/nocoder` forces it off, `/coder default` clears back to scoring. The
- * override is persistent (no TTL) and wins over the score, mirroring the
- * `/viewcoder` store shape (see viewCoder.ts).
+ * override wins over the score, mirroring the `/viewcoder` store shape (see
+ * viewCoder.ts) — but it DECAYS rather than latching forever (see the two
+ * bounds on the store below). A month-long stuck override forcing every
+ * conversational turn onto the coding model is exactly the failure this decay
+ * prevents.
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { xdgStateHome } from "../config.ts";
+import { writeFileAtomic } from "./io.ts";
 
 /** The single paranoia-level dial: distinct-weight sum at/above which we swap. */
 export const CODER_SWAP_THRESHOLD = 3;
@@ -477,8 +481,32 @@ export function normalizeCoderSwapRequest(
   return undefined;
 }
 
+/**
+ * Two decay bounds keep a manual override from latching forever (the
+ * kimi-k3-forced-for-a-month failure). Both are checked lazily on read — no
+ * timer, no restart, exactly like reply-mode's expiry (see replyMode.ts).
+ *
+ *   IDLE_TTL   — a sliding window: the override releases after this long with no
+ *                conversation activity. Each turn that consults the override
+ *                refreshes `touchedAt`, so a live coding session (turns spaced
+ *                out by reading diffs / running builds) survives, but an
+ *                abandoned conversation drops back to the scorer. 30 min, not
+ *                reply-mode's 10, because coding turns are naturally further
+ *                apart than chat turns.
+ *   MAX_AGE    — an absolute backstop: the override releases this long after it
+ *                was SET regardless of activity. This is the real cure for the
+ *                month-long latch — even a conversation kept perpetually warm
+ *                cannot pin the coding brain indefinitely. 12 h anchors on
+ *                `setAt`, which (unlike `touchedAt`) is never refreshed.
+ */
+export const DEFAULT_CODER_SWAP_IDLE_TTL_MS = 30 * 60_000;
+export const DEFAULT_CODER_SWAP_MAX_AGE_MS = 12 * 60 * 60_000;
+
 interface StoredOverride {
   mode: CoderSwapMode;
+  /** When the override was first set — the absolute MAX_AGE anchor; never refreshed. */
+  setAt: string;
+  /** Last activity — the sliding IDLE_TTL anchor; refreshed on each active read. */
   touchedAt: string;
 }
 
@@ -508,20 +536,70 @@ async function load(path = coderSwapStatePath()): Promise<StoredOverrides> {
 }
 
 async function save(state: StoredOverrides, path = coderSwapStatePath()): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf8");
+  // Atomic write: a torn overrides file makes load() throw and force-drops the
+  // override decision on every turn. Never expose a half-written file.
+  await writeFileAtomic(path, JSON.stringify(state, null, 2) + "\n");
 }
 
-/** Read the persistent override for a conversation, or undefined (defer to score). */
+/**
+ * Is `entry` still live under both decay bounds? Legacy entries written before
+ * `setAt` existed fall back to `touchedAt` for the absolute anchor, so a
+ * pre-upgrade override is bounded from its last activity rather than never.
+ */
+function active(
+  entry: StoredOverride | undefined,
+  idleTtlMs: number,
+  maxAgeMs: number,
+  now: Date,
+): entry is StoredOverride {
+  if (!entry) return false;
+  const touched = Date.parse(entry.touchedAt);
+  const set = Date.parse(entry.setAt ?? entry.touchedAt);
+  if (!Number.isFinite(touched) || !Number.isFinite(set)) return false;
+  const t = now.getTime();
+  if (t - touched > idleTtlMs) return false; // idle expiry (sliding)
+  if (t - set > maxAgeMs) return false; // absolute backstop
+  return true;
+}
+
+/**
+ * Read the override for a conversation, or undefined (defer to score). Expires
+ * lazily on read under both decay bounds, and — when still live — slides the
+ * IDLE_TTL window forward by refreshing `touchedAt`, so an active coding
+ * session keeps the brain while an abandoned one releases it.
+ */
 export async function getCoderSwapOverride(input: {
   persona: string;
   conversation: string;
+  idleTtlMs?: number;
+  maxAgeMs?: number;
+  now?: Date;
 }): Promise<CoderSwapMode | undefined> {
-  const state = await load();
-  return state[key(input.persona, input.conversation)]?.mode;
+  const idleTtlMs = input.idleTtlMs ?? DEFAULT_CODER_SWAP_IDLE_TTL_MS;
+  const maxAgeMs = input.maxAgeMs ?? DEFAULT_CODER_SWAP_MAX_AGE_MS;
+  const now = input.now ?? new Date();
+  const path = coderSwapStatePath();
+  const state = await load(path);
+  const k = key(input.persona, input.conversation);
+  const entry = state[k];
+  if (!active(entry, idleTtlMs, maxAgeMs, now)) {
+    if (entry) {
+      delete state[k];
+      await save(state, path);
+    }
+    return undefined;
+  }
+  // Slide the idle window: this consult IS conversation activity.
+  entry.touchedAt = now.toISOString();
+  await save(state, path);
+  return entry.mode;
 }
 
-/** Force the override to "on" or "off" for a conversation. */
+/**
+ * Force the override to "on" or "off" for a conversation. Resets both decay
+ * clocks: `setAt` (absolute backstop) and `touchedAt` (idle window) start now,
+ * so re-issuing `/coder` mid-session earns a fresh full window.
+ */
 export async function setCoderSwapOverride(input: {
   persona: string;
   conversation: string;
@@ -530,9 +608,11 @@ export async function setCoderSwapOverride(input: {
 }): Promise<void> {
   const path = coderSwapStatePath();
   const state = await load(path);
+  const stamp = (input.now ?? new Date()).toISOString();
   state[key(input.persona, input.conversation)] = {
     mode: input.mode,
-    touchedAt: (input.now ?? new Date()).toISOString(),
+    setAt: stamp,
+    touchedAt: stamp,
   };
   await save(state, path);
 }

--- a/src/lib/coderSwap.ts
+++ b/src/lib/coderSwap.ts
@@ -39,10 +39,12 @@
  * MANUAL OVERRIDE: `/coder` forces the coding brain on for a conversation,
  * `/nocoder` forces it off, `/coder default` clears back to scoring. The
  * override wins over the score, mirroring the `/viewcoder` store shape (see
- * viewCoder.ts) — but it DECAYS rather than latching forever (see the two
- * bounds on the store below). A month-long stuck override forcing every
- * conversational turn onto the coding model is exactly the failure this decay
- * prevents.
+ * viewCoder.ts) — but it DECAYS on a sliding idle timeout rather than latching
+ * forever (see the store below). `/coder` is a temporary escalation of the
+ * coding brain to primary; once the conversation goes idle past the TTL it
+ * releases and the per-turn scorer is back in charge. A month-long stuck
+ * override forcing every conversational turn onto the coding model is exactly
+ * the failure this decay prevents.
  */
 
 import { readFile } from "node:fs/promises";
@@ -482,31 +484,23 @@ export function normalizeCoderSwapRequest(
 }
 
 /**
- * Two decay bounds keep a manual override from latching forever (the
- * kimi-k3-forced-for-a-month failure). Both are checked lazily on read — no
- * timer, no restart, exactly like reply-mode's expiry (see replyMode.ts).
+ * A single sliding idle TTL keeps a manual override from latching forever (the
+ * kimi-k3-forced-for-a-month failure). Checked lazily on read — no timer, no
+ * restart — exactly mirroring reply-mode's expiry (see replyMode.ts).
  *
- *   IDLE_TTL   — a sliding window: the override releases after this long with no
- *                conversation activity. Each turn that consults the override
- *                refreshes `touchedAt`, so a live coding session (turns spaced
- *                out by reading diffs / running builds) survives, but an
- *                abandoned conversation drops back to the scorer. 30 min, not
- *                reply-mode's 10, because coding turns are naturally further
- *                apart than chat turns.
- *   MAX_AGE    — an absolute backstop: the override releases this long after it
- *                was SET regardless of activity. This is the real cure for the
- *                month-long latch — even a conversation kept perpetually warm
- *                cannot pin the coding brain indefinitely. 12 h anchors on
- *                `setAt`, which (unlike `touchedAt`) is never refreshed.
+ * The override releases after this long with no conversation activity. Each turn
+ * that consults the override refreshes `touchedAt`, so a live coding session
+ * survives, but the moment the conversation goes idle past the TTL it drops back
+ * to the scorer. Same 10-minute window as reply-mode: `/coder` is a temporary
+ * escalation, not a persistent mode, so once it releases the scorer decides each
+ * turn on its own (and may re-escalate on its own if the recent turns are still
+ * code-shaped).
  */
-export const DEFAULT_CODER_SWAP_IDLE_TTL_MS = 30 * 60_000;
-export const DEFAULT_CODER_SWAP_MAX_AGE_MS = 12 * 60 * 60_000;
+export const DEFAULT_CODER_SWAP_OVERRIDE_TTL_MS = 600_000;
 
 interface StoredOverride {
   mode: CoderSwapMode;
-  /** When the override was first set — the absolute MAX_AGE anchor; never refreshed. */
-  setAt: string;
-  /** Last activity — the sliding IDLE_TTL anchor; refreshed on each active read. */
+  /** Last activity — the sliding idle-TTL anchor; refreshed on each active read. */
   touchedAt: string;
 }
 
@@ -541,48 +535,37 @@ async function save(state: StoredOverrides, path = coderSwapStatePath()): Promis
   await writeFileAtomic(path, JSON.stringify(state, null, 2) + "\n");
 }
 
-/**
- * Is `entry` still live under both decay bounds? Legacy entries written before
- * `setAt` existed fall back to `touchedAt` for the absolute anchor, so a
- * pre-upgrade override is bounded from its last activity rather than never.
- */
+/** Is `entry` still live within the sliding idle TTL? */
 function active(
   entry: StoredOverride | undefined,
-  idleTtlMs: number,
-  maxAgeMs: number,
+  ttlMs: number,
   now: Date,
 ): entry is StoredOverride {
   if (!entry) return false;
   const touched = Date.parse(entry.touchedAt);
-  const set = Date.parse(entry.setAt ?? entry.touchedAt);
-  if (!Number.isFinite(touched) || !Number.isFinite(set)) return false;
-  const t = now.getTime();
-  if (t - touched > idleTtlMs) return false; // idle expiry (sliding)
-  if (t - set > maxAgeMs) return false; // absolute backstop
-  return true;
+  if (!Number.isFinite(touched)) return false;
+  return now.getTime() - touched <= ttlMs;
 }
 
 /**
  * Read the override for a conversation, or undefined (defer to score). Expires
- * lazily on read under both decay bounds, and — when still live — slides the
- * IDLE_TTL window forward by refreshing `touchedAt`, so an active coding
- * session keeps the brain while an abandoned one releases it.
+ * lazily on read past the idle TTL, and — when still live — slides the window
+ * forward by refreshing `touchedAt`, so an active coding session keeps the brain
+ * while an abandoned one releases it.
  */
 export async function getCoderSwapOverride(input: {
   persona: string;
   conversation: string;
-  idleTtlMs?: number;
-  maxAgeMs?: number;
+  ttlMs?: number;
   now?: Date;
 }): Promise<CoderSwapMode | undefined> {
-  const idleTtlMs = input.idleTtlMs ?? DEFAULT_CODER_SWAP_IDLE_TTL_MS;
-  const maxAgeMs = input.maxAgeMs ?? DEFAULT_CODER_SWAP_MAX_AGE_MS;
+  const ttlMs = input.ttlMs ?? DEFAULT_CODER_SWAP_OVERRIDE_TTL_MS;
   const now = input.now ?? new Date();
   const path = coderSwapStatePath();
   const state = await load(path);
   const k = key(input.persona, input.conversation);
   const entry = state[k];
-  if (!active(entry, idleTtlMs, maxAgeMs, now)) {
+  if (!active(entry, ttlMs, now)) {
     if (entry) {
       delete state[k];
       await save(state, path);
@@ -596,9 +579,8 @@ export async function getCoderSwapOverride(input: {
 }
 
 /**
- * Force the override to "on" or "off" for a conversation. Resets both decay
- * clocks: `setAt` (absolute backstop) and `touchedAt` (idle window) start now,
- * so re-issuing `/coder` mid-session earns a fresh full window.
+ * Force the override to "on" or "off" for a conversation. Stamps `touchedAt`
+ * now, so re-issuing `/coder` mid-session earns a fresh full idle window.
  */
 export async function setCoderSwapOverride(input: {
   persona: string;
@@ -608,11 +590,9 @@ export async function setCoderSwapOverride(input: {
 }): Promise<void> {
   const path = coderSwapStatePath();
   const state = await load(path);
-  const stamp = (input.now ?? new Date()).toISOString();
   state[key(input.persona, input.conversation)] = {
     mode: input.mode,
-    setAt: stamp,
-    touchedAt: stamp,
+    touchedAt: (input.now ?? new Date()).toISOString(),
   };
   await save(state, path);
 }

--- a/tests/lib-coderSwap.test.ts
+++ b/tests/lib-coderSwap.test.ts
@@ -5,7 +5,7 @@
  *   - the persistent per-conversation /coder override store
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -15,6 +15,8 @@ import {
   CODER_SWAP_THRESHOLD,
   coderSwapStatePath,
   CONTEXT_DEFAULTS,
+  DEFAULT_CODER_SWAP_IDLE_TTL_MS,
+  DEFAULT_CODER_SWAP_MAX_AGE_MS,
   getCoderSwapOverride,
   normalizeCoderSwapRequest,
   resolveSwapModel,
@@ -338,6 +340,95 @@ describe("override store", () => {
     ).toBeUndefined();
     expect(
       await getCoderSwapOverride({ persona: "lena", conversation: "telegram:2" }),
+    ).toBeUndefined();
+  });
+});
+
+describe("override decay (idle TTL + absolute backstop)", () => {
+  const SAVED = process.env.PHANTOMBOT_CODER_SWAP_STATE;
+  let dir: string;
+  const who = { persona: "lena", conversation: "telegram:1" };
+  const t0 = new Date("2026-06-24T12:00:00.000Z");
+  const at = (ms: number) => new Date(t0.getTime() + ms);
+  const MIN = 60_000;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "phantombot-coder-swap-decay-"));
+    process.env.PHANTOMBOT_CODER_SWAP_STATE = join(dir, "state.json");
+  });
+  afterEach(async () => {
+    if (SAVED === undefined) delete process.env.PHANTOMBOT_CODER_SWAP_STATE;
+    else process.env.PHANTOMBOT_CODER_SWAP_STATE = SAVED;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("defaults: 30 min idle, 12 h absolute", () => {
+    expect(DEFAULT_CODER_SWAP_IDLE_TTL_MS).toBe(30 * 60_000);
+    expect(DEFAULT_CODER_SWAP_MAX_AGE_MS).toBe(12 * 60 * 60_000);
+  });
+
+  test("live within idle window", async () => {
+    await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
+    expect(await getCoderSwapOverride({ ...who, now: at(29 * MIN) })).toBe("on");
+  });
+
+  test("releases after idle TTL with no activity", async () => {
+    await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
+    expect(
+      await getCoderSwapOverride({ ...who, now: at(31 * MIN) }),
+    ).toBeUndefined();
+    // Expired entry is pruned from disk on read.
+    const raw = JSON.parse(await readFile(coderSwapStatePath(), "utf8"));
+    expect(Object.keys(raw)).toHaveLength(0);
+  });
+
+  test("idle window slides forward on each active read", async () => {
+    await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
+    // A consult at +25m keeps it alive AND refreshes touchedAt...
+    expect(await getCoderSwapOverride({ ...who, now: at(25 * MIN) })).toBe("on");
+    // ...so a consult at +50m (25m after the last) is still within the window.
+    expect(await getCoderSwapOverride({ ...who, now: at(50 * MIN) })).toBe("on");
+  });
+
+  test("absolute backstop releases despite continuous activity", async () => {
+    await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
+    // Keep it warm across the whole 12 h with sub-idle-window consults.
+    for (let m = 25; m < 12 * 60; m += 25) {
+      expect(await getCoderSwapOverride({ ...who, now: at(m * MIN) })).toBe("on");
+    }
+    // Past 12 h from setAt it must release even though it was just touched.
+    expect(
+      await getCoderSwapOverride({ ...who, now: at(12 * 60 * MIN + MIN) }),
+    ).toBeUndefined();
+  });
+
+  test("re-issuing /coder resets the absolute clock", async () => {
+    await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
+    // Re-issue just before the 12 h backstop → fresh setAt, fresh idle window.
+    const reissue = 11 * 60 * MIN + 59 * MIN; // +11h59m
+    await setCoderSwapOverride({ ...who, mode: "on", now: at(reissue) });
+    // Past 12 h after the ORIGINAL set (so the original would have expired), but
+    // only 6 min after the re-issue → within both new bounds, still live.
+    expect(
+      await getCoderSwapOverride({ ...who, now: at(reissue + 6 * MIN) }),
+    ).toBe("on");
+  });
+
+  test("legacy entry without setAt is bounded from touchedAt", async () => {
+    // Simulate a pre-upgrade file: write a normal override, then strip the
+    // setAt field so the on-disk shape matches what old builds persisted. This
+    // stays agnostic to the store's internal key separator.
+    await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
+    const path = coderSwapStatePath();
+    const state = JSON.parse(await readFile(path, "utf8"));
+    for (const k of Object.keys(state)) delete state[k].setAt;
+    await writeFile(path, JSON.stringify(state));
+    // Within idle window it still reads (setAt falls back to touchedAt).
+    expect(await getCoderSwapOverride({ ...who, now: at(10 * MIN) })).toBe("on");
+    // Beyond idle it releases rather than latching forever. NB: the read above
+    // slid touchedAt to +10m, so idle expiry is measured from there.
+    expect(
+      await getCoderSwapOverride({ ...who, now: at(10 * MIN + 31 * MIN) }),
     ).toBeUndefined();
   });
 });

--- a/tests/lib-coderSwap.test.ts
+++ b/tests/lib-coderSwap.test.ts
@@ -5,7 +5,7 @@
  *   - the persistent per-conversation /coder override store
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -15,8 +15,7 @@ import {
   CODER_SWAP_THRESHOLD,
   coderSwapStatePath,
   CONTEXT_DEFAULTS,
-  DEFAULT_CODER_SWAP_IDLE_TTL_MS,
-  DEFAULT_CODER_SWAP_MAX_AGE_MS,
+  DEFAULT_CODER_SWAP_OVERRIDE_TTL_MS,
   getCoderSwapOverride,
   normalizeCoderSwapRequest,
   resolveSwapModel,
@@ -344,7 +343,7 @@ describe("override store", () => {
   });
 });
 
-describe("override decay (idle TTL + absolute backstop)", () => {
+describe("override decay (sliding idle TTL)", () => {
   const SAVED = process.env.PHANTOMBOT_CODER_SWAP_STATE;
   let dir: string;
   const who = { persona: "lena", conversation: "telegram:1" };
@@ -362,20 +361,19 @@ describe("override decay (idle TTL + absolute backstop)", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  test("defaults: 30 min idle, 12 h absolute", () => {
-    expect(DEFAULT_CODER_SWAP_IDLE_TTL_MS).toBe(30 * 60_000);
-    expect(DEFAULT_CODER_SWAP_MAX_AGE_MS).toBe(12 * 60 * 60_000);
+  test("default: 10 min idle TTL (mirrors reply-mode)", () => {
+    expect(DEFAULT_CODER_SWAP_OVERRIDE_TTL_MS).toBe(600_000);
   });
 
   test("live within idle window", async () => {
     await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
-    expect(await getCoderSwapOverride({ ...who, now: at(29 * MIN) })).toBe("on");
+    expect(await getCoderSwapOverride({ ...who, now: at(9 * MIN) })).toBe("on");
   });
 
   test("releases after idle TTL with no activity", async () => {
     await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
     expect(
-      await getCoderSwapOverride({ ...who, now: at(31 * MIN) }),
+      await getCoderSwapOverride({ ...who, now: at(11 * MIN) }),
     ).toBeUndefined();
     // Expired entry is pruned from disk on read.
     const raw = JSON.parse(await readFile(coderSwapStatePath(), "utf8"));
@@ -384,51 +382,26 @@ describe("override decay (idle TTL + absolute backstop)", () => {
 
   test("idle window slides forward on each active read", async () => {
     await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
-    // A consult at +25m keeps it alive AND refreshes touchedAt...
-    expect(await getCoderSwapOverride({ ...who, now: at(25 * MIN) })).toBe("on");
-    // ...so a consult at +50m (25m after the last) is still within the window.
-    expect(await getCoderSwapOverride({ ...who, now: at(50 * MIN) })).toBe("on");
+    // A consult at +8m keeps it alive AND refreshes touchedAt...
+    expect(await getCoderSwapOverride({ ...who, now: at(8 * MIN) })).toBe("on");
+    // ...so a consult at +16m (8m after the last) is still within the window.
+    expect(await getCoderSwapOverride({ ...who, now: at(16 * MIN) })).toBe("on");
   });
 
-  test("absolute backstop releases despite continuous activity", async () => {
+  test("stays live indefinitely while actively used — no absolute cap", async () => {
     await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
-    // Keep it warm across the whole 12 h with sub-idle-window consults.
-    for (let m = 25; m < 12 * 60; m += 25) {
+    // A long coding session: sub-TTL consults keep it warm for hours. There is
+    // deliberately NO absolute backstop — /coder is idle-decayed only, exactly
+    // like reply-mode, so a genuinely active session is never yanked mid-work.
+    for (let m = 8; m <= 12 * 60; m += 8) {
       expect(await getCoderSwapOverride({ ...who, now: at(m * MIN) })).toBe("on");
     }
-    // Past 12 h from setAt it must release even though it was just touched.
-    expect(
-      await getCoderSwapOverride({ ...who, now: at(12 * 60 * MIN + MIN) }),
-    ).toBeUndefined();
   });
 
-  test("re-issuing /coder resets the absolute clock", async () => {
+  test("re-issuing /coder refreshes the idle window", async () => {
     await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
-    // Re-issue just before the 12 h backstop → fresh setAt, fresh idle window.
-    const reissue = 11 * 60 * MIN + 59 * MIN; // +11h59m
-    await setCoderSwapOverride({ ...who, mode: "on", now: at(reissue) });
-    // Past 12 h after the ORIGINAL set (so the original would have expired), but
-    // only 6 min after the re-issue → within both new bounds, still live.
-    expect(
-      await getCoderSwapOverride({ ...who, now: at(reissue + 6 * MIN) }),
-    ).toBe("on");
-  });
-
-  test("legacy entry without setAt is bounded from touchedAt", async () => {
-    // Simulate a pre-upgrade file: write a normal override, then strip the
-    // setAt field so the on-disk shape matches what old builds persisted. This
-    // stays agnostic to the store's internal key separator.
-    await setCoderSwapOverride({ ...who, mode: "on", now: t0 });
-    const path = coderSwapStatePath();
-    const state = JSON.parse(await readFile(path, "utf8"));
-    for (const k of Object.keys(state)) delete state[k].setAt;
-    await writeFile(path, JSON.stringify(state));
-    // Within idle window it still reads (setAt falls back to touchedAt).
-    expect(await getCoderSwapOverride({ ...who, now: at(10 * MIN) })).toBe("on");
-    // Beyond idle it releases rather than latching forever. NB: the read above
-    // slid touchedAt to +10m, so idle expiry is measured from there.
-    expect(
-      await getCoderSwapOverride({ ...who, now: at(10 * MIN + 31 * MIN) }),
-    ).toBeUndefined();
+    // Re-issue at +8m → fresh touchedAt, so +17m (9m after re-issue) is live.
+    await setCoderSwapOverride({ ...who, mode: "on", now: at(8 * MIN) });
+    expect(await getCoderSwapOverride({ ...who, now: at(17 * MIN) })).toBe("on");
   });
 });


### PR DESCRIPTION
Closes #331.

## Problem

A manual `/coder` override was persisted with no expiry. Once a user ran bare `/coder` (force coding brain on) and forgot `/coder default`, **every** subsequent turn in that conversation — chat included — was force-routed to the coding model, bypassing the per-turn scorer forever.

On Lena, an override set **2026-06-24** forced Telegram turns onto `moonshotai/kimi-k3` for over a month; on conversational turns the coding model emitted degenerate ~10-char output that surfaced as **"(no reply)"**. Another user hit the same symptom with no obvious cause.

## Fix

Lazy on-read decay in `src/lib/coderSwap.ts`, mirroring reply-mode's expiry exactly (no timer, no restart):

- **Single sliding 10-min idle TTL** — the same window as reply-mode. Each consult refreshes `touchedAt`, so an actively-used coding session stays hot indefinitely; the moment the conversation goes idle past the TTL the override releases and the per-turn scorer is back in charge.
- `/coder` is a **temporary escalation** of the coding brain to primary, not a persistent mode. After the idle release the scorer decides each turn on its own — and may re-escalate on its own if the recent turns are still code-shaped. This is exactly how a *natural* coding-brain escalation already behaves.
- **No absolute cap.** Idle-decay alone cures the month-long latch (an abandoned conversation always releases within 10 min), and dropping the 12-h backstop means a genuinely active session is never yanked mid-work.
- Store shape is now `{ mode, touchedAt }` — identical to reply-mode. `getCoderSwapOverride` takes `ttlMs` (was `idleTtlMs` + `maxAgeMs`).
- Store uses **atomic writes** — a torn overrides file makes `load()` throw and drops the decision every turn.

Stuck overrides **self-heal**: the check runs on the next incoming turn to that conversation, prunes the stale entry, and reverts to the scorer. No manual step, no restart.

## Tests

`tests/lib-coderSwap.test.ts` covering: default 10-min TTL, live-within-idle, idle release + disk pruning, sliding-window refresh, stays-live-indefinitely-while-actively-used (no absolute cap), and re-issue refreshing the window. 54 pass / 0 fail. `tsc --noEmit` clean.

## Note — suspected classifier bug ruled out (the "#2" red herring)

The "(no reply)" symptom initially looked like it might *also* involve the streaming bubble classifier sweeping a swapped-turn's reply into narration. It does **not**: a "swept-away answer" (text streamed → tool call → `done.finalText` equals that text) is structurally identical to intended narration-then-silence, and `resolveOutgoingSuffix` already delivers any genuinely-new post-tool text. There's no signal to separate the two, and a guard attempt broke existing tests encoding the intended behaviour. The incident is fully explained by the latched override alone — so this PR is scoped to bug #1 only.