### PR TITLE
fix(mcp): order vault write before registry write in runMcpAdd

### DIFF
--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -168,10 +168,11 @@ export async function runMcpAdd(input: McpAddInput): Promise<number> {
   }
 
   const dir = await resolvePersonaDir(input.persona);
-  const registry = await loadRegistry(dir);
-  await saveRegistry(dir, upsertServer(registry, input.id, entry));
-  out.write(`registered MCP server '${input.id}' (${transport})\n`);
 
+  // Write the vault client secret BEFORE the registry entry. The registry is
+  // what agents read to reach a server; if we registered first and the vault
+  // write then failed, we'd leave a server registered without its stored
+  // client. Ordering the vault write first keeps that invariant intact.
   if (preClient && tokenRef) {
     const vault = await openPersonaVault(dir);
     try {
@@ -184,6 +185,10 @@ export async function runMcpAdd(input: McpAddInput): Promise<number> {
         `(DCR will be skipped for this server)\n`,
     );
   }
+
+  const registry = await loadRegistry(dir);
+  await saveRegistry(dir, upsertServer(registry, input.id, entry));
+  out.write(`registered MCP server '${input.id}' (${transport})\n`);
 
   printNextSteps(input.id, entry, out, { hasStaticClient: Boolean(preClient) });
   return 0;


### PR DESCRIPTION
## What

When `runMcpAdd` ingests a pre-registered OAuth client (`--client-id/--secret/--client-file`), swap the write order so the **vault client secret is written before the registry entry**.

## Why

The registry is what agents read to reach a server. Previously we wrote the registry entry first, then the vault secret — so a vault-write failure *after* the registry write landed would leave a server registered without its stored client secret. Writing the vault secret first keeps the invariant: a registered server always has its client in the vault.

Low impact (the command errors loudly and `mcp add` is idempotent on re-run), but a cleaner ordering. Raised by Kai, echoed by Lena, filed by Robbie in PR #342 to fold into the next MCP change.

## Test

- `bun test tests/cli-mcp.test.ts` → 12 pass
- `bun tsc --noEmit` clean

Closes #343