### PR TITLE
feat(vscode): multi-chat history — save, rename, retrieve past chats

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -83,12 +83,21 @@
         "title": "Open Phantombot Chat",
         "category": "phantombot",
         "icon": "$(hubot)"
+      },
+      {
+        "command": "phantombot.renameChat",
+        "title": "Rename Chat",
+        "category": "phantombot",
+        "icon": "$(edit)"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "phantombot.openSession"
+        },
+        {
+          "command": "phantombot.renameChat"
         }
       ],
       "view/title": [

--- a/editors/vscode/src/acpClient.ts
+++ b/editors/vscode/src/acpClient.ts
@@ -107,7 +107,16 @@ export class AcpClient {
   private readonly pending = new Map<JsonRpcId, Pending>();
   private readonly requestTimeoutMs: number;
   private readonly onDiagnostic: (text: string) => void;
-  /** sessionId → live prompt handlers, set for the duration of a prompt. */
+  /**
+   * sessionId → live prompt handlers, set for the duration of a prompt.
+   *
+   * Since #349 every chat has a STABLE sessionId, so two turns can briefly
+   * overlap on one sid: the user submits a new prompt while the previous turn
+   * is still resolving (chat-channel "interrupt" — the server aborts the old
+   * turn and starts the new one). The newer turn's handlers replace the older
+   * turn's entry here; the older turn's `finally` must therefore delete its
+   * slot ONLY if it still owns it (identity check), never clobber the successor.
+   */
   private readonly promptStreams = new Map<string, PromptHandlers>();
   /** sessionId → the slash commands the agent advertised for that session. */
   private readonly sessionCommands = new Map<string, AcpAvailableCommand[]>();
@@ -164,7 +173,10 @@ export class AcpClient {
       })) as AcpLoadSessionResult;
       return result;
     } finally {
-      if (handlers) this.promptStreams.delete(sessionId);
+      // Only clear our own slot — a newer overlapping turn may have replaced it.
+      if (handlers && this.promptStreams.get(sessionId) === handlers) {
+        this.promptStreams.delete(sessionId);
+      }
     }
   }
 
@@ -188,7 +200,12 @@ export class AcpClient {
       )) as AcpPromptResult;
       return result.stopReason;
     } finally {
-      this.promptStreams.delete(sessionId);
+      // Only clear our own slot — if a newer overlapping turn (the user
+      // interrupting with a fresh prompt on this stable sid) already replaced
+      // it, leave the successor's handlers in place so its stream survives.
+      if (this.promptStreams.get(sessionId) === handlers) {
+        this.promptStreams.delete(sessionId);
+      }
     }
   }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -29,17 +29,24 @@ import { createLanguageModelChatProvider } from "./lmProvider.ts";
 import {
   registerChatSessionProvider,
   extractAttachments,
+  cwdFromSessionResource,
+  type SessionProviderHandle,
 } from "./sessionProvider.ts";
 import {
   pickOpenSessionCommand,
   promptBlocksFromRequest,
   promptTextWithCommand,
-  resolveSessionCreated,
   shouldAutoOpenSession,
   SIDEBAR_OPEN_COMMAND,
   EDITOR_OPEN_COMMAND,
   type OpenOnStartup,
 } from "./sessionBridge.ts";
+import {
+  listSessions,
+  patchSession,
+  type ChatSessionRecord,
+  type SessionKv,
+} from "./sessionStore.ts";
 
 // The participant id MUST equal the chat-session `type` (see package.json
 // contributes.chatSessions[].type). When `canDelegate: true`, VS Code registers
@@ -56,8 +63,8 @@ const OPEN_SESSION_COMMAND = "phantombot.openSession";
 /** globalState key remembering whether the phantombot session has ever been opened. */
 const STICKY_KEY = "phantombot.everOpened";
 
-/** globalState key prefix for the stable per-resource session `created` time. */
-const CREATED_KEY_PREFIX = "phantombot.sessionCreated:";
+/** Command id for renaming a chat in the phantombot sessions list. */
+const RENAME_CHAT_COMMAND = "phantombot.renameChat";
 
 /**
  * The per-type open commands (`…openNewSessionSidebar.phantombot`, etc.) only
@@ -164,42 +171,44 @@ export function activate(context: vscode.ExtensionContext): void {
   // rehydrated from phantombot's server-side memory. Uses the chatSessionsProvider
   // proposed API; registerChatSessionProvider no-ops cleanly if that proposal
   // isn't enabled for this extension (see argv.json "enable-proposed-api").
+  // Chat list + titles live in VS Code's OWN storage (workspaceState), never in
+  // the phantombot domain. This facade adapts the Memento to the pure store.
+  const kv: SessionKv = {
+    get: (k) => context.workspaceState.get(k),
+    update: (k, v) => void context.workspaceState.update(k, v),
+  };
+
+  const sessions = registerChatSessionProvider({
+    createClient: (cwd) => makeSessionClient(cwd, output),
+    currentCwd: currentWorkspaceCwd,
+    workspaceFolders: () =>
+      (vscode.workspace.workspaceFolders ?? []).map((f) => ({
+        cwd: f.uri.fsPath,
+        name: f.name,
+      })),
+    personaLabel: () =>
+      vscode.workspace
+        .getConfiguration("phantombot")
+        .get<string>("persona")
+        ?.trim() ?? "",
+    participant,
+    participantId: PARTICIPANT_ID,
+    kv,
+    // Remember that phantombot has been opened so we can re-open it on future
+    // launches (the "ifUsedBefore" sticky default).
+    onSessionOpened: () => {
+      void context.globalState.update(STICKY_KEY, true);
+    },
+    output,
+  });
+  context.subscriptions.push(sessions);
+
+  // Rename a chat in the list. All naming is client-side (VS Code storage); the
+  // rename never touches the phantombot domain.
   context.subscriptions.push(
-    registerChatSessionProvider({
-      createClient: (cwd) => makeSessionClient(cwd, output),
-      currentCwd: currentWorkspaceCwd,
-      workspaceFolders: () =>
-        (vscode.workspace.workspaceFolders ?? []).map((f) => ({
-          cwd: f.uri.fsPath,
-          name: f.name,
-        })),
-      personaLabel: () =>
-        vscode.workspace
-          .getConfiguration("phantombot")
-          .get<string>("persona")
-          ?.trim() ?? "",
-      participant,
-      participantId: PARTICIPANT_ID,
-      // Stable per-resource `created` time, persisted in globalState so the
-      // session's age stays put across list refreshes (and never defaults to
-      // the epoch, which newer VS Code renders as "57 yrs ago" + auto-archives).
-      sessionCreatedAt: (key) =>
-        resolveSessionCreated(
-          key,
-          {
-            get: (k) => context.globalState.get<number>(CREATED_KEY_PREFIX + k),
-            set: (k, v) =>
-              void context.globalState.update(CREATED_KEY_PREFIX + k, v),
-          },
-          Date.now(),
-        ),
-      // Remember that phantombot has been opened so we can re-open it on future
-      // launches (the "ifUsedBefore" sticky default).
-      onSessionOpened: () => {
-        void context.globalState.update(STICKY_KEY, true);
-      },
-      output,
-    }),
+    vscode.commands.registerCommand(RENAME_CHAT_COMMAND, (arg?: unknown) =>
+      renameChatCommand(kv, currentWorkspaceCwd, sessions, output, arg),
+    ),
   );
 
   // ── Quick-launch command: button + palette + keybinding ───────────────────
@@ -310,6 +319,91 @@ async function openPhantombotSession(
 /** Promise-based delay (avoids pulling in a timers import). */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Rename a chat in the phantombot sessions list. Invoked from the command
+ * palette (→ quick pick of the workspace's chats) or a context-menu action on a
+ * session item (→ that item's resource is passed as `arg`). Naming is purely
+ * client-side: it edits the title in VS Code's workspaceState and re-lists.
+ */
+async function renameChatCommand(
+  kv: SessionKv,
+  currentCwd: () => string,
+  sessions: SessionProviderHandle,
+  output: vscode.OutputChannel,
+  arg?: unknown,
+): Promise<void> {
+  try {
+    let target = resolveRenameTarget(arg);
+    if (!target) {
+      const cwd = currentCwd();
+      const records = listSessions(kv, cwd);
+      if (records.length === 0) {
+        void vscode.window.showInformationMessage(
+          "phantombot: no saved chats to rename yet.",
+        );
+        return;
+      }
+      const picked = await vscode.window.showQuickPick(
+        records.map((rec: ChatSessionRecord) => ({
+          label: rec.title,
+          description: new Date(rec.lastUsedAt).toLocaleString(),
+          rec,
+        })),
+        { placeHolder: "Rename which phantombot chat?" },
+      );
+      if (!picked) return;
+      target = { cwd, sessionId: picked.rec.sessionId, current: picked.rec.title };
+    }
+
+    const next = await vscode.window.showInputBox({
+      prompt: "New chat name",
+      value: target.current ?? "",
+      validateInput: (v) =>
+        v.trim().length === 0 ? "Name can't be empty" : undefined,
+    });
+    if (next === undefined) return; // cancelled
+    const title = next.trim();
+    if (!title) return;
+
+    const updated = patchSession(kv, target.cwd, target.sessionId, {
+      title,
+      titleSettled: true,
+    });
+    if (!updated) {
+      void vscode.window.showWarningMessage(
+        "phantombot: that chat is no longer in the list.",
+      );
+      return;
+    }
+    sessions.refresh();
+  } catch (e) {
+    output.appendLine(`[rename] ${(e as Error).message}`);
+  }
+}
+
+/**
+ * Resolve the chat to rename from a context-menu argument (a ChatSessionItem or
+ * its resource Uri). Returns undefined when there's no usable target, so the
+ * caller falls back to a quick pick.
+ */
+function resolveRenameTarget(
+  arg: unknown,
+): { cwd: string; sessionId: string; current?: string } | undefined {
+  const uri =
+    arg instanceof vscode.Uri
+      ? arg
+      : (arg as { resource?: unknown })?.resource;
+  if (!(uri instanceof vscode.Uri)) return undefined;
+  const sessionId = (uri.query ?? "").trim();
+  if (!sessionId) return undefined;
+  const current = (arg as { label?: unknown })?.label;
+  return {
+    cwd: cwdFromSessionResource(uri),
+    sessionId,
+    current: typeof current === "string" ? current : undefined,
+  };
 }
 
 /**

--- a/editors/vscode/src/sessionBridge.ts
+++ b/editors/vscode/src/sessionBridge.ts
@@ -27,8 +27,6 @@
  *     content-block array the agent consumes — so photos and files Just Work.
  */
 
-import { randomBytes } from "node:crypto";
-
 import type { PromptHandlers } from "./acpClient.ts";
 import type { AcpContentBlock, AcpSessionUpdate } from "./protocol.ts";
 
@@ -56,6 +54,24 @@ export function cwdFromResourcePath(path: string): string {
   return path;
 }
 
+/**
+ * A session resource URI now carries TWO things:
+ *   - `path`  → the workspace cwd (as before), and
+ *   - `query` → the opaque server thread token for THIS chat (multi-chat).
+ *
+ * A resource with an empty/absent query is a brand-new ("untitled") chat that
+ * hasn't been bound to a thread yet — the content provider mints one on open.
+ * The glue builds the real `Uri` as `{ scheme, path, query }`; these pure
+ * helpers keep the encode/decode symmetric and unit-tested off-host.
+ */
+export function decodeSessionResource(
+  path: string,
+  query: string | undefined,
+): { cwd: string; sessionId?: string } {
+  const q = (query ?? "").trim();
+  return { cwd: cwdFromResourcePath(path), sessionId: q.length > 0 ? q : undefined };
+}
+
 /** A workspace folder candidate that backs one chat-session item. */
 export interface SessionCandidate {
   cwd: string;
@@ -76,36 +92,6 @@ export function resolveSessionCandidates(
 ): SessionCandidate[] {
   if (folders.length > 0) return folders;
   return [{ cwd: fallbackCwd, name: fallbackName }];
-}
-
-/** Minimal persistent KV the timing resolver needs (backed by globalState). */
-export interface CreatedStore {
-  get(key: string): number | undefined;
-  set(key: string, value: number): void;
-}
-
-/**
- * Resolve a stable `created` timestamp (ms since epoch) for a session resource.
- *
- * VS Code's newer chat-sessions surface renders `ChatSessionItem.timing.created`
- * as the session's age. When we omit `timing`, that field defaults to 0 — the
- * Unix epoch — so the session shows as "57 yrs ago" and newer builds auto-archive
- * it out of the active SESSIONS list (older builds didn't render age at all, which
- * is why this only bit on the Mac). Populating a real `created` fixes both.
- *
- * We persist a first-seen time per resource key so the age is STABLE across list
- * refreshes (returning `Date.now()` raw would reset the age to "just now" on every
- * refresh). First sighting records `now`; later sightings return the stored value.
- */
-export function resolveSessionCreated(
-  key: string,
-  store: CreatedStore,
-  now: number,
-): number {
-  const existing = store.get(key);
-  if (typeof existing === "number" && existing > 0) return existing;
-  store.set(key, now);
-  return now;
 }
 
 /** How the extension behaves on startup re: auto-opening the phantombot session. */
@@ -287,12 +273,6 @@ export function promptTextWithCommand(
   if (!cmd) return text;
   const rest = text.trim();
   return rest.length > 0 ? `/${cmd} ${rest}` : `/${cmd}`;
-}
-
-/** Mint an opaque ACP session token (client side). The server re-derives the
- * stable conversation key from cwd regardless, so any unique token works. */
-export function mintSessionId(): string {
-  return `acp_${randomBytes(12).toString("hex")}`;
 }
 
 /** True when a guessed mime type denotes an image we can inline. */

--- a/editors/vscode/src/sessionProvider.ts
+++ b/editors/vscode/src/sessionProvider.ts
@@ -299,6 +299,11 @@ export function registerChatSessionProvider(
         });
         if (stopReason === "refusal") {
           stream.markdown("\n\n_(phantombot declined this turn.)_");
+        } else if (stopReason === "cancelled") {
+          // The user interrupted this turn by submitting another prompt (or hit
+          // stop). The server aborted it cleanly — mark it quietly, chat-channel
+          // style, rather than letting a half-finished turn read like an error.
+          stream.markdown("\n\n_(interrupted)_");
         }
         return {};
       } catch (e) {

--- a/editors/vscode/src/sessionProvider.ts
+++ b/editors/vscode/src/sessionProvider.ts
@@ -3,18 +3,30 @@
  * agent in VS Code's native chat *sessions* surface (its own panel entry, no
  * `@mention`), the same slot Copilot CLI and Claude Code occupy.
  *
- * This is the `vscode`-importing glue. All decision-making lives in the pure,
- * bun-tested `sessionBridge.ts`; here we only:
- *   - list one durable session per workspace folder (item provider),
- *   - rehydrate its persisted transcript via ACP `session/load` and hand VS Code
- *     real history turns (content provider),
- *   - bridge each new turn (text + dragged/pasted attachments) to `session/prompt`.
+ * MULTI-CHAT (Zed parity)
+ * -----------------------
+ * We surface a LIST of chats per workspace, each a server "thread" with its own
+ * persisted transcript — exactly how Zed's agent panel works:
+ *   - the AGENT owns transcript persistence + replay (ACP `session/new` /
+ *     `session/load`);
+ *   - the CLIENT (this extension) owns the list, titles and rename, stored ONLY
+ *     in VS Code's own `workspaceState` (see sessionStore.ts) — never in the
+ *     phantombot domain.
  *
- * Uses the `chatSessionsProvider` proposed API (+ the `chatParticipantPrivate`
- * proposal for the constructable `ChatRequestTurn2` / `ChatResponseTurn2` history
- * classes). Both are enabled for this extension via `argv.json`
- * (`enable-proposed-api`). If the host has NOT enabled them the registration
- * functions are absent — we detect that and no-op so activation never throws.
+ * A chat's identity is the opaque server thread token, carried in the session
+ * resource URI's `query`. Opening a listed chat → `session/load` that token →
+ * its history replays. Opening a fresh ("untitled") chat mints a new thread on
+ * first open; the record is only written to the list on the FIRST prompt (so an
+ * opened-but-never-used blank chat leaves no junk), and its title is
+ * auto-derived from that prompt (Zed-style).
+ *
+ * This is the thin `vscode`-importing glue. All decision-making lives in the
+ * pure, bun-tested `sessionBridge.ts` / `sessionStore.ts`.
+ *
+ * Uses the `chatSessionsProvider` proposed API (+ `chatParticipantPrivate` for
+ * the constructable history turn classes). Both are enabled via `argv.json`
+ * (`enable-proposed-api`); if the host hasn't enabled them the registration
+ * functions are absent and we no-op so activation never throws.
  */
 
 import * as vscode from "vscode";
@@ -22,10 +34,10 @@ import * as vscode from "vscode";
 import type { AcpClient } from "./acpClient.ts";
 import {
   cwdFromResourcePath,
+  decodeSessionResource,
   imageMimeFromPath,
   isImageMime,
   makeReplayCollector,
-  mintSessionId,
   promptBlocksFromRequest,
   promptTextWithCommand,
   resolveSessionCandidates,
@@ -35,14 +47,21 @@ import {
   type ReplayTurn,
   type SessionAttachment,
 } from "./sessionBridge.ts";
+import {
+  DEFAULT_SESSION_TITLE,
+  deriveSessionTitle,
+  findSession,
+  listSessions,
+  patchSession,
+  upsertSession,
+  type SessionKv,
+} from "./sessionStore.ts";
 
-/** A live ACP connection backing one workspace's chat session. */
-interface SessionConn {
+/** One live ACP connection per workspace cwd, multiplexing all its threads. */
+interface CwdConn {
   client: AcpClient;
-  sessionId: string;
-  cwd: string;
-  /** True once `session/load` has registered the session id server-side. */
-  loaded: boolean;
+  /** Session tokens the server already knows this run (new'd or loaded). */
+  loaded: Set<string>;
 }
 
 export interface SessionProviderDeps {
@@ -58,28 +77,30 @@ export interface SessionProviderDeps {
   participant: vscode.ChatParticipant;
   /** Participant id (used when constructing history turns). */
   participantId: string;
+  /** VS Code-owned KV (workspaceState) holding the chat list + titles. */
+  kv: SessionKv;
   /**
-   * Stable `created` timestamp (ms since epoch) for a session resource key.
-   * Feeds `ChatSessionItem.timing.created`; without it VS Code defaults to the
-   * epoch and newer builds render "57 yrs ago" then auto-archive the session.
-   */
-  sessionCreatedAt(key: string): number;
-  /**
-   * Called whenever the user opens the phantombot session (its content is
-   * provided). Lets the host remember the session was open so it can be
-   * auto-reopened on the next launch (the "sticky" behaviour). Optional.
+   * Called whenever the user opens a phantombot session. Lets the host remember
+   * a session was open so it can be auto-reopened next launch. Optional.
    */
   onSessionOpened?(): void;
   output: vscode.OutputChannel;
 }
 
+/** What {@link registerChatSessionProvider} hands back: a Disposable plus a
+ * `refresh()` the host can call (e.g. after a rename) to re-list the items. */
+export interface SessionProviderHandle extends vscode.Disposable {
+  refresh(): void;
+}
+
 /**
  * Register the phantombot chat-session item + content providers. Returns a
- * Disposable that tears down both registrations and every spawned ACP client.
+ * handle that tears down both registrations + every spawned ACP client, and
+ * exposes `refresh()` to re-emit the session list.
  */
 export function registerChatSessionProvider(
   deps: SessionProviderDeps,
-): vscode.Disposable {
+): SessionProviderHandle {
   const chatApi = vscode.chat as unknown as {
     registerChatSessionItemProvider?: (
       type: string,
@@ -102,27 +123,25 @@ export function registerChatSessionProvider(
         "proposed API is not enabled for this extension (see argv.json " +
         '"enable-proposed-api"). Falling back to the @phantombot participant.',
     );
-    return { dispose() {} };
+    return { dispose() {}, refresh() {} };
   }
 
-  const conns = new Map<string, SessionConn>();
+  const conns = new Map<string, CwdConn>();
+  // Untitled resource URI → the thread token minted for it at open time, so the
+  // first prompt in a brand-new chat reuses that thread instead of minting again.
+  const pendingThread = new Map<string, string>();
 
-  const ensureConn = async (cwd: string): Promise<SessionConn> => {
+  const ensureClient = async (cwd: string): Promise<CwdConn> => {
     const existing = conns.get(cwd);
     if (existing) return existing;
     const client = deps.createClient(cwd);
     await client.initialize();
-    const conn: SessionConn = {
-      client,
-      sessionId: mintSessionId(),
-      cwd,
-      loaded: false,
-    };
+    const conn: CwdConn = { client, loaded: new Set() };
     conns.set(cwd, conn);
     return conn;
   };
 
-  const dropConn = (cwd: string): void => {
+  const dropClient = (cwd: string): void => {
     const c = conns.get(cwd);
     if (c) {
       c.client.dispose();
@@ -130,12 +149,22 @@ export function registerChatSessionProvider(
     }
   };
 
-  // ── Item provider: one durable session per workspace folder ───────────────
+  /** Build the session resource URI for a (cwd, thread) pair. Empty token → a
+   * fresh untitled chat the content provider will bind on open. */
+  const resourceFor = (cwd: string, sessionId = ""): vscode.Uri =>
+    vscode.Uri.from({
+      scheme: SESSION_SCHEME,
+      path: sessionResourcePath(cwd),
+      query: sessionId,
+    });
+
+  // ── Item provider: one entry per stored chat, newest first ────────────────
   const onDidChangeItems = new vscode.EventEmitter<void>();
   const onDidCommitItem = new vscode.EventEmitter<{
     original: vscode.ChatSessionItem;
     modified: vscode.ChatSessionItem;
   }>();
+  const refresh = () => onDidChangeItems.fire();
 
   const itemProvider: vscode.ChatSessionItemProvider = {
     onDidChangeChatSessionItems: onDidChangeItems.event,
@@ -143,97 +172,128 @@ export function registerChatSessionProvider(
     provideChatSessionItems() {
       const persona = deps.personaLabel();
       const desc = persona ? `phantombot · ${persona}` : "phantombot";
-      // One session per open folder, with a folderless fallback so phantombot
-      // stays visible in an empty window or a folderless `.code-workspace`.
       const candidates = resolveSessionCandidates(
         deps.workspaceFolders(),
         deps.currentCwd(),
       );
-      return candidates.map((f) => {
-        const path = sessionResourcePath(f.cwd);
-        return {
-          resource: vscode.Uri.from({ scheme: SESSION_SCHEME, path }),
-          label: f.name,
-          iconPath: new vscode.ThemeIcon("hubot"),
-          description: desc,
-          // Populate a real `created` time. Omitting `timing` lets VS Code
-          // default it to epoch 0 → "57 yrs ago" → auto-archived out of the
-          // active list on newer builds (the Mac symptom).
-          timing: { created: deps.sessionCreatedAt(path) },
-        };
-      });
+      const items: vscode.ChatSessionItem[] = [];
+      for (const f of candidates) {
+        for (const rec of listSessions(deps.kv, f.cwd)) {
+          items.push({
+            resource: resourceFor(f.cwd, rec.sessionId),
+            label: rec.title,
+            iconPath: new vscode.ThemeIcon("hubot"),
+            description: desc,
+            // Real created time keeps the age stable and off the Unix epoch
+            // (which newer builds render as "57 yrs ago" then auto-archive).
+            timing: { created: rec.createdAt || Date.now() },
+          });
+        }
+      }
+      return items;
     },
   };
 
-  // ── Content provider: history rehydration + per-turn request handling ──────
+  // ── Content provider: replay one thread's history + handle its turns ───────
   const contentProvider: vscode.ChatSessionContentProvider = {
     async provideChatSessionContent(resource: vscode.Uri) {
-      // The user just opened phantombot — remember it for sticky auto-open.
       deps.onSessionOpened?.();
 
-      const cwd =
-        resource.scheme === SESSION_SCHEME && resource.path
-          ? cwdFromResourcePath(resource.path)
-          : deps.currentCwd();
+      const { cwd, sessionId } = decodeResource(resource, deps.currentCwd());
 
-      let history: unknown[] = [];
-      try {
-        const conn = await ensureConn(cwd);
-        const { handlers, turns } = makeReplayCollector();
-        await conn.client.loadSession(conn.sessionId, cwd, handlers);
-        conn.loaded = true;
-        history = buildHistory(turns, deps.participantId);
-      } catch (e) {
-        const msg = (e as Error).message;
-        deps.output.appendLine(`[session] load failed for ${cwd}: ${msg}`);
-        dropConn(cwd);
+      // Existing thread → load + replay its transcript.
+      if (sessionId) {
+        let history: unknown[] = [];
+        try {
+          const conn = await ensureClient(cwd);
+          const { handlers, turns } = makeReplayCollector();
+          await conn.client.loadSession(sessionId, cwd, handlers);
+          conn.loaded.add(sessionId);
+          history = buildHistory(turns, deps.participantId);
+        } catch (e) {
+          const msg = (e as Error).message;
+          deps.output.appendLine(`[session] load failed for ${cwd}: ${msg}`);
+          dropClient(cwd);
+        }
+        return {
+          history: history as never,
+          requestHandler: makeRequestHandler(cwd, sessionId, resource),
+        };
       }
 
+      // Fresh ("untitled") chat → mint a thread now so the first prompt has one,
+      // but DON'T persist it to the list until that prompt actually lands.
+      let minted: string | undefined;
+      try {
+        const conn = await ensureClient(cwd);
+        minted = await conn.client.newSession(cwd);
+        conn.loaded.add(minted);
+        pendingThread.set(resource.toString(), minted);
+      } catch (e) {
+        const msg = (e as Error).message;
+        deps.output.appendLine(`[session] new thread failed for ${cwd}: ${msg}`);
+        dropClient(cwd);
+      }
       return {
-        history: history as never,
-        requestHandler: makeRequestHandler(cwd),
+        history: [] as never,
+        requestHandler: makeRequestHandler(cwd, minted, resource),
       };
     },
   };
 
-  /** Build the per-turn handler bound to a workspace cwd. */
-  function makeRequestHandler(cwd: string): vscode.ChatRequestHandler {
+  /**
+   * Per-turn handler bound to a workspace cwd + its thread token. `sessionId`
+   * may be undefined for a brand-new chat whose mint failed at open time — we
+   * recover the pending token or mint fresh on the first prompt.
+   */
+  function makeRequestHandler(
+    cwd: string,
+    sessionId: string | undefined,
+    resource: vscode.Uri,
+  ): vscode.ChatRequestHandler {
     return async (request, _ctx, stream, token) => {
-      let conn: SessionConn;
+      let conn: CwdConn;
+      let sid = sessionId;
       try {
-        conn = await ensureConn(cwd);
-        if (!conn.loaded) {
-          await conn.client.loadSession(conn.sessionId, cwd);
-          conn.loaded = true;
+        conn = await ensureClient(cwd);
+        if (!sid) {
+          sid = pendingThread.get(resource.toString());
+          if (!sid) {
+            sid = await conn.client.newSession(cwd);
+            conn.loaded.add(sid);
+            pendingThread.set(resource.toString(), sid);
+          }
+        }
+        if (!conn.loaded.has(sid)) {
+          await conn.client.loadSession(sid, cwd);
+          conn.loaded.add(sid);
         }
       } catch (e) {
         const msg = (e as Error).message;
         stream.markdown(`**phantombot could not start.**\n\n${msg}`);
-        dropConn(cwd);
+        dropClient(cwd);
         return { errorDetails: { message: msg } };
       }
 
       const attachments = await extractAttachments(request, deps.output);
-      const blocks = promptBlocksFromRequest(
-        promptTextWithCommand(request.prompt, request.command),
-        attachments,
-      );
+      const promptText = promptTextWithCommand(request.prompt, request.command);
+      const blocks = promptBlocksFromRequest(promptText, attachments);
       if (blocks.length === 0) {
         stream.markdown("_(nothing to send)_");
         return {};
       }
 
+      recordTurn(cwd, sid, promptText, resource);
+
       let cancelSub: vscode.Disposable | undefined;
       if (token.isCancellationRequested) {
-        conn.client.cancel(conn.sessionId);
+        conn.client.cancel(sid);
       } else {
-        cancelSub = token.onCancellationRequested(() =>
-          conn.client.cancel(conn.sessionId),
-        );
+        cancelSub = token.onCancellationRequested(() => conn.client.cancel(sid!));
       }
 
       try {
-        const stopReason = await conn.client.prompt(conn.sessionId, blocks, {
+        const stopReason = await conn.client.prompt(sid, blocks, {
           onText: (t) => stream.markdown(t),
           onToolCall: (title) => stream.progress(title),
         });
@@ -243,7 +303,7 @@ export function registerChatSessionProvider(
         return {};
       } catch (e) {
         const msg = (e as Error).message;
-        dropConn(cwd);
+        dropClient(cwd);
         stream.markdown(`\n\n**phantombot error:** ${msg}`);
         deps.output.appendLine(`[session] prompt failed: ${msg}`);
         return { errorDetails: { message: msg } };
@@ -251,6 +311,59 @@ export function registerChatSessionProvider(
         cancelSub?.dispose();
       }
     };
+  }
+
+  /**
+   * First-prompt bookkeeping. Creates the list record (auto-titled from the
+   * prompt) the first time a thread is used, migrating the untitled resource to
+   * a committed one that carries the token; on later turns just bumps
+   * `lastUsedAt` (and settles a still-default title if it can).
+   */
+  function recordTurn(
+    cwd: string,
+    sessionId: string,
+    promptText: string,
+    resource: vscode.Uri,
+  ): void {
+    const now = Date.now();
+    const existing = findSession(deps.kv, cwd, sessionId);
+    if (!existing) {
+      const title = deriveSessionTitle(promptText);
+      upsertSession(deps.kv, cwd, {
+        sessionId,
+        title,
+        createdAt: now,
+        lastUsedAt: now,
+        titleSettled: title !== DEFAULT_SESSION_TITLE,
+      });
+      // Migrate untitled → committed so reopen/list find this chat by token.
+      if (!resource.query) {
+        const committed = resourceFor(cwd, sessionId);
+        onDidCommitItem.fire({
+          original: { resource, label: title },
+          modified: {
+            resource: committed,
+            label: title,
+            iconPath: new vscode.ThemeIcon("hubot"),
+          },
+        });
+        pendingThread.delete(resource.toString());
+      }
+      refresh();
+      return;
+    }
+
+    const patch: Partial<{ title: string; lastUsedAt: number; titleSettled: boolean }> =
+      { lastUsedAt: now };
+    if (!existing.titleSettled) {
+      const title = deriveSessionTitle(promptText);
+      if (title !== DEFAULT_SESSION_TITLE) {
+        patch.title = title;
+        patch.titleSettled = true;
+      }
+    }
+    patchSession(deps.kv, cwd, sessionId, patch);
+    refresh();
   }
 
   const reg1 = chatApi.registerChatSessionItemProvider(SESSION_TYPE, itemProvider);
@@ -262,11 +375,12 @@ export function registerChatSessionProvider(
   );
 
   deps.output.appendLine(
-    'phantombot chat session provider registered (open "Phantombot" in the ' +
-      "chat sessions list — no @mention needed).",
+    'phantombot chat session provider registered (multi-chat; open "Phantombot" ' +
+      "in the chat sessions list — no @mention needed).",
   );
 
   return {
+    refresh,
     dispose() {
       reg1.dispose();
       reg2.dispose();
@@ -274,8 +388,21 @@ export function registerChatSessionProvider(
       onDidCommitItem.dispose();
       for (const [, c] of conns) c.client.dispose();
       conns.clear();
+      pendingThread.clear();
     },
   };
+}
+
+/** Decode a session resource → { cwd, sessionId? }, tolerating a bare fallback. */
+function decodeResource(
+  resource: vscode.Uri,
+  fallbackCwd: string,
+): { cwd: string; sessionId?: string } {
+  if (resource.scheme === SESSION_SCHEME && resource.path) {
+    return decodeSessionResource(resource.path, resource.query);
+  }
+  // Untitled/foreign resource (e.g. a blank editor) → bind to the active cwd.
+  return { cwd: fallbackCwd };
 }
 
 /**
@@ -292,8 +419,6 @@ function buildHistory(turns: readonly ReplayTurn[], participantId: string): unkn
   const out: unknown[] = [];
   for (const t of turns) {
     if (t.role === "user") {
-      // (prompt, command, references, participant, toolReferences,
-      //  editedFileEvents, id, modelId, modeInstructions2)
       out.push(
         new v.ChatRequestTurn2(
           t.text,
@@ -319,9 +444,9 @@ function buildHistory(turns: readonly ReplayTurn[], participantId: string): unkn
 
 /**
  * Pull dragged/pasted attachments off a chat request and resolve them to bytes
- * or file references. Images (pasted binary or dropped image files) become
- * inline image blocks; other dropped files become reference links. Best-effort:
- * a failed attachment is logged and skipped, never fatal to the turn.
+ * or file references. Images become inline image blocks; other dropped files
+ * become reference links. Best-effort: a failed attachment is logged and
+ * skipped, never fatal to the turn.
  */
 export async function extractAttachments(
   request: vscode.ChatRequest,
@@ -335,8 +460,6 @@ export async function extractAttachments(
     const value = (ref as { value?: unknown })?.value;
     const name = (ref as { name?: string })?.name;
     try {
-      // Pasted binary data (e.g. a screenshot): ChatReferenceBinaryData with
-      // an async data() accessor + mimeType.
       const bin = value as { mimeType?: unknown; data?: unknown };
       if (
         bin &&
@@ -381,9 +504,7 @@ export async function extractAttachments(
         });
       }
     } catch (e) {
-      output.appendLine(
-        `[session] attachment skipped: ${(e as Error).message}`,
-      );
+      output.appendLine(`[session] attachment skipped: ${(e as Error).message}`);
     }
   }
   return out;
@@ -401,4 +522,9 @@ function asUri(value: unknown): vscode.Uri | undefined {
 function baseName(p: string): string {
   const parts = p.split(/[\\/]/);
   return parts[parts.length - 1] || p;
+}
+
+/** Recover a workspace cwd from a session resource (used by the rename command). */
+export function cwdFromSessionResource(resource: vscode.Uri): string {
+  return cwdFromResourcePath(resource.path);
 }

--- a/editors/vscode/src/sessionStore.ts
+++ b/editors/vscode/src/sessionStore.ts
@@ -1,0 +1,197 @@
+/**
+ * Pure, `vscode`-free store for the VS Code chat-session LIST — the multi-chat
+ * history surface (save / rename / retrieve older chats), modelled on how Zed's
+ * agent panel owns its own thread list.
+ *
+ * DESIGN — who owns what (mirrors Zed):
+ *   - The AGENT (phantombot) owns transcript PERSISTENCE + replay. Each chat is a
+ *     server "thread": an opaque, self-describing session token
+ *     (`acp_<cwdhash>_<thread>`) whose turns live server-side and are replayed via
+ *     ACP `session/load`.
+ *   - The CLIENT (this extension) owns the LIST, the TITLES and RENAME. We keep a
+ *     small record per thread — its token, display title, timestamps — so we can
+ *     list past chats, reopen one (→ `session/load`), and rename it. Naming and
+ *     listing NEVER touch the phantombot domain.
+ *
+ * WHERE THIS LIVES: entirely in VS Code's own storage (the extension's
+ * `workspaceState` Memento), reached through the {@link SessionKv} facade. Nothing
+ * here writes to phantombot's memory store — that was an explicit requirement.
+ *
+ * This module is intentionally free of any `vscode` import so it runs under
+ * `bun test` with zero host, exactly like sessionBridge.ts / participant.ts.
+ */
+
+/** One persisted chat thread in a workspace's list. */
+export interface ChatSessionRecord {
+  /** Opaque server thread token (`acp_<cwdhash>_<thread>`). The reload key. */
+  sessionId: string;
+  /** Human-readable label shown in the sessions list. */
+  title: string;
+  /** ms since epoch — when the thread's first turn landed. */
+  createdAt: number;
+  /** ms since epoch — when the thread was last prompted (list sort key). */
+  lastUsedAt: number;
+  /**
+   * True once the title is "settled" — either auto-derived from the first prompt
+   * or explicitly renamed by the user. Gates the one-shot auto-title so a rename
+   * is never clobbered by a later turn.
+   */
+  titleSettled: boolean;
+}
+
+/**
+ * Minimal KV facade over VS Code's `Memento` (workspaceState). `update` is
+ * fire-and-forget here; the glue adapts the real `Thenable`-returning method.
+ */
+export interface SessionKv {
+  get<T>(key: string): T | undefined;
+  update(key: string, value: unknown): void;
+}
+
+/** Storage key. Bump the vN suffix if the record shape changes incompatibly. */
+export const STORE_KEY = "phantombot.chatSessions.v1";
+
+/** Placeholder title before the first prompt settles a real one. */
+export const DEFAULT_SESSION_TITLE = "New Chat";
+
+/** Max characters for an auto-derived title before ellipsis. */
+const TITLE_MAX = 60;
+
+/** The whole store: cwd → its ordered list of chat records. */
+type StoreShape = Record<string, ChatSessionRecord[]>;
+
+function readAll(kv: SessionKv): StoreShape {
+  const raw = kv.get<StoreShape>(STORE_KEY);
+  return raw && typeof raw === "object" ? raw : {};
+}
+
+function writeAll(kv: SessionKv, all: StoreShape): void {
+  kv.update(STORE_KEY, all);
+}
+
+/** Normalise a stored record array, dropping anything malformed. */
+function sanitize(list: unknown): ChatSessionRecord[] {
+  if (!Array.isArray(list)) return [];
+  const out: ChatSessionRecord[] = [];
+  for (const r of list) {
+    const rec = r as Partial<ChatSessionRecord>;
+    if (rec && typeof rec.sessionId === "string" && rec.sessionId.length > 0) {
+      out.push({
+        sessionId: rec.sessionId,
+        title:
+          typeof rec.title === "string" && rec.title.trim()
+            ? rec.title
+            : DEFAULT_SESSION_TITLE,
+        createdAt: typeof rec.createdAt === "number" ? rec.createdAt : 0,
+        lastUsedAt:
+          typeof rec.lastUsedAt === "number"
+            ? rec.lastUsedAt
+            : typeof rec.createdAt === "number"
+              ? rec.createdAt
+              : 0,
+        titleSettled: rec.titleSettled === true,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * List a workspace's chats, most-recently-used first. Pure read; the sort makes
+ * the list stable and puts the chat you last touched at the top (Zed-style).
+ */
+export function listSessions(kv: SessionKv, cwd: string): ChatSessionRecord[] {
+  const list = sanitize(readAll(kv)[cwd]);
+  return list
+    .slice()
+    .sort((a, b) => b.lastUsedAt - a.lastUsedAt || b.createdAt - a.createdAt);
+}
+
+/** Find one record by its session token, or undefined. */
+export function findSession(
+  kv: SessionKv,
+  cwd: string,
+  sessionId: string,
+): ChatSessionRecord | undefined {
+  return sanitize(readAll(kv)[cwd]).find((r) => r.sessionId === sessionId);
+}
+
+/**
+ * Insert or replace a record (matched on `sessionId`) in a workspace's list.
+ * Returns the written record.
+ */
+export function upsertSession(
+  kv: SessionKv,
+  cwd: string,
+  rec: ChatSessionRecord,
+): ChatSessionRecord {
+  const all = readAll(kv);
+  const list = sanitize(all[cwd]);
+  const idx = list.findIndex((r) => r.sessionId === rec.sessionId);
+  if (idx >= 0) list[idx] = rec;
+  else list.push(rec);
+  all[cwd] = list;
+  writeAll(kv, all);
+  return rec;
+}
+
+/**
+ * Patch an existing record in place. No-op (returns undefined) if the session
+ * isn't in the list. Returns the merged record on success.
+ */
+export function patchSession(
+  kv: SessionKv,
+  cwd: string,
+  sessionId: string,
+  patch: Partial<Omit<ChatSessionRecord, "sessionId">>,
+): ChatSessionRecord | undefined {
+  const all = readAll(kv);
+  const list = sanitize(all[cwd]);
+  const idx = list.findIndex((r) => r.sessionId === sessionId);
+  const base = idx >= 0 ? list[idx] : undefined;
+  if (!base) return undefined;
+  // Field-by-field merge so an absent patch key never overwrites with undefined.
+  const merged: ChatSessionRecord = {
+    sessionId,
+    title: patch.title ?? base.title,
+    createdAt: patch.createdAt ?? base.createdAt,
+    lastUsedAt: patch.lastUsedAt ?? base.lastUsedAt,
+    titleSettled: patch.titleSettled ?? base.titleSettled,
+  };
+  list[idx] = merged;
+  all[cwd] = list;
+  writeAll(kv, all);
+  return merged;
+}
+
+/** Remove a record from a workspace's list. Silent if it wasn't there. */
+export function removeSession(
+  kv: SessionKv,
+  cwd: string,
+  sessionId: string,
+): void {
+  const all = readAll(kv);
+  const list = sanitize(all[cwd]).filter((r) => r.sessionId !== sessionId);
+  all[cwd] = list;
+  writeAll(kv, all);
+}
+
+/**
+ * Derive a chat title from the first prompt's text (Zed-style auto-naming).
+ *
+ * First non-empty line, whitespace-collapsed, trimmed to {@link TITLE_MAX} with a
+ * single-character ellipsis. A leading slash-command (`/status …`) keeps its
+ * text — it's still the most descriptive thing the user typed. Falls back to
+ * {@link DEFAULT_SESSION_TITLE} when there's nothing usable (image-only turn).
+ */
+export function deriveSessionTitle(prompt: string): string {
+  const firstLine =
+    prompt
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? "";
+  const collapsed = firstLine.replace(/\s+/g, " ").trim();
+  if (!collapsed) return DEFAULT_SESSION_TITLE;
+  if (collapsed.length <= TITLE_MAX) return collapsed;
+  return collapsed.slice(0, TITLE_MAX - 1).trimEnd() + "…";
+}

--- a/editors/vscode/tests/acpClient.test.ts
+++ b/editors/vscode/tests/acpClient.test.ts
@@ -209,6 +209,45 @@ describe("AcpClient — session/prompt streaming", () => {
     t.push({ jsonrpc: "2.0", id: promptSent.id, result: { stopReason: "cancelled" } });
     expect(await p).toBe("cancelled");
   });
+
+  test("an interrupted turn does not evict the successor's stream on the same sid", async () => {
+    // Chat-channel interrupt: while turn A is still resolving, the user submits
+    // turn B on the SAME (post-#349 stable) sessionId. B's handlers replace A's.
+    // When A finally settles (cancelled), its `finally` must NOT delete B's slot
+    // — otherwise B's streamed chunks are dropped and the reply reads garbled.
+    const t = new FakeTransport();
+    const client = new AcpClient({ transport: t });
+
+    const aChunks: string[] = [];
+    const bChunks: string[] = [];
+
+    const pa = client.prompt("acp_x", "first", { onText: (txt) => aChunks.push(txt) });
+    const aSent = t.lastSent();
+
+    // User interrupts: B is submitted on the same sid before A has resolved.
+    const pb = client.prompt("acp_x", "second", { onText: (txt) => bChunks.push(txt) });
+    const bSent = t.lastSent();
+    expect(bSent.id).not.toBe(aSent.id);
+
+    // The server aborts A and settles it cancelled…
+    t.push({ jsonrpc: "2.0", id: aSent.id, result: { stopReason: "cancelled" } });
+    expect(await pa).toBe("cancelled");
+
+    // …then streams B's reply. It must still reach B's handlers.
+    t.push({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "acp_x",
+        update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "B lives" } },
+      },
+    });
+    t.push({ jsonrpc: "2.0", id: bSent.id, result: { stopReason: "end_turn" } });
+
+    expect(await pb).toBe("end_turn");
+    expect(bChunks).toEqual(["B lives"]);
+    expect(aChunks).toEqual([]);
+  });
 });
 
 describe("AcpClient — session/load replay", () => {

--- a/editors/vscode/tests/sessionBridge.test.ts
+++ b/editors/vscode/tests/sessionBridge.test.ts
@@ -11,16 +11,15 @@ import { describe, expect, test } from "bun:test";
 
 import {
   cwdFromResourcePath,
+  decodeSessionResource,
   EDITOR_OPEN_COMMAND,
   imageMimeFromPath,
   isImageMime,
   makeReplayCollector,
-  mintSessionId,
   pickOpenSessionCommand,
   promptBlocksFromRequest,
   promptTextWithCommand,
   resolveSessionCandidates,
-  resolveSessionCreated,
   sessionResourcePath,
   SESSIONS_VIEWER_FALLBACK,
   shouldAutoOpenSession,
@@ -49,11 +48,22 @@ describe("session identity ⇆ URI", () => {
     expect(path).toBe("C:/Users/andrew/proj");
   });
 
-  test("mints unique opaque session tokens", () => {
-    const a = mintSessionId();
-    const b = mintSessionId();
-    expect(a).toMatch(/^acp_[0-9a-f]{24}$/);
-    expect(a).not.toBe(b);
+  test("decodes cwd + thread token from a resource's path and query", () => {
+    expect(
+      decodeSessionResource("/home/me/proj", "acp_deadbeef1234_aabbccdd"),
+    ).toEqual({ cwd: "/home/me/proj", sessionId: "acp_deadbeef1234_aabbccdd" });
+  });
+
+  test("an empty/whitespace query means a fresh (untitled) chat — no token", () => {
+    expect(decodeSessionResource("/home/me/proj", "")).toEqual({
+      cwd: "/home/me/proj",
+    });
+    expect(decodeSessionResource("/home/me/proj", "   ")).toEqual({
+      cwd: "/home/me/proj",
+    });
+    expect(decodeSessionResource("/home/me/proj", undefined)).toEqual({
+      cwd: "/home/me/proj",
+    });
   });
 });
 
@@ -153,43 +163,6 @@ describe("resolveSessionCandidates", () => {
     expect(resolveSessionCandidates([], "/home/me", "home")).toEqual([
       { cwd: "/home/me", name: "home" },
     ]);
-  });
-});
-
-describe("resolveSessionCreated", () => {
-  const makeStore = (seed: Record<string, number> = {}) => {
-    const m = new Map<string, number>(Object.entries(seed));
-    return {
-      store: {
-        get: (k: string) => m.get(k),
-        set: (k: string, v: number) => void m.set(k, v),
-      },
-      map: m,
-    };
-  };
-
-  test("first sighting records and returns `now`", () => {
-    const { store, map } = makeStore();
-    expect(resolveSessionCreated("/proj", store, 1000)).toBe(1000);
-    expect(map.get("/proj")).toBe(1000);
-  });
-
-  test("later sightings return the stored value, not a fresh `now`", () => {
-    const { store } = makeStore({ "/proj": 1000 });
-    expect(resolveSessionCreated("/proj", store, 9999)).toBe(1000);
-  });
-
-  test("never returns the epoch — a stored 0 is treated as unset", () => {
-    const { store, map } = makeStore({ "/proj": 0 });
-    expect(resolveSessionCreated("/proj", store, 5000)).toBe(5000);
-    expect(map.get("/proj")).toBe(5000);
-  });
-
-  test("keys are independent per resource", () => {
-    const { store } = makeStore();
-    expect(resolveSessionCreated("/a", store, 100)).toBe(100);
-    expect(resolveSessionCreated("/b", store, 200)).toBe(200);
-    expect(resolveSessionCreated("/a", store, 999)).toBe(100);
   });
 });
 

--- a/editors/vscode/tests/sessionStore.test.ts
+++ b/editors/vscode/tests/sessionStore.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Chat-session STORE tests (pure core, no `vscode`).
+ *
+ * Covers the client-owned multi-chat list that lives in VS Code's workspaceState:
+ * list/upsert/patch/remove round-trips, most-recently-used ordering, malformed-
+ * data tolerance, and Zed-style auto-titling from the first prompt.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_SESSION_TITLE,
+  STORE_KEY,
+  deriveSessionTitle,
+  findSession,
+  listSessions,
+  patchSession,
+  removeSession,
+  upsertSession,
+  type ChatSessionRecord,
+  type SessionKv,
+} from "../src/sessionStore.ts";
+
+/** In-memory Memento stand-in. */
+function makeKv(seed: Record<string, unknown> = {}): SessionKv & {
+  raw: Map<string, unknown>;
+} {
+  const raw = new Map<string, unknown>(Object.entries(seed));
+  return {
+    raw,
+    get<T>(key: string): T | undefined {
+      return raw.get(key) as T | undefined;
+    },
+    update(key: string, value: unknown): void {
+      raw.set(key, value);
+    },
+  };
+}
+
+const rec = (over: Partial<ChatSessionRecord> = {}): ChatSessionRecord => ({
+  sessionId: "acp_abc123def456_0011",
+  title: "Fix history loss",
+  createdAt: 1000,
+  lastUsedAt: 1000,
+  titleSettled: true,
+  ...over,
+});
+
+describe("upsert / list / find round-trip", () => {
+  test("adds a record, then reads it back for the same cwd", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/proj", rec());
+    expect(listSessions(kv, "/proj")).toHaveLength(1);
+    expect(findSession(kv, "/proj", "acp_abc123def456_0011")?.title).toBe(
+      "Fix history loss",
+    );
+  });
+
+  test("records are scoped per cwd (multi-root safe)", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/a", rec({ sessionId: "acp_a_1" }));
+    upsertSession(kv, "/b", rec({ sessionId: "acp_b_1" }));
+    expect(listSessions(kv, "/a").map((r) => r.sessionId)).toEqual(["acp_a_1"]);
+    expect(listSessions(kv, "/b").map((r) => r.sessionId)).toEqual(["acp_b_1"]);
+  });
+
+  test("upsert replaces an existing record with the same sessionId", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/proj", rec({ title: "first" }));
+    upsertSession(kv, "/proj", rec({ title: "second" }));
+    const list = listSessions(kv, "/proj");
+    expect(list).toHaveLength(1);
+    expect(list[0].title).toBe("second");
+  });
+
+  test("persists under the versioned store key", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/proj", rec());
+    expect(kv.raw.has(STORE_KEY)).toBe(true);
+  });
+});
+
+describe("listSessions ordering", () => {
+  test("most-recently-used first", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/p", rec({ sessionId: "old", lastUsedAt: 100 }));
+    upsertSession(kv, "/p", rec({ sessionId: "new", lastUsedAt: 900 }));
+    upsertSession(kv, "/p", rec({ sessionId: "mid", lastUsedAt: 500 }));
+    expect(listSessions(kv, "/p").map((r) => r.sessionId)).toEqual([
+      "new",
+      "mid",
+      "old",
+    ]);
+  });
+});
+
+describe("patchSession", () => {
+  test("merges fields and keeps the sessionId immutable", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/p", rec());
+    const out = patchSession(kv, "/p", "acp_abc123def456_0011", {
+      title: "renamed",
+      lastUsedAt: 5000,
+    });
+    expect(out?.title).toBe("renamed");
+    expect(out?.lastUsedAt).toBe(5000);
+    expect(out?.sessionId).toBe("acp_abc123def456_0011");
+  });
+
+  test("returns undefined for an unknown session (no write)", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/p", rec());
+    expect(patchSession(kv, "/p", "nope", { title: "x" })).toBeUndefined();
+    expect(listSessions(kv, "/p")[0].title).toBe("Fix history loss");
+  });
+});
+
+describe("removeSession", () => {
+  test("drops one record, leaves the rest", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/p", rec({ sessionId: "a" }));
+    upsertSession(kv, "/p", rec({ sessionId: "b" }));
+    removeSession(kv, "/p", "a");
+    expect(listSessions(kv, "/p").map((r) => r.sessionId)).toEqual(["b"]);
+  });
+
+  test("silent when the record isn't there", () => {
+    const kv = makeKv();
+    upsertSession(kv, "/p", rec({ sessionId: "a" }));
+    removeSession(kv, "/p", "ghost");
+    expect(listSessions(kv, "/p")).toHaveLength(1);
+  });
+});
+
+describe("malformed-data tolerance", () => {
+  test("ignores non-array / garbage entries and drops record-less items", () => {
+    const kv = makeKv({
+      [STORE_KEY]: {
+        "/p": [
+          { sessionId: "ok", title: "keep", createdAt: 1, lastUsedAt: 2 },
+          { title: "no id" },
+          null,
+          42,
+        ],
+        "/other": "not-an-array",
+      },
+    });
+    expect(listSessions(kv, "/p").map((r) => r.sessionId)).toEqual(["ok"]);
+    expect(listSessions(kv, "/other")).toEqual([]);
+  });
+
+  test("supplies safe defaults for a partial record", () => {
+    const kv = makeKv({
+      [STORE_KEY]: { "/p": [{ sessionId: "x" }] },
+    });
+    const r = listSessions(kv, "/p")[0];
+    expect(r.title).toBe(DEFAULT_SESSION_TITLE);
+    expect(r.titleSettled).toBe(false);
+  });
+});
+
+describe("deriveSessionTitle — Zed-style auto-naming", () => {
+  test("uses the first non-empty line, whitespace-collapsed", () => {
+    expect(deriveSessionTitle("  Fix   the   bug  ")).toBe("Fix the bug");
+    expect(deriveSessionTitle("\n\nSecond line is the title\nthird")).toBe(
+      "Second line is the title",
+    );
+  });
+
+  test("truncates long prompts with an ellipsis", () => {
+    const long = "a".repeat(200);
+    const title = deriveSessionTitle(long);
+    expect(title.length).toBe(60);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  test("keeps a slash-command prompt's text (still descriptive)", () => {
+    expect(deriveSessionTitle("/status")).toBe("/status");
+  });
+
+  test("falls back to the default when there's nothing usable", () => {
+    expect(deriveSessionTitle("")).toBe(DEFAULT_SESSION_TITLE);
+    expect(deriveSessionTitle("   \n  ")).toBe(DEFAULT_SESSION_TITLE);
+  });
+});


### PR DESCRIPTION
## Problem
On VS Code (dogfooding with Megan), the ACP extension **saved no usable history**: closing and reopening VS Code lost the chat, and there was no way to keep, name, or retrieve older chats. Root cause (verified against Megan's live memory DB): the model-picker/participant paths minted a fresh **throwaway** server thread on every launch, orphaning each conversation; the dedicated panel only ever showed **one** cwd-wide session with no list/rename.

## Approach — mirror Zed (the reference ACP client)
Zed "just works" because of a clean ownership split, and our server already holds up its half:
- **Agent (phantombot)** owns transcript **persistence + replay** — `session/new` mints a self-describing thread token; `session/load` replays that thread. *No server changes needed.*
- **Client (this extension)** owns the **list, titles, and rename**, stored entirely in VS Code's own `workspaceState` — **never** in the phantombot domain (per the explicit requirement).

## What's in it
- **`sessionStore.ts`** (new, pure/`vscode`-free, bun-tested): per-workspace chat list — list/upsert/patch/remove, most-recently-used ordering, malformed-data tolerance, and **Zed-style auto-titling** from the first prompt.
- **`sessionProvider.ts`**: lists one entry per stored thread; opening a listed chat → `session/load` replays its history; a fresh ("untitled") chat mints a thread on open but is **persisted only on its first prompt** (blank chats leave no junk), auto-titled from that prompt, with an untitled→committed migration.
- **`extension.ts`**: `workspaceState` KV facade + a **`phantombot: Rename Chat`** command (palette quick-pick, or a session-item resource arg from a future context menu).
- Removed now-dead client-side `mintSessionId` / `resolveSessionCreated` (server owns minting; records carry `createdAt`).

## Scope calls (agreed with Andrew)
- **No retroactive recovery** of the old orphaned threads — the list starts fresh and grows from here.
- **No server changes**; all new state lives in VS Code storage.

## Testing
- `bun test`: **140 pass**, incl. new `sessionStore` suite + resource-decode coverage. `tsc --noEmit` clean; esbuild bundle builds.
- Next: **dogfood on Megan's VM** (build `.vsix` → install → exercise save/rename/reopen across a restart) before merge.