### PR TITLE
ci: skip release on docs/website-only merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,14 @@ name: Release on PR merge
 # skip a release. Over-releasing is harmless (a duplicate-content binary at a
 # higher version); under-releasing ships a fix to nobody.
 #
-# NOTE on the denylist scope: it is deliberately NARROW. `**.md` is NOT here
-# because `agents/phantom/*.md` are the persona system prompts embedded into
-# the compiled binary — changing them IS a functional change and MUST release.
-# Only the pure documentation/marketing surfaces are listed:
+# NOTE on the denylist scope: it is deliberately NARROW. `**.md` is NOT here —
+# a blanket markdown ignore is too broad and would risk silently skipping a
+# release for markdown that matters. In particular `agents/phantom/*.md` are
+# persona system prompts; the binary does not embed them (they are loaded at
+# runtime from persona directories — see src/persona/loader.ts), but keeping
+# them out of the denylist is the conservative, fail-open call: at worst a
+# redundant binary at a higher version, never an under-release. Only the pure
+# documentation/marketing surfaces are listed:
 #   - README.md / AGENTS.md / LICENSE — top-level docs, not compiled in
 #   - docs/**  — the docs site markdown
 #   - www/**   — the AIRE marketing website (deployed separately by

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release on PR merge
 
-# Fires on every push to main (i.e. every PR merge — branch protection
-# requires PRs, so a push to main IS a merge). Cuts a GitHub Release tagged
+# Fires on pushes to main (i.e. PR merges — branch protection requires PRs,
+# so a push to main IS a merge) EXCEPT docs/website-only merges, which are
+# filtered out by the paths-ignore denylist below. Cuts a GitHub Release tagged
 # v1.1.<RUN_NUMBER> with cross-compiled binaries (linux x64-baseline +
 # arm64, darwin x64 + arm64, windows x64 + arm64) and a SHA256SUMS file.
 # `phantombot update` reads this feed.
@@ -57,9 +58,47 @@ name: Release on PR merge
 # Don't 'optimise' to plain x64 without verifying every deploy target has
 # AVX2 — see the SIGILL post-mortem from the May 2026 first deploy.
 
+# Why paths-ignore (docs/website-only merges do NOT cut a release): a README
+# or website copy change is not functional to the app binary, and cutting a
+# fresh release for it churns `phantombot update` on every client for nothing.
+# The push still lands on main; it just doesn't produce a new binary.
+#
+# We use paths-ignore (a DENYLIST of non-functional surfaces) rather than a
+# paths ALLOWLIST of source dirs on purpose — the model is fail-open to
+# releasing. Anything NOT in this list still triggers a release, so a
+# functional change to a file type we forgot to allowlist can never silently
+# skip a release. Over-releasing is harmless (a duplicate-content binary at a
+# higher version); under-releasing ships a fix to nobody.
+#
+# NOTE on the denylist scope: it is deliberately NARROW. `**.md` is NOT here
+# because `agents/phantom/*.md` are the persona system prompts embedded into
+# the compiled binary — changing them IS a functional change and MUST release.
+# Only the pure documentation/marketing surfaces are listed:
+#   - README.md / AGENTS.md / LICENSE — top-level docs, not compiled in
+#   - docs/**  — the docs site markdown
+#   - www/**   — the AIRE marketing website (deployed separately by
+#                deploy-pages.yml, which triggers on www/** — so website
+#                changes still ship, just via Pages, not a binary release)
+#
+# run_number implication: when only ignored paths change the workflow does not
+# run, so github.run_number does not increment for that merge. That is fine —
+# run_number only ever GROWS (the invariant above still holds); it just skips
+# the values that would have belonged to docs-only merges. Versions never
+# regress, they just aren't contiguous, which nothing depends on.
+#
+# Squash-merge note: this repo squash-merges (linear history is required), so
+# the pushed commit on main carries the PR's FULL diff and the path filter sees
+# every changed file. A mixed PR (docs + src) therefore still releases, because
+# not all of its files match the ignore list.
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'README.md'
+      - 'AGENTS.md'
+      - 'LICENSE'
+      - 'docs/**'
+      - 'www/**'
 
 permissions:
   contents: write        # create release + upload assets


### PR DESCRIPTION
## What

Adds a `paths-ignore` denylist to the release workflow so a **README, docs, or marketing-website** change merged to `main` no longer cuts a phantombot binary release. Refs #339 (so the upcoming website PR won't churn `phantombot update` for every client).

## The rule

```yaml
on:
  push:
    branches: [main]
    paths-ignore:
      - 'README.md'
      - 'AGENTS.md'
      - 'LICENSE'
      - 'docs/**'
      - 'www/**'
```

## Design choices (documented inline in the workflow header)

- **Denylist, not a source allowlist.** Fail-open to releasing: anything *not* listed still triggers a release, so a functional change to a file type we forgot can never *silently* skip a release. Over-releasing is harmless; under-releasing ships a fix to nobody.
- **Scope is narrow — `**.md` is intentionally NOT ignored.** `agents/phantom/*.md` are persona system prompts loaded at runtime from persona directories (not embedded in the binary), but keeping `**.md` out of the denylist is the conservative fail-open call — a blanket markdown ignore is too broad and could silently skip a release that matters. Only pure doc/marketing surfaces are listed.
- **`www/**` still ships** — `deploy-pages.yml` triggers on `www/**` and deploys the site via Pages, independent of the binary release.
- **run_number stays monotonic.** Docs-only merges just don't run the workflow, so `github.run_number` skips those values but never regresses — the version-counter invariant holds.
- **Squash-merge safe.** The repo squash-merges, so the pushed commit carries the PR's full diff and the path filter sees every changed file; a mixed docs+src PR still releases.
