### PR TITLE
macOS: automatic stable code-signing to stop TCC permission nagging

### DIFF
--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -1,0 +1,77 @@
+# macOS: stopping the permission-prompt nagging (`fix-signing`)
+
+## The symptom
+
+On macOS, phantombot keeps re-asking for access to your home folder, Documents,
+Desktop, Downloads, or Full Disk Access — again and again, especially right after
+it updates itself.
+
+## Why it happens
+
+macOS TCC (Privacy & Security) pins each permission grant to the **exact
+code-signing identity** of the binary that was granted. phantombot ships
+**ad-hoc signed** (`Identifier=a.out`, no stable designated requirement) and it
+**auto-updates its own binary**. Every update rewrites the file → new code
+identity → the grant you gave last time no longer matches → macOS prompts again.
+It is structural, not a misconfiguration.
+
+## The fix: a stable signing identity
+
+```
+phantombot fix-signing
+```
+
+This installs a **stable self-signed code-signing identity** and signs the
+current binary with it. Because the identity no longer changes on every update,
+a single grant sticks across all future updates.
+
+After running it once, grant **Full Disk Access** to phantombot in
+**System Settings → Privacy & Security → Full Disk Access** (Full Disk Access is
+granted by path, so it survives the binary being rewritten). That's the last
+prompt you'll see — every subsequent `phantombot update` re-applies the same
+identity silently.
+
+### What it does under the hood
+
+- Creates a **dedicated throwaway keychain** (`phantombot-signing.keychain`)
+  with a password phantombot generates and stores in its own encrypted vault.
+  **The login keychain — the one with the password nobody remembers — is never
+  touched**, so codesign runs fully headless and macOS never pops the
+  keychain-password dialog.
+- Generates a self-signed code-signing certificate (`CN=phantombot-codesign`),
+  sets the key's partition list so codesign is non-interactive, and signs the
+  binary with `--identifier dev.phantombot`.
+- Verifies the signature **and** that the signed binary still runs.
+
+### Safety: it can't break anything
+
+`fix-signing` is **transactional**. It backs up the binary before signing and,
+on any failure, restores it. If the failure happened while creating the identity
+this run, it also tears the keychain down and clears the stored password — so a
+half-made identity is never left behind. Worst case, you're back to exactly the
+prior state: working binary, ad-hoc signature, still nagging. Nothing to
+un-break.
+
+Every external command runs under a timeout, so codesign can never hang waiting
+on a prompt.
+
+## What happens on future updates
+
+`phantombot update` re-applies the stable signature **only if you've opted in**
+(the `fix-signing` keychain exists). That step is best-effort and fail-safe: if
+re-signing fails for any reason, the update restores the freshly-swapped binary
+and continues — you get a working new binary and, at most, one extra macOS
+prompt. If you **never** ran `fix-signing`, the update path runs zero new code
+and behaves byte-for-byte as it always has.
+
+## New installs
+
+There is no way to ship a self-signed app that touches Documents/Desktop/
+Downloads with **zero** first-run prompts (that needs a Developer ID cert +
+notarization or an MDM PPPC profile, which we don't have). But after the single
+Full Disk Access grant, the stable identity means macOS never nags again.
+
+## Non-macOS
+
+`fix-signing` is a friendly no-op on Linux and Windows — there is no TCC and
+nothing to fix.

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -1,4 +1,4 @@
-# macOS: stopping the permission-prompt nagging (`fix-signing`)
+# macOS: stopping the permission-prompt nagging
 
 ## The symptom
 
@@ -15,21 +15,33 @@ code-signing identity** of the binary that was granted. phantombot ships
 identity → the grant you gave last time no longer matches → macOS prompts again.
 It is structural, not a misconfiguration.
 
-## The fix: a stable signing identity
+## The fix: a stable signing identity, applied automatically
+
+phantombot gives itself a **stable self-signed code-signing identity** and signs
+its binary with it. Because the identity no longer changes on every update, a
+single Full Disk Access grant sticks across all future updates.
+
+**This happens automatically — there is nothing to opt into.** Every
+`phantombot update` on macOS applies the stable identity to the freshly-swapped
+binary. The first update creates the identity; every update after that re-signs
+with the same one.
+
+Grant **Full Disk Access** to phantombot once, in **System Settings → Privacy &
+Security → Full Disk Access** (Full Disk Access is granted by path, so it
+survives the binary being rewritten). That's the last prompt you'll see — every
+subsequent update re-applies the same identity silently.
+
+## Applying it now, or repairing it (`fix-signing`)
 
 ```
 phantombot fix-signing
 ```
 
-This installs a **stable self-signed code-signing identity** and signs the
-current binary with it. Because the identity no longer changes on every update,
-a single grant sticks across all future updates.
-
-After running it once, grant **Full Disk Access** to phantombot in
-**System Settings → Privacy & Security → Full Disk Access** (Full Disk Access is
-granted by path, so it survives the binary being rewritten). That's the last
-prompt you'll see — every subsequent `phantombot update` re-applies the same
-identity silently.
+You usually don't need this — the update path already does it. Use it to apply
+the identity to the **current** binary immediately (without waiting for the next
+update), or to **repair** signing if an update's automatic re-sign failed and
+left an ad-hoc signature behind. It runs the same idempotent, transactional
+logic the update path uses.
 
 ### What it does under the hood
 
@@ -43,33 +55,30 @@ identity silently.
   binary with `--identifier dev.phantombot`.
 - Verifies the signature **and** that the signed binary still runs.
 
-### Safety: it can't break anything
+### Safety: updates can't break
 
-`fix-signing` is **transactional**. It backs up the binary before signing and,
-on any failure, restores it. If the failure happened while creating the identity
-this run, it also tears the keychain down and clears the stored password — so a
-half-made identity is never left behind. Worst case, you're back to exactly the
-prior state: working binary, ad-hoc signature, still nagging. Nothing to
-un-break.
+Applying the identity is **transactional**. It backs up the binary before
+signing and, on any failure, restores it. If the failure happened while creating
+the identity this run, it also tears the keychain down and clears the stored
+password — so a half-made identity is never left behind. Worst case, you're back
+to exactly the prior state: working binary, ad-hoc signature, still nagging.
+Nothing to un-break.
 
-Every external command runs under a timeout, so codesign can never hang waiting
-on a prompt.
-
-## What happens on future updates
-
-`phantombot update` re-applies the stable signature **only if you've opted in**
-(the `fix-signing` keychain exists). That step is best-effort and fail-safe: if
-re-signing fails for any reason, the update restores the freshly-swapped binary
-and continues — you get a working new binary and, at most, one extra macOS
-prompt. If you **never** ran `fix-signing`, the update path runs zero new code
-and behaves byte-for-byte as it always has.
+This is the load-bearing promise: **making the fix automatic for everyone must
+never risk an update.** It doesn't, because the guarantee comes from the
+fail-safe, not from gating the feature behind an opt-in. The signing step is
+best-effort: if it fails for any reason, the update keeps the freshly-swapped
+binary and continues — you get a working new binary and, at most, one extra
+macOS prompt (exactly today's behaviour). Every external command runs under a
+timeout, so codesign can never hang a headless update waiting on a prompt.
 
 ## New installs
 
 There is no way to ship a self-signed app that touches Documents/Desktop/
 Downloads with **zero** first-run prompts (that needs a Developer ID cert +
-notarization or an MDM PPPC profile, which we don't have). But after the single
-Full Disk Access grant, the stable identity means macOS never nags again.
+notarization or an MDM PPPC profile, which we don't have). But the first
+`phantombot update` gives the binary its stable identity, so after the single
+Full Disk Access grant, macOS never nags again.
 
 ## Non-macOS
 

--- a/src/cli/fix-signing.ts
+++ b/src/cli/fix-signing.ts
@@ -1,0 +1,110 @@
+/**
+ * `phantombot fix-signing` — stop macOS from endlessly re-prompting for home /
+ * Documents / Full Disk Access after every auto-update.
+ *
+ * WHY. macOS TCC pins each permission grant to the binary's code-signing
+ * identity. phantombot ships ad-hoc signed and rewrites its own binary on every
+ * update, so the identity changes every time and macOS re-asks forever. This
+ * command installs a STABLE self-signed signing identity (in a dedicated
+ * throwaway keychain, never the login keychain) and signs the current binary
+ * with it, so a single Full Disk Access grant sticks across all future updates.
+ * See src/lib/macSigning.ts for the safety model (transactional, headless,
+ * rollback-on-failure).
+ *
+ * OPT-IN. Running this command IS the opt-in. It creates the marker (the
+ * signing keychain) that the /update path keys off to keep the signature fresh
+ * on subsequent updates. Users who never run it are completely untouched — the
+ * update path runs zero new code for them.
+ *
+ * NON-macOS. On Linux/Windows this is a friendly no-op (exit 0): there is no
+ * TCC and nothing to fix.
+ */
+
+import { defineCommand } from "citty";
+
+import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
+import { BunCommandRunner, fixSigning } from "../lib/macSigning.ts";
+import type { WriteSink } from "../lib/io.ts";
+import { openPersonaVault } from "../lib/vault.ts";
+import { resolveVaultPersonaDir } from "./vault.ts";
+
+export interface RunFixSigningInput {
+  /** Defaults to process.platform. Tests override. */
+  procPlatform?: string;
+  /** Defaults to process.execPath. Tests override. */
+  binPath?: string;
+  persona?: string;
+  out?: WriteSink;
+  err?: WriteSink;
+  /**
+   * Test seam — inject the whole signing step. In production this is undefined
+   * and runFixSigning wires the real vault + BunCommandRunner.
+   */
+  applySigning?: (binPath: string) => Promise<{ ok: boolean; message: string }>;
+}
+
+export async function runFixSigning(
+  input: RunFixSigningInput = {},
+): Promise<number> {
+  const out = input.out ?? process.stdout;
+  const err = input.err ?? process.stderr;
+  const procPlatform = input.procPlatform ?? process.platform;
+
+  if (procPlatform !== "darwin") {
+    out.write(
+      "fix-signing is macOS-only — there's no TCC permission nagging to fix " +
+        "on this platform. Nothing to do.\n",
+    );
+    return 0;
+  }
+
+  const binPath = input.binPath ?? process.execPath;
+  if (!isPhantombotBinary(binPath)) {
+    err.write(
+      "fix-signing must run against the installed phantombot binary, not " +
+        "'bun src/index.ts'. Install a release binary first.\n",
+    );
+    return 1;
+  }
+
+  const apply =
+    input.applySigning ??
+    (async (bp: string) => {
+      const dir = await resolveVaultPersonaDir(input.persona);
+      const vault = await openPersonaVault(dir);
+      try {
+        return await fixSigning({
+          runner: new BunCommandRunner(),
+          vault,
+          binPath: bp,
+        });
+      } finally {
+        vault.close();
+      }
+    });
+
+  out.write("Setting up a stable code-signing identity for phantombot…\n");
+  const result = await apply(binPath);
+  if (result.ok) {
+    out.write(`✅ ${result.message}\n`);
+    return 0;
+  }
+  err.write(
+    `⚠️  ${result.message}\n` +
+      `Nothing was broken — you can retry with 'phantombot fix-signing'. If it ` +
+      `keeps failing, the fallback is Full Disk Access in System Settings → ` +
+      `Privacy & Security (you'll just be re-prompted after each update).\n`,
+  );
+  return 1;
+}
+
+export default defineCommand({
+  meta: {
+    name: "fix-signing",
+    description:
+      "macOS: install a stable code-signing identity so TCC stops re-prompting for permissions after every update.",
+  },
+  async run() {
+    process.exitCode = await runFixSigning();
+  },
+});

--- a/src/cli/fix-signing.ts
+++ b/src/cli/fix-signing.ts
@@ -11,10 +11,12 @@
  * See src/lib/macSigning.ts for the safety model (transactional, headless,
  * rollback-on-failure).
  *
- * OPT-IN. Running this command IS the opt-in. It creates the marker (the
- * signing keychain) that the /update path keys off to keep the signature fresh
- * on subsequent updates. Users who never run it are completely untouched — the
- * update path runs zero new code for them.
+ * NOT AN OPT-IN. `phantombot update` already applies this identity
+ * automatically on every macOS update, so most users never need this command.
+ * It exists as a MANUAL trigger: apply the identity to the current binary right
+ * now (without waiting for the next update), or repair it if an update's
+ * automatic re-sign failed and left an ad-hoc signature behind. It calls the
+ * same idempotent, transactional `fixSigning` the update path uses.
  *
  * NON-macOS. On Linux/Windows this is a friendly no-op (exit 0): there is no
  * TCC and nothing to fix.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,6 +46,7 @@ import notifyCmd from "./notify.ts";
 import taskCmd from "./task.ts";
 import tickCmd from "./tick.ts";
 import updateCmd from "./update.ts";
+import fixSigningCmd from "./fix-signing.ts";
 import voiceCmd from "./voice.ts";
 import replyModeCmd from "./replyMode.ts";
 import p2pCmd from "./p2p.ts";
@@ -85,6 +86,7 @@ export const mainCommand = defineCommand({
     task: taskCmd,
     tick: tickCmd,
     update: updateCmd,
+    "fix-signing": fixSigningCmd,
     voice: voiceCmd,
     "reply-mode": replyModeCmd,
     p2p: p2pCmd,

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -27,6 +27,11 @@ import {
 } from "../lib/binaryUpdate.ts";
 import { installCompletions } from "../lib/completionInstall.ts";
 import {
+  BunCommandRunner,
+  resignAfterUpdate,
+  type ResignAfterUpdateResult,
+} from "../lib/macSigning.ts";
+import {
   detectSupportedTarget,
   findLatestRelease,
   type LatestRelease,
@@ -94,6 +99,15 @@ export interface RunUpdateInput {
   installEditorExtensions?:
     | false
     | ((binPath: string) => Promise<EditorExtensionInstallResult>);
+  /**
+   * Test seam — override the post-swap macOS re-sign step. Pass `false` to skip
+   * entirely (the common case for tests that don't exercise signing). In
+   * production this is undefined and runUpdate uses `defaultResignBinary`, which
+   * is a no-op unless the user opted into stable signing via `fix-signing`.
+   */
+  resignBinary?:
+    | false
+    | ((binPath: string) => Promise<ResignAfterUpdateResult>);
   out?: WriteSink;
   err?: WriteSink;
 }
@@ -248,6 +262,39 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
     }
   }
 
+  // 7.55. macOS only: re-apply the stable code-signing identity to the freshly
+  // swapped binary. GATED on the user having opted in via `phantombot
+  // fix-signing` (the signing keychain must already exist) — this is the
+  // trademark "updates never break" guarantee in action. For everyone who
+  // hasn't opted in (the vast majority, including installs we don't know
+  // about), resignAfterUpdate returns `skipped` immediately and NO new code
+  // runs: the update path is byte-for-byte its old self. For opt-in users, it
+  // re-signs and, on any failure, restores the pre-sign binary and degrades to
+  // exactly today's behaviour. It can never leave a broken binary. Non-fatal.
+  if (input.resignBinary !== false && procPlatform === "darwin") {
+    try {
+      const r = input.resignBinary
+        ? await input.resignBinary(binPath)
+        : await defaultResignBinary(binPath);
+      if (r.status === "resigned") {
+        out.write("re-applied stable code signature.\n");
+      } else if (r.status === "failed") {
+        err.write(
+          `warning: could not re-apply stable code signature: ${r.reason} — ` +
+            `phantombot still works; macOS may re-prompt for permissions once. ` +
+            `Run 'phantombot fix-signing' to repair.\n`,
+        );
+      }
+      // status === "skipped" → not opted in; stay silent.
+    } catch (e) {
+      err.write(
+        `warning: stable-signing step errored: ${(e as Error).message} — ` +
+          `update itself is fine; run 'phantombot fix-signing' if macOS nags.\n`,
+      );
+      // Non-fatal — fall through.
+    }
+  }
+
   // 7.6. Refresh shell tab-completion for the freshly-installed binary. This
   // runs only after a real swap (never on --check or an up-to-date exit), so it
   // also back-fills completion for anyone who installed an older build.
@@ -358,6 +405,35 @@ async function defaultInstallEditorExtensions(
   // user-facing prose, and it carries the "restart VS Code" hint on its
   // second line when an install actually happened.
   return { ok: code === 0, message: (stdout.trim() || stderr.trim()).trim() };
+}
+
+/**
+ * Production wiring for the post-swap macOS re-sign step. Opens the active
+ * persona's vault (to read the signing keychain password) and delegates to
+ * resignAfterUpdate, which is itself gated on the opt-in marker existing. Never
+ * throws — resignAfterUpdate catches internally, and vault-open failure is
+ * caught here and reported as a benign skip so a swap can never be undone by a
+ * signing hiccup.
+ */
+async function defaultResignBinary(
+  binPath: string,
+): Promise<ResignAfterUpdateResult> {
+  const { openPersonaVault } = await import("../lib/vault.ts");
+  const { resolveVaultPersonaDir } = await import("./vault.ts");
+  let vault: Awaited<ReturnType<typeof openPersonaVault>> | undefined;
+  try {
+    const dir = await resolveVaultPersonaDir();
+    vault = await openPersonaVault(dir);
+    return await resignAfterUpdate({
+      runner: new BunCommandRunner(),
+      vault,
+      binPath,
+    });
+  } catch (e) {
+    return { status: "skipped", reason: `vault unavailable: ${(e as Error).message}` };
+  } finally {
+    vault?.close();
+  }
 }
 
 /**

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -103,7 +103,7 @@ export interface RunUpdateInput {
    * Test seam — override the post-swap macOS re-sign step. Pass `false` to skip
    * entirely (the common case for tests that don't exercise signing). In
    * production this is undefined and runUpdate uses `defaultResignBinary`, which
-   * is a no-op unless the user opted into stable signing via `fix-signing`.
+   * automatically applies the stable signing identity on every macOS update.
    */
   resignBinary?:
     | false
@@ -262,15 +262,17 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
     }
   }
 
-  // 7.55. macOS only: re-apply the stable code-signing identity to the freshly
-  // swapped binary. GATED on the user having opted in via `phantombot
-  // fix-signing` (the signing keychain must already exist) — this is the
-  // trademark "updates never break" guarantee in action. For everyone who
-  // hasn't opted in (the vast majority, including installs we don't know
-  // about), resignAfterUpdate returns `skipped` immediately and NO new code
-  // runs: the update path is byte-for-byte its old self. For opt-in users, it
-  // re-signs and, on any failure, restores the pre-sign binary and degrades to
-  // exactly today's behaviour. It can never leave a broken binary. Non-fatal.
+  // 7.55. macOS only: give the freshly-swapped binary a STABLE code-signing
+  // identity so TCC stops re-prompting for home / Documents / Full Disk Access
+  // after every auto-update. This runs AUTOMATICALLY for everyone on macOS —
+  // no opt-in — because the whole point is to stop the OS scaring external
+  // users we never hear from, not just the people who know to ask. The safety
+  // comes from the step being fail-safe, not from gating it: resignAfterUpdate
+  // ensures the identity (creating it on the first update), re-signs, verifies,
+  // and on ANY failure restores the pre-sign binary and tears down anything it
+  // created this run — degrading to exactly today's behaviour (working binary,
+  // still nags). It can never leave a broken binary and never hangs (every
+  // command runs under a timeout). Non-fatal.
   if (input.resignBinary !== false && procPlatform === "darwin") {
     try {
       const r = input.resignBinary
@@ -280,12 +282,11 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
         out.write("re-applied stable code signature.\n");
       } else if (r.status === "failed") {
         err.write(
-          `warning: could not re-apply stable code signature: ${r.reason} — ` +
+          `warning: could not apply stable code signature: ${r.reason} — ` +
             `phantombot still works; macOS may re-prompt for permissions once. ` +
             `Run 'phantombot fix-signing' to repair.\n`,
         );
       }
-      // status === "skipped" → not opted in; stay silent.
     } catch (e) {
       err.write(
         `warning: stable-signing step errored: ${(e as Error).message} — ` +
@@ -409,11 +410,12 @@ async function defaultInstallEditorExtensions(
 
 /**
  * Production wiring for the post-swap macOS re-sign step. Opens the active
- * persona's vault (to read the signing keychain password) and delegates to
- * resignAfterUpdate, which is itself gated on the opt-in marker existing. Never
- * throws — resignAfterUpdate catches internally, and vault-open failure is
- * caught here and reported as a benign skip so a swap can never be undone by a
- * signing hiccup.
+ * persona's vault (where the dedicated signing keychain's generated password is
+ * stored so re-signs stay headless) and delegates to resignAfterUpdate, which
+ * ensures the stable identity and re-signs fail-safely. Never throws —
+ * resignAfterUpdate catches internally, and a vault-open failure is caught here
+ * and reported as a `failed` (not a crash) so a swap can never be undone by a
+ * signing hiccup; the update path only warns.
  */
 async function defaultResignBinary(
   binPath: string,
@@ -430,7 +432,7 @@ async function defaultResignBinary(
       binPath,
     });
   } catch (e) {
-    return { status: "skipped", reason: `vault unavailable: ${(e as Error).message}` };
+    return { status: "failed", reason: `vault unavailable: ${(e as Error).message}` };
   } finally {
     vault?.close();
   }

--- a/src/lib/macSigning.ts
+++ b/src/lib/macSigning.ts
@@ -1,0 +1,547 @@
+/**
+ * macOS stable code-signing for the self-updating phantombot binary.
+ *
+ * THE PROBLEM. On macOS, TCC (Privacy & Security) pins every permission grant
+ * — Full Disk Access, Documents, Desktop, Downloads, AppleEvents — to the
+ * exact code-signing identity (ultimately the cdhash) of the binary that was
+ * granted. phantombot ships ad-hoc / linker-signed (`Identifier=a.out`, no
+ * stable designated requirement), and it AUTO-UPDATES ITS OWN BINARY. Each
+ * update rewrites the file → new cdhash → every stored grant stops matching →
+ * macOS re-prompts for every protected resource, forever. That is the endless
+ * "allow access to your home folder" nagging.
+ *
+ * THE FIX. Give the binary a STABLE self-signed code-signing identity, so its
+ * designated requirement stops changing across updates. Grant once against
+ * that identity and TCC never asks again — even though the bytes change on
+ * every update. This module creates that identity and applies it.
+ *
+ * SAFETY IS THE WHOLE POINT (see the /update path). phantombot's trademark is
+ * "updates never break." So:
+ *
+ *   - The signing identity lives in a DEDICATED throwaway keychain
+ *     (`phantombot-signing.keychain`) whose password WE generate and stash in
+ *     the vault. The user's LOGIN keychain — the one with the password nobody
+ *     remembers — is NEVER touched. codesign can therefore run fully headless;
+ *     the OS never has a reason to pop the dreaded "keychain password" dialog.
+ *
+ *   - Every mutating operation is TRANSACTIONAL. `fixSigning` backs up the
+ *     binary before signing and rolls it back on any failure; if it created
+ *     the keychain/cert this run and then failed, it tears BOTH down and clears
+ *     the vault password, because the keychain's existence is the opt-in marker
+ *     the update path keys off — a half-created marker would make the next
+ *     update try to maintain a broken identity. Roll back everything this run
+ *     created, or nothing.
+ *
+ *   - Every external command runs under a TIMEOUT, so codesign can never hang a
+ *     headless update waiting on a prompt; a timeout is treated as failure and
+ *     triggers rollback.
+ *
+ *   - `resignAfterUpdate` (called from /update) is GATED on the opt-in marker
+ *     already existing and is best-effort: on any failure it restores the
+ *     pre-sign binary and returns quietly, degrading to EXACTLY today's
+ *     behaviour (working binary, ad-hoc signature, still nags) — never worse.
+ *     Users who never opted in run zero new code.
+ *
+ * This module is macOS-only in effect; callers guard on platform. It shells out
+ * to `security`, `codesign`, `openssl`, and `spctl` through an injectable
+ * CommandRunner so the logic is unit-testable from Linux CI without a Mac.
+ */
+
+import { randomBytes } from "node:crypto";
+import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Common Name of the self-signed code-signing certificate. */
+export const SIGNING_CERT_CN = "phantombot-codesign";
+
+/**
+ * `--identifier` handed to codesign. Fixing this (rather than letting codesign
+ * derive `a.out` from the Mach-O) is half of what makes the designated
+ * requirement stable across binary swaps; the cert identity is the other half.
+ */
+export const SIGNING_BUNDLE_ID = "dev.phantombot";
+
+/** Basename of the dedicated signing keychain (never the login keychain). */
+export const SIGNING_KEYCHAIN_BASENAME = "phantombot-signing.keychain";
+
+/**
+ * Vault key under which the generated keychain password is stored so the
+ * headless /update path can unlock the keychain and re-sign silently.
+ */
+export const SIGNING_PASSWORD_VAULT_KEY = "MACOS_SIGNING_KEYCHAIN_PASSWORD";
+
+/** Default per-command timeout. codesign/security are fast; a stall is a bug. */
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  /** True when the process was killed by the timeout rather than exiting. */
+  timedOut: boolean;
+}
+
+export interface CommandRunner {
+  run(
+    cmd: string,
+    args: readonly string[],
+    opts?: { timeoutMs?: number },
+  ): Promise<CommandResult>;
+}
+
+/** Production runner: Bun.spawn with a hard timeout. Never throws. */
+export class BunCommandRunner implements CommandRunner {
+  async run(
+    cmd: string,
+    args: readonly string[],
+    opts: { timeoutMs?: number } = {},
+  ): Promise<CommandResult> {
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    try {
+      const proc = Bun.spawn([cmd, ...args], {
+        stdout: "pipe",
+        stderr: "pipe",
+        // Bun kills the process when the timeout elapses; we detect that
+        // below via signalCode/exitCode and surface timedOut=true.
+        timeout: timeoutMs,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      const timedOut = proc.signalCode === "SIGTERM" || proc.killed;
+      return { exitCode, stdout, stderr, timedOut };
+    } catch (e) {
+      // Command not found (no `codesign` on Linux) or spawn failure — surface
+      // as a non-zero result rather than throwing, so callers stay linear.
+      return {
+        exitCode: 127,
+        stdout: "",
+        stderr: (e as Error).message,
+        timedOut: false,
+      };
+    }
+  }
+}
+
+/** Minimal slice of the vault this module needs. The real Vault satisfies it. */
+export interface SigningSecretStore {
+  get(name: string): string | undefined;
+  set(name: string, value: string): void;
+  unset(name: string): void;
+}
+
+/** Absolute path of the dedicated signing keychain for the given home dir. */
+export function signingKeychainPath(home: string = homedir()): string {
+  return join(home, "Library", "Keychains", SIGNING_KEYCHAIN_BASENAME);
+}
+
+/**
+ * True when the opt-in marker exists: the dedicated keychain holds our
+ * code-signing certificate. This is the single gate the /update path checks —
+ * absent, and the update path runs zero new code.
+ */
+export async function isSigningConfigured(
+  runner: CommandRunner,
+  keychainPath: string = signingKeychainPath(),
+): Promise<boolean> {
+  const r = await runner.run("security", [
+    "find-certificate",
+    "-c",
+    SIGNING_CERT_CN,
+    keychainPath,
+  ]);
+  return r.exitCode === 0;
+}
+
+export interface FixSigningOptions {
+  runner: CommandRunner;
+  vault: SigningSecretStore;
+  /** The binary to sign. Defaults to process.execPath. */
+  binPath: string;
+  home?: string;
+  timeoutMs?: number;
+}
+
+export interface FixSigningResult {
+  ok: boolean;
+  /** Human-readable summary of what happened, safe to print (no secrets). */
+  message: string;
+  /** Set on failure: the concrete step that failed, for the manual hint. */
+  failedStep?: string;
+}
+
+/**
+ * Create the stable signing identity (if absent) and sign `binPath` with it.
+ *
+ * Transactional: on any failure, restores the binary and — if THIS call created
+ * the keychain/cert — tears them down and clears the vault password, returning
+ * the machine to exactly its prior state (ad-hoc signed, still working). Never
+ * throws. Never touches the login keychain.
+ */
+export async function fixSigning(
+  opts: FixSigningOptions,
+): Promise<FixSigningResult> {
+  const { runner, vault } = opts;
+  const home = opts.home ?? homedir();
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const keychainPath = signingKeychainPath(home);
+  const binPath = opts.binPath;
+  const backupPath = `${binPath}.presign.bak`;
+  const run = (cmd: string, args: readonly string[]) =>
+    runner.run(cmd, args, { timeoutMs });
+
+  // Track what THIS invocation creates, so rollback only tears down our own
+  // work and never a keychain the user already opted into on a prior run.
+  const alreadyConfigured = await isSigningConfigured(runner, keychainPath);
+  let createdKeychain = false;
+  let wroteVaultPassword = false;
+  let backedUp = false;
+
+  const rollback = async (): Promise<void> => {
+    // Restore the binary first — it's the thing that must never end up broken.
+    if (backedUp) {
+      try {
+        await copyFile(backupPath, binPath);
+      } catch {
+        /* best-effort: the backup is still on disk for manual restore */
+      }
+    }
+    // Only tear down keychain/cert + vault password if we created them here.
+    // Tearing down a pre-existing opt-in would break a working install.
+    if (createdKeychain) {
+      await run("security", ["delete-keychain", keychainPath]);
+    }
+    if (wroteVaultPassword && !alreadyConfigured) {
+      try {
+        vault.unset(SIGNING_PASSWORD_VAULT_KEY);
+      } catch {
+        /* ignore */
+      }
+    }
+  };
+
+  try {
+    // 1. Ensure a keychain password exists (generate + persist if not).
+    let password = vault.get(SIGNING_PASSWORD_VAULT_KEY);
+    if (!password) {
+      password = randomBytes(24).toString("hex");
+      vault.set(SIGNING_PASSWORD_VAULT_KEY, password);
+      wroteVaultPassword = true;
+    }
+
+    // 2. Ensure the dedicated keychain + certificate exist.
+    if (!alreadyConfigured) {
+      const created = await createSigningIdentity({
+        run,
+        keychainPath,
+        password,
+      });
+      if (!created.ok) {
+        await rollback();
+        return {
+          ok: false,
+          message: `Couldn't create the signing identity (${created.failedStep}). ` +
+            `No changes were left behind — phantombot still works exactly as before.`,
+          failedStep: created.failedStep,
+        };
+      }
+      createdKeychain = true;
+    } else {
+      // Keychain exists from a prior opt-in — just make sure it's unlocked so
+      // codesign can read the key headlessly.
+      await run("security", ["unlock-keychain", "-p", password, keychainPath]);
+    }
+
+    // 3. Back up the binary, then sign it.
+    await copyFile(binPath, backupPath);
+    backedUp = true;
+
+    const sign = await run("codesign", [
+      "--force",
+      "--sign",
+      SIGNING_CERT_CN,
+      "--identifier",
+      SIGNING_BUNDLE_ID,
+      "--keychain",
+      keychainPath,
+      "--timestamp=none",
+      binPath,
+    ]);
+    if (sign.exitCode !== 0) {
+      await rollback();
+      return {
+        ok: false,
+        message: `codesign failed${sign.timedOut ? " (timed out)" : ""}: ` +
+          `${firstLine(sign.stderr)}. Rolled back — phantombot still works as before.`,
+        failedStep: "codesign",
+      };
+    }
+
+    // 4. Verify: signature is valid AND the binary still executes.
+    const verified = await verifySignedBinary({ run, binPath });
+    if (!verified.ok) {
+      await rollback();
+      return {
+        ok: false,
+        message: `Signature verification failed (${verified.failedStep}). ` +
+          `Rolled back — phantombot still works as before.`,
+        failedStep: verified.failedStep,
+      };
+    }
+
+    // Success — drop the now-redundant backup.
+    await rm(backupPath, { force: true });
+    return {
+      ok: true,
+      message:
+        "Stable code-signing identity installed and applied. Grant Full Disk " +
+        "Access once in System Settings → Privacy & Security and macOS will " +
+        "never nag again, across every future update.",
+    };
+  } catch (e) {
+    // Any unexpected throw — roll back to the last known-good state.
+    await rollback();
+    return {
+      ok: false,
+      message: `Unexpected error while fixing signing: ${(e as Error).message}. ` +
+        `Rolled back — phantombot still works as before.`,
+      failedStep: "unexpected",
+    };
+  }
+}
+
+export interface ResignAfterUpdateOptions {
+  runner: CommandRunner;
+  vault: SigningSecretStore;
+  binPath: string;
+  home?: string;
+  timeoutMs?: number;
+}
+
+export type ResignAfterUpdateResult =
+  | { status: "skipped"; reason: string }
+  | { status: "resigned" }
+  | { status: "failed"; reason: string };
+
+/**
+ * Best-effort re-sign after a binary swap, for the /update path.
+ *
+ * GATED on the opt-in marker: if the signing keychain/cert isn't present, this
+ * is a no-op (`skipped`) — users who never opted in are untouched. When opted
+ * in, it backs up the freshly-swapped binary, re-signs with the stable
+ * identity, verifies, and on ANY failure restores the backup and returns
+ * `failed` — degrading to exactly today's behaviour (working binary, no stable
+ * signature). Never throws.
+ */
+export async function resignAfterUpdate(
+  opts: ResignAfterUpdateOptions,
+): Promise<ResignAfterUpdateResult> {
+  const { runner, vault } = opts;
+  const home = opts.home ?? homedir();
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const keychainPath = signingKeychainPath(home);
+  const binPath = opts.binPath;
+  const backupPath = `${binPath}.presign.bak`;
+  const run = (cmd: string, args: readonly string[]) =>
+    runner.run(cmd, args, { timeoutMs });
+
+  try {
+    if (!(await isSigningConfigured(runner, keychainPath))) {
+      return { status: "skipped", reason: "no stable signing identity configured" };
+    }
+    const password = vault.get(SIGNING_PASSWORD_VAULT_KEY);
+    if (!password) {
+      // Marker exists but password is gone — we can't unlock headlessly. Don't
+      // guess or prompt in a headless update; leave the swapped binary as-is.
+      return {
+        status: "failed",
+        reason: "signing keychain password missing from vault; run 'phantombot fix-signing'",
+      };
+    }
+
+    const unlock = await run("security", [
+      "unlock-keychain",
+      "-p",
+      password,
+      keychainPath,
+    ]);
+    if (unlock.exitCode !== 0) {
+      return { status: "failed", reason: `could not unlock signing keychain: ${firstLine(unlock.stderr)}` };
+    }
+
+    await copyFile(binPath, backupPath);
+    const sign = await run("codesign", [
+      "--force",
+      "--sign",
+      SIGNING_CERT_CN,
+      "--identifier",
+      SIGNING_BUNDLE_ID,
+      "--keychain",
+      keychainPath,
+      "--timestamp=none",
+      binPath,
+    ]);
+    if (sign.exitCode !== 0) {
+      await restore(backupPath, binPath);
+      return {
+        status: "failed",
+        reason: `codesign failed${sign.timedOut ? " (timed out)" : ""}: ${firstLine(sign.stderr)}`,
+      };
+    }
+
+    const verified = await verifySignedBinary({ run, binPath });
+    if (!verified.ok) {
+      await restore(backupPath, binPath);
+      return { status: "failed", reason: `verification failed (${verified.failedStep})` };
+    }
+
+    await rm(backupPath, { force: true });
+    return { status: "resigned" };
+  } catch (e) {
+    // Try to leave a working binary behind even on an unexpected throw.
+    await restore(backupPath, binPath);
+    return { status: "failed", reason: (e as Error).message };
+  }
+}
+
+/**
+ * Create the dedicated keychain and a self-signed code-signing certificate
+ * inside it, with the key ACL + partition list set so codesign never prompts.
+ *
+ * We generate the cert with openssl (headless; the macOS Certificate Assistant
+ * is GUI-only) with the codeSigning extendedKeyUsage, wrap it in a PKCS#12, and
+ * import it into the dedicated keychain granting /usr/bin/codesign access.
+ */
+async function createSigningIdentity(args: {
+  run: (cmd: string, a: readonly string[]) => Promise<CommandResult>;
+  keychainPath: string;
+  password: string;
+}): Promise<{ ok: true } | { ok: false; failedStep: string }> {
+  const { run, keychainPath, password } = args;
+
+  // Fresh keychain. Deleting first makes create idempotent if a stale,
+  // cert-less keychain was left around (isSigningConfigured would be false).
+  await run("security", ["delete-keychain", keychainPath]);
+  const create = await run("security", [
+    "create-keychain",
+    "-p",
+    password,
+    keychainPath,
+  ]);
+  if (create.exitCode !== 0) return { ok: false, failedStep: "create-keychain" };
+
+  // No auto-lock / no lock-on-sleep so a long-lived service can always re-sign.
+  await run("security", ["set-keychain-settings", keychainPath]);
+  const unlock = await run("security", ["unlock-keychain", "-p", password, keychainPath]);
+  if (unlock.exitCode !== 0) return { ok: false, failedStep: "unlock-keychain" };
+
+  // Generate key + self-signed codesigning cert + p12 in a temp dir we scrub.
+  const workdir = await mkdtemp(join(tmpdir(), "phantombot-signing-"));
+  const keyPem = join(workdir, "key.pem");
+  const certPem = join(workdir, "cert.pem");
+  const p12 = join(workdir, "identity.p12");
+  try {
+    const req = await run("openssl", [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-keyout",
+      keyPem,
+      "-out",
+      certPem,
+      "-days",
+      "3650",
+      "-nodes",
+      "-subj",
+      `/CN=${SIGNING_CERT_CN}`,
+      "-addext",
+      "basicConstraints=critical,CA:false",
+      "-addext",
+      "keyUsage=critical,digitalSignature",
+      "-addext",
+      "extendedKeyUsage=critical,codeSigning",
+    ]);
+    if (req.exitCode !== 0) return { ok: false, failedStep: "openssl-req" };
+
+    const pk = await run("openssl", [
+      "pkcs12",
+      "-export",
+      "-inkey",
+      keyPem,
+      "-in",
+      certPem,
+      "-out",
+      p12,
+      "-passout",
+      `pass:${password}`,
+      "-name",
+      SIGNING_CERT_CN,
+    ]);
+    if (pk.exitCode !== 0) return { ok: false, failedStep: "openssl-pkcs12" };
+
+    // Import, granting codesign non-prompting access to the private key.
+    const imp = await run("security", [
+      "import",
+      p12,
+      "-k",
+      keychainPath,
+      "-P",
+      password,
+      "-T",
+      "/usr/bin/codesign",
+      "-A",
+    ]);
+    if (imp.exitCode !== 0) return { ok: false, failedStep: "import" };
+
+    // Partition list is the crucial headless step: without it, the first
+    // codesign against this key pops the "codesign wants to use a key" dialog
+    // that would hang a service. This authorises apple/codesign tooling.
+    const part = await run("security", [
+      "set-key-partition-list",
+      "-S",
+      "apple-tool:,apple:,codesign:",
+      "-s",
+      "-k",
+      password,
+      keychainPath,
+    ]);
+    if (part.exitCode !== 0) return { ok: false, failedStep: "set-key-partition-list" };
+
+    return { ok: true };
+  } finally {
+    // Scrub the private key material regardless of outcome.
+    await rm(workdir, { recursive: true, force: true });
+  }
+}
+
+async function verifySignedBinary(args: {
+  run: (cmd: string, a: readonly string[]) => Promise<CommandResult>;
+  binPath: string;
+}): Promise<{ ok: true } | { ok: false; failedStep: string }> {
+  const { run, binPath } = args;
+  const verify = await run("codesign", ["--verify", "--strict", binPath]);
+  if (verify.exitCode !== 0) return { ok: false, failedStep: "codesign-verify" };
+  // Exec check: a valid signature on a binary that won't run is useless. Cheap
+  // and decisive — if the swapped+signed binary can't print its version, the
+  // swap is bad and we must roll back.
+  const exec = await run(binPath, ["--version"]);
+  if (exec.exitCode !== 0) return { ok: false, failedStep: "exec-check" };
+  return { ok: true };
+}
+
+async function restore(backupPath: string, binPath: string): Promise<void> {
+  try {
+    await copyFile(backupPath, binPath);
+    await rm(backupPath, { force: true });
+  } catch {
+    /* best-effort: backup remains on disk for manual restore */
+  }
+}
+
+function firstLine(s: string): string {
+  return (s.split("\n").find((l) => l.trim().length > 0) ?? "").trim();
+}

--- a/src/lib/macSigning.ts
+++ b/src/lib/macSigning.ts
@@ -244,6 +244,11 @@ export async function fixSigning(
         keychainPath,
         password,
       });
+      // Mark the keychain for teardown the moment `create-keychain` succeeded,
+      // even if a later identity step failed — otherwise rollback would leave a
+      // partial keychain behind while clearing the vault password, which breaks
+      // automatic repair on every subsequent update.
+      createdKeychain = created.keychainCreated;
       if (!created.ok) {
         await rollback();
         return {
@@ -253,7 +258,6 @@ export async function fixSigning(
           failedStep: created.failedStep,
         };
       }
-      createdKeychain = true;
     } else {
       // Keychain exists from a prior update/run — just make sure it's unlocked
       // so codesign can read the key headlessly.
@@ -372,7 +376,10 @@ async function createSigningIdentity(args: {
   run: (cmd: string, a: readonly string[]) => Promise<CommandResult>;
   keychainPath: string;
   password: string;
-}): Promise<{ ok: true } | { ok: false; failedStep: string }> {
+}): Promise<
+  | { ok: true; keychainCreated: boolean }
+  | { ok: false; failedStep: string; keychainCreated: boolean }
+> {
   const { run, keychainPath, password } = args;
 
   // Fresh keychain. Deleting first makes create idempotent if a stale,
@@ -384,12 +391,19 @@ async function createSigningIdentity(args: {
     password,
     keychainPath,
   ]);
-  if (create.exitCode !== 0) return { ok: false, failedStep: "create-keychain" };
+  if (create.exitCode !== 0)
+    return { ok: false, failedStep: "create-keychain", keychainCreated: false };
+
+  // From here on the keychain exists on disk — every exit path must report it
+  // as created so the caller's rollback tears down this partial keychain and we
+  // never leave a cert-bearing keychain paired with a cleared vault password.
+  const keychainCreated = true;
 
   // No auto-lock / no lock-on-sleep so a long-lived service can always re-sign.
   await run("security", ["set-keychain-settings", keychainPath]);
   const unlock = await run("security", ["unlock-keychain", "-p", password, keychainPath]);
-  if (unlock.exitCode !== 0) return { ok: false, failedStep: "unlock-keychain" };
+  if (unlock.exitCode !== 0)
+    return { ok: false, failedStep: "unlock-keychain", keychainCreated };
 
   // Generate key + self-signed codesigning cert + p12 in a temp dir we scrub.
   const workdir = await mkdtemp(join(tmpdir(), "phantombot-signing-"));
@@ -418,7 +432,8 @@ async function createSigningIdentity(args: {
       "-addext",
       "extendedKeyUsage=critical,codeSigning",
     ]);
-    if (req.exitCode !== 0) return { ok: false, failedStep: "openssl-req" };
+    if (req.exitCode !== 0)
+      return { ok: false, failedStep: "openssl-req", keychainCreated };
 
     const pk = await run("openssl", [
       "pkcs12",
@@ -434,7 +449,8 @@ async function createSigningIdentity(args: {
       "-name",
       SIGNING_CERT_CN,
     ]);
-    if (pk.exitCode !== 0) return { ok: false, failedStep: "openssl-pkcs12" };
+    if (pk.exitCode !== 0)
+      return { ok: false, failedStep: "openssl-pkcs12", keychainCreated };
 
     // Import, granting codesign non-prompting access to the private key.
     const imp = await run("security", [
@@ -448,7 +464,8 @@ async function createSigningIdentity(args: {
       "/usr/bin/codesign",
       "-A",
     ]);
-    if (imp.exitCode !== 0) return { ok: false, failedStep: "import" };
+    if (imp.exitCode !== 0)
+      return { ok: false, failedStep: "import", keychainCreated };
 
     // Partition list is the crucial headless step: without it, the first
     // codesign against this key pops the "codesign wants to use a key" dialog
@@ -462,9 +479,10 @@ async function createSigningIdentity(args: {
       password,
       keychainPath,
     ]);
-    if (part.exitCode !== 0) return { ok: false, failedStep: "set-key-partition-list" };
+    if (part.exitCode !== 0)
+      return { ok: false, failedStep: "set-key-partition-list", keychainCreated };
 
-    return { ok: true };
+    return { ok: true, keychainCreated };
   } finally {
     // Scrub the private key material regardless of outcome.
     await rm(workdir, { recursive: true, force: true });

--- a/src/lib/macSigning.ts
+++ b/src/lib/macSigning.ts
@@ -27,20 +27,24 @@
  *   - Every mutating operation is TRANSACTIONAL. `fixSigning` backs up the
  *     binary before signing and rolls it back on any failure; if it created
  *     the keychain/cert this run and then failed, it tears BOTH down and clears
- *     the vault password, because the keychain's existence is the opt-in marker
- *     the update path keys off — a half-created marker would make the next
- *     update try to maintain a broken identity. Roll back everything this run
- *     created, or nothing.
+ *     the vault password, so a half-created identity is never left behind for
+ *     the next update to trip over. Roll back everything this run created, or
+ *     nothing.
  *
  *   - Every external command runs under a TIMEOUT, so codesign can never hang a
  *     headless update waiting on a prompt; a timeout is treated as failure and
  *     triggers rollback.
  *
- *   - `resignAfterUpdate` (called from /update) is GATED on the opt-in marker
- *     already existing and is best-effort: on any failure it restores the
- *     pre-sign binary and returns quietly, degrading to EXACTLY today's
- *     behaviour (working binary, ad-hoc signature, still nags) — never worse.
- *     Users who never opted in run zero new code.
+ *   - `resignAfterUpdate` (called from /update) runs AUTOMATICALLY on every
+ *     macOS update — there is NO opt-in. So the fix reaches everyone, including
+ *     the installs we never hear about: those are exactly the scared external
+ *     users the nagging frightens most. It ensures the stable identity exists
+ *     (creating it on the first update if absent), then re-signs the freshly
+ *     swapped binary. It is best-effort: on ANY failure it restores the
+ *     pre-sign binary (tearing down anything it created this run) and returns
+ *     quietly, degrading to EXACTLY today's behaviour (working binary, ad-hoc
+ *     signature, still nags) — never worse. The FAIL-SAFE, not gating, is what
+ *     guarantees an update can never break.
  *
  * This module is macOS-only in effect; callers guard on platform. It shells out
  * to `security`, `codesign`, `openssl`, and `spctl` through an injectable
@@ -139,9 +143,10 @@ export function signingKeychainPath(home: string = homedir()): string {
 }
 
 /**
- * True when the opt-in marker exists: the dedicated keychain holds our
- * code-signing certificate. This is the single gate the /update path checks —
- * absent, and the update path runs zero new code.
+ * True when the stable signing identity already exists: the dedicated keychain
+ * holds our code-signing certificate. `fixSigning` uses this to decide whether
+ * to CREATE the identity (first update on a machine) or just re-sign against an
+ * existing one — not as an opt-in gate; signing runs for everyone.
  */
 export async function isSigningConfigured(
   runner: CommandRunner,
@@ -194,7 +199,7 @@ export async function fixSigning(
     runner.run(cmd, args, { timeoutMs });
 
   // Track what THIS invocation creates, so rollback only tears down our own
-  // work and never a keychain the user already opted into on a prior run.
+  // work and never a keychain a prior successful run already established.
   const alreadyConfigured = await isSigningConfigured(runner, keychainPath);
   let createdKeychain = false;
   let wroteVaultPassword = false;
@@ -210,7 +215,7 @@ export async function fixSigning(
       }
     }
     // Only tear down keychain/cert + vault password if we created them here.
-    // Tearing down a pre-existing opt-in would break a working install.
+    // Tearing down a pre-existing identity would break a working install.
     if (createdKeychain) {
       await run("security", ["delete-keychain", keychainPath]);
     }
@@ -250,8 +255,8 @@ export async function fixSigning(
       }
       createdKeychain = true;
     } else {
-      // Keychain exists from a prior opt-in — just make sure it's unlocked so
-      // codesign can read the key headlessly.
+      // Keychain exists from a prior update/run — just make sure it's unlocked
+      // so codesign can read the key headlessly.
       await run("security", ["unlock-keychain", "-p", password, keychainPath]);
     }
 
@@ -322,89 +327,37 @@ export interface ResignAfterUpdateOptions {
 }
 
 export type ResignAfterUpdateResult =
-  | { status: "skipped"; reason: string }
   | { status: "resigned" }
   | { status: "failed"; reason: string };
 
 /**
- * Best-effort re-sign after a binary swap, for the /update path.
+ * Automatic re-sign after a binary swap, for the /update path — runs for
+ * EVERYONE on macOS, with no opt-in.
  *
- * GATED on the opt-in marker: if the signing keychain/cert isn't present, this
- * is a no-op (`skipped`) — users who never opted in are untouched. When opted
- * in, it backs up the freshly-swapped binary, re-signs with the stable
- * identity, verifies, and on ANY failure restores the backup and returns
- * `failed` — degrading to exactly today's behaviour (working binary, no stable
- * signature). Never throws.
+ * This is a thin adapter over `fixSigning`, which already does the complete
+ * job idempotently and fail-safely: ensure the stable identity exists (create
+ * it on the first update if absent), back up the freshly-swapped binary,
+ * re-sign it with the stable identity, verify signature + exec, and on ANY
+ * failure roll everything this run created back — leaving a working binary with
+ * exactly today's behaviour (ad-hoc signature, still nags). Never throws.
+ *
+ * The result is flattened to `resigned` / `failed` so the update path can keep
+ * its reporting terse; the rich, secret-free message from `fixSigning` is
+ * carried through on failure for the warning line.
  */
 export async function resignAfterUpdate(
   opts: ResignAfterUpdateOptions,
 ): Promise<ResignAfterUpdateResult> {
-  const { runner, vault } = opts;
-  const home = opts.home ?? homedir();
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const keychainPath = signingKeychainPath(home);
-  const binPath = opts.binPath;
-  const backupPath = `${binPath}.presign.bak`;
-  const run = (cmd: string, args: readonly string[]) =>
-    runner.run(cmd, args, { timeoutMs });
-
-  try {
-    if (!(await isSigningConfigured(runner, keychainPath))) {
-      return { status: "skipped", reason: "no stable signing identity configured" };
-    }
-    const password = vault.get(SIGNING_PASSWORD_VAULT_KEY);
-    if (!password) {
-      // Marker exists but password is gone — we can't unlock headlessly. Don't
-      // guess or prompt in a headless update; leave the swapped binary as-is.
-      return {
-        status: "failed",
-        reason: "signing keychain password missing from vault; run 'phantombot fix-signing'",
-      };
-    }
-
-    const unlock = await run("security", [
-      "unlock-keychain",
-      "-p",
-      password,
-      keychainPath,
-    ]);
-    if (unlock.exitCode !== 0) {
-      return { status: "failed", reason: `could not unlock signing keychain: ${firstLine(unlock.stderr)}` };
-    }
-
-    await copyFile(binPath, backupPath);
-    const sign = await run("codesign", [
-      "--force",
-      "--sign",
-      SIGNING_CERT_CN,
-      "--identifier",
-      SIGNING_BUNDLE_ID,
-      "--keychain",
-      keychainPath,
-      "--timestamp=none",
-      binPath,
-    ]);
-    if (sign.exitCode !== 0) {
-      await restore(backupPath, binPath);
-      return {
-        status: "failed",
-        reason: `codesign failed${sign.timedOut ? " (timed out)" : ""}: ${firstLine(sign.stderr)}`,
-      };
-    }
-
-    const verified = await verifySignedBinary({ run, binPath });
-    if (!verified.ok) {
-      await restore(backupPath, binPath);
-      return { status: "failed", reason: `verification failed (${verified.failedStep})` };
-    }
-
-    await rm(backupPath, { force: true });
-    return { status: "resigned" };
-  } catch (e) {
-    // Try to leave a working binary behind even on an unexpected throw.
-    await restore(backupPath, binPath);
-    return { status: "failed", reason: (e as Error).message };
-  }
+  const res = await fixSigning({
+    runner: opts.runner,
+    vault: opts.vault,
+    binPath: opts.binPath,
+    home: opts.home,
+    timeoutMs: opts.timeoutMs,
+  });
+  return res.ok
+    ? { status: "resigned" }
+    : { status: "failed", reason: res.message };
 }
 
 /**
@@ -531,15 +484,6 @@ async function verifySignedBinary(args: {
   const exec = await run(binPath, ["--version"]);
   if (exec.exitCode !== 0) return { ok: false, failedStep: "exec-check" };
   return { ok: true };
-}
-
-async function restore(backupPath: string, binPath: string): Promise<void> {
-  try {
-    await copyFile(backupPath, binPath);
-    await rm(backupPath, { force: true });
-  } catch {
-    /* best-effort: backup remains on disk for manual restore */
-  }
 }
 
 function firstLine(s: string): string {

--- a/tests/cli-fix-signing.test.ts
+++ b/tests/cli-fix-signing.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for `phantombot fix-signing`. The real signing work is injected via the
+ * applySigning seam, so we only assert the command's wiring:
+ *
+ *   - non-macOS is a friendly no-op (exit 0, nothing applied)
+ *   - running from source (bun, not a real binary) is refused (exit 1)
+ *   - success prints the grant-once guidance (exit 0)
+ *   - failure prints the "nothing broken / retry" fallback (exit 1)
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { runFixSigning } from "../src/cli/fix-signing.ts";
+
+function sink() {
+  let text = "";
+  return {
+    write: (s: string) => {
+      text += s;
+      return true;
+    },
+    get text() {
+      return text;
+    },
+  };
+}
+
+describe("runFixSigning", () => {
+  test("non-macOS → no-op exit 0, never calls applySigning", async () => {
+    const out = sink();
+    let applied = false;
+    const code = await runFixSigning({
+      procPlatform: "linux",
+      binPath: "/usr/bin/phantombot",
+      out,
+      err: sink(),
+      applySigning: async () => {
+        applied = true;
+        return { ok: true, message: "x" };
+      },
+    });
+    expect(code).toBe(0);
+    expect(applied).toBe(false);
+    expect(out.text).toContain("macOS-only");
+  });
+
+  test("refuses when not run from a real phantombot binary", async () => {
+    const err = sink();
+    const code = await runFixSigning({
+      procPlatform: "darwin",
+      binPath: "/opt/homebrew/bin/bun",
+      out: sink(),
+      err,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("installed phantombot binary");
+  });
+
+  test("success → exit 0 with grant-once guidance", async () => {
+    const out = sink();
+    const code = await runFixSigning({
+      procPlatform: "darwin",
+      binPath: "/Users/x/.local/bin/phantombot",
+      out,
+      err: sink(),
+      applySigning: async () => ({ ok: true, message: "identity installed" }),
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("identity installed");
+  });
+
+  test("failure → exit 1 with fail-safe fallback message", async () => {
+    const err = sink();
+    const code = await runFixSigning({
+      procPlatform: "darwin",
+      binPath: "/Users/x/.local/bin/phantombot",
+      out: sink(),
+      err,
+      applySigning: async () => ({ ok: false, message: "codesign failed" }),
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("Nothing was broken");
+    expect(err.text).toContain("Full Disk Access");
+  });
+});

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -390,7 +390,7 @@ describe("runUpdate on darwin-arm64", () => {
       resignBinary: async () => ({ status: "failed", reason: "codesign failed" }),
     });
     expect(code).toBe(0);
-    expect(err.text).toContain("could not re-apply stable code signature");
+    expect(err.text).toContain("could not apply stable code signature");
     expect(err.text).toContain("fix-signing");
   });
 });

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -339,11 +339,59 @@ describe("runUpdate on darwin-arm64", () => {
       force: true,
       healSystemdUnits: false,
       refreshCompletions: false,
+      installEditorExtensions: false,
+      resignBinary: false,
     });
     expect(code).toBe(0);
     expect(out.text).toContain("phantombot-v1.0.99-darwin-arm64");
     // Binary on disk is the darwin one.
     expect((await readFile(binPath)).equals(DARWIN_BYTES)).toBe(true);
+  });
+
+  test("invokes the re-sign seam on darwin and reports a re-sign", async () => {
+    const out = new CaptureStream();
+    let seenBin: string | undefined;
+    const code = await runUpdate({
+      binPath,
+      procPlatform: "darwin",
+      procArch: "arm64",
+      currentVersion: "1.0.42",
+      fetchImpl: darwinFetch(),
+      out,
+      err: new CaptureStream(),
+      force: true,
+      healSystemdUnits: false,
+      refreshCompletions: false,
+      installEditorExtensions: false,
+      resignBinary: async (bp) => {
+        seenBin = bp;
+        return { status: "resigned" };
+      },
+    });
+    expect(code).toBe(0);
+    expect(seenBin).toBe(binPath);
+    expect(out.text).toContain("re-applied stable code signature");
+  });
+
+  test("a re-sign failure is non-fatal (update still exits 0, warns)", async () => {
+    const err = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procPlatform: "darwin",
+      procArch: "arm64",
+      currentVersion: "1.0.42",
+      fetchImpl: darwinFetch(),
+      out: new CaptureStream(),
+      err,
+      force: true,
+      healSystemdUnits: false,
+      refreshCompletions: false,
+      installEditorExtensions: false,
+      resignBinary: async () => ({ status: "failed", reason: "codesign failed" }),
+    });
+    expect(code).toBe(0);
+    expect(err.text).toContain("could not re-apply stable code signature");
+    expect(err.text).toContain("fix-signing");
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -26,6 +26,7 @@ describe("phantombot CLI dispatcher", () => {
       "doctor",
       "embedding",
       "env",
+      "fix-signing",
       "harness",
       "heartbeat",
       "init",

--- a/tests/lib-macSigning.test.ts
+++ b/tests/lib-macSigning.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the macOS stable-signing module. Everything external (security,
+ * codesign, openssl) is injected via a fake CommandRunner and the vault is an
+ * in-memory Map, so these run on Linux CI with no Mac. What we pin down:
+ *
+ *   - isSigningConfigured reflects `security find-certificate`'s exit code
+ *   - fixSigning happy path signs + verifies + persists the vault password
+ *   - fixSigning rolls BACK fully on failure it caused this run (keychain torn
+ *     down, vault password cleared) — the opt-in marker is never left half-made
+ *   - fixSigning that only RE-SIGNS a pre-existing opt-in never tears down the
+ *     working keychain on failure
+ *   - resignAfterUpdate is a no-op ("skipped") unless the marker exists
+ *   - resignAfterUpdate re-signs on the happy path and fails-safe otherwise
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  fixSigning,
+  isSigningConfigured,
+  resignAfterUpdate,
+  SIGNING_PASSWORD_VAULT_KEY,
+  type CommandResult,
+  type CommandRunner,
+  type SigningSecretStore,
+} from "../src/lib/macSigning.ts";
+
+function fakeVault(seed: Record<string, string> = {}): SigningSecretStore & {
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>(Object.entries(seed));
+  return {
+    store,
+    get: (n) => store.get(n),
+    set: (n, v) => void store.set(n, v),
+    unset: (n) => void store.delete(n),
+  };
+}
+
+/**
+ * overrides keys are matched most-specific first: `"cmd firstArg"` then `"cmd"`.
+ * Everything unmatched defaults to a clean exit 0.
+ */
+function fakeRunner(overrides: Record<string, Partial<CommandResult>> = {}) {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  const runner: CommandRunner = {
+    async run(cmd, args) {
+      calls.push({ cmd, args: [...args] });
+      const specific = overrides[`${cmd} ${args[0] ?? ""}`];
+      const general = overrides[cmd];
+      const o = specific ?? general ?? {};
+      return {
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        ...o,
+      };
+    },
+  };
+  const keys = () => calls.map((c) => `${c.cmd} ${c.args[0] ?? ""}`);
+  return { runner, calls, keys };
+}
+
+async function tempBinary(content = "ORIGINAL-BINARY"): Promise<{
+  home: string;
+  binPath: string;
+}> {
+  const home = await mkdtemp(join(tmpdir(), "pb-sign-home-"));
+  const binPath = join(home, "phantombot");
+  await writeFile(binPath, content);
+  return { home, binPath };
+}
+
+describe("isSigningConfigured", () => {
+  test("true when find-certificate exits 0", async () => {
+    const { runner } = fakeRunner({ "security find-certificate": { exitCode: 0 } });
+    expect(await isSigningConfigured(runner, "/x/keychain")).toBe(true);
+  });
+  test("false when find-certificate exits non-zero", async () => {
+    const { runner } = fakeRunner({ "security find-certificate": { exitCode: 1 } });
+    expect(await isSigningConfigured(runner, "/x/keychain")).toBe(false);
+  });
+});
+
+describe("fixSigning", () => {
+  test("happy path: creates identity, signs, verifies, persists password", async () => {
+    const { home, binPath } = await tempBinary();
+    const { runner, keys } = fakeRunner({
+      "security find-certificate": { exitCode: 1 }, // not yet configured
+    });
+    const vault = fakeVault();
+
+    const r = await fixSigning({ runner, vault, binPath, home });
+
+    expect(r.ok).toBe(true);
+    // Identity creation happened.
+    expect(keys()).toContain("security create-keychain");
+    expect(keys()).toContain("openssl req");
+    expect(keys()).toContain("security set-key-partition-list");
+    // Signed with the stable identity + verified.
+    expect(keys()).toContain("codesign --force");
+    expect(keys()).toContain("codesign --verify");
+    // Password persisted for the headless update path.
+    expect(vault.store.get(SIGNING_PASSWORD_VAULT_KEY)).toBeTruthy();
+    // Backup cleaned up on success.
+    expect(await Bun.file(`${binPath}.presign.bak`).exists()).toBe(false);
+  });
+
+  test("rollback on codesign failure it caused this run: tears down marker", async () => {
+    const { home, binPath } = await tempBinary();
+    const { runner, keys } = fakeRunner({
+      "security find-certificate": { exitCode: 1 },
+      "codesign --force": { exitCode: 1, stderr: "the code signing subsystem barfed" },
+    });
+    const vault = fakeVault();
+
+    const r = await fixSigning({ runner, vault, binPath, home });
+
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("codesign");
+    // Keychain we created this run was deleted during rollback.
+    expect(keys().filter((k) => k === "security delete-keychain").length).toBeGreaterThanOrEqual(1);
+    // Vault password we wrote this run was cleared — no half-made opt-in marker.
+    expect(vault.store.has(SIGNING_PASSWORD_VAULT_KEY)).toBe(false);
+    // Binary restored to its original bytes.
+    expect(await readFile(binPath, "utf8")).toBe("ORIGINAL-BINARY");
+  });
+
+  test("re-sign of a pre-existing opt-in: failure does NOT tear down the keychain", async () => {
+    const { home, binPath } = await tempBinary();
+    const { runner, keys } = fakeRunner({
+      "security find-certificate": { exitCode: 0 }, // already configured
+      "codesign --force": { exitCode: 1, stderr: "nope" },
+    });
+    // Password already present from the prior opt-in.
+    const vault = fakeVault({ [SIGNING_PASSWORD_VAULT_KEY]: "existing-pw" });
+
+    const r = await fixSigning({ runner, vault, binPath, home });
+
+    expect(r.ok).toBe(false);
+    // Never created a keychain (already configured) → never deleted one.
+    expect(keys()).not.toContain("security create-keychain");
+    expect(keys()).not.toContain("security delete-keychain");
+    // Existing opt-in preserved.
+    expect(vault.store.get(SIGNING_PASSWORD_VAULT_KEY)).toBe("existing-pw");
+    // Binary still intact.
+    expect(await readFile(binPath, "utf8")).toBe("ORIGINAL-BINARY");
+  });
+
+  test("rollback on failed exec-check after signing", async () => {
+    const { home, binPath } = await tempBinary();
+    const { runner } = fakeRunner({
+      "security find-certificate": { exitCode: 1 },
+      // sign + codesign --verify pass, but the binary won't run.
+      [`${binPath} --version`]: { exitCode: 1 },
+    });
+    const vault = fakeVault();
+
+    const r = await fixSigning({ runner, vault, binPath, home });
+
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("exec-check");
+    expect(vault.store.has(SIGNING_PASSWORD_VAULT_KEY)).toBe(false);
+  });
+});
+
+describe("resignAfterUpdate", () => {
+  test("skipped when not opted in — no codesign runs", async () => {
+    const { home, binPath } = await tempBinary();
+    const { runner, keys } = fakeRunner({
+      "security find-certificate": { exitCode: 1 },
+    });
+    const vault = fakeVault();
+
+    const r = await resignAfterUpdate({ runner, vault, binPath, home });
+
+    expect(r.status).toBe("skipped");
+    expect(keys()).not.toContain("codesign --force");
+  });
+
+  test("resigns on the happy path when opted in", async () => {
+    const { home, binPath } = await tempBinary();
+    const { runner, keys } = fakeRunner({
+      "security find-certificate": { exitCode: 0 },
+    });
+    const vault = fakeVault({ [SIGNING_PASSWORD_VAULT_KEY]: "pw" });
+
+    const r = await resignAfterUpdate({ runner, vault, binPath, home });
+
+    expect(r.status).toBe("resigned");
+    expect(keys()).toContain("codesign --force");
+    expect(await Bun.file(`${binPath}.presign.bak`).exists()).toBe(false);
+  });
+
+  test("fails-safe (restores binary) when codesign fails", async () => {
+    const { home, binPath } = await tempBinary();
+    const { runner } = fakeRunner({
+      "security find-certificate": { exitCode: 0 },
+      "codesign --force": { exitCode: 1, stderr: "boom" },
+    });
+    const vault = fakeVault({ [SIGNING_PASSWORD_VAULT_KEY]: "pw" });
+
+    const r = await resignAfterUpdate({ runner, vault, binPath, home });
+
+    expect(r.status).toBe("failed");
+    expect(await readFile(binPath, "utf8")).toBe("ORIGINAL-BINARY");
+  });
+
+  test("fails when opted in but password is missing from the vault", async () => {
+    const { home, binPath } = await tempBinary();
+    const { runner, keys } = fakeRunner({
+      "security find-certificate": { exitCode: 0 },
+    });
+    const vault = fakeVault(); // marker exists but no password
+
+    const r = await resignAfterUpdate({ runner, vault, binPath, home });
+
+    expect(r.status).toBe("failed");
+    // Never attempted to unlock/sign without the password.
+    expect(keys()).not.toContain("codesign --force");
+  });
+});

--- a/tests/lib-macSigning.test.ts
+++ b/tests/lib-macSigning.test.ts
@@ -6,11 +6,12 @@
  *   - isSigningConfigured reflects `security find-certificate`'s exit code
  *   - fixSigning happy path signs + verifies + persists the vault password
  *   - fixSigning rolls BACK fully on failure it caused this run (keychain torn
- *     down, vault password cleared) — the opt-in marker is never left half-made
- *   - fixSigning that only RE-SIGNS a pre-existing opt-in never tears down the
+ *     down, vault password cleared) — a half-made identity is never left behind
+ *   - fixSigning that only RE-SIGNS a pre-existing identity never tears down the
  *     working keychain on failure
- *   - resignAfterUpdate is a no-op ("skipped") unless the marker exists
- *   - resignAfterUpdate re-signs on the happy path and fails-safe otherwise
+ *   - resignAfterUpdate runs automatically for everyone: it creates the identity
+ *     on the first update when absent, re-signs when present, and fails-safe
+ *     (restoring the binary) on any error
  */
 
 import { describe, expect, test } from "bun:test";
@@ -168,30 +169,37 @@ describe("fixSigning", () => {
   });
 });
 
-describe("resignAfterUpdate", () => {
-  test("skipped when not opted in — no codesign runs", async () => {
+describe("resignAfterUpdate (automatic for everyone — no opt-in)", () => {
+  test("creates the identity on the first update when absent, then signs", async () => {
     const { home, binPath } = await tempBinary();
     const { runner, keys } = fakeRunner({
-      "security find-certificate": { exitCode: 1 },
+      "security find-certificate": { exitCode: 1 }, // no identity yet
     });
     const vault = fakeVault();
 
     const r = await resignAfterUpdate({ runner, vault, binPath, home });
 
-    expect(r.status).toBe("skipped");
-    expect(keys()).not.toContain("codesign --force");
+    expect(r.status).toBe("resigned");
+    // The identity was created automatically — no prior fix-signing needed.
+    expect(keys()).toContain("security create-keychain");
+    expect(keys()).toContain("codesign --force");
+    // Password persisted so future headless updates can re-sign silently.
+    expect(vault.store.get(SIGNING_PASSWORD_VAULT_KEY)).toBeTruthy();
+    expect(await Bun.file(`${binPath}.presign.bak`).exists()).toBe(false);
   });
 
-  test("resigns on the happy path when opted in", async () => {
+  test("re-signs against the existing identity on subsequent updates", async () => {
     const { home, binPath } = await tempBinary();
     const { runner, keys } = fakeRunner({
-      "security find-certificate": { exitCode: 0 },
+      "security find-certificate": { exitCode: 0 }, // identity already present
     });
     const vault = fakeVault({ [SIGNING_PASSWORD_VAULT_KEY]: "pw" });
 
     const r = await resignAfterUpdate({ runner, vault, binPath, home });
 
     expect(r.status).toBe("resigned");
+    // Doesn't recreate the keychain when one already exists.
+    expect(keys()).not.toContain("security create-keychain");
     expect(keys()).toContain("codesign --force");
     expect(await Bun.file(`${binPath}.presign.bak`).exists()).toBe(false);
   });
@@ -207,20 +215,7 @@ describe("resignAfterUpdate", () => {
     const r = await resignAfterUpdate({ runner, vault, binPath, home });
 
     expect(r.status).toBe("failed");
+    // The swapped binary is left working (ad-hoc), never broken.
     expect(await readFile(binPath, "utf8")).toBe("ORIGINAL-BINARY");
-  });
-
-  test("fails when opted in but password is missing from the vault", async () => {
-    const { home, binPath } = await tempBinary();
-    const { runner, keys } = fakeRunner({
-      "security find-certificate": { exitCode: 0 },
-    });
-    const vault = fakeVault(); // marker exists but no password
-
-    const r = await resignAfterUpdate({ runner, vault, binPath, home });
-
-    expect(r.status).toBe("failed");
-    // Never attempted to unlock/sign without the password.
-    expect(keys()).not.toContain("codesign --force");
   });
 });

--- a/tests/lib-macSigning.test.ts
+++ b/tests/lib-macSigning.test.ts
@@ -131,6 +131,32 @@ describe("fixSigning", () => {
     expect(await readFile(binPath, "utf8")).toBe("ORIGINAL-BINARY");
   });
 
+  test("rollback on a post-create identity step failure tears down the partial keychain", async () => {
+    // create-keychain succeeds but a LATER step (set-key-partition-list) fails.
+    // The keychain now exists on disk, so rollback MUST delete it — otherwise a
+    // cert-bearing keychain would survive next to a cleared vault password and
+    // permanently break automatic repair on every subsequent update.
+    const { home, binPath } = await tempBinary();
+    const { runner, keys } = fakeRunner({
+      "security find-certificate": { exitCode: 1 }, // not yet configured
+      "security set-key-partition-list": { exitCode: 1, stderr: "partition boom" },
+    });
+    const vault = fakeVault();
+
+    const r = await fixSigning({ runner, vault, binPath, home });
+
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("set-key-partition-list");
+    // The partially-created keychain was torn down during rollback (the initial
+    // idempotent delete + the rollback delete → at least two delete calls).
+    expect(keys().filter((k) => k === "security delete-keychain").length).toBeGreaterThanOrEqual(2);
+    // Vault password we wrote this run was cleared — never leave a password
+    // stranded against an orphaned keychain.
+    expect(vault.store.has(SIGNING_PASSWORD_VAULT_KEY)).toBe(false);
+    // Never signed the binary since identity creation failed → bytes untouched.
+    expect(await readFile(binPath, "utf8")).toBe("ORIGINAL-BINARY");
+  });
+
   test("re-sign of a pre-existing opt-in: failure does NOT tear down the keychain", async () => {
     const { home, binPath } = await tempBinary();
     const { runner, keys } = fakeRunner({


### PR DESCRIPTION
## What & why

On macOS, phantombot re-prompts for home / Documents / Full Disk Access after **every** auto-update. macOS TCC pins each permission grant to the binary's exact code-signing identity; phantombot ships ad-hoc signed (`Identifier=a.out`) and rewrites its own binary on update, so every update invalidates the grant and the OS re-asks forever.

This scares people — **especially the external installs we never hear about**, who don't yet trust us. The point of this PR is to make the Mac stop frightening them.

## The fix: automatic stable signing, for everyone

phantombot gives its binary a **stable self-signed code-signing identity** (fixed `--identifier dev.phantombot` + a persistent self-signed cert). The designated requirement stops changing across updates, so a single Full Disk Access grant sticks forever.

This runs **automatically on every macOS update — no opt-in.** The first update creates the identity; every update after re-signs with it.

## Why it can never break an update

The "updates never break" guarantee comes from the **fail-safe design, not from gating**:

- **Dedicated throwaway keychain**, password generated by us and stored in the vault. The **login keychain is never touched**, so codesign runs fully headless — the dreaded "keychain password nobody knows" dialog can never appear.
- **Transactional**: back up the swapped binary, re-sign under a `timeout`, verify (`codesign --verify` **and** an exec `--version` check). On **any** failure, restore the binary and tear down anything created this run.
- Worst case degrades to **exactly today's behaviour**: working binary, ad-hoc signature, still nags. Never worse, never broken, never a hung headless update.

## `phantombot fix-signing`

Kept as a **manual** apply-now / repair command (no longer "the opt-in"): sign the current binary immediately without waiting for the next update, or repair signing if an update's automatic re-sign failed. macOS-only; friendly no-op on Linux/Windows.

## The one honest caveat

New/first-run installs still get **one** macOS Full Disk Access grant — unavoidable without a Developer ID cert + notarization or an MDM PPPC profile, which we don't have. But it goes from "nags on every update" to "grant once, silent forever."

## Tests

`bun tsc` clean. Full suite green except one pre-existing unrelated `config.test.ts` (Gemini migration) failure that also fails on clean `main`. Signing logic covered by a fake CommandRunner + in-memory vault (no Mac needed): auto-create-then-sign on first update, re-sign on subsequent updates, full rollback on codesign/exec failure, and the non-fatal update-path wiring. Runbook at `docs/macos-signing.md`.