### PR TITLE
fix(acp): force vscode extension reinstall to heal orphaned installs

### DIFF
--- a/src/cli/acp.ts
+++ b/src/cli/acp.ts
@@ -59,10 +59,21 @@ const installVscodeCmd = defineCommand({
   meta: {
     name: "vscode",
     description:
-      "Install phantombot's first-party VS Code extension (bundled .vsix) via the `code` CLI — idempotent + version-aware. Skips cleanly if VS Code isn't installed.",
+      "Install phantombot's first-party VS Code extension (bundled .vsix) via the `code` CLI — idempotent + version-aware. Forces a reinstall by default so an orphaned/ghosted install self-heals; pass --no-force to keep the version gate. Skips cleanly if VS Code isn't installed.",
   },
-  async run() {
-    const result = installVscode();
+  args: {
+    force: {
+      type: "boolean",
+      description:
+        "Re-lay the bundled extension even when the reported version is already current. This heals an orphaned install where VS Code's registry still lists the extension but its on-disk folder was pruned (the version gate alone reads the registry and would no-op forever). Default: true; pass --no-force to only install when missing or older.",
+      default: true,
+    },
+  },
+  async run({ args }) {
+    // Explicit `acp install vscode` forces by default — a user running it by
+    // hand almost always wants a real reinstall (the ghost-install fix). The
+    // automatic reconcile loop stays version-gated and never sets force.
+    const result = installVscode({ force: args.force !== false });
     // Unlike Zed (a settings merge), VS Code installs OUR extension via the
     // `code` CLI; print the human-readable outcome line for both success and
     // the "code CLI not found" / failure cases.
@@ -73,7 +84,11 @@ const installVscodeCmd = defineCommand({
     // otherwise the user updates, sees the old broken behaviour, and
     // reasonably concludes the update did nothing. Only worth saying when we
     // actually changed something ("current" / "not-detected" need no action).
-    if (result.action === "installed" || result.action === "updated") {
+    if (
+      result.action === "installed" ||
+      result.action === "updated" ||
+      result.action === "reinstalled"
+    ) {
       sink.write(
         "  restart VS Code (or run “Developer: Reload Window”) to load it.\n",
       );

--- a/src/connectors/acp/autoInstall.ts
+++ b/src/connectors/acp/autoInstall.ts
@@ -201,6 +201,15 @@ export function vscodeResultToConnector(
         action: repair ? "updated" : "stale",
         settingsPath,
       };
+    case "reinstalled":
+      // A forced re-lay over an already-current version (orphan heal). In
+      // repair mode that's work done → surface as "updated"; report-only can't
+      // produce it (checkVscode never forces), but map it defensively.
+      return {
+        editor: "vscode",
+        action: repair ? "updated" : "stale",
+        settingsPath,
+      };
     case "error":
       return {
         editor: "vscode",

--- a/src/connectors/acp/installVscode.ts
+++ b/src/connectors/acp/installVscode.ts
@@ -78,6 +78,14 @@ export type VscodeInstallAction =
   | "installed"
   /** An older version was installed; we upgraded it. */
   | "updated"
+  /**
+   * A version >= bundled was already registered, but a forced install
+   * re-laid the .vsix anyway. Self-heals an orphaned/ghosted install where
+   * VS Code's registry (`extensions.json`) still lists the extension but its
+   * on-disk folder was pruned — the version gate would otherwise no-op and
+   * leave the ACP surface dead. Only reachable when `force` is set.
+   */
+  | "reinstalled"
   /** `code --install-extension` failed (surfaced, not thrown). */
   | "error";
 
@@ -237,6 +245,16 @@ export interface InstallVscodeOptions {
   bundledVersion?: string;
   /** Override the extension id (tests). Default: the embedded constant. */
   extensionId?: string;
+  /**
+   * Bypass the version gate and re-lay the bundled .vsix even when the
+   * reported installed version is already >= bundled. This is the fix for the
+   * orphaned-install failure mode: `code --list-extensions` reads VS Code's
+   * registry, not disk, so a GC'd extension folder still reports "current" and
+   * the gate no-ops forever. The explicit `phantombot acp install vscode`
+   * command sets this by default; the automatic reconcile loop leaves it off
+   * to avoid reinstalling on every startup. Default: false.
+   */
+  force?: boolean;
 }
 
 /**
@@ -315,6 +333,7 @@ export function installVscode(
   const deps = options.deps ?? defaultVscodeDeps();
   const bundledVersion = options.bundledVersion ?? VSCODE_EXTENSION_VERSION;
   const extensionId = options.extensionId ?? VSCODE_EXTENSION_ID;
+  const force = options.force ?? false;
 
   try {
     // ── Detection gate: no usable `code` CLI ⇒ do nothing, say so clearly. ──
@@ -339,11 +358,16 @@ export function installVscode(
     const installedVersion = list
       ? findInstalledVersion(list.stdout, extensionId)
       : undefined;
-
-    if (
+    const alreadyCurrent =
       installedVersion !== undefined &&
-      compareVersions(installedVersion, bundledVersion) >= 0
-    ) {
+      compareVersions(installedVersion, bundledVersion) >= 0;
+
+    // The version gate only short-circuits when NOT forcing. `--list-extensions`
+    // reads VS Code's registry, not disk, so a "current" report can be a lie
+    // when the extension folder was GC'd out from under it (orphaned install).
+    // Forcing re-lays the .vsix via `code --install-extension --force`, which
+    // rewrites the folder and heals the ghost.
+    if (alreadyCurrent && !force) {
       return {
         code: 0,
         action: "current",
@@ -381,16 +405,27 @@ export function installVscode(
       deps.cleanup(vsixPath);
     }
 
-    const wasUpgrade = installedVersion !== undefined;
+    // Distinguish a forced re-lay over an already-current version (the
+    // orphan-heal path) from a genuine upgrade or first install, so the output
+    // line is honest rather than claiming an "upgrade" from X → X.
+    const action: VscodeInstallAction = alreadyCurrent
+      ? "reinstalled"
+      : installedVersion !== undefined
+        ? "updated"
+        : "installed";
+    const message =
+      action === "reinstalled"
+        ? `Reinstalled VS Code extension ${extensionId}@${bundledVersion} (forced; was reported ${installedVersion}).`
+        : action === "updated"
+          ? `Upgraded VS Code extension ${extensionId} ${installedVersion} → ${bundledVersion}.`
+          : `Installed VS Code extension ${extensionId}@${bundledVersion}.`;
     return {
       code: 0,
-      action: wasUpgrade ? "updated" : "installed",
+      action,
       bundledVersion,
       installedVersion,
       codeCommand,
-      message: wasUpgrade
-        ? `Upgraded VS Code extension ${extensionId} ${installedVersion} → ${bundledVersion}.`
-        : `Installed VS Code extension ${extensionId}@${bundledVersion}.`,
+      message,
     };
   } catch (e) {
     // Belt-and-suspenders: the entry point never throws.

--- a/tests/connectors-acp-installVscode.test.ts
+++ b/tests/connectors-acp-installVscode.test.ts
@@ -198,6 +198,67 @@ describe("installVscode idempotency + actions", () => {
     expect(r.action).toBe("current");
   });
 
+  test("force: already-current is reinstalled anyway (heals an orphaned install)", () => {
+    const { deps, writes, cleaned, runs } = makeDeps({
+      platform: "linux",
+      responses: {
+        "code --version": OK("1.90.0"),
+        // Registry reports current, but (in the real bug) the on-disk folder is
+        // gone. --force must re-lay the .vsix regardless of this "current" lie.
+        "code --list-extensions --show-versions": OK(`${ID}@1.0.0\n`),
+      },
+    });
+    const r = installVscode({
+      deps,
+      bundledVersion: "1.0.0",
+      extensionId: ID,
+      force: true,
+    });
+    expect(r.action).toBe("reinstalled");
+    expect(r.code).toBe(0);
+    expect(r.installedVersion).toBe("1.0.0");
+    // Actually re-laid the vsix with --force, then cleaned up.
+    expect(
+      runs.some(
+        (x) => x.args[0] === "--install-extension" && x.args.includes("--force"),
+      ),
+    ).toBe(true);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.path).toBe(STAGED_VSIX_POSIX);
+    expect(cleaned).toContain(STAGED_VSIX_POSIX);
+  });
+
+  test("force is off by default → already-current still short-circuits (no write)", () => {
+    const { deps, writes, runs } = makeDeps({
+      platform: "linux",
+      responses: {
+        "code --version": OK("1.90.0"),
+        "code --list-extensions --show-versions": OK(`${ID}@1.0.0\n`),
+      },
+    });
+    const r = installVscode({ deps, bundledVersion: "1.0.0", extensionId: ID });
+    expect(r.action).toBe("current");
+    expect(writes).toHaveLength(0);
+    expect(runs.some((x) => x.args.includes("--install-extension"))).toBe(false);
+  });
+
+  test("force on a missing extension → plain install (not reinstalled)", () => {
+    const { deps } = makeDeps({
+      platform: "linux",
+      responses: {
+        "code --version": OK("1.90.0"),
+        "code --list-extensions --show-versions": OK("other.ext@1.0.0\n"),
+      },
+    });
+    const r = installVscode({
+      deps,
+      bundledVersion: "0.1.0",
+      extensionId: ID,
+      force: true,
+    });
+    expect(r.action).toBe("installed");
+  });
+
   test("missing extension → installs (writes vsix, runs --install-extension --force, cleans up)", () => {
     const { deps, writes, cleaned, runs } = makeDeps({
       platform: "linux",


### PR DESCRIPTION
## Problem

`phantombot acp install vscode` version-gates on `code --list-extensions --show-versions`, which reads VS Code's **registry** (`extensions.json`), not disk. When the extension folder is pruned out from under the registry, the gate reports the version as `current` and no-ops — reinstalling appears to do nothing and the ACP/chat surface stays dead.

Hit live on Megan: VS Code 1.128.0 ran its extension GC, pruned the pinned sideloaded VSIX folder, but left the manifest row behind. `code --list-extensions` cheerfully reported `phantomyard.phantombot-vscode@1.1.242` as installed while the folder was gone (`FOLDER_MISSING`). The `--force` already on the install command never got reached because the gate short-circuited first. The manual heal was `code --uninstall-extension … && phantombot acp install vscode`.

## Fix

- Add a `force` option to `installVscode()` that bypasses the version gate and re-lays the bundled `.vsix` via `code --install-extension --force`, emitting a new honest `reinstalled` action (rather than a bogus "upgraded X → X").
- Wire the **explicit** `phantombot acp install vscode` command to force by default, with `--no-force` to opt back into version-gated behaviour. A user running the command by hand almost always wants a real reinstall.
- The **automatic** reconcile loop (`autoInstall`) stays version-gated and never forces, so it doesn't reinstall on every startup.
- `vscodeResultToConnector` maps `reinstalled` like `updated` in doctor output; the CLI's "restart VS Code to load it" hint now fires for it too.

## Tests

Added four cases: forced reinstall over an already-current version → `reinstalled` (re-lays vsix, cleans up); force off by default still short-circuits with no write; force on a missing extension is a plain `installed`. Full suite green (`installVscode` + `autoInstall-vscode`: 45 pass), typecheck clean.

## Note

The underlying orphan (registry row without a folder) is a VS Code GC quirk, not something we create — but forcing the reinstall makes the documented user command self-heal it instead of silently no-opping.