### PR TITLE
feat(mcp): pre-registered OAuth client (skip-DCR) — Google Workspace path

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -46,9 +46,43 @@ a pasted link — or say plainly that it isn't supported.
 | `oauth`  | http      | Remote server behind interactive OAuth 2.1: PKCE + RFC 9728 protected-resource-metadata discovery + RFC 7591 dynamic client registration, all driven by the SDK's `OAuthClientProvider`. We implement only vault token storage + loopback redirect capture. | "I'll open a login link — approve it" |
 
 **Google is an adapter under `oauth`**, not the core model — its
-`client_secret.json` is a non-DCR variant. If a discovered server needs a shape
-outside these three, the agent reports it as **unsupported** rather than
-half-configuring it.
+`client_secret.json` is a non-DCR variant (see below). If a discovered server
+needs a shape outside these three, the agent reports it as **unsupported**
+rather than half-configuring it.
+
+### `oauth` with a pre-registered client (skip-DCR)
+
+Some providers reject RFC 7591 dynamic client registration — **Google's remote
+MCP servers most notably**, where `mcp login` fails with *"Incompatible auth
+server: does not support dynamic client registration"*. For these the user
+pre-registers an OAuth client themselves and hands phantombot the credentials;
+the SDK then skips registration (it only runs DCR when
+`OAuthClientProvider.clientInformation()` returns `undefined`).
+
+Flow:
+
+1. **User creates the client once** — Google Cloud Console → APIs & Services →
+   Credentials → *Create OAuth client ID*. Prefer type **Desktop app**: it
+   allows the loopback redirect (`http://127.0.0.1:<port>`) on any port, which
+   matches our dynamic loopback listener. (A **Web app** client would need the
+   exact redirect port pre-registered.) Download the JSON.
+2. **Attach it at registration** — phantombot parses the file, stores the
+   `client_id`/`client_secret` in the vault (encrypted at rest), and the file
+   can be deleted:
+   ```
+   phantombot mcp add google-mcp --http --url https://…/mcp --oauth \
+       --client-file ./credentials.json --scopes "…"
+   # or, without a file:
+   phantombot mcp add google-mcp --http --url https://…/mcp --oauth \
+       --client-id <id> --client-secret <secret>
+   ```
+3. **Log in as usual** — `phantombot mcp login google-mcp`. Browser approve →
+   loopback captures the code → tokens land in the vault; refresh is automatic.
+
+The pre-registered client lives in a **durable** vault row
+(`<tokenRef>__CLIENT_STATIC`) that `invalidateCredentials` never wipes, so a
+token-refresh failure re-runs consent instead of falling back to DCR (which the
+provider would reject). `mcp remove --purge` cleans it up with the rest.
 
 Secrets are always referenced **by vault key** in `mcp.json`, resolved only at
 connection time. `mcp list`/`status`/`describe` never echo a secret value.
@@ -141,7 +175,8 @@ provenance obvious.
 |------|----------------|
 | `src/mcp/registry.ts` | `mcp.json` schema, validation, CRUD, secret-ref resolution |
 | `src/mcp/client.ts` | SDK client wrapper — build transport per auth method, connect/list/call |
-| `src/mcp/authProvider.ts` | vault-backed `OAuthClientProvider` (persistence only) |
+| `src/mcp/authProvider.ts` | vault-backed `OAuthClientProvider` (persistence only; DCR + skip-DCR client rows) |
+| `src/mcp/oauthClient.ts` | parse a pre-registered OAuth client (`credentials.json`) → skip-DCR client info |
 | `src/mcp/loopback.ts` | loopback HTTP listener for OAuth redirect capture |
 | `src/mcp/login.ts` | OAuth login orchestration (begin / complete) |
 | `src/mcp/hub.ts` | shared connection manager + lazy search behind both faces |
@@ -159,10 +194,13 @@ end against a real stdio MCP server (`tests/fixtures/mcp-echo-server.ts`) — th
 client connect/list/call path, env-secret injection, the hub, and the proxy
 meta-tools over an in-memory transport.
 
-Needs live verification against real endpoints (documented, not automatable in
-CI): the `oauth` flow against a real provider (Google / GitHub remote MCP), a
-`header` remote server, and the projected proxy running under a live
-`claude --print` / `codex exec` turn.
+The skip-DCR path is unit-tested here (`credentials.json` parse, the durable
+client row taking precedence over DCR, and — end to end against a fixture OAuth
+server — a real SDK `auth()` run that skips registration and exchanges a code
+using the pre-registered client). What still needs a **live** provider is the
+same as before: the `oauth` flow (with DCR *and* skip-DCR) against Google /
+GitHub remote MCP, a `header` remote server, and the projected proxy under a
+live `claude --print` / `codex exec` turn — tracked in #341.
 
 **Binary weight.** The `@modelcontextprotocol/sdk` dependency adds **~640 KB**
 to the compiled binary (arm64: 104.34 MB on `main` → 104.99 MB on this branch,

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -15,11 +15,14 @@
  */
 
 import { defineCommand } from "citty";
+import { readFile } from "node:fs/promises";
 
 import { loadConfig, personaDir } from "../config.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { openPersonaVault, type Vault } from "../lib/vault.ts";
+import { staticClientVaultKey, writeStaticClient } from "../mcp/authProvider.ts";
 import { discoverFromUrl } from "../mcp/discovery.ts";
+import { parseOAuthClientFile, toClientInformation, type ParsedOAuthClient } from "../mcp/oauthClient.ts";
 import { MCP_HELP } from "../mcp/help.ts";
 import { McpHub } from "../mcp/hub.ts";
 import { beginLogin, completeLogin } from "../mcp/login.ts";
@@ -82,6 +85,12 @@ export interface McpAddInput {
   oauth?: boolean;
   tokenRef?: string;
   scopes?: string;
+  /** oauth skip-DCR: path to a downloaded OAuth-client credentials.json. */
+  clientFile?: string;
+  /** oauth skip-DCR: client_id supplied directly (alternative to --client-file). */
+  clientId?: string;
+  /** oauth skip-DCR: client_secret supplied directly (paired with --client-id). */
+  clientSecret?: string;
   fromUrl?: string;
   note?: string;
   dryRun?: boolean;
@@ -126,9 +135,35 @@ export async function runMcpAdd(input: McpAddInput): Promise<number> {
   if (input.fromUrl) entry.note = input.note ?? input.fromUrl;
   else if (input.note) entry.note = input.note;
 
+  // Pre-registered OAuth client (skip-DCR): parse it now so a bad file fails
+  // before we write anything.
+  let preClient: ParsedOAuthClient | undefined;
+  if (input.clientFile || input.clientId) {
+    if (entry.auth?.type !== "oauth") {
+      err.write("--client-file/--client-id only apply to an oauth server (add --oauth too).\n");
+      return 2;
+    }
+    try {
+      preClient = input.clientFile
+        ? parseOAuthClientFile(await readFile(input.clientFile, "utf8"))
+        : { clientId: input.clientId!, clientSecret: input.clientSecret };
+    } catch (e) {
+      err.write(`${(e as Error).message}\n`);
+      return 2;
+    }
+  }
+
+  const tokenRef = entry.auth?.type === "oauth" ? entry.auth.tokenRef : undefined;
+
   if (input.dryRun) {
     out.write(JSON.stringify({ [input.id]: entry }, null, 2) + "\n");
-    printNextSteps(input.id, entry, out);
+    if (preClient && tokenRef) {
+      out.write(
+        `  would store pre-registered client ${preClient.clientId} ` +
+          `(secret: ${preClient.clientSecret ? "yes" : "no"}) in vault key ${staticClientVaultKey(tokenRef)}\n`,
+      );
+    }
+    printNextSteps(input.id, entry, out, { hasStaticClient: Boolean(preClient) });
     return 0;
   }
 
@@ -136,7 +171,21 @@ export async function runMcpAdd(input: McpAddInput): Promise<number> {
   const registry = await loadRegistry(dir);
   await saveRegistry(dir, upsertServer(registry, input.id, entry));
   out.write(`registered MCP server '${input.id}' (${transport})\n`);
-  printNextSteps(input.id, entry, out);
+
+  if (preClient && tokenRef) {
+    const vault = await openPersonaVault(dir);
+    try {
+      writeStaticClient(vault, tokenRef, toClientInformation(preClient));
+    } finally {
+      vault.close();
+    }
+    out.write(
+      `  stored pre-registered OAuth client ${preClient.clientId} in the vault ` +
+        `(DCR will be skipped for this server)\n`,
+    );
+  }
+
+  printNextSteps(input.id, entry, out, { hasStaticClient: Boolean(preClient) });
   return 0;
 }
 
@@ -178,7 +227,12 @@ function buildHttpEntry(input: McpAddInput, d?: { url?: string; auth?: string; s
   return { transport: "http", url, auth };
 }
 
-function printNextSteps(id: string, entry: McpServerEntry, out: WriteSink): void {
+function printNextSteps(
+  id: string,
+  entry: McpServerEntry,
+  out: WriteSink,
+  opts: { hasStaticClient?: boolean } = {},
+): void {
   const auth = entry.auth ?? { type: "none" };
   switch (auth.type) {
     case "env":
@@ -190,6 +244,12 @@ function printNextSteps(id: string, entry: McpServerEntry, out: WriteSink): void
       out.write(`  next: ask the user to generate a token, then  phantombot vault set ${auth.valueRef} "<token>"\n`);
       break;
     case "oauth":
+      if (!opts.hasStaticClient) {
+        out.write(
+          `  note: if 'mcp login' reports the server "does not support dynamic client registration",\n` +
+            `        the user must pre-register an OAuth client and re-run add with --client-file <credentials.json>\n`,
+        );
+      }
       out.write(`  next: run  phantombot mcp login ${id}  and have the user approve the login link\n`);
       break;
     default:
@@ -408,7 +468,23 @@ export async function runMcpLogin(input: {
     );
     return 0;
   } catch (e) {
-    err.write(`${(e as Error).message}\n`);
+    const msg = (e as Error).message;
+    err.write(`${msg}\n`);
+    // Google (and some others) reject RFC 7591 DCR. If that's the failure and
+    // no pre-registered client is stored yet, point the agent at the skip-DCR
+    // path rather than leaving a dead end.
+    if (/dynamic client registration/i.test(msg) && entry.auth?.type === "oauth") {
+      const hasStatic = vault.get(staticClientVaultKey(entry.auth.tokenRef)) !== undefined;
+      if (!hasStatic) {
+        err.write(
+          `\nThis server needs a pre-registered OAuth client. Have the user create one in the\n` +
+            `provider's console (e.g. Google Cloud Console → Credentials → OAuth client ID →\n` +
+            `Download JSON), then attach it and retry:\n` +
+            `  phantombot mcp add ${input.id} --http --url <url> --oauth --client-file <credentials.json>\n` +
+            `  phantombot mcp login ${input.id}\n`,
+        );
+      }
+    }
     return 1;
   } finally {
     vault.close();
@@ -465,6 +541,9 @@ export default defineCommand({
         oauth: { type: "boolean", description: "oauth auth: interactive OAuth 2.1 (finish with `mcp login`)." },
         "token-ref": { type: "string", description: "oauth auth: vault key stem for tokens (default derived)." },
         scopes: { type: "string", description: "oauth auth: comma-separated scopes." },
+        "client-file": { type: "string", description: "oauth auth: path to a downloaded OAuth-client credentials.json (skip-DCR; e.g. Google). Stored in the vault." },
+        "client-id": { type: "string", description: "oauth auth: OAuth client_id supplied directly (alternative to --client-file)." },
+        "client-secret": { type: "string", description: "oauth auth: OAuth client_secret (paired with --client-id)." },
         "from-url": { type: "string", description: "Infer transport+auth from a pasted 'Learn More' link and write the registration." },
         note: { type: "string", description: "Freeform note (e.g. the setup link)." },
         "dry-run": { type: "boolean", description: "Print the entry that would be written, don't save." },
@@ -485,6 +564,9 @@ export default defineCommand({
           oauth: Boolean(args.oauth),
           tokenRef: args["token-ref"] ? String(args["token-ref"]) : undefined,
           scopes: args.scopes ? String(args.scopes) : undefined,
+          clientFile: args["client-file"] ? String(args["client-file"]) : undefined,
+          clientId: args["client-id"] ? String(args["client-id"]) : undefined,
+          clientSecret: args["client-secret"] ? String(args["client-secret"]) : undefined,
           fromUrl: args["from-url"] ? String(args["from-url"]) : undefined,
           note: args.note ? String(args.note) : undefined,
           dryRun: Boolean(args["dry-run"]),

--- a/src/mcp/authProvider.ts
+++ b/src/mcp/authProvider.ts
@@ -17,10 +17,20 @@
  *                     the registered redirect_uri.
  *
  * Vault row layout under the server's `tokenRef` stem:
- *   <tokenRef>              — OAuthTokens JSON (access + refresh)
- *   <tokenRef>__CLIENT      — OAuthClientInformationFull JSON (DCR result)
- *   <tokenRef>__VERIFIER    — PKCE code_verifier (in-flight, cleared after use)
- *   <tokenRef>__DISCOVERY   — cached OAuthDiscoveryState JSON (latency shortcut)
+ *   <tokenRef>                 — OAuthTokens JSON (access + refresh)
+ *   <tokenRef>__CLIENT         — OAuthClientInformationFull JSON (DCR result)
+ *   <tokenRef>__CLIENT_STATIC  — user-supplied pre-registered client (skip-DCR)
+ *   <tokenRef>__VERIFIER       — PKCE code_verifier (in-flight, cleared after use)
+ *   <tokenRef>__DISCOVERY      — cached OAuthDiscoveryState JSON (latency shortcut)
+ *
+ * __CLIENT vs __CLIENT_STATIC: __CLIENT holds a client REGISTERED FOR US by the
+ * server (DCR) and is disposable — invalidateCredentials() may wipe it so the
+ * SDK re-registers. __CLIENT_STATIC holds a client the USER pre-registered in a
+ * provider console (Google) and handed us via `mcp add --client-file`; it is
+ * DURABLE and never invalidated, so a token-refresh failure re-runs consent
+ * WITHOUT falling back to DCR (which the provider would reject). When present it
+ * takes precedence, and returning it from clientInformation() is what makes the
+ * SDK skip registration entirely.
  */
 
 import type {
@@ -40,9 +50,28 @@ import type { Vault } from "../lib/vault.ts";
 export const OAUTH_ROW_SUFFIX = {
   tokens: "",
   client: "__CLIENT",
+  staticClient: "__CLIENT_STATIC",
   verifier: "__VERIFIER",
   discovery: "__DISCOVERY",
 } as const;
+
+/** Vault key of the durable user-supplied client row for a given tokenRef stem. */
+export function staticClientVaultKey(tokenRef: string): string {
+  return tokenRef + OAUTH_ROW_SUFFIX.staticClient;
+}
+
+/**
+ * Persist a user-supplied pre-registered client (from `mcp add --client-file`)
+ * into the durable __CLIENT_STATIC vault row. Written once at registration;
+ * consumed by VaultOAuthClientProvider.clientInformation() at login time.
+ */
+export function writeStaticClient(
+  vault: Pick<Vault, "set">,
+  tokenRef: string,
+  info: OAuthClientInformationFull,
+): void {
+  vault.set(staticClientVaultKey(tokenRef), JSON.stringify(info));
+}
 
 export interface VaultOAuthOptions {
   /** The server's tokenRef stem (from its registry entry). */
@@ -89,9 +118,21 @@ export class VaultOAuthClientProvider implements OAuthClientProvider {
   }
 
   clientInformation(): OAuthClientInformation | undefined {
+    // Prefer a user-supplied, pre-registered client (skip-DCR). Returning a
+    // non-undefined value here is precisely what makes the SDK bypass RFC 7591
+    // dynamic client registration — the fix for providers (Google) that reject
+    // DCR. This durable row survives invalidateCredentials, so token-refresh
+    // failures re-run consent instead of attempting DCR again.
+    const staticRaw = this.vault.get(this.row("staticClient"));
+    if (staticRaw !== undefined) return JSON.parse(staticRaw) as OAuthClientInformationFull;
     const raw = this.vault.get(this.row("client"));
     if (raw === undefined) return undefined;
     return JSON.parse(raw) as OAuthClientInformationFull;
+  }
+
+  /** True when a user-supplied pre-registered client is stored (skip-DCR active). */
+  hasStaticClient(): boolean {
+    return this.vault.get(this.row("staticClient")) !== undefined;
   }
 
   saveClientInformation(info: OAuthClientInformationFull): void {

--- a/src/mcp/help.ts
+++ b/src/mcp/help.ts
@@ -60,6 +60,20 @@ THE THREE AUTH METHODS (this is the whole ecosystem in practice)
                   URL. Tell the user "open this link and approve"; the callback
                   is captured on a loopback listener and tokens are saved.
 
+     PRE-REGISTERED CLIENT (skip-DCR) — for providers that REJECT dynamic client
+     registration. Google's remote MCP servers are the main case: 'mcp login'
+     fails with "does not support dynamic client registration". The fix: the
+     user pre-registers an OAuth client in the provider console (Google Cloud
+     Console → APIs & Services → Credentials → OAuth client ID → prefer type
+     "Desktop app", which allows the loopback redirect on any port → Download
+     JSON) and hands you the file. Attach it once and the SDK skips DCR:
+       Register:  phantombot mcp add <id> --http --url https://.../mcp --oauth \\
+                    --client-file ./credentials.json  [--scopes "..."]
+                  (or pass --client-id/--client-secret directly). phantombot
+                  reads the file, stores the client_id/secret in the vault, and
+                  the file can be deleted.
+       You then:  run  phantombot mcp login <id>  as usual.
+
   If a discovered server needs an auth shape OUTSIDE these three (a bespoke
   handshake, mutual TLS, a transport phantombot doesn't speak), say so plainly:
   it is not supported yet. Do NOT half-configure it.

--- a/src/mcp/oauthClient.ts
+++ b/src/mcp/oauthClient.ts
@@ -1,0 +1,90 @@
+/**
+ * User-supplied (pre-registered) OAuth client support — the "skip-DCR" path.
+ *
+ * The `oauth` method (authProvider.ts / login.ts) normally lets the SDK register
+ * a client on the fly via RFC 7591 Dynamic Client Registration (DCR). Some
+ * providers — Google's remote MCP servers most notably — REJECT DCR outright
+ * ("Incompatible auth server: does not support dynamic client registration").
+ * For those, the user pre-registers an OAuth client in the provider's console
+ * (Google Cloud Console → APIs & Services → Credentials → OAuth client ID) and
+ * downloads a `credentials.json`. We ingest that once, store the client_id /
+ * client_secret in the persona vault, and the provider hands them straight to
+ * the SDK — which then SKIPS registration entirely (auth.js: DCR only runs when
+ * `provider.clientInformation()` returns undefined).
+ *
+ * This module is pure parsing/shaping: no vault, no network, no SDK calls. The
+ * CLI (`mcp add --client-file`) does the vault write; login.ts consumes it.
+ */
+
+import type { OAuthClientInformationFull } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+/** The two fields we extract from a downloaded OAuth-client credentials file. */
+export interface ParsedOAuthClient {
+  clientId: string;
+  /** Absent for "public"/installed clients that ship no secret. */
+  clientSecret?: string;
+}
+
+/**
+ * Parse a Google Cloud "OAuth client" `credentials.json`. Google wraps the
+ * client under `installed` (Desktop-app type) or `web` (Web-app type); some
+ * tools export a flat object. We accept all three, and any provider whose
+ * download uses the same client_id/client_secret shape — this is not Google-
+ * specific, it just matches the common console-download format.
+ */
+export function parseOAuthClientFile(raw: string): ParsedOAuthClient {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`credentials file is not valid JSON: ${(e as Error).message}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("credentials file must be a JSON object (an OAuth client download)");
+  }
+  const obj = parsed as Record<string, unknown>;
+  const innerRaw = obj.installed ?? obj.web ?? obj;
+  if (typeof innerRaw !== "object" || innerRaw === null || Array.isArray(innerRaw)) {
+    throw new Error("credentials file: 'installed'/'web' section must be an object");
+  }
+  const inner = innerRaw as Record<string, unknown>;
+
+  const clientId = inner.client_id;
+  if (typeof clientId !== "string" || clientId.trim() === "") {
+    throw new Error(
+      "credentials file has no client_id — expected a downloaded OAuth client JSON " +
+        "(Google Cloud Console → Credentials → OAuth client ID → Download JSON)",
+    );
+  }
+  const secret = inner.client_secret;
+  const clientSecret =
+    typeof secret === "string" && secret.trim() !== "" ? secret : undefined;
+
+  return { clientId, clientSecret };
+}
+
+/**
+ * Shape a ParsedOAuthClient into the OAuthClientInformationFull the SDK expects
+ * back from `provider.clientInformation()`. Returning this (non-undefined) is
+ * exactly what makes the SDK skip DCR.
+ *
+ * - `redirect_uris` is left empty on purpose: the SDK drives the authorization
+ *   request from `provider.redirectUrl` (the live loopback listener), not from
+ *   this field, so we don't pin a port here.
+ * - `token_endpoint_auth_method` picks how the token exchange authenticates:
+ *   a confidential client (has a secret) uses `client_secret_post`; a public
+ *   client uses `none`. selectClientAuthMethod() in the SDK honours this.
+ */
+export function toClientInformation(parsed: ParsedOAuthClient): OAuthClientInformationFull {
+  const info = {
+    client_id: parsed.clientId,
+    redirect_uris: [] as string[],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: parsed.clientSecret ? "client_secret_post" : "none",
+  } as OAuthClientInformationFull;
+  if (parsed.clientSecret) {
+    (info as { client_secret?: string }).client_secret = parsed.clientSecret;
+  }
+  return info;
+}

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -313,8 +313,14 @@ export function referencedVaultKeys(entry: McpServerEntry): string[] {
     case "header":
       return [auth.valueRef];
     case "oauth":
-      // Mirror the row layout in authProvider.ts.
-      return [auth.tokenRef, `${auth.tokenRef}__CLIENT`, `${auth.tokenRef}__VERIFIER`, `${auth.tokenRef}__DISCOVERY`];
+      // Mirror the row layout in authProvider.ts (OAUTH_ROW_SUFFIX).
+      return [
+        auth.tokenRef,
+        `${auth.tokenRef}__CLIENT`,
+        `${auth.tokenRef}__CLIENT_STATIC`,
+        `${auth.tokenRef}__VERIFIER`,
+        `${auth.tokenRef}__DISCOVERY`,
+      ];
     default:
       return [];
   }

--- a/tests/cli-mcp.test.ts
+++ b/tests/cli-mcp.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -17,6 +17,8 @@ import {
   runMcpList,
   runMcpRemove,
 } from "../src/cli/mcp.ts";
+import { openPersonaVault } from "../src/lib/vault.ts";
+import { staticClientVaultKey } from "../src/mcp/authProvider.ts";
 import { rmrf } from "./fixtures/rmrf.ts";
 
 class Cap {
@@ -119,5 +121,91 @@ describe("add / list / remove", () => {
     const list2 = new Cap();
     await runMcpList({ out: list2 });
     expect(list2.text).toContain("(no MCP servers registered)");
+  });
+});
+
+describe("oauth pre-registered client (skip-DCR)", () => {
+  test("--client-id/--client-file only valid with --oauth", async () => {
+    const err = new Cap();
+    const code = await runMcpAdd({
+      id: "g",
+      http: true,
+      url: "https://x/mcp",
+      clientId: "cid",
+      out: new Cap(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toMatch(/only apply to an oauth server/);
+  });
+
+  test("dry-run reports the client that would be vaulted, writes nothing", async () => {
+    const out = new Cap();
+    const code = await runMcpAdd({
+      id: "gdry",
+      http: true,
+      url: "https://x/mcp",
+      oauth: true,
+      clientId: "dry-id",
+      clientSecret: "dry-secret",
+      dryRun: true,
+      out,
+      err: out,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toMatch(/would store pre-registered client dry-id \(secret: yes\)/);
+    expect(await readFile(join(workdir, "tester", "mcp.json"), "utf8").catch(() => "MISSING")).toBe("MISSING");
+  });
+
+  test("--client-file ingests credentials.json and stores the static client in the vault", async () => {
+    const credPath = join(workdir, "credentials.json");
+    await writeFile(
+      credPath,
+      JSON.stringify({ installed: { client_id: "file-id", client_secret: "file-secret" } }),
+    );
+    const out = new Cap();
+    const code = await runMcpAdd({
+      id: "gmail",
+      http: true,
+      url: "https://example.com/mcp",
+      oauth: true,
+      tokenRef: "MCP_GMAIL_OAUTH",
+      clientFile: credPath,
+      out,
+      err: out,
+    });
+    expect(code).toBe(0);
+    expect(out.text).toMatch(/stored pre-registered OAuth client file-id/);
+
+    // The static client row is present in the persona vault, DCR-skip ready.
+    const vault = await openPersonaVault(join(workdir, "tester"));
+    try {
+      const raw = vault.get(staticClientVaultKey("MCP_GMAIL_OAUTH"));
+      expect(raw).toBeDefined();
+      const info = JSON.parse(raw!);
+      expect(info.client_id).toBe("file-id");
+      expect(info.client_secret).toBe("file-secret");
+      expect(info.token_endpoint_auth_method).toBe("client_secret_post");
+    } finally {
+      vault.close();
+    }
+  });
+
+  test("a malformed credentials file fails before writing the registry", async () => {
+    const credPath = join(workdir, "bad.json");
+    await writeFile(credPath, "{ not json");
+    const err = new Cap();
+    const code = await runMcpAdd({
+      id: "gbad",
+      http: true,
+      url: "https://x/mcp",
+      oauth: true,
+      clientFile: credPath,
+      out: new Cap(),
+      err,
+    });
+    expect(code).toBe(2);
+    expect(err.text).toMatch(/not valid JSON/);
+    expect(await readFile(join(workdir, "tester", "mcp.json"), "utf8").catch(() => "MISSING")).toBe("MISSING");
   });
 });

--- a/tests/mcp-oauth-client.test.ts
+++ b/tests/mcp-oauth-client.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Pre-registered OAuth client (skip-DCR) — the Google-Workspace path.
+ *
+ * Covers the whole chain that lets a user hand phantombot a downloaded
+ * `credentials.json` and connect a provider that REJECTS dynamic client
+ * registration:
+ *   - parsing the credentials file (installed / web / flat shapes),
+ *   - shaping it into the client info the SDK consumes,
+ *   - the vault-backed provider preferring the durable static client over DCR
+ *     and surviving credential invalidation,
+ *   - and — end to end against a fixture OAuth server — a real SDK `auth()` run
+ *     that SKIPS registration and exchanges an authorization code using the
+ *     pre-registered client_id/client_secret.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import { generateSecretKey } from "nostr-tools/pure";
+
+import { openVaultWithSecret, type Vault } from "../src/lib/vault.ts";
+import {
+  OAUTH_ROW_SUFFIX,
+  staticClientVaultKey,
+  VaultOAuthClientProvider,
+  writeStaticClient,
+} from "../src/mcp/authProvider.ts";
+import { parseOAuthClientFile, toClientInformation } from "../src/mcp/oauthClient.ts";
+import { referencedVaultKeys } from "../src/mcp/registry.ts";
+import { rmrf } from "./fixtures/rmrf.ts";
+
+let workdir: string;
+let vault: Vault;
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-mcp-oauth-"));
+  vault = openVaultWithSecret(workdir, generateSecretKey());
+});
+afterEach(async () => {
+  vault.close();
+  await rmrf(workdir);
+});
+
+describe("parseOAuthClientFile", () => {
+  const GOOGLE_DESKTOP = JSON.stringify({
+    installed: {
+      client_id: "123.apps.googleusercontent.com",
+      project_id: "my-proj",
+      auth_uri: "https://accounts.google.com/o/oauth2/auth",
+      token_uri: "https://oauth2.googleapis.com/token",
+      client_secret: "GOCSPX-secret",
+      redirect_uris: ["http://localhost"],
+    },
+  });
+
+  test("Google Desktop-app 'installed' shape", () => {
+    expect(parseOAuthClientFile(GOOGLE_DESKTOP)).toEqual({
+      clientId: "123.apps.googleusercontent.com",
+      clientSecret: "GOCSPX-secret",
+    });
+  });
+
+  test("Google 'web' shape", () => {
+    const raw = JSON.stringify({ web: { client_id: "web-id", client_secret: "web-secret" } });
+    expect(parseOAuthClientFile(raw)).toEqual({ clientId: "web-id", clientSecret: "web-secret" });
+  });
+
+  test("flat shape with no secret (public client)", () => {
+    const raw = JSON.stringify({ client_id: "public-id" });
+    expect(parseOAuthClientFile(raw)).toEqual({ clientId: "public-id", clientSecret: undefined });
+  });
+
+  test("blank client_secret is treated as absent", () => {
+    const raw = JSON.stringify({ installed: { client_id: "x", client_secret: "  " } });
+    expect(parseOAuthClientFile(raw).clientSecret).toBeUndefined();
+  });
+
+  test("missing client_id throws a fixable error", () => {
+    expect(() => parseOAuthClientFile(JSON.stringify({ installed: { project_id: "p" } }))).toThrow(
+      /no client_id/,
+    );
+  });
+
+  test("invalid JSON throws", () => {
+    expect(() => parseOAuthClientFile("not json")).toThrow(/not valid JSON/);
+  });
+
+  test("non-object throws", () => {
+    expect(() => parseOAuthClientFile("[1,2]")).toThrow(/must be a JSON object/);
+  });
+});
+
+describe("toClientInformation", () => {
+  test("confidential client → client_secret_post + secret carried", () => {
+    const info = toClientInformation({ clientId: "cid", clientSecret: "sec" });
+    expect(info.client_id).toBe("cid");
+    expect((info as { client_secret?: string }).client_secret).toBe("sec");
+    expect(info.token_endpoint_auth_method).toBe("client_secret_post");
+    expect(info.grant_types).toEqual(["authorization_code", "refresh_token"]);
+  });
+
+  test("public client → auth method none, no secret field", () => {
+    const info = toClientInformation({ clientId: "cid" });
+    expect(info.token_endpoint_auth_method).toBe("none");
+    expect((info as { client_secret?: string }).client_secret).toBeUndefined();
+  });
+});
+
+describe("VaultOAuthClientProvider — skip-DCR precedence", () => {
+  const tokenRef = "MCP_GOOGLE_OAUTH";
+  const provider = () =>
+    new VaultOAuthClientProvider(vault, { tokenRef, redirectUrl: "http://127.0.0.1:9/cb" });
+
+  test("clientInformation() returns the static client when present (skips DCR)", () => {
+    writeStaticClient(vault, tokenRef, toClientInformation({ clientId: "static-id", clientSecret: "s" }));
+    const info = provider().clientInformation();
+    expect(info?.client_id).toBe("static-id");
+    expect(provider().hasStaticClient()).toBe(true);
+  });
+
+  test("static client takes precedence over a DCR-registered client", () => {
+    // DCR row present…
+    vault.set(tokenRef + OAUTH_ROW_SUFFIX.client, JSON.stringify({ client_id: "dcr-id" }));
+    // …but a user-supplied client wins.
+    writeStaticClient(vault, tokenRef, toClientInformation({ clientId: "static-id" }));
+    expect(provider().clientInformation()?.client_id).toBe("static-id");
+  });
+
+  test("static client is DURABLE — invalidateCredentials('all') never wipes it", () => {
+    writeStaticClient(vault, tokenRef, toClientInformation({ clientId: "static-id", clientSecret: "s" }));
+    vault.set(tokenRef, JSON.stringify({ access_token: "a", token_type: "Bearer" }));
+    provider().invalidateCredentials("all");
+    // tokens gone, static client preserved so re-login uses it instead of DCR.
+    expect(vault.get(tokenRef)).toBeUndefined();
+    expect(provider().clientInformation()?.client_id).toBe("static-id");
+  });
+
+  test("no static client → falls back to DCR row (undefined when neither set)", () => {
+    expect(provider().clientInformation()).toBeUndefined();
+    expect(provider().hasStaticClient()).toBe(false);
+  });
+});
+
+describe("registry cleanup", () => {
+  test("referencedVaultKeys includes the static-client row for purge", () => {
+    const keys = referencedVaultKeys({
+      transport: "http",
+      url: "https://x/mcp",
+      auth: { type: "oauth", tokenRef: "MCP_G_OAUTH" },
+    });
+    expect(keys).toContain(staticClientVaultKey("MCP_G_OAUTH"));
+    expect(keys).toContain("MCP_G_OAUTH__CLIENT_STATIC");
+  });
+});
+
+describe("end-to-end skip-DCR via real SDK auth()", () => {
+  // A minimal OAuth authorization server with NO registration_endpoint — exactly
+  // the shape that makes the SDK throw "does not support dynamic client
+  // registration" unless a client is pre-registered.
+  function startFixtureAuthServer() {
+    let registrationHit = false;
+    let tokenAuthSawSecret: string | undefined;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const meta = (origin: string) => ({
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+          response_types_supported: ["code"],
+          code_challenge_methods_supported: ["S256"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          // deliberately NO registration_endpoint
+        });
+        const origin = url.origin;
+        // RFC 9728 protected-resource metadata: 404 → SDK falls back to origin.
+        if (url.pathname.startsWith("/.well-known/oauth-protected-resource")) {
+          return new Response("not found", { status: 404 });
+        }
+        if (
+          url.pathname === "/.well-known/oauth-authorization-server" ||
+          url.pathname === "/.well-known/openid-configuration"
+        ) {
+          return Response.json(meta(origin));
+        }
+        if (url.pathname === "/register") {
+          registrationHit = true;
+          return new Response("nope", { status: 400 });
+        }
+        if (url.pathname === "/token" && req.method === "POST") {
+          const body = new URLSearchParams(await req.text());
+          tokenAuthSawSecret = body.get("client_secret") ?? undefined;
+          return Response.json({
+            access_token: "access-123",
+            token_type: "Bearer",
+            refresh_token: "refresh-123",
+            expires_in: 3600,
+          });
+        }
+        return new Response("ok");
+      },
+    });
+    return {
+      url: `${server.url.origin}/mcp`,
+      close: () => server.stop(true),
+      get registrationHit() {
+        return registrationHit;
+      },
+      get tokenAuthSawSecret() {
+        return tokenAuthSawSecret;
+      },
+    };
+  }
+
+  test("pre-registered client → DCR skipped, code exchanged with secret, tokens vaulted", async () => {
+    const fx = startFixtureAuthServer();
+    const tokenRef = "MCP_FIXTURE_OAUTH";
+    try {
+      // 1. User hands us credentials.json → we store the static client.
+      const parsed = parseOAuthClientFile(
+        JSON.stringify({ installed: { client_id: "pre-reg-id", client_secret: "pre-reg-secret" } }),
+      );
+      writeStaticClient(vault, tokenRef, toClientInformation(parsed));
+
+      let authUrl: string | undefined;
+      const provider = new VaultOAuthClientProvider(vault, {
+        tokenRef,
+        redirectUrl: "http://127.0.0.1:65535/callback",
+        onAuthorizationUrl: (u) => {
+          authUrl = u.href;
+        },
+      });
+
+      // 2. First auth() call: discovery + build authorization URL. Must NOT
+      //    attempt DCR because clientInformation() returns the static client.
+      const first = await auth(provider, { serverUrl: fx.url });
+      expect(first).toBe("REDIRECT");
+      expect(fx.registrationHit).toBe(false);
+      expect(vault.get(tokenRef + OAUTH_ROW_SUFFIX.client)).toBeUndefined(); // no DCR client saved
+      expect(authUrl).toContain("client_id=pre-reg-id");
+      expect(authUrl).toContain("code_challenge=");
+      expect(vault.get(tokenRef + OAUTH_ROW_SUFFIX.verifier)).toBeDefined(); // PKCE verifier saved
+
+      // 3. Second auth() call with the captured code: token exchange.
+      const done = await auth(provider, { serverUrl: fx.url, authorizationCode: "the-code" });
+      expect(done).toBe("AUTHORIZED");
+      // Confidential client authenticated the token request with its secret.
+      expect(fx.tokenAuthSawSecret).toBe("pre-reg-secret");
+      // Tokens landed in the vault; PKCE verifier spent.
+      expect(provider.tokens()?.access_token).toBe("access-123");
+      expect(vault.get(tokenRef + OAUTH_ROW_SUFFIX.verifier)).toBeUndefined();
+    } finally {
+      fx.close();
+    }
+  });
+});

--- a/tests/mcp-registry.test.ts
+++ b/tests/mcp-registry.test.ts
@@ -150,6 +150,12 @@ describe("secret resolution", () => {
 
   test("referencedVaultKeys enumerates every key an entry touches", () => {
     const oauth = validateEntry("o", { transport: "http", url: "https://x.test/mcp", auth: { type: "oauth", tokenRef: "T" } });
-    expect(referencedVaultKeys(oauth)).toEqual(["T", "T__CLIENT", "T__VERIFIER", "T__DISCOVERY"]);
+    expect(referencedVaultKeys(oauth)).toEqual([
+      "T",
+      "T__CLIENT",
+      "T__CLIENT_STATIC",
+      "T__VERIFIER",
+      "T__DISCOVERY",
+    ]);
   });
 });


### PR DESCRIPTION
## What & why

Fast-follow to #340 / #338, closing the one hole that blocked Google Workspace: **providers that reject RFC 7591 Dynamic Client Registration (DCR)**. Google's remote MCP servers are the case — `mcp login` failed with:

> Incompatible auth server: does not support dynamic client registration

The fix is the design Andrew specced: the user pre-registers an OAuth client in the provider's console once, hands phantombot the downloaded `credentials.json`, phantombot vaults the `client_id`/`client_secret`, and `mcp login` runs the normal PKCE + browser-approve dance — **skipping DCR**. This works because the SDK only runs registration when `OAuthClientProvider.clientInformation()` returns `undefined`; returning the stored client makes it skip.

## The flow

```
phantombot mcp add google-gmail --http --url https://…/mcp --oauth \
    --client-file ./credentials.json --scopes "…"
phantombot mcp login google-gmail        # browser approve → tokens vaulted
```

(`--client-id`/`--client-secret` accepted directly as an alternative to the file.)

## What landed

- **`src/mcp/oauthClient.ts`** (new) — parse a downloaded OAuth-client JSON (`installed` / `web` / flat) → `OAuthClientInformationFull`. Pure, no I/O.
- **`authProvider.ts`** — a **durable** `__CLIENT_STATIC` vault row, preferred over the disposable DCR `__CLIENT` row and **never wiped by `invalidateCredentials`**, so a token-refresh failure re-runs consent instead of re-attempting DCR (which the provider would reject). `writeStaticClient` / `staticClientVaultKey` helpers.
- **`cli/mcp.ts`** — `mcp add --client-file`/`--client-id`/`--client-secret`; ingests + vaults the client at registration; `mcp login` prints a targeted skip-DCR hint when it hits the DCR-rejection error and no client is stored; `remove --purge` cleans the new row.
- **`help.ts` + `docs/mcp.md`** — the pre-registered-client / Google-Workspace path, including the "prefer Desktop-app client type (loopback on any port)" gotcha.

## Verification

- **Real end-to-end SDK run** (`tests/mcp-oauth-client.test.ts`): a fixture OAuth server with **no** `registration_endpoint` (the exact shape that triggers the DCR error). Proves `auth()` **skips registration**, builds the authorization URL with the pre-registered `client_id`, and exchanges the code authenticating with the `client_secret` — tokens land in the vault, PKCE verifier is spent.
- Unit: `credentials.json` parsing, client shaping, provider precedence + durability across `invalidateCredentials('all')`, registry purge, CLI ingestion (file + direct + dry-run + malformed).
- Full suite green (**2598 pass, 0 fail** with a clean env), `tsc` clean, arm64 compiled binary builds (104.99 MB) and carries the new help.

## For review

- This is the concrete Google path flagged during #340 review and in #341. The **live** OAuth round-trip against a real Google endpoint still needs manual verification — same `#341` caveat (do not run `mcp login` against a real provider in prod until checked off). This PR makes that path *possible*; it doesn't claim it's been run live yet.
- Scope kept tight: no multi-header work (the separate `x-goog-user-project` wrinkle) — that's a distinct follow-up if a given Google endpoint needs it.
