### PR TITLE
feat(cli): add optional voice step to init onboarding wizard

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -17,6 +17,7 @@ import { runInstall } from "./install.ts";
 import { runPersona } from "./persona.ts";
 import { runPhantomchat } from "./phantomchat.ts";
 import { runTelegram } from "./telegram.ts";
+import { runVoice } from "./voice.ts";
 
 export interface InitFlowInput {
   config: Config;
@@ -122,7 +123,8 @@ export default defineCommand({
       "  3. Connect PhantomChat (your private Nostr DM channel)\n" +
       "  4. Connect Telegram (optional — skippable)\n" +
       "  5. Enable semantic memory search (optional)\n" +
-      "  6. Install as a background service",
+      "  6. Enable voice — TTS/STT (optional)\n" +
+      "  7. Install as a background service",
       "Setup Flow"
     );
 
@@ -240,7 +242,30 @@ export default defineCommand({
       await runEmbedding({ embedded: true });
     }
 
-    // 5. Install
+    // 5. Optional: voice (TTS/STT).
+    // Same shape as the embeddings step above: a separate skippable confirm
+    // (default OFF) so it never blocks a quick install, and runVoice is called
+    // in `embedded` mode so it doesn't render its own intro/outro or prompt for
+    // a service restart (the service isn't installed until the next step). The
+    // return is intentionally non-fatal — voice is optional, so a skip or a
+    // key-validation failure must never abort the wizard before install.
+    p.log.step("Voice — TTS / STT (optional)");
+    p.note(
+      "Give your agent a voice: it can speak replies (text-to-speech) and\n" +
+      "transcribe voice notes you send it (speech-to-text). Pick from ElevenLabs\n" +
+      "or OpenAI (paid, API key), or Azure Edge (free, no key). It's optional —\n" +
+      "you can always set it up later with `phantombot voice`.",
+      "What this adds"
+    );
+    const wantVoice = await p.confirm({
+      message: "Set up voice now? (optional)",
+      initialValue: false,
+    });
+    if (!p.isCancel(wantVoice) && wantVoice) {
+      await runVoice({ embedded: true });
+    }
+
+    // 6. Install
     // Use a step marker, not a second p.intro — clack renders one
     // open / one close bracket per flow, and a second intro mid-flow
     // produces a stray opening bracket in the rendered TUI.

--- a/src/cli/voice.ts
+++ b/src/cli/voice.ts
@@ -71,16 +71,27 @@ export async function applyVoiceConfig(input: ApplyVoiceInput): Promise<void> {
 interface RunInput {
   config?: Config;
   serviceControl?: ServiceControl;
+  /**
+   * When true, this runs as a sub-step of another wizard (e.g.
+   * `phantombot init`) rather than standalone. Two effects:
+   *   - suppresses the standalone intro/outro and the "Existing config"
+   *     note (the parent owns the framing; a nested clack intro renders a
+   *     stray bracket), and
+   *   - skips the post-save restart prompt (the parent installs/starts the
+   *     service afterwards, so there is nothing running to restart yet).
+   */
+  embedded?: boolean;
 }
 
 export async function runVoice(input: RunInput = {}): Promise<number> {
   const config = input.config ?? (await loadConfig());
   const svc = input.serviceControl ?? defaultServiceControl();
+  const embedded = input.embedded ?? false;
 
-  p.intro("Configure TTS / STT");
+  if (!embedded) p.intro("Configure TTS / STT");
 
   const existing = config.voice;
-  if (existing.provider !== "none") {
+  if (!embedded && existing.provider !== "none") {
     p.note(
       `provider:  ${existing.provider}\n` +
         formatExistingDetails(existing),
@@ -123,14 +134,19 @@ export async function runVoice(input: RunInput = {}): Promise<number> {
       voice: { provider: "none" },
     });
     p.note(`provider set to "none"`, "Saved");
-    await maybePromptRestart(svc);
-    p.outro("done");
+    if (!embedded) {
+      await maybePromptRestart(svc);
+      p.outro("done");
+    }
     return 0;
   }
 
-  if (provider === "elevenlabs") return runElevenLabsFlow(config, svc, existing);
-  if (provider === "openai") return runOpenAIFlow(config, svc, existing);
-  if (provider === "azure_edge") return runAzureEdgeFlow(config, svc, existing);
+  if (provider === "elevenlabs")
+    return runElevenLabsFlow(config, svc, existing, embedded);
+  if (provider === "openai")
+    return runOpenAIFlow(config, svc, existing, embedded);
+  if (provider === "azure_edge")
+    return runAzureEdgeFlow(config, svc, existing, embedded);
   return 0;
 }
 
@@ -138,6 +154,7 @@ async function runElevenLabsFlow(
   config: Config,
   svc: ServiceControl,
   existing: VoiceConfig,
+  embedded: boolean,
 ): Promise<number> {
   const cur = existing.elevenlabs ?? ELEVENLABS_DEFAULTS;
   const key = await p.password({
@@ -200,8 +217,10 @@ async function runElevenLabsFlow(
       `key saved to ${defaultEnvFilePath()} as ${ENV_KEY_FOR_PROVIDER.elevenlabs}`,
     "Saved",
   );
-  await maybePromptRestart(svc);
-  p.outro("done");
+  if (!embedded) {
+    await maybePromptRestart(svc);
+    p.outro("done");
+  }
   return 0;
 }
 
@@ -209,6 +228,7 @@ async function runOpenAIFlow(
   config: Config,
   svc: ServiceControl,
   existing: VoiceConfig,
+  embedded: boolean,
 ): Promise<number> {
   const cur = existing.openai ?? OPENAI_DEFAULTS;
   const key = await p.password({
@@ -271,8 +291,10 @@ async function runOpenAIFlow(
       `key saved to ${defaultEnvFilePath()} as ${ENV_KEY_FOR_PROVIDER.openai}`,
     "Saved",
   );
-  await maybePromptRestart(svc);
-  p.outro("done");
+  if (!embedded) {
+    await maybePromptRestart(svc);
+    p.outro("done");
+  }
   return 0;
 }
 
@@ -280,6 +302,7 @@ async function runAzureEdgeFlow(
   config: Config,
   svc: ServiceControl,
   existing: VoiceConfig,
+  embedded: boolean,
 ): Promise<number> {
   const cur = existing.azure_edge ?? AZURE_EDGE_DEFAULTS;
   const voice = await p.select<string>({
@@ -310,8 +333,10 @@ async function runAzureEdgeFlow(
       `(no API key required)`,
     "Saved",
   );
-  await maybePromptRestart(svc);
-  p.outro("done");
+  if (!embedded) {
+    await maybePromptRestart(svc);
+    p.outro("done");
+  }
   return 0;
 }
 


### PR DESCRIPTION
## What

The `init` onboarding wizard walked through welcome → harness probe → channels → **embeddings** → linger → install, but never voice. A dedicated voice TUI exists (`phantombot voice`), yet new users only found it by going looking. This adds an **optional** Voice (TTS/STT) step, symmetric with how embeddings already nests.

## Changes

- **`voice.ts`** — add `embedded?: boolean` to `runVoice`, threaded through all four sub-flows (elevenlabs/openai/azure_edge/none). When set it suppresses the intro/outro, the "Existing config" note, and the post-save restart prompt — the parent wizard owns framing and installs the service afterward. Standalone `phantombot voice` behavior is untouched.
- **`init.ts`** — import `runVoice`, add a "Voice — TTS/STT (optional)" step (note + `confirm` gate, default OFF) right after embeddings and before install. Renumbered the welcome flow to 7 steps.

## Testing

- Typecheck clean on both touched files (remaining repo errors are pre-existing MCP SDK module-resolution noise in unrelated tests).
- 25/25 voice + init tests pass. Voice/embeddings both live in the interactive `run()` path, which sits outside the `runInitFlow` unit-test boundary, so the new step matches embeddings' existing coverage line.

## Blast radius

Low. Standalone `phantombot voice` is unchanged; voice stays optional/skippable in the wizard, default off.