### PR TITLE
signing: register dedicated keychain in user search list so codesign can find the identity

### DIFF
--- a/src/lib/macSigning.ts
+++ b/src/lib/macSigning.ts
@@ -23,6 +23,10 @@
  *     the vault. The user's LOGIN keychain — the one with the password nobody
  *     remembers — is NEVER touched. codesign can therefore run fully headless;
  *     the OS never has a reason to pop the dreaded "keychain password" dialog.
+ *     The dedicated keychain IS added to the USER keychain search list (never
+ *     the login keychain, and never the system domain) because codesign
+ *     resolves the signing identity by name through that list rather than the
+ *     `--keychain` argument; on any failure the prior search list is restored.
  *
  *   - Every mutating operation is TRANSACTIONAL. `fixSigning` backs up the
  *     binary before signing and rolls it back on any failure; if it created
@@ -161,6 +165,58 @@ export async function isSigningConfigured(
   return r.exitCode === 0;
 }
 
+/**
+ * Parse `security list-keychains` output into bare paths. Each line is a
+ * whitespace-indented, double-quoted path; strip both.
+ */
+export function parseKeychainSearchList(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .map((l) => l.replace(/^"(.*)"$/, "$1"));
+}
+
+/**
+ * Ensure the dedicated signing keychain is on the USER keychain search list, so
+ * `codesign --sign <name>` can resolve the identity (it searches the list, not
+ * the `--keychain` path). Idempotent: no-op if already present; otherwise
+ * appends and returns the prior list so a failed run can restore it exactly.
+ *
+ * Matching tolerates macOS's `-db` suffix: `create-keychain foo.keychain`
+ * materialises `foo.keychain-db` on disk and the search list reports the real
+ * path, so a naive exact compare would re-append a duplicate every run.
+ */
+export async function ensureKeychainInSearchList(args: {
+  run: (cmd: string, a: readonly string[]) => Promise<CommandResult>;
+  keychainPath: string;
+}): Promise<
+  | { ok: true; added: false }
+  | { ok: true; added: true; priorList: string[] }
+  | { ok: false; failedStep: string }
+> {
+  const { run, keychainPath } = args;
+  const read = await run("security", ["list-keychains", "-d", "user"]);
+  if (read.exitCode !== 0)
+    return { ok: false, failedStep: "list-keychains-read" };
+  const priorList = parseKeychainSearchList(read.stdout);
+  const norm = (p: string) => p.replace(/-db$/, "");
+  const target = norm(keychainPath);
+  if (priorList.some((p) => norm(p) === target))
+    return { ok: true, added: false };
+  const set = await run("security", [
+    "list-keychains",
+    "-d",
+    "user",
+    "-s",
+    ...priorList,
+    keychainPath,
+  ]);
+  if (set.exitCode !== 0)
+    return { ok: false, failedStep: "list-keychains-set" };
+  return { ok: true, added: true, priorList };
+}
+
 export interface FixSigningOptions {
   runner: CommandRunner;
   vault: SigningSecretStore;
@@ -204,6 +260,9 @@ export async function fixSigning(
   let createdKeychain = false;
   let wroteVaultPassword = false;
   let backedUp = false;
+  // If we add our keychain to the user search list this run, remember the prior
+  // list so rollback restores it exactly (roll back everything, or nothing).
+  let priorSearchList: string[] | null = null;
 
   const rollback = async (): Promise<void> => {
     // Restore the binary first — it's the thing that must never end up broken.
@@ -213,6 +272,17 @@ export async function fixSigning(
       } catch {
         /* best-effort: the backup is still on disk for manual restore */
       }
+    }
+    // Restore the user keychain search list if we changed it this run, before
+    // deleting the keychain (so we never leave a dangling search-list entry).
+    if (priorSearchList) {
+      await run("security", [
+        "list-keychains",
+        "-d",
+        "user",
+        "-s",
+        ...priorSearchList,
+      ]);
     }
     // Only tear down keychain/cert + vault password if we created them here.
     // Tearing down a pre-existing identity would break a working install.
@@ -264,7 +334,24 @@ export async function fixSigning(
       await run("security", ["unlock-keychain", "-p", password, keychainPath]);
     }
 
-    // 3. Back up the binary, then sign it.
+    // 3. Make the identity resolvable by codesign. codesign looks up
+    //    `--sign <name>` through the USER keychain search list; the
+    //    `--keychain <path>` argument does NOT scope that lookup. A dedicated
+    //    keychain that isn't in the search list yields "no identity found",
+    //    which stalls headless and rolls back. Add ours if absent (idempotent).
+    const searchList = await ensureKeychainInSearchList({ run, keychainPath });
+    if (!searchList.ok) {
+      await rollback();
+      return {
+        ok: false,
+        message: `Couldn't register the signing keychain (${searchList.failedStep}). ` +
+          `Rolled back — phantombot still works as before.`,
+        failedStep: searchList.failedStep,
+      };
+    }
+    if (searchList.added) priorSearchList = searchList.priorList;
+
+    // 4. Back up the binary, then sign it.
     await copyFile(binPath, backupPath);
     backedUp = true;
 
@@ -289,7 +376,7 @@ export async function fixSigning(
       };
     }
 
-    // 4. Verify: signature is valid AND the binary still executes.
+    // 5. Verify: signature is valid AND the binary still executes.
     const verified = await verifySignedBinary({ run, binPath });
     if (!verified.ok) {
       await rollback();

--- a/tests/lib-macSigning.test.ts
+++ b/tests/lib-macSigning.test.ts
@@ -20,8 +20,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  ensureKeychainInSearchList,
   fixSigning,
   isSigningConfigured,
+  parseKeychainSearchList,
   resignAfterUpdate,
   SIGNING_PASSWORD_VAULT_KEY,
   type CommandResult,
@@ -102,6 +104,9 @@ describe("fixSigning", () => {
     expect(keys()).toContain("security create-keychain");
     expect(keys()).toContain("openssl req");
     expect(keys()).toContain("security set-key-partition-list");
+    // Keychain registered on the user search list so codesign can resolve the
+    // identity by name (the crux of the #363 fix).
+    expect(keys()).toContain("security list-keychains");
     // Signed with the stable identity + verified.
     expect(keys()).toContain("codesign --force");
     expect(keys()).toContain("codesign --verify");
@@ -178,6 +183,34 @@ describe("fixSigning", () => {
     expect(await readFile(binPath, "utf8")).toBe("ORIGINAL-BINARY");
   });
 
+  test("rollback restores the prior keychain search list on codesign failure", async () => {
+    const { home, binPath } = await tempBinary();
+    const prior = "/Users/x/Library/Keychains/login.keychain-db";
+    const { runner, calls } = fakeRunner({
+      "security find-certificate": { exitCode: 1 },
+      "security list-keychains": { stdout: `    "${prior}"\n` },
+      "codesign --force": { exitCode: 1, stderr: "nope" },
+    });
+    const vault = fakeVault();
+
+    const r = await fixSigning({ runner, vault, binPath, home });
+
+    expect(r.ok).toBe(false);
+    expect(r.failedStep).toBe("codesign");
+    // The LAST list-keychains -s call restores exactly the prior list (no
+    // dangling entry for the keychain we tore down).
+    const setCalls = calls.filter(
+      (c) => c.cmd === "security" && c.args.includes("-s"),
+    );
+    expect(setCalls.at(-1)?.args).toEqual([
+      "list-keychains",
+      "-d",
+      "user",
+      "-s",
+      prior,
+    ]);
+  });
+
   test("rollback on failed exec-check after signing", async () => {
     const { home, binPath } = await tempBinary();
     const { runner } = fakeRunner({
@@ -192,6 +225,83 @@ describe("fixSigning", () => {
     expect(r.ok).toBe(false);
     expect(r.failedStep).toBe("exec-check");
     expect(vault.store.has(SIGNING_PASSWORD_VAULT_KEY)).toBe(false);
+  });
+});
+
+describe("parseKeychainSearchList", () => {
+  test("strips indentation and surrounding quotes", () => {
+    const out =
+      '    "/Users/x/Library/Keychains/login.keychain-db"\n' +
+      '    "/Library/Keychains/System.keychain"\n';
+    expect(parseKeychainSearchList(out)).toEqual([
+      "/Users/x/Library/Keychains/login.keychain-db",
+      "/Library/Keychains/System.keychain",
+    ]);
+  });
+  test("ignores blank lines", () => {
+    expect(parseKeychainSearchList('\n   "/a/b.keychain"\n\n')).toEqual([
+      "/a/b.keychain",
+    ]);
+  });
+});
+
+describe("ensureKeychainInSearchList", () => {
+  const kc = "/home/u/Library/Keychains/phantombot-signing.keychain";
+
+  test("adds the keychain when absent, preserving the prior list", async () => {
+    const { runner, calls } = fakeRunner({
+      "security list-keychains": {
+        stdout: '    "/home/u/Library/Keychains/login.keychain-db"\n',
+      },
+    });
+    const r = await ensureKeychainInSearchList({
+      run: (c, a) => runner.run(c, a),
+      keychainPath: kc,
+    });
+    expect(r.ok).toBe(true);
+    expect(r).toMatchObject({ added: true });
+    // The set call appended our keychain AFTER the existing entries.
+    const setCall = calls.find(
+      (c) => c.cmd === "security" && c.args.includes("-s"),
+    );
+    expect(setCall?.args).toEqual([
+      "list-keychains",
+      "-d",
+      "user",
+      "-s",
+      "/home/u/Library/Keychains/login.keychain-db",
+      kc,
+    ]);
+  });
+
+  test("is a no-op when already present (tolerates the -db suffix)", async () => {
+    // macOS reports the on-disk `.keychain-db` even though we pass `.keychain`.
+    const { runner, calls } = fakeRunner({
+      "security list-keychains": {
+        stdout:
+          '    "/home/u/Library/Keychains/login.keychain-db"\n' +
+          `    "${kc}-db"\n`,
+      },
+    });
+    const r = await ensureKeychainInSearchList({
+      run: (c, a) => runner.run(c, a),
+      keychainPath: kc,
+    });
+    expect(r).toEqual({ ok: true, added: false });
+    // No mutating `-s` call was issued.
+    expect(calls.some((c) => c.args.includes("-s"))).toBe(false);
+  });
+
+  test("surfaces a read failure without mutating", async () => {
+    const { runner, calls } = fakeRunner({
+      "security list-keychains": { exitCode: 1 },
+    });
+    const r = await ensureKeychainInSearchList({
+      run: (c, a) => runner.run(c, a),
+      keychainPath: kc,
+    });
+    expect(r).toEqual({ ok: false, failedStep: "list-keychains-read" });
+    expect(calls.some((c) => c.args.includes("-s"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Root cause (reproduced on a live install)

The stable code-signing re-sign has been silently failing on **every** macOS `/update` and `fix-signing`, leaving installs ad-hoc signed and still nagging. Root-caused on Matt:

`codesign --sign phantombot-codesign` resolves the identity **by name through the USER keychain search list** — the `--keychain <path>` argument does *not* scope that lookup. We create a dedicated `phantombot-signing.keychain` but never add it to the search list, so:

```
codesign: phantombot-codesign: no identity found
```

In a headless context (launchd after `/update`, or SSH) that stalls → 60s timeout → rollback. The safety net (#361) fired correctly every time — clean teardown, working binary — but the stable identity never landed.

**Proof:** on the exact headless SSH session, `codesign --sign … --keychain <path>` with the keychain *not* in the search list → `no identity found`; after `security list-keychains -d user -s <old…> <kc>`, the same codesign signs first try (`Identifier=dev.phantombot`).

Two earlier hypotheses were **checked and killed**: the `set-key-partition-list` call is already present and correct, and cert trust is a red herring (codesign signs fine with an untrusted-but-findable identity).

## Fix

- **`ensureKeychainInSearchList`** — idempotent add of the dedicated keychain to the user search list, run right before codesign. Tolerates macOS's `-db` suffix (`create-keychain foo.keychain` materialises `foo.keychain-db`) so it never appends a duplicate. Returns the prior list.
- **`fixSigning` rollback** — if we changed the search list this run, restore the prior list *before* deleting the keychain, so no dangling entry is left. Roll back everything this run created, or nothing.
- Login keychain and the system domain are never touched; only the user search list, only our own keychain.

## Tests
- 8 new unit tests (injected CommandRunner, no Mac): parse, idempotent no-op with `-db` tolerance, add-when-absent preserving order, read-failure surfaces without mutating, and `fixSigning` rollback restores the prior search list on codesign failure.
- `tsc` clean. Full suite: 2651 pass / 1 fail — the pre-existing unrelated `config.test.ts` Gemini-embeddings failure that's on `main` (verified by stashing this diff).

Follow-up to #361/#362. Once merged it cuts a release; `/update` on an affected Mac should then land the stable `dev.phantombot` identity and stop the TCC nagging for good.