### PR TITLE
fix(memory): retry WAL-mode switch on SQLITE_BUSY so a fresh DB survives an aligned boot

### DIFF
--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1451,6 +1451,37 @@ function mapDisplayRows(rows: RawDisplayRow[]): Turn[] {
   }));
 }
 
+/**
+ * Switch a database to WAL journal mode, retrying on SQLITE_BUSY.
+ *
+ * Converting a rollback-journal DB to WAL needs a momentary EXCLUSIVE lock,
+ * and SQLite does NOT invoke the busy handler for that conversion — so
+ * `busy_timeout` cannot wait it out. Empirically, if any other connection
+ * holds a write lock at that instant, the switch throws SQLITE_BUSY in 0ms
+ * regardless of the configured timeout. This bites a fresh install whose
+ * scheduler fires two processes at once (e.g. a Windows phantom's `run` and
+ * `tick` tasks aligned on boot) against a brand-new memory.sqlite: one wins
+ * the conversion, the other throws and crash-loops the daemon.
+ *
+ * So we retry on our own deadline instead of relying on busy_timeout. Once
+ * the file is in WAL mode (the steady state after first boot) this pragma is
+ * a lock-free no-op and the first attempt returns immediately, even while
+ * another process holds a write lock.
+ */
+async function enableWalMode(db: Database, deadlineMs = 5000): Promise<void> {
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    try {
+      db.exec("PRAGMA journal_mode = WAL");
+      return;
+    } catch (err) {
+      const busy = (err as { code?: string } | null)?.code === "SQLITE_BUSY";
+      if (!busy || Date.now() >= deadline) throw err;
+      await Bun.sleep(50);
+    }
+  }
+}
+
 export async function openMemoryStore(path: string): Promise<MemoryStore> {
   if (path !== ":memory:") {
     await mkdir(dirname(path), { recursive: true });
@@ -1461,8 +1492,13 @@ export async function openMemoryStore(path: string): Promise<MemoryStore> {
   // records task runs against the same DB. WAL permits one writer at a
   // time; without busy_timeout a concurrent writer gets an immediate
   // SQLITE_BUSY throw. busy_timeout makes it block-and-retry instead.
-  db.exec("PRAGMA journal_mode = WAL");
+  //
+  // Set busy_timeout FIRST so every statement below — schema DDL, the
+  // idempotent migrations, and normal writes — is covered. The WAL switch
+  // is the one thing busy_timeout can't protect (see enableWalMode), so it
+  // gets its own retry loop.
   db.exec("PRAGMA busy_timeout = 5000");
+  await enableWalMode(db);
   db.exec("PRAGMA foreign_keys = ON");
   return new SqliteMemoryStore(db);
 }

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -3,8 +3,21 @@
  * (":memory:") per test so there's no filesystem cleanup needed.
  */
 
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { type MemoryStore, openMemoryStore } from "../src/memory/store.ts";
+
+async function waitForFile(path: string, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    await Bun.sleep(25);
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
 
 let store: MemoryStore;
 
@@ -320,5 +333,57 @@ describe("MemoryStore — persistence to a real file", () => {
     expect(turns).toEqual([{ role: "user", text: "remember me" }]);
     await b.close();
     await Bun.file(tmp).delete?.();
+  });
+});
+
+describe("MemoryStore — concurrent open under a transient cross-process lock", () => {
+  // Regression for the crash loop that took Megan down on update: a fresh
+  // DB opened while another process (a concurrent `tick`, an aligned second
+  // `run`, or the outgoing daemon mid-restart) briefly holds the file must
+  // block-and-retry, not throw "database is locked". The failure mode was an
+  // ordering bug in openMemoryStore — `PRAGMA journal_mode = WAL` (which
+  // itself needs a momentary exclusive lock) ran BEFORE `busy_timeout` was
+  // set, so the WAL switch threw SQLITE_BUSY on the spot instead of waiting.
+  test("openMemoryStore blocks until a briefly-held lock releases, then succeeds", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "phantombot-memstore-"));
+    const dbPath = join(dir, "memory.sqlite");
+    const readyPath = join(dir, "ready");
+    const lingerMs = 750;
+
+    // Separate OS process: takes a write lock on the fresh (rollback-mode)
+    // DB, signals readiness, lingers, then releases. It must be a distinct
+    // process because bun:sqlite is synchronous — a same-thread holder would
+    // deadlock the blocking open we're about to make.
+    const holder = Bun.spawn([
+      "bun",
+      "-e",
+      [
+        `const { Database } = require("bun:sqlite");`,
+        `const db = new Database(${JSON.stringify(dbPath)}, { create: true });`,
+        `db.exec("PRAGMA busy_timeout = 0");`,
+        `db.exec("CREATE TABLE IF NOT EXISTS lk(x)");`,
+        `db.exec("BEGIN IMMEDIATE");`,
+        `db.exec("INSERT INTO lk VALUES (1)");`,
+        `require("fs").writeFileSync(${JSON.stringify(readyPath)}, "1");`,
+        `setTimeout(() => { try { db.exec("COMMIT"); } catch {} process.exit(0); }, ${lingerMs});`,
+      ].join("\n"),
+    ]);
+
+    try {
+      await waitForFile(readyPath);
+      const started = Date.now();
+      // Pre-fix this rejects immediately with SQLITE_BUSY; post-fix it waits
+      // out the holder (busy_timeout armed first) and resolves.
+      const s = await openMemoryStore(dbPath);
+      const elapsed = Date.now() - started;
+      // Proves it genuinely blocked on the contended lock rather than either
+      // failing fast or never contending at all.
+      expect(elapsed).toBeGreaterThan(200);
+      await s.close();
+    } finally {
+      holder.kill();
+      await holder.exited;
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## What this fixes

`openMemoryStore` could throw `database is locked` (SQLITE_BUSY) while opening a **brand-new** `memory.sqlite` if a second process is touching the file at the same instant — crash-looping the daemon. The trigger is an aligned boot: a phantom's scheduler firing `run` and `tick` (or two `run` starts) simultaneously against a DB that doesn't exist yet.

## Root cause (with a correction to the earlier hunch)

I originally suspected a simple pragma-ordering bug (`journal_mode = WAL` running before `busy_timeout`). Building a deterministic cross-process reproduction proved that **reordering alone does not fix it**:

- Converting a rollback-journal DB to WAL needs a momentary **EXCLUSIVE** lock, and SQLite **does not invoke the busy handler** for that conversion. With another connection holding a write lock, `PRAGMA journal_mode = WAL` throws SQLITE_BUSY in **0 ms** regardless of `busy_timeout`.
- Once the file is already in WAL mode (the steady state after first boot), the same pragma is a **lock-free no-op** and succeeds instantly even under a held write lock.

So the hazard is confined to the **first-ever open of a fresh DB** under contention — exactly a new-install / aligned-boot race, not a steady-state one. (An existing, months-old store — e.g. Megan's — does not hit this; that separate crash loop was a duplicate scheduled task hammering writes, already resolved operationally.)

## The fix

- Set `busy_timeout` **first**, so schema DDL, migrations, and normal writes are all covered by block-and-retry.
- Give the WAL switch its **own retry-until-deadline loop** (`enableWalMode`), since `busy_timeout` provably can't protect it. Steady-state opens still return on the first attempt.

## Test

Adds a cross-process regression (`tests/memory.test.ts`): a separate process takes a write lock on a fresh DB, lingers, then releases; `openMemoryStore` must block-and-retry and succeed rather than throw. Verified it **fails without the retry loop** (throws SQLITE_BUSY in ~29 ms) and **passes with it**; 5x flake-stress clean.

## Verification

- `bun test tests/memory.test.ts` — 23/23 green.
- Full suite: only the known pre-existing PiHarness `--api-key` fails and the missing-MCP-SDK-dep env errors remain; this change adds none.
- Typecheck clean for the touched files.
- Cross-platform: pure SQLite/Bun, no OS-specific code — behaves identically on Windows CI.