### PR TITLE
fix(vscode): mark LM as agent-capable so chat sessions can resolve it

### DIFF
--- a/editors/vscode/src/lmProvider.ts
+++ b/editors/vscode/src/lmProvider.ts
@@ -67,9 +67,14 @@ export function createLanguageModelChatProvider(
         tooltip: "phantombot — persona, memory and tools live server-side",
         capabilities: {
           imageInput: true,
-          // phantombot owns its tools server-side; we do NOT let VS Code inject
-          // or decompose tools, so the agent stays itself.
-          toolCalling: false,
+          // Must be true: VS Code's chat sessions run in agent-mode and its
+          // model picker filters on `suitableForAgentMode` (agentMode && toolCalling).
+          // With toolCalling:false our model is dropped from the session picker,
+          // userSelectedModelId stays empty, and getModelForRequest falls back to
+          // the (disabled) Copilot default → "Language model unavailable".
+          // Marking it agent-capable does NOT force VS Code to inject tools;
+          // phantombot still owns its tools server-side and the handler ignores any.
+          toolCalling: true,
         },
       };
       return [info];


### PR DESCRIPTION
## Problem

When Copilot Chat is broken/unauthenticated, opening a phantombot chat session and pressing Enter fails with **"Language model unavailable"**.

## Root cause

VS Code chat sessions run in **agent-mode**. The renderer's model picker filters candidates on `suitableForAgentMode = (agentMode !== false) && capabilities.toolCalling`.

Our provider advertised `toolCalling: false`, so the phantombot model was **dropped from the session model picker** → `input.currentLanguageModel` stayed empty → the request's `userSelectedModelId` was empty → `getModelForRequest` fell back to the global default (Copilot, which is disabled/broken) → throw → "Language model unavailable".

## Fix

Set `toolCalling: true`. This only marks the model **agent-capable** so it survives the picker filter and gets selected as the session model. VS Code does not force tool injection — phantombot still owns its tools server-side and the handler ignores any injected tools.

One-line capability change; no behavioural change to tool handling.

## Verification

- `bun run build` + typecheck clean
- 128 unit tests pass
- Manually verified in VS Code 1.131: session now resolves the phantombot model, no "unavailable", Enter submits.

Fixes #335