### PR TITLE
fix(mcp): keep loopback listener open during oauth login + add logging

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -79,6 +79,15 @@ Flow:
 3. **Log in as usual** — `phantombot mcp login google-mcp`. Browser approve →
    loopback captures the code → tokens land in the vault; refresh is automatic.
 
+> **Same-host redirect.** The redirect target is `http://127.0.0.1:<port>`, so
+> the approving browser must run on the **same host** as `mcp login` (SSH/RDP
+> into the box, or tunnel the port). `login` holds the loopback listener open
+> **~180s** by default (`--wait <ms>`; `--wait 0` = manual only) — earlier it
+> tore the listener down the instant the URL printed, so every redirect hit a
+> dead port. If the browser is elsewhere, copy the `?code=` value from the
+> redirect and finish out-of-band:
+> `phantombot mcp login <id> --code <CODE> --redirect-url <URL>`.
+
 The pre-registered client lives in a **durable** vault row
 (`<tokenRef>__CLIENT_STATIC`) that `invalidateCredentials` never wipes, so a
 token-refresh failure re-runs consent instead of falling back to DCR (which the

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -425,6 +425,13 @@ export async function runMcpCall(input: {
 
 // ─── login ────────────────────────────────────────────────────────────────────
 
+/**
+ * How long `mcp login` keeps the loopback listener open awaiting the browser
+ * redirect when the user doesn't pass `--wait`. Chosen to comfortably cover a
+ * human clicking through a provider's consent screen. `--wait 0` opts out.
+ */
+export const DEFAULT_LOGIN_WAIT_MS = 180_000;
+
 export async function runMcpLogin(input: {
   id: string;
   persona?: string;
@@ -454,16 +461,29 @@ export async function runMcpLogin(input: {
       out.write(`'${input.id}' authorized.\n`);
       return 0;
     }
+    // Default: hold the loopback listener open long enough for the user to
+    // approve in the browser and get redirected back. Without this the listener
+    // was torn down the instant the URL was printed, so the callback always hit
+    // a dead port (ERR_CONNECTION_REFUSED) — even on the same host. Pass
+    // `--wait 0` to opt out and drive the manual `--code` path from the start.
+    const waitMs = input.waitMs ?? DEFAULT_LOGIN_WAIT_MS;
     const result = await beginLogin(input.id, entry, vault, {
-      waitForRedirectMs: input.waitMs ?? 0,
+      waitForRedirectMs: waitMs,
       onUrl: (url) => out.write(`Open this URL and approve:\n  ${url}\n`),
+      onWaiting: ({ redirectUrl }) =>
+        out.write(
+          `Waiting up to ${Math.round(waitMs / 1000)}s for you to approve in the browser…\n` +
+            `If the browser is on another machine and can't reach this host, copy the '?code='\n` +
+            `value from the redirect URL and run:\n` +
+            `  phantombot mcp login ${input.id} --code <CODE> --redirect-url ${redirectUrl}\n`,
+        ),
     });
     if (result.status === "authorized") {
       out.write(`'${input.id}' authorized.\n`);
       return 0;
     }
     out.write(
-      `Waiting for approval. If the browser can't reach this host, copy the '?code=' value from the redirect and run:\n` +
+      `\nNo redirect received yet. Copy the '?code=' value from the redirect and run:\n` +
         `  phantombot mcp login ${input.id} --code <CODE> --redirect-url ${result.redirectUrl}\n`,
     );
     return 0;
@@ -624,7 +644,7 @@ export default defineCommand({
         id: { type: "positional", required: true, description: "Server id." },
         code: { type: "string", description: "Complete a login with a pasted authorization code." },
         "redirect-url": { type: "string", description: "The redirect URL printed when the flow began (needed with --code)." },
-        wait: { type: "string", description: "Wait up to N ms for the browser redirect on the loopback listener." },
+        wait: { type: "string", description: "Milliseconds to hold the loopback listener open for the browser redirect (default 180000; '0' = manual --code path only)." },
         ...personaArg,
       },
       async run({ args }) {

--- a/src/mcp/help.ts
+++ b/src/mcp/help.ts
@@ -59,6 +59,12 @@ THE THREE AUTH METHODS (this is the whole ecosystem in practice)
        You then:  run  phantombot mcp login <id>  — this prints an authorization
                   URL. Tell the user "open this link and approve"; the callback
                   is captured on a loopback listener and tokens are saved.
+                  login holds the listener open ~180s for the approval (change
+                  with --wait <ms>; --wait 0 = manual only). Loopback is
+                  127.0.0.1, so the browser must be on THIS host (e.g. RDP into
+                  the box). If it's on another machine, copy the '?code=' value
+                  from the redirect and finish with:
+                    phantombot mcp login <id> --code <CODE> --redirect-url <URL>
 
      PRE-REGISTERED CLIENT (skip-DCR) — for providers that REJECT dynamic client
      registration. Google's remote MCP servers are the main case: 'mcp login'

--- a/src/mcp/login.ts
+++ b/src/mcp/login.ts
@@ -18,6 +18,7 @@
 
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
 
+import { log } from "../lib/logger.ts";
 import type { Vault } from "../lib/vault.ts";
 import { VaultOAuthClientProvider } from "./authProvider.ts";
 import { startLoopbackCapture } from "./loopback.ts";
@@ -48,9 +49,15 @@ export async function beginLogin(
   serverId: string,
   entry: McpServerEntry,
   vault: Pick<Vault, "get" | "set" | "unset">,
-  opts: { waitForRedirectMs?: number; onUrl?: (url: string) => void } = {},
+  opts: {
+    waitForRedirectMs?: number;
+    onUrl?: (url: string) => void;
+    onWaiting?: (info: { redirectUrl: string; waitMs: number }) => void;
+  } = {},
 ): Promise<LoginResult> {
   const { url, auth: oauth } = oauthEntry(serverId, entry);
+  const waitMs = opts.waitForRedirectMs ?? 0;
+  log.info("mcp.oauth.login begin", { serverId, waitForRedirectMs: waitMs });
   const capture = await startLoopbackCapture();
   let authorizationUrl: string | undefined;
   const provider = new VaultOAuthClientProvider(vault, {
@@ -59,6 +66,7 @@ export async function beginLogin(
     scopes: oauth.scopes,
     onAuthorizationUrl: (u) => {
       authorizationUrl = u.href;
+      log.info("mcp.oauth.login authorization url issued", { serverId });
       opts.onUrl?.(u.href);
     },
   });
@@ -67,16 +75,20 @@ export async function beginLogin(
     const result = await auth(provider, { serverUrl: url });
     if (result === "AUTHORIZED") {
       // Already had a valid token / completed without a redirect.
+      log.info("mcp.oauth.login authorized without redirect", { serverId });
       return { status: "authorized" };
     }
     // result === "REDIRECT": provider.redirectToAuthorization has run, so we
     // have the URL and the verifier is saved. Wait for the loopback callback
     // if asked, else hand back for the manual code path.
     if (!authorizationUrl) throw new Error("oauth: SDK requested a redirect but produced no URL");
-    const waitMs = opts.waitForRedirectMs ?? 0;
     if (waitMs <= 0) {
+      log.info("mcp.oauth.login pending (no wait requested)", { serverId });
       return { status: "pending", authorizationUrl, redirectUrl: capture.redirectUrl };
     }
+    // Hold the listener open and let the caller surface the manual fallback
+    // NOW (not only on timeout), so a cross-host browser has an escape hatch.
+    opts.onWaiting?.({ redirectUrl: capture.redirectUrl, waitMs });
     let code: string;
     try {
       code = await capture.waitForCode(waitMs);
@@ -87,12 +99,18 @@ export async function beginLogin(
       // pending so the caller can print the paste-the-code instructions.
       const msg = (e as Error).message;
       if (/timed out|authorization error/.test(msg)) {
+        log.warn("mcp.oauth.login redirect not captured — falling back to manual code", {
+          serverId,
+          reason: msg,
+        });
         return { status: "pending", authorizationUrl, redirectUrl: capture.redirectUrl };
       }
       throw e;
     }
+    log.info("mcp.oauth.login redirect captured — exchanging code", { serverId });
     const done = await auth(provider, { serverUrl: url, authorizationCode: code });
     if (done !== "AUTHORIZED") throw new Error(`oauth: token exchange returned ${done}`);
+    log.info("mcp.oauth.login authorized", { serverId });
     return { status: "authorized" };
   } finally {
     capture.close();
@@ -116,6 +134,8 @@ export async function completeLogin(
     redirectUrl,
     scopes: oauth.scopes,
   });
+  log.info("mcp.oauth.login completing with pasted code", { serverId });
   const result = await auth(provider, { serverUrl: url, authorizationCode });
   if (result !== "AUTHORIZED") throw new Error(`oauth: token exchange returned ${result}`);
+  log.info("mcp.oauth.login authorized (manual code)", { serverId });
 }

--- a/src/mcp/loopback.ts
+++ b/src/mcp/loopback.ts
@@ -20,6 +20,8 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 
+import { log } from "../lib/logger.ts";
+
 export interface LoopbackCapture {
   /** The redirect_uri to register with the auth server (e.g. http://127.0.0.1:54321/callback). */
   redirectUrl: string;
@@ -41,21 +43,32 @@ export async function startLoopbackCapture(path = "/callback"): Promise<Loopback
 
   const server: Server = createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    // Never log the raw `code`/`error` query values — codes are single-use
+    // secrets. Log only presence + path so a failed round-trip is diagnosable.
+    log.info("mcp.oauth.loopback request received", {
+      path: url.pathname,
+      hasCode: url.searchParams.has("code"),
+      hasError: url.searchParams.has("error"),
+    });
     if (url.pathname !== path) {
+      log.warn("mcp.oauth.loopback request to unexpected path", { path: url.pathname, expected: path });
       res.writeHead(404).end("not found");
       return;
     }
     const error = url.searchParams.get("error");
     const code = url.searchParams.get("code");
     if (error) {
+      log.warn("mcp.oauth.loopback authorization error returned", { error });
       res.writeHead(400, { "content-type": "text/plain" }).end(`Authorization failed: ${error}`);
       if (!settled) { settled = true; rejectCode?.(new Error(`authorization error: ${error}`)); }
       return;
     }
     if (!code) {
+      log.warn("mcp.oauth.loopback callback missing code");
       res.writeHead(400, { "content-type": "text/plain" }).end("Missing authorization code.");
       return;
     }
+    log.info("mcp.oauth.loopback authorization code captured");
     res
       .writeHead(200, { "content-type": "text/html" })
       .end("<html><body><h3>Authorized.</h3><p>You can close this tab and return to phantombot.</p></body></html>");
@@ -69,6 +82,7 @@ export async function startLoopbackCapture(path = "/callback"): Promise<Loopback
 
   const addr = server.address() as AddressInfo;
   const redirectUrl = `http://127.0.0.1:${addr.port}${path}`;
+  log.info("mcp.oauth.loopback listening", { host: "127.0.0.1", port: addr.port, path });
 
   return {
     redirectUrl,
@@ -76,9 +90,11 @@ export async function startLoopbackCapture(path = "/callback"): Promise<Loopback
       return new Promise<string>((resolve, reject) => {
         resolveCode = resolve;
         rejectCode = reject;
+        log.info("mcp.oauth.loopback waiting for redirect", { timeoutMs, redirectUrl });
         const timer = setTimeout(() => {
           if (!settled) {
             settled = true;
+            log.warn("mcp.oauth.loopback timed out waiting for redirect", { timeoutMs });
             reject(new Error(`timed out after ${timeoutMs}ms waiting for the OAuth redirect`));
           }
         }, timeoutMs);
@@ -88,6 +104,7 @@ export async function startLoopbackCapture(path = "/callback"): Promise<Loopback
     close(): void {
       try {
         server.close();
+        log.debug("mcp.oauth.loopback listener closed", { port: addr.port });
       } catch {
         /* already closed */
       }

--- a/tests/mcp-login-wait.test.ts
+++ b/tests/mcp-login-wait.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Loopback-wait regression guard for `phantombot mcp login`.
+ *
+ * The bug this locks down: with no `--wait`, `beginLogin` printed the auth URL
+ * and then IMMEDIATELY closed the loopback listener (its `finally`), so the
+ * browser's redirect to 127.0.0.1:<port> hit a dead port
+ * (ERR_CONNECTION_REFUSED) — even when browser and listener were on the same
+ * host. The fix holds the listener open (default 180s) so the redirect lands
+ * and the code is exchanged automatically.
+ *
+ * Both layers are covered:
+ *   - beginLogin: the listener survives after the URL is issued and completes
+ *     when the redirect arrives during the wait window (and onWaiting fires so
+ *     the manual fallback is offered immediately, not only on timeout).
+ *   - runMcpLogin (CLI): with NO --wait it applies the default wait and
+ *     auto-completes when the browser reaches the loopback.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DEFAULT_LOGIN_WAIT_MS, runMcpAdd, runMcpLogin } from "../src/cli/mcp.ts";
+import { openVaultWithSecret, type Vault } from "../src/lib/vault.ts";
+import { toClientInformation } from "../src/mcp/oauthClient.ts";
+import { writeStaticClient } from "../src/mcp/authProvider.ts";
+import { beginLogin } from "../src/mcp/login.ts";
+import type { McpServerEntry } from "../src/mcp/registry.ts";
+import { generateSecretKey } from "nostr-tools/pure";
+import { rmrf } from "./fixtures/rmrf.ts";
+
+/**
+ * A minimal OAuth authorization server with NO registration endpoint. Combined
+ * with a pre-registered static client this lets `auth()` run without DCR, so
+ * these tests exercise the loopback path, not registration.
+ */
+function startFixtureAuthServer() {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const origin = url.origin;
+      if (url.pathname.startsWith("/.well-known/oauth-protected-resource")) {
+        return new Response("not found", { status: 404 });
+      }
+      if (
+        url.pathname === "/.well-known/oauth-authorization-server" ||
+        url.pathname === "/.well-known/openid-configuration"
+      ) {
+        return Response.json({
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+          response_types_supported: ["code"],
+          code_challenge_methods_supported: ["S256"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+        });
+      }
+      if (url.pathname === "/token" && req.method === "POST") {
+        return Response.json({
+          access_token: "access-123",
+          token_type: "Bearer",
+          refresh_token: "refresh-123",
+          expires_in: 3600,
+        });
+      }
+      return new Response("ok");
+    },
+  });
+  return { url: `${server.url.origin}/mcp`, close: () => server.stop(true) };
+}
+
+async function pollFor<T>(fn: () => T | undefined, timeoutMs = 5000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const v = fn();
+    if (v !== undefined) return v;
+    if (Date.now() > deadline) throw new Error("pollFor timed out");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe("beginLogin — loopback listener survives until the redirect", () => {
+  let workdir: string;
+  let vault: Vault;
+  beforeEach(async () => {
+    workdir = await mkdtemp(join(tmpdir(), "phantombot-login-wait-"));
+    vault = openVaultWithSecret(workdir, generateSecretKey());
+  });
+  afterEach(async () => {
+    vault.close();
+    await rmrf(workdir);
+  });
+
+  test("redirect delivered during the wait window completes the exchange", async () => {
+    const fx = startFixtureAuthServer();
+    const tokenRef = "MCP_WAIT_OAUTH";
+    try {
+      // Pre-registered client → skip DCR, isolate the loopback behaviour.
+      writeStaticClient(vault, tokenRef, toClientInformation({ clientId: "cid", clientSecret: "sec" }));
+      const entry: McpServerEntry = { transport: "http", url: fx.url, auth: { type: "oauth", tokenRef } };
+
+      let onWaitingFired = false;
+      const result = await beginLogin("wsrv", entry, vault, {
+        waitForRedirectMs: 5000,
+        onWaiting: ({ redirectUrl }) => {
+          onWaitingFired = true;
+          // Simulate the browser redirect AFTER the URL was issued — the listener
+          // must still be alive here. Fire-and-forget; beginLogin's waitForCode
+          // resolves from it.
+          void fetch(`${redirectUrl}?code=the-code`);
+        },
+      });
+
+      expect(onWaitingFired).toBe(true); // manual fallback offered while waiting
+      expect(result.status).toBe("authorized");
+      expect(vault.get(tokenRef)).toBeDefined(); // tokens landed
+    } finally {
+      fx.close();
+    }
+  }, 15_000);
+
+  test("waitForRedirectMs=0 returns pending without waiting (explicit opt-out)", async () => {
+    const tokenRef = "MCP_NOWAIT_OAUTH";
+    const fx = startFixtureAuthServer();
+    try {
+      writeStaticClient(vault, tokenRef, toClientInformation({ clientId: "cid" }));
+      const entry: McpServerEntry = { transport: "http", url: fx.url, auth: { type: "oauth", tokenRef } };
+      const result = await beginLogin("nsrv", entry, vault, { waitForRedirectMs: 0 });
+      expect(result.status).toBe("pending");
+      if (result.status === "pending") {
+        expect(result.redirectUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+      }
+    } finally {
+      fx.close();
+    }
+  }, 15_000);
+});
+
+describe("runMcpLogin (CLI) — default wait auto-completes", () => {
+  let workdir: string;
+  const savedEnv = { ...process.env };
+  beforeEach(async () => {
+    workdir = await mkdtemp(join(tmpdir(), "phantombot-cli-login-wait-"));
+    process.env.PHANTOMBOT_PERSONAS_DIR = workdir;
+    process.env.PHANTOMBOT_DEFAULT_PERSONA = "tester";
+    process.env.PHANTOMBOT_PERSONA = "tester";
+  });
+  afterEach(async () => {
+    process.env = { ...savedEnv };
+    await rmrf(workdir);
+  });
+
+  test("the default wait is a sane, non-zero window", () => {
+    expect(DEFAULT_LOGIN_WAIT_MS).toBeGreaterThanOrEqual(60_000);
+  });
+
+  test("no --wait: holds the listener, browser reaches it, login authorizes", async () => {
+    const fx = startFixtureAuthServer();
+    try {
+      // Register the oauth server (pointing at the fixture) with a pre-registered
+      // client so DCR is skipped.
+      const add = await runMcpAdd({
+        id: "gmail",
+        http: true,
+        url: fx.url,
+        oauth: true,
+        tokenRef: "MCP_GMAIL_OAUTH",
+        clientId: "cid",
+        clientSecret: "sec",
+        out: { write: () => true },
+        err: { write: () => true },
+      });
+      expect(add).toBe(0);
+
+      const chunks: string[] = [];
+      const out = { write: (s: string | Uint8Array) => (chunks.push(String(s)), true) };
+      // Do NOT pass waitMs — prove the default keeps the listener open.
+      const p = runMcpLogin({ id: "gmail", out, err: out });
+
+      // Once the login prints the redirect URL, the listener is live — hit it.
+      const redirectUrl = await pollFor(() => {
+        const m = chunks.join("").match(/--redirect-url (\S+)/);
+        return m?.[1];
+      });
+      await fetch(`${redirectUrl}?code=the-code`);
+
+      expect(await p).toBe(0);
+      expect(chunks.join("")).toContain("authorized");
+    } finally {
+      fx.close();
+    }
+  }, 20_000);
+});


### PR DESCRIPTION
## Why
Megan hit `ERR_CONNECTION_REFUSED` on the OAuth callback during `mcp login`, even over RDP on the same VM. Not a flaky port — a broken default.

## Root cause
`phantombot mcp login <server>` with no `--wait` → `waitForRedirectMs = 0`. `beginLogin` printed the auth URL, returned `pending`, and its `finally { capture.close() }` **closed the loopback listener immediately** — before the user could approve. The browser's redirect to `127.0.0.1:<port>` then hit a dead port. The listener path only ever worked if the caller explicitly passed a wait.

Compounding it: `src/mcp/` had **zero logging**, so the failure was invisible.

## Fix
- **Default `mcp login` to hold the listener open 180s** (`DEFAULT_LOGIN_WAIT_MS`). `--wait <ms>` overrides; `--wait 0` opts out to the manual `--code` path.
- **Offer the manual `--code` fallback *while* waiting** (new `onWaiting` hook), so a cross-host browser has an immediate escape hatch — not only after a timeout.
- **Structured logging across the whole flow**: listener bound + port, auth URL issued, redirect received (path + code/error **presence only**), timeout, token exchange, close. Auth codes are single-use secrets — only presence is logged, never the value (the log redactor covers the rest).

## Tests
New `tests/mcp-login-wait.test.ts`:
- redirect delivered during the wait window completes the exchange (listener-survives regression guard);
- `onWaiting` fires so the fallback is offered immediately;
- `--wait 0` returns `pending` without waiting;
- CLI default (no `--wait`) auto-completes end-to-end through `runMcpLogin`.

Full suite green except one **pre-existing, unrelated** failure (`loadConfig — TOML overlay`, fails on `main` too). tsc clean; arm64 binary builds and carries the new help.

## Note
The same-host constraint is inherent to loopback OAuth (`127.0.0.1`): the approving browser must be on the box (SSH/RDP/tunnel) — that's Megan's case, and it now works. Cross-machine still uses the `--code` paste path, now surfaced up front. Live Google round-trip verification still lives in #341.
