### PR TITLE
fix(pi): completion signal + tool-activity watchdog cap (closes #351, #352)

### DIFF
--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -15,9 +15,13 @@
  * Stream-json events translated to phantombot HarnessChunks:
  *   message_update with text_delta  → { type: "text", text }
  *   tool_execution_start            → { type: "progress", note: "tool: <name>" }
- *   anything else (agent_start,
- *     tool_execution_end, turn_end,
- *     extension_*) → ignored        (the done chunk is emitted from process exit)
+ *   turn_end                        → { type: "done" } COMPLETION marker: the
+ *     model finished this turn. The shared engine requires it before it will
+ *     synthesize the terminal `done` on exit 0, so an exit-0 that stopped
+ *     mid-task (only tool narration, no turn_end) falls through to the next
+ *     harness instead of being stored as a finished answer (issue #352).
+ *   anything else (agent_start, agent_end, agent_settled,
+ *     tool_execution_end, extension_*) → ignored
  *
  * Auth (per-turn, with local-store fallback): when PHANTOMBOT_PI_API_KEY is
  * set, phantombot threads it onto `--api-key` per turn (the same way it threads
@@ -271,6 +275,12 @@ export class PiHarness implements Harness {
       parseEvent: parsePiEvent,
       activity: piActivity,
       buildDoneMeta: () => ({ harnessId: this.id, payloadBytes: totalBytes }),
+      // pi is the only harness with no native terminal `done` in its stream —
+      // it derives completion from turn_end (mapped to a `done` marker in
+      // parsePiEvent). Require that marker before accepting an exit-0 run as a
+      // finished answer, so a narration-only mid-task exit falls through to the
+      // next harness rather than being stored as the reply (issue #352).
+      requireCompletion: true,
     });
 
     } finally {
@@ -367,6 +377,27 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
   // emitted on genuine child output, so a wedged tool still trips the idle kill.
   if (obj.type === "tool_execution_update") {
     return { type: "heartbeat" };
+  }
+
+  // turn_end is pi's end-of-turn COMPLETION signal — the model has finished
+  // this turn. Verified against pi 0.80.x: a successful run always ends
+  // turn_end → agent_end → agent_settled, in --no-tools mode too. Surface it
+  // as a `done` marker (payload-less: the reply text already streamed as
+  // text_delta chunks and is accumulated by the shared engine) so that engine
+  // can distinguish a genuinely COMPLETED turn from an exit-0 that stopped
+  // mid-task having emitted only tool narration — see runHarnessProcess's
+  // `requireCompletion` gate and issue #352. We deliberately gate on turn_end
+  // ALONE, not the later agent_end/agent_settled: a run that errors out can
+  // still emit agent_end, and treating that as "done" would accept a broken
+  // turn as complete. turn_end fires only when the turn itself finished.
+  //
+  // Version caveat: on a hypothetical pi build that does not emit turn_end,
+  // every turn would fail the gate and fall through to the next harness. That
+  // degrades safely — a recoverable fallback that still yields a real answer
+  // (double work, not a wrong answer) — whereas the pre-fix behaviour returned
+  // the trimmed narration as if it were the answer.
+  if (obj.type === "turn_end") {
+    return { type: "done", finalText: "", meta: undefined };
   }
 
   if (obj.type !== "message_update") return undefined;

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -281,6 +281,21 @@ export class PiHarness implements Harness {
       // finished answer, so a narration-only mid-task exit falls through to the
       // next harness rather than being stored as the reply (issue #352).
       requireCompletion: true,
+      // Bound how long a single contiguous tool-run may keep the idle watchdog
+      // alive via tool_execution_* activity alone, with no user-facing text. pi
+      // only emits tool_execution_update on genuine new output (bash streams
+      // stdout, the coder delegate forwards its child's progress) so a healthy
+      // turn is rarely affected — but a tool that trickles output forever (a
+      // stalled auto-router, a hung network retry that keeps logging) could
+      // otherwise reset the idle timer up to the 60-min hard cap with no
+      // fallback (issue #351). This is a GENEROUS last-resort net: comfortably
+      // above any realistic tool-run yet well under the hard cap, so a
+      // wedged-but-chattery turn fails over in minutes, not an hour. Derived
+      // from the idle window, floored at 20 min, and never above the hard cap.
+      toolTimeoutMs: Math.min(
+        req.hardTimeoutMs ?? Number.POSITIVE_INFINITY,
+        Math.max(req.idleTimeoutMs * 4, 1_200_000),
+      ),
     });
 
     } finally {
@@ -373,8 +388,12 @@ export function parsePiEvent(parsed: unknown): HarnessChunk | undefined {
   // onUpdate) as its child makes real progress, so the PRIMARY stays visibly
   // alive while it's blocked awaiting the delegate. Surface a payload-less
   // heartbeat (no partialResult leak, no spurious bubble flush) — piActivity
-  // classifies it as in-tool activity so it RESETS the idle watchdog. Only ever
-  // emitted on genuine child output, so a wedged tool still trips the idle kill.
+  // classifies it as in-tool activity so it RESETS the idle watchdog. It is
+  // emitted on genuine new output (bash streams stdout, the coder delegate
+  // forwards its child), so a tool that goes truly silent still trips the idle
+  // kill. A tool that instead TRICKLES output forever can't defeat the watchdog
+  // indefinitely either: the shared engine caps how long tool activity alone
+  // may keep the idle timer alive (runHarnessProcess toolTimeoutMs, issue #351).
   if (obj.type === "tool_execution_update") {
     return { type: "heartbeat" };
   }

--- a/src/lib/harnessRunner.ts
+++ b/src/lib/harnessRunner.ts
@@ -274,6 +274,21 @@ export interface HarnessProcessSpec {
    /** Parse the decoder tail after stdout closes, when an adapter needs it. */
   flushTail?: boolean;
   /**
+   * Require an explicit completion signal before treating an exit-0 run as a
+   * finished answer. When true, the engine yields the terminal `done` on exit 0
+   * ONLY if the parser emitted at least one `done` chunk during the stream (the
+   * harness's "the model finished" marker); otherwise it yields a recoverable
+   * error so the orchestrator falls through to the next harness.
+   *
+   * This exists for harnesses whose stream carries no native terminal `done`
+   * and would otherwise derive completion from the exit code alone — pi, whose
+   * only completion signal is `turn_end` (issue #352). A run that exits 0
+   * mid-task (only tool narration, no turn_end) is a "no real answer" state,
+   * not a success. Omit/false ⇒ exit 0 is accepted as done (the legacy
+   * behaviour every other harness relies on).
+   */
+  requireCompletion?: boolean;
+  /**
    * Terminal error to emit with priority over kill-cause / exit-code, e.g.
    * An adapter's mid-stream 4XX fast-fallback. Called after the loop; if it returns
    * a chunk, the engine drains the process and yields that instead.
@@ -328,6 +343,10 @@ export async function* runHarnessProcess(
   let buffer = "";
   let finalText = "";
   let captured: Record<string, unknown> | undefined;
+  // Set once the parser emits a `done` chunk — the harness's "the model
+  // finished this turn" marker (pi's turn_end, codex's turn.completed). Only
+  // consulted when spec.requireCompletion is set; see the exit-0 gate below.
+  let sawCompletion = false;
   // Set when a parser returns a terminal policy error (e.g. the subagent
   // tripwire). The error chunk is yielded, the subprocess is killed NOW,
   // and every line after it — same batch or later — is dropped: nothing a
@@ -351,6 +370,7 @@ export async function* runHarnessProcess(
     if (c.type === "text") finalText += c.text;
     if (c.type === "done") {
       captured = c.meta;
+      sawCompletion = true;
       return;
     }
     yield c;
@@ -437,6 +457,23 @@ export async function* runHarnessProcess(
       // network blips, transient model errors) is recoverable so the
       // orchestrator tries the next harness.
       recoverable: code !== 127,
+    };
+    return;
+  }
+
+  // Completion gate (opt-in via spec.requireCompletion): an exit-0 run that
+  // never emitted the harness's completion marker (pi's turn_end) is a
+  // "stopped mid-turn" state, not a finished answer — the accumulated text is
+  // only partial output / tool narration. Yield a recoverable error so the
+  // orchestrator falls through to the next harness instead of storing the
+  // fragment as the reply. See issue #352. Note `finalText` may be non-empty
+  // here (narration IS text), so the existing empty-done fall-through in
+  // runWithFallback cannot catch this case — the completion marker can.
+  if (spec.requireCompletion && !sawCompletion) {
+    yield {
+      type: "error",
+      error: `${harnessId} exited 0 without a completion signal (only partial/tool output — likely stopped mid-turn)`,
+      recoverable: true,
     };
     return;
   }

--- a/src/lib/harnessRunner.ts
+++ b/src/lib/harnessRunner.ts
@@ -48,6 +48,16 @@ export interface KillCoordinatorOpts {
   idleTimeoutMs: number;
   /** Hard wall-clock cap. Never resets. Omit to disable the wall-clock SIGTERM. */
   hardTimeoutMs?: number;
+  /**
+   * Wall-clock cap on how long a SINGLE contiguous tool-run may keep resetting
+   * the idle timer via `"tool"` activity WITHOUT any productive output.
+   * Measured from the start of the tool-run; any productive output resets the
+   * budget. Past this cap, tool activity stops deferring the idle kill, so a
+   * wedged-but-chattery tool trips the idle timeout instead of surviving to the
+   * hard cap. Omit to disable (tool activity resets the idle timer for as long
+   * as it keeps arriving — the legacy behaviour). See touch() and issue #351.
+   */
+  toolTimeoutMs?: number;
   /** External abort, e.g. user typed /stop. */
   signal?: AbortSignal;
   /** For log lines only. */
@@ -86,6 +96,10 @@ export function createKillCoordinator(
   let cause: KillCause;
   let disposed = false;
   let toolRunning = false;
+  // Wall-clock start of the current contiguous tool-run (undefined when no tool
+  // is running). Used with opts.toolTimeoutMs to cap how long tool activity
+  // alone may keep deferring the idle kill. See touch().
+  let toolRunStart: number | undefined;
 
   const triggerKill = (newCause: Exclude<KillCause, undefined>): void => {
     if (cause || disposed) return;
@@ -121,9 +135,30 @@ export function createKillCoordinator(
     touch(activity: HarnessActivity = "productive"): void {
       if (cause || disposed) return;
       if (activity === "tool") {
-        toolRunning = true;
+        if (!toolRunning) {
+          toolRunning = true;
+          toolRunStart = Date.now();
+        } else if (
+          opts.toolTimeoutMs !== undefined &&
+          toolRunStart !== undefined &&
+          Date.now() - toolRunStart >= opts.toolTimeoutMs
+        ) {
+          // This contiguous tool-run has kept the idle timer alive via tool
+          // activity for longer than the tool cap WITHOUT any productive
+          // (text) output. Past the cap a tool update no longer counts as
+          // liveness: fall through WITHOUT re-arming the idle timer, so the
+          // last-armed idle window runs out and triggerKill("idle") finally
+          // fires — a wedged-but-chattery tool (e.g. a stalled router that
+          // keeps trickling tool_execution_update) fails over in minutes
+          // instead of surviving to the hard cap (issue #351). Any productive
+          // output resets the budget (the "productive" branch clears
+          // toolRunStart), so a healthy turn interleaving tools with text is
+          // never affected.
+          return;
+        }
       } else if (activity === "productive") {
         toolRunning = false;
+        toolRunStart = undefined;
       } else if (toolRunning) {
         return;
       }
@@ -289,6 +324,16 @@ export interface HarnessProcessSpec {
    */
   requireCompletion?: boolean;
   /**
+   * Wall-clock cap (ms) on how long a SINGLE contiguous tool-run may keep the
+   * idle watchdog alive via `"tool"` activity alone, with no productive output.
+   * Forwarded to the kill coordinator. Guards against a wedged-but-chattery
+   * tool (e.g. a stalled router or a hung retry that keeps trickling output)
+   * resetting the idle timer up to the hard cap with no fallback (issue #351).
+   * Omit to disable (legacy: any tool activity resets the idle timer as long as
+   * it keeps arriving).
+   */
+  toolTimeoutMs?: number;
+  /**
    * Terminal error to emit with priority over kill-cause / exit-code, e.g.
    * An adapter's mid-stream 4XX fast-fallback. Called after the loop; if it returns
    * a chunk, the engine drains the process and yields that instead.
@@ -313,6 +358,7 @@ export async function* runHarnessProcess(
     proc,
     idleTimeoutMs: req.idleTimeoutMs,
     hardTimeoutMs: req.hardTimeoutMs,
+    toolTimeoutMs: spec.toolTimeoutMs,
     signal: req.signal,
     harnessId,
   });

--- a/tests/fixtures/fake-pi.sh
+++ b/tests/fixtures/fake-pi.sh
@@ -7,6 +7,8 @@
 #
 # Modes:
 #   normal   — emit thinking + text deltas + turn_end, exit 0
+#   nofinish — emit tool-narration text deltas then exit 0 WITHOUT turn_end
+#              (the #352 "stopped mid-turn" case: must fall through, not 'done')
 #   error    — exit 1
 #   notfound — exit 127
 #   hang     — sleep forever (for the timeout test)
@@ -45,6 +47,16 @@ case "$mode" in
     printf '%s\n' '{"type":"message_end","message":{}}'
     printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
     printf '%s\n' '{"type":"agent_end","messages":[]}'
+    exit 0
+    ;;
+  nofinish)
+    printf '%s\n' '{"type":"session","version":3,"id":"abc"}'
+    printf '%s\n' '{"type":"agent_start"}'
+    printf '%s\n' '{"type":"turn_start"}'
+    # Only tool narration — real answer never produced, and crucially NO turn_end.
+    printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Ik ga de repo ophalen...","partial":{}},"message":{}}'
+    printf '%s\n' '{"type":"tool_execution_start","toolName":"bash","args":{}}'
+    # Process exits 0 mid-task with no turn_end completion signal.
     exit 0
     ;;
   error)

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -228,18 +228,32 @@ describe("parsePiEvent", () => {
     }
   });
 
-  test("ignores session / agent_start / turn_start / turn_end / agent_end / message_start / message_end", () => {
+  test("ignores session / agent_start / turn_start / agent_end / agent_settled / message_start / message_end", () => {
     for (const t of [
       "session",
       "agent_start",
       "turn_start",
-      "turn_end",
       "agent_end",
+      "agent_settled",
       "message_start",
       "message_end",
     ]) {
       expect(parsePiEvent({ type: t })).toBeUndefined();
     }
+  });
+
+  test("turn_end → done completion marker (payload-less, drives requireCompletion)", () => {
+    // turn_end is pi's only completion signal. parsePiEvent surfaces it as a
+    // `done` chunk so runHarnessProcess can tell a finished turn from an exit-0
+    // that stopped mid-task. No finalText — the reply text already streamed as
+    // text_delta chunks. See issue #352. NB agent_end is deliberately NOT a
+    // completion marker (a run that errors can still emit it).
+    expect(parsePiEvent({ type: "turn_end", message: {}, toolResults: [] })).toEqual({
+      type: "done",
+      finalText: "",
+      meta: undefined,
+    });
+    expect(parsePiEvent({ type: "agent_end", messages: [] })).toBeUndefined();
   });
 
   test("ignores empty text_delta", () => {
@@ -350,6 +364,20 @@ describe("PiHarness.invoke (subprocess)", () => {
       finalText: "hello world",
       meta: { harnessId: "pi" },
     });
+  });
+
+  test("exit 0 without turn_end → recoverable error, NOT done (issue #352)", async () => {
+    // A narration-only run that exits 0 with no completion signal must fall
+    // through to the next harness, not be stored as a finished answer.
+    process.env.FAKE_PI_MODE = "nofinish";
+    const chunks = await collect(mkHarness().invoke(newRequest()));
+    expect(chunks.some((c) => c.type === "done")).toBe(false);
+    const err = chunks.find((c) => c.type === "error") as
+      | { type: "error"; error: string; recoverable: boolean }
+      | undefined;
+    expect(err).toBeDefined();
+    expect(err!.recoverable).toBe(true);
+    expect(err!.error).toContain("without a completion signal");
   });
 
   test("toolsMode 'none' passes pi's native --no-tools (true zero-tools)", async () => {

--- a/tests/lib-harnessRunner.test.ts
+++ b/tests/lib-harnessRunner.test.ts
@@ -94,6 +94,93 @@ describe("createKillCoordinator — idle timer", () => {
   });
 });
 
+describe("createKillCoordinator — tool cap (issue #351)", () => {
+  test("sustained 'tool' activity past toolTimeoutMs lets the idle kill fire", async () => {
+    // A wedged-but-chattery tool: we drive touch("tool") forever. Without a
+    // cap that would reset the idle timer indefinitely and defeat the watchdog
+    // up to the hard cap. With toolTimeoutMs the tool-run's idle-reset budget
+    // runs out and the idle timer finally fires — even though tool activity
+    // never stops. That's the fix: the kill is caused by the cap, not silence.
+    const proc = spawnInNewSession(["sleep", "30"], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 150,
+      toolTimeoutMs: 300,
+      hardTimeoutMs: 10_000,
+      harnessId: "test",
+    });
+
+    // Hammer tool activity the whole time — proving it's the cap, not a lull.
+    const interval = setInterval(() => killer.touch("tool"), 30);
+    try {
+      await proc.exited; // killed once the cap + idle window elapse (~450ms)
+    } finally {
+      clearInterval(interval);
+      await killer.dispose();
+    }
+    expect(killer.killCause()).toBe("idle");
+  });
+
+  test("without a tool cap, sustained 'tool' activity keeps the process alive", async () => {
+    // Legacy behaviour (toolTimeoutMs omitted): a long-but-working tool that
+    // keeps emitting activity must never be killed. Held well past what the
+    // capped test kills at.
+    const proc = spawnInNewSession(["sleep", "30"], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 150,
+      hardTimeoutMs: 10_000,
+      harnessId: "test",
+    });
+
+    const interval = setInterval(() => killer.touch("tool"), 30);
+    await Bun.sleep(700);
+    clearInterval(interval);
+    await killer.dispose();
+    expect(killer.killCause()).toBeUndefined();
+  });
+
+  test("productive output resets the tool-run budget", async () => {
+    // Two tool-runs, each under the cap, separated by productive output. Total
+    // tool time exceeds toolTimeoutMs, but no SINGLE contiguous run does — so a
+    // healthy turn interleaving tools with text is never killed.
+    const proc = spawnInNewSession(["sleep", "30"], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 200,
+      toolTimeoutMs: 300,
+      hardTimeoutMs: 10_000,
+      harnessId: "test",
+    });
+
+    const interval = setInterval(() => killer.touch("tool"), 30);
+    await Bun.sleep(250); // first tool-run, under the 300ms cap
+    killer.touch("productive"); // resets the budget (toolRunStart cleared)
+    await Bun.sleep(250); // second tool-run, again under the cap
+    clearInterval(interval);
+    await killer.dispose();
+    expect(killer.killCause()).toBeUndefined();
+  });
+});
+
 describe("createKillCoordinator — hard timer", () => {
   test("hard timer fires regardless of touch() activity", async () => {
     // Process keeps emitting (so idle never fires) but hard cap is short.


### PR DESCRIPTION
Two fixes to the `pi` harness for the same root gap — the harness had **no completion signal** and derived `done` purely from the process exit code. They are the two sides of that gap and are fixed together, one commit each.

## #352 — narration-only exit-0 accepted as a finished answer

A long task where the model narrates each tool step as `text` and then exits 0 **before** producing the real deliverable was synthesized straight into a terminal `done`. The stored "reply" was just trimmed tool narration, no fallback fired, and a follow-up "continue" re-did the work because nothing had actually completed. Emptiness can't discriminate — narration *is* non-empty text.

pi does emit a completion signal, `turn_end`, but `parsePiEvent` dropped it at the `message_update` guard. Fix:

- `parsePiEvent` surfaces `turn_end` as a payload-less `done` marker. Gated on `turn_end` **alone**, not the later `agent_end`/`agent_settled`: a run that errors out can still emit `agent_end`, and accepting that as "done" would store a broken turn as complete.
- `runHarnessProcess` gains an opt-in `requireCompletion` flag: on exit 0 with no completion marker, it yields a **recoverable** error so the orchestrator falls through to the next harness. pi opts in; every other harness keeps deriving `done` from the exit code.

**Verified empirically** against the installed pi (0.80.10): a successful run always ends `turn_end → agent_end → agent_settled`, in `--no-tools` mode too. On a hypothetical pi build that never emits `turn_end`, this degrades **safely** — a recoverable fallback that still yields a real answer, rather than returning trimmed narration as the reply.

## #351 — chattery `tool_execution_update` defeats the idle watchdog

`piActivity` classifies both `tool_execution_start` and `tool_execution_update` as `"tool"`, and `touch("tool")` resets the idle timer every time. pi emits `tool_execution_update` on genuine new output (bash streams stdout, the coder delegate forwards its child) so a truly silent wedge still trips the idle kill — but a tool that **trickles output forever** (a stalled auto-router, a hung retry that keeps logging) resets the idle timer over and over, leaving only the 3600s hard cap as the net. Fix:

- `KillCoordinator` gains `toolTimeoutMs`: a wall-clock cap on a single **contiguous** tool-run. Past the cap, tool activity no longer re-arms the idle timer, so the idle kill fires (recoverable → fallback). Any productive output resets the budget, so a healthy turn interleaving tools with text is untouched. Omit ⇒ legacy behaviour (unchanged for claude/codex).
- pi opts in with a **generous** net: `max(idle×4, 20min)`, capped at the hard timeout — comfortably above any realistic tool-run (a legit long build/delegation streams real output the whole time) yet well under the hard cap, so a wedge fails over in minutes instead of an hour.

## Notes

- Not a regression — the harness has derived `done` from the exit code since the harness consolidation in #151; `turn_end` was never wired as a completion signal (it only appeared in a doc comment).
- The mid-stream fall-through follows the existing streaming-first trade-off in `runWithFallback` (a user may briefly see partial narration before the next harness's full reply).

## Tests

- `parsePiEvent`: `turn_end` → `done`; `agent_end` stays ignored.
- e2e (`fake-pi.sh` `nofinish` mode): exit 0 with no `turn_end` → recoverable error, not `done`.
- `KillCoordinator` tool cap: sustained `"tool"` activity past the cap lets the idle kill fire; without a cap it keeps the process alive; productive output resets the budget.

`bun tsc --noEmit` clean (pre-existing `werift`/p2p errors aside). New tests green; the one failing `lib-harnessRunner` idle-timing test is a pre-existing environment flake (fails on `main` unchanged).