### PR TITLE
harness: startup timeout + mcpMode:none for tool-less transports (#360)

### DIFF
--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -490,6 +490,7 @@ export async function runTelegramServer(
           memory: input.memory,
           idleTimeoutMs: input.config.harnessIdleTimeoutMs,
           hardTimeoutMs: input.config.harnessHardTimeoutMs,
+          startupTimeoutMs: input.config.harnessStartupTimeoutMs,
           // Reaction from an allow-listed principal → trusted, so the memory
           // capture may write. runReactionTurn skips the threat screen for it.
           trusted: true,
@@ -1267,6 +1268,7 @@ async function processChatMessage(
       memory: input.memory,
       idleTimeoutMs: input.config.harnessIdleTimeoutMs,
       hardTimeoutMs: input.config.harnessHardTimeoutMs,
+      startupTimeoutMs: input.config.harnessStartupTimeoutMs,
       signal: controller.signal,
       // Security perimeter: the ONLY place `trusted: true` originates.
       // True iff the sender is an allow-listed principal (see the

--- a/src/channels/core/reactions.ts
+++ b/src/channels/core/reactions.ts
@@ -240,6 +240,7 @@ export interface RunReactionTurnInput {
   memory: MemoryStore;
   idleTimeoutMs: number;
   hardTimeoutMs?: number;
+  startupTimeoutMs?: number;
   /**
    * Trust provenance — true only when the reactor is an allow-listed principal.
    * A reaction from the principal is trusted (so the capture can write memory);
@@ -287,6 +288,7 @@ export async function runReactionTurn(
       memory: input.memory,
       idleTimeoutMs: input.idleTimeoutMs,
       hardTimeoutMs: input.hardTimeoutMs,
+      startupTimeoutMs: input.startupTimeoutMs,
       signal: input.signal,
       trusted: input.trusted,
       // Reactions from the principal are trusted, so no threat screen. Pass

--- a/src/channels/phantomchat/greet.ts
+++ b/src/channels/phantomchat/greet.ts
@@ -59,6 +59,7 @@ export async function resolvePersonaGreeting(input: {
   harnesses: Harness[];
   idleTimeoutMs: number;
   hardTimeoutMs?: number;
+  startupTimeoutMs?: number;
   signal?: AbortSignal;
 }): Promise<string> {
   try {
@@ -78,6 +79,7 @@ export async function resolvePersonaGreeting(input: {
       workingDir: input.agentDir,
       idleTimeoutMs: input.idleTimeoutMs,
       hardTimeoutMs: input.hardTimeoutMs,
+      startupTimeoutMs: input.startupTimeoutMs,
       signal: input.signal,
     })) {
       if (chunk.type === "text") text += chunk.text;

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -879,6 +879,7 @@ export async function runPhantomchatServer(
         memory: input.memory,
         idleTimeoutMs: input.config.harnessIdleTimeoutMs,
         hardTimeoutMs: input.config.harnessHardTimeoutMs,
+        startupTimeoutMs: input.config.harnessStartupTimeoutMs,
         signal: turnSignal,
         // The trust grant — see the auth gate above. Always true here because
         // we already dropped non-allowlisted senders.
@@ -1249,6 +1250,7 @@ export async function runPhantomchatServer(
         memory: input.memory,
         idleTimeoutMs: input.config.harnessIdleTimeoutMs,
         hardTimeoutMs: input.config.harnessHardTimeoutMs,
+        startupTimeoutMs: input.config.harnessStartupTimeoutMs,
         trusted: true,
         send: (text) => transport.sendMessage(reaction.conversationId, text),
         retrieve: makeRetriever(

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -820,6 +820,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
               harnesses,
               idleTimeoutMs: config.harnessIdleTimeoutMs,
               hardTimeoutMs: config.harnessHardTimeoutMs,
+              startupTimeoutMs: config.harnessStartupTimeoutMs,
               signal: ac.signal,
             });
             await greetPendingNpubs({

--- a/src/config.ts
+++ b/src/config.ts
@@ -474,6 +474,16 @@ export interface Config {
    * Caps runaway agents that legitimately keep emitting but never finish.
    */
   harnessHardTimeoutMs: number;
+  /**
+   * Cap on time-to-first-output for a foreground harness turn. A subprocess
+   * that emits nothing at all (classically `claude --print` wedged on its MCP
+   * `initialize` handshake) would otherwise idle for the full
+   * harnessIdleTimeoutMs before failing over. This bounds the startup phase
+   * separately so the orchestrator advances to the next harness in seconds.
+   * Set generously (default 60s) so a healthy-but-slow cold start under load —
+   * the same contention that triggers the wedge — is never false-killed.
+   */
+  harnessStartupTimeoutMs: number;
   /** Directory holding `<persona>/` subdirs. */
   personasDir: string;
   /** Path to the SQLite memory store file. */
@@ -723,6 +733,20 @@ export async function loadConfig(): Promise<Config> {
         : undefined) ??
       legacyTurnTimeoutMs(toml) ??
       300_000,
+
+    // Time-to-first-output cap for foreground turns. Default 60s: a healthy
+    // `claude --print` emits its `system init` line within ~1s once the MCP
+    // handshake completes (a live proxy answers `initialize` in well under a
+    // second), so 60s is a wide margin over even a loaded cold start while
+    // still cutting a genuine startup wedge from the 300s idle window down to
+    // one minute. Env/toml overridable; the idle timer still runs concurrently,
+    // so whichever ceiling is lower fires first.
+    harnessStartupTimeoutMs:
+      asInt(process.env.PHANTOMBOT_HARNESS_STARTUP_TIMEOUT_MS) ??
+      (asInt(toml.harness_startup_timeout_s) !== undefined
+        ? asInt(toml.harness_startup_timeout_s)! * 1000
+        : undefined) ??
+      60_000,
 
     harnessHardTimeoutMs,
 

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -50,6 +50,19 @@ export interface HarnessRequest {
    * fed but never converge on a final reply.
    */
   hardTimeoutMs?: number;
+  /**
+   * Startup timeout: kill the subprocess if it produces NO stdout at all
+   * within this window. Distinct from idleTimeoutMs, which only bounds silence
+   * AFTER output has begun — a subprocess that emits nothing still had to wait
+   * the full idle window before the idle timer fired. This bounds the
+   * pre-first-output phase so a harness wedged on startup (classically
+   * `claude --print` blocking its MCP `initialize` handshake on a proxy that
+   * never answers) fails over in seconds, not minutes. Omit to disable (only
+   * the idle window bounds startup silence). Foreground persona turns set this;
+   * tool-less background transports (threat judge, durable-facts) omit it
+   * because they run with `mcpMode: "none"` and cannot wedge on the handshake.
+   */
+  startupTimeoutMs?: number;
   /** External abort signal (e.g. /stop command). When fired, the harness should kill the subprocess and yield a non-recoverable "stopped" error. */
   signal?: AbortSignal;
   /**

--- a/src/lib/harnessRunner.ts
+++ b/src/lib/harnessRunner.ts
@@ -39,7 +39,13 @@ type HarnessSubprocess = Subprocess<
   SpawnOptions.Readable
 >;
 
-export type KillCause = "timeout" | "idle" | "aborted" | "policy" | undefined;
+export type KillCause =
+  | "timeout"
+  | "idle"
+  | "startup"
+  | "aborted"
+  | "policy"
+  | undefined;
 export type HarnessActivity = "model" | "tool" | "productive";
 
 export interface KillCoordinatorOpts {
@@ -48,6 +54,19 @@ export interface KillCoordinatorOpts {
   idleTimeoutMs: number;
   /** Hard wall-clock cap. Never resets. Omit to disable the wall-clock SIGTERM. */
   hardTimeoutMs?: number;
+  /**
+   * Cap on time-to-FIRST-stdout-byte. Distinct from idleTimeoutMs, which only
+   * starts biting once output has begun and then resets on every chunk — a
+   * subprocess that emits NOTHING at all still had to wait the full idle window
+   * (default 300s) before the idle timer fired. This bounds that startup phase
+   * separately so a harness wedged BEFORE it produces any output (the classic
+   * case: `claude --print` blocking its MCP `initialize` handshake on a proxy
+   * that never answers — e.g. under Windows SQLite lock contention) fails over
+   * to the next harness in seconds, not minutes. Cleared on the first stdout
+   * byte via firstOutput(); after that, only idle/hard/tool timers apply. Omit
+   * to disable (legacy behaviour: only the idle window bounds startup silence).
+   */
+  startupTimeoutMs?: number;
   /**
    * Wall-clock cap on how long a SINGLE contiguous tool-run may keep resetting
    * the idle timer via `"tool"` activity WITHOUT any productive output.
@@ -76,6 +95,13 @@ export interface KillCoordinator {
    *   the idle window until productive output arrives
    */
   touch(activity?: HarnessActivity): void;
+  /**
+   * Signal that the subprocess has produced its first stdout byte, cancelling
+   * the startup timer (see startupTimeoutMs). Idempotent and cheap — the runner
+   * calls it on every stdout chunk; only the first call does anything. A no-op
+   * when startupTimeoutMs was not set or the coordinator already fired/disposed.
+   */
+  firstOutput(): void;
   /** Stop all timers and detach signal listener. Idempotent. */
   dispose(): Promise<void>;
   /**
@@ -121,6 +147,13 @@ export function createKillCoordinator(
     opts.hardTimeoutMs === undefined
       ? undefined
       : setTimeout(() => triggerKill("timeout"), opts.hardTimeoutMs);
+  // Startup timer: fires only if the subprocess emits NO stdout at all before
+  // it elapses. Cancelled by firstOutput() on the first stdout byte. See
+  // KillCoordinatorOpts.startupTimeoutMs.
+  let startupTimer: ReturnType<typeof setTimeout> | undefined =
+    opts.startupTimeoutMs === undefined
+      ? undefined
+      : setTimeout(() => triggerKill("startup"), opts.startupTimeoutMs);
 
   const onAbort = (): void => triggerKill("aborted");
   if (opts.signal) {
@@ -168,6 +201,13 @@ export function createKillCoordinator(
         opts.idleTimeoutMs,
       );
     },
+    firstOutput(): void {
+      if (cause || disposed) return;
+      if (startupTimer) {
+        clearTimeout(startupTimer);
+        startupTimer = undefined;
+      }
+    },
     terminate(): void {
       triggerKill("policy");
     },
@@ -176,6 +216,7 @@ export function createKillCoordinator(
       disposed = true;
       clearTimeout(idleTimer);
       if (hardTimer) clearTimeout(hardTimer);
+      if (startupTimer) clearTimeout(startupTimer);
       if (opts.signal && !opts.signal.aborted) {
         opts.signal.removeEventListener("abort", onAbort);
       }
@@ -192,6 +233,8 @@ export function createKillCoordinator(
  *
  *   - "timeout"  → recoverable (orchestrator advances to next harness)
  *   - "idle"     → recoverable (same — wedged subprocess, try a different one)
+ *   - "startup"  → recoverable (never produced output — likely wedged on init;
+ *     orchestrator falls through fast instead of eating the full idle window)
  *   - "aborted"  → non-recoverable (user said /stop and meant it)
  *   - "policy"   → recoverable (terminal tripwire; normally unreachable here
  *     because the tripwire's own error chunk was already yielded and the
@@ -202,6 +245,7 @@ export function killCauseToErrorChunk(
   harnessId: string,
   hardTimeoutMs: number | undefined,
   idleTimeoutMs: number,
+  startupTimeoutMs?: number,
 ):
   | { type: "error"; error: string; recoverable: boolean }
   | undefined {
@@ -216,6 +260,13 @@ export function killCauseToErrorChunk(
     return {
       type: "error",
       error: `${harnessId} timed out after ${idleTimeoutMs}ms with no output (likely wedged on a tool call)`,
+      recoverable: true,
+    };
+  }
+  if (cause === "startup") {
+    return {
+      type: "error",
+      error: `${harnessId} produced no output within ${startupTimeoutMs ?? "unknown"}ms of startup (likely wedged on the MCP/init handshake)`,
       recoverable: true,
     };
   }
@@ -358,6 +409,7 @@ export async function* runHarnessProcess(
     proc,
     idleTimeoutMs: req.idleTimeoutMs,
     hardTimeoutMs: req.hardTimeoutMs,
+    startupTimeoutMs: req.startupTimeoutMs,
     toolTimeoutMs: spec.toolTimeoutMs,
     signal: req.signal,
     harnessId,
@@ -424,9 +476,15 @@ export async function* runHarnessProcess(
 
   try {
     for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
-      // NB: do NOT touch() here. The idle timer must measure time since last
-      // *productive* output, not since last raw chunk — otherwise synthetic
-      // heartbeats keep postponing the idle kill on a wedged turn. See #123.
+      // First stdout byte means the subprocess got past its startup/init
+      // handshake and is alive — cancel the startup timer. Idempotent, so
+      // calling it every iteration is cheap. NB: this is deliberately distinct
+      // from touch(): startup measures "any output at all", while the idle
+      // timer below measures "productive output". We do NOT touch() here — the
+      // idle timer must measure time since last *productive* output, not since
+      // last raw chunk, or synthetic heartbeats keep postponing the idle kill
+      // on a wedged turn. See #123.
+      killer.firstOutput();
       buffer += decoder.decode(chunk, { stream: true });
       const lines = buffer.split("\n");
       buffer = lines.pop() ?? "";
@@ -488,6 +546,7 @@ export async function* runHarnessProcess(
     harnessId,
     req.hardTimeoutMs,
     req.idleTimeoutMs,
+    req.startupTimeoutMs,
   );
   if (errChunk) {
     yield errChunk;

--- a/src/lib/threatJudge.ts
+++ b/src/lib/threatJudge.ts
@@ -453,6 +453,13 @@ export function makeHarnessJudgeComplete(
       idleTimeoutMs,
       hardTimeoutMs,
       toolsMode: "none",
+      // The judge is a tool-less classifier that never needs MCP. Without this
+      // the claude harness takes the foreground branch and spawns the loopback
+      // MCP proxy, blocking the `--print` initialize handshake on it — which can
+      // wedge for the full idle window under load. mcpMode:"none" runs zero MCP
+      // servers, matching the intended contract (toolsMode alone did not) and
+      // keeping every untrusted-input screen off the proxy-spawn path.
+      mcpMode: "none",
       signal,
     })) {
       const c: HarnessChunk = chunk;

--- a/src/orchestrator/durableFacts.ts
+++ b/src/orchestrator/durableFacts.ts
@@ -406,6 +406,13 @@ export function makeExtractionComplete(
       idleTimeoutMs: config.harnessIdleTimeoutMs,
       hardTimeoutMs: config.harnessHardTimeoutMs,
       toolsMode: "none",
+      // Persona-less, tool-less extraction NEVER needs MCP. Without this the
+      // claude harness falls into the foreground branch, spawns the loopback
+      // MCP proxy, and blocks the `--print` initialize handshake on it — which
+      // can wedge for the full idle window under load (e.g. Windows SQLite lock
+      // contention on the proxy's store). mcpMode:"none" runs zero MCP servers,
+      // matching the intended "no MCP" contract (toolsMode alone did not).
+      mcpMode: "none",
       signal,
     })) {
       const c: HarnessChunk = chunk;

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -64,6 +64,8 @@ export interface TurnInput {
   idleTimeoutMs: number;
   /** Hard wall-clock ceiling regardless of activity. */
   hardTimeoutMs?: number;
+  /** Kill subprocess if it emits no output at all within this long (startup/init wedge guard). Omit to disable. */
+  startupTimeoutMs?: number;
   /** Number of prior turns to load. Default 30. */
   historyLimit?: number;
   /** Skip loading prior turns AND skip persisting this one. Default false. */
@@ -334,6 +336,7 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
       workingDir: input.workingDir ?? homedir(),
       idleTimeoutMs: input.idleTimeoutMs,
       hardTimeoutMs: input.hardTimeoutMs,
+      startupTimeoutMs: input.startupTimeoutMs,
       mcpMode: input.mcpMode,
       signal: input.signal,
     },

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -441,7 +441,7 @@ describe("/update", () => {
     const minimalConfig = {
       defaultPersona: "phantom",
       harnessIdleTimeoutMs: 1000,
-      harnessHardTimeoutMs: 1000,
+      harnessHardTimeoutMs: 1000, harnessStartupTimeoutMs: 1000,
       personasDir: "/tmp",
       memoryDbPath: ":memory:",
       configPath: "/tmp/c.toml",

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -114,7 +114,7 @@ afterEach(async () => {
 const baseConfig = (): Config => ({
   defaultPersona: "phantom",
   harnessIdleTimeoutMs: 5_000,
-  harnessHardTimeoutMs: 5_000,
+  harnessHardTimeoutMs: 5_000, harnessStartupTimeoutMs: 5_000,
   personasDir: join(workdir, "personas"),
   memoryDbPath: join(workdir, "memory.sqlite"),
   configPath: join(workdir, "config.toml"),

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -692,7 +692,7 @@ const baseConfig = (
   overrides: Partial<NonNullable<Config["channels"]["telegram"]>> = {},
 ): Config => ({
   defaultPersona: "phantom",
-  harnessIdleTimeoutMs: 5_000, harnessHardTimeoutMs: 5_000,
+  harnessIdleTimeoutMs: 5_000, harnessHardTimeoutMs: 5_000, harnessStartupTimeoutMs: 5_000,
   personasDir: join(workdir, "personas"),
   memoryDbPath: join(workdir, "memory.sqlite"),
   configPath: join(workdir, "config.toml"),

--- a/tests/cli-ask.test.ts
+++ b/tests/cli-ask.test.ts
@@ -54,7 +54,7 @@ beforeEach(async () => {
   config = {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 5000,
-    harnessHardTimeoutMs: 5000,
+    harnessHardTimeoutMs: 5000, harnessStartupTimeoutMs: 5000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-create-persona.test.ts
+++ b/tests/cli-create-persona.test.ts
@@ -23,7 +23,7 @@ beforeEach(async () => {
   process.env.PHANTOMBOT_STATE = join(workdir, "state.json");
   config = {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -27,7 +27,7 @@ beforeEach(async () => {
   config = {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 600_000,
-    harnessHardTimeoutMs: 600_000,
+    harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -36,7 +36,7 @@ beforeEach(async () => {
   process.env.XDG_STATE_HOME = workdir;
   config = {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-import-persona.test.ts
+++ b/tests/cli-import-persona.test.ts
@@ -60,7 +60,7 @@ beforeEach(async () => {
   await mkdir(join(workdir, "personas"), { recursive: true });
   config = {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-memory.test.ts
+++ b/tests/cli-memory.test.ts
@@ -45,7 +45,7 @@ beforeEach(async () => {
   indexPath = join(workdir, "index.sqlite");
   config = {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -24,7 +24,7 @@ beforeEach(async () => {
   await mkdir(join(workdir, "personas", "phantom"), { recursive: true });
   config = {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-notify.test.ts
+++ b/tests/cli-notify.test.ts
@@ -74,7 +74,7 @@ afterEach(() => {
 function baseConfig(): Config {
   return {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000,
+    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000, harnessStartupTimeoutMs: 1000,
     personasDir: "/tmp",
     memoryDbPath: ":memory:",
     configPath: "/tmp/c.toml",

--- a/tests/cli-persona.test.ts
+++ b/tests/cli-persona.test.ts
@@ -67,7 +67,7 @@ afterEach(async () => {
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000,
+    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000, harnessStartupTimeoutMs: 1000,
     personasDir,
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath,

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -44,7 +44,7 @@ beforeEach(async () => {
   );
   config = {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-task.test.ts
+++ b/tests/cli-task.test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
   store = await openTaskStore(join(workdir, "tasks.sqlite"));
   config = {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000,
+    harnessIdleTimeoutMs: 1000, harnessHardTimeoutMs: 1000, harnessStartupTimeoutMs: 1000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "tasks.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -118,7 +118,7 @@ beforeEach(async () => {
 
   config = {
     defaultPersona: "phantom",
-    harnessIdleTimeoutMs: 5000, harnessHardTimeoutMs: 5000,
+    harnessIdleTimeoutMs: 5000, harnessHardTimeoutMs: 5000, harnessStartupTimeoutMs: 5000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/connectors-acp-server.test.ts
+++ b/tests/connectors-acp-server.test.ts
@@ -91,7 +91,7 @@ beforeEach(async () => {
   config = {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 5000,
-    harnessHardTimeoutMs: 5000,
+    harnessHardTimeoutMs: 5000, harnessStartupTimeoutMs: 5000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),
@@ -1076,7 +1076,7 @@ describe("ACP server — persona resolution & self-heal", () => {
     healConfig = {
       defaultPersona: "phantom", // built-in default whose dir is NOT created
       harnessIdleTimeoutMs: 5000,
-      harnessHardTimeoutMs: 5000,
+      harnessHardTimeoutMs: 5000, harnessStartupTimeoutMs: 5000,
       personasDir: join(pdir, "personas"),
       memoryDbPath: join(pdir, "memory.sqlite"),
       configPath: join(pdir, "config.toml"),

--- a/tests/lib-audio.test.ts
+++ b/tests/lib-audio.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 function makeConfig(provider: Config["voice"]["provider"]): Config {
   const base: Omit<Config, "voice"> = {
     defaultPersona: "x",
-    harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1,
+    harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1, harnessStartupTimeoutMs: 1,
     personasDir: "/tmp",
     memoryDbPath: "/tmp/m.sqlite",
     configPath: "/tmp/c.toml",

--- a/tests/lib-embedJob.test.ts
+++ b/tests/lib-embedJob.test.ts
@@ -252,7 +252,7 @@ describe("defaultEmbedder", () => {
   test("returns undefined when provider is not gemini", () => {
     const e = defaultEmbedder({
       defaultPersona: "x",
-      harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1,
+      harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1, harnessStartupTimeoutMs: 1,
       personasDir: "/tmp",
       memoryDbPath: "/tmp/m.sqlite",
       configPath: "/tmp/c.toml",
@@ -271,7 +271,7 @@ describe("defaultEmbedder", () => {
   test("returns undefined when provider is gemini but apiKey is empty", () => {
     const e = defaultEmbedder({
       defaultPersona: "x",
-      harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1,
+      harnessIdleTimeoutMs: 1, harnessHardTimeoutMs: 1, harnessStartupTimeoutMs: 1,
       personasDir: "/tmp",
       memoryDbPath: "/tmp/m.sqlite",
       configPath: "/tmp/c.toml",

--- a/tests/lib-harnessRunner.test.ts
+++ b/tests/lib-harnessRunner.test.ts
@@ -94,6 +94,91 @@ describe("createKillCoordinator — idle timer", () => {
   });
 });
 
+describe("createKillCoordinator — startup timer", () => {
+  test("startup timer fires when the subprocess emits NO output before startupTimeoutMs", async () => {
+    // Process is silent for 30s (mimics `claude --print` wedged on its MCP
+    // init handshake — nothing ever reaches stdout). firstOutput() is never
+    // called, so the startup timer must fire and kill the group.
+    const proc = spawnInNewSession(["sh", "-c", "sleep 30"], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 10_000, // long; would NOT fire in this window
+      hardTimeoutMs: 10_000,
+      startupTimeoutMs: 150,
+      harnessId: "test",
+    });
+
+    await proc.exited;
+    await killer.dispose();
+
+    expect(killer.killCause()).toBe("startup");
+  });
+
+  test("firstOutput() cancels the startup timer so a slow-but-alive turn survives", async () => {
+    // Emits one line immediately, then goes quiet for 300ms — longer than the
+    // 100ms startup window but well under the 5s idle window. firstOutput() on
+    // the first byte must cancel the startup timer; the idle timer governs from
+    // there, so the process runs to completion uncancelled.
+    const proc = spawnInNewSession(["sh", "-c", "echo hi; sleep 0.3"], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 5000,
+      hardTimeoutMs: 10_000,
+      startupTimeoutMs: 100,
+      harnessId: "test",
+    });
+
+    const decoder = new TextDecoder();
+    const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+    const { value } = await reader.read();
+    killer.firstOutput(); // first byte: cancels the startup timer
+    if (value) killer.touch();
+    expect(decoder.decode(value)).toContain("hi");
+    reader.releaseLock();
+
+    await proc.exited;
+    await killer.dispose();
+
+    // Startup timer was cancelled; idle window (5s) never elapsed → clean exit.
+    expect(killer.killCause()).toBeUndefined();
+  });
+
+  test("no startupTimeoutMs → startup timer disabled (legacy behaviour)", async () => {
+    // Silent process, but startupTimeoutMs omitted: only the idle window bounds
+    // startup silence. With a long idle window the process is NOT startup-killed.
+    const proc = spawnInNewSession(["sh", "-c", "sleep 0.3"], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    trackedPids.push(proc.pid!);
+
+    const killer = createKillCoordinator({
+      proc,
+      idleTimeoutMs: 5000,
+      hardTimeoutMs: 10_000,
+      harnessId: "test",
+    });
+
+    await proc.exited;
+    await killer.dispose();
+
+    expect(killer.killCause()).toBeUndefined();
+  });
+});
+
 describe("createKillCoordinator — tool cap (issue #351)", () => {
   test("sustained 'tool' activity past toolTimeoutMs lets the idle kill fire", async () => {
     // A wedged-but-chattery tool: we drive touch("tool") forever. Without a
@@ -285,6 +370,17 @@ describe("killCauseToErrorChunk", () => {
     expect(c?.error).toContain("no output");
   });
 
+  test("startup cause → recoverable error mentioning the startup window", () => {
+    const c = killCauseToErrorChunk("startup", "claude", 60_000, 300_000, 45_000);
+    expect(c).toMatchObject({
+      type: "error",
+      recoverable: true,
+    });
+    expect(c?.error).toContain("45000ms");
+    expect(c?.error).toContain("no output");
+    expect(c?.error).toContain("handshake");
+  });
+
   test("aborted cause → non-recoverable 'stopped'", () => {
     const c = killCauseToErrorChunk("aborted", "pi", 1000, 100);
     expect(c).toMatchObject({
@@ -350,6 +446,51 @@ describe("runHarnessProcess — regression: stdin blocking hang", () => {
     const errorChunk = chunks.find(c => c.type === "error");
     expect(errorChunk).toBeDefined();
     expect(errorChunk.error).toContain("hard wall-clock");
+    expect(errorChunk.recoverable).toBe(true);
+  });
+});
+
+describe("runHarnessProcess — startup wedge", () => {
+  test("a silent subprocess yields a recoverable 'startup' error fast", async () => {
+    // Mimics a foreground harness wedged before any output (blocked MCP init).
+    // startupTimeoutMs is short; the runner must surface a recoverable error
+    // WELL before the (long) idle window would have fired.
+    const proc = spawnInNewSession(["sleep", "30"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    trackedPids.push(proc.pid!);
+
+    const startTime = Date.now();
+    const chunks: any[] = [];
+    const generator = runHarnessProcess({
+      proc,
+      harnessId: "test-harness",
+      req: {
+        idleTimeoutMs: 10_000, // would NOT fire in the test window
+        hardTimeoutMs: 10_000,
+        startupTimeoutMs: 200,
+        workingDir: process.cwd(),
+        persona: "test",
+        trusted: true,
+        conversation: "test",
+        userMessage: "test",
+      } as any,
+      stdinPayload: "hi",
+      parseEvent: () => undefined,
+      activity: () => "productive",
+      buildDoneMeta: () => ({}),
+    });
+
+    for await (const chunk of generator) {
+      chunks.push(chunk);
+    }
+
+    expect(Date.now() - startTime).toBeLessThan(5000);
+    const errorChunk = chunks.find((c) => c.type === "error");
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error).toContain("no output");
     expect(errorChunk.recoverable).toBe(true);
   });
 });

--- a/tests/lib-heartbeat.test.ts
+++ b/tests/lib-heartbeat.test.ts
@@ -249,7 +249,7 @@ describe("runHeartbeat update check hook", () => {
     return {
       defaultPersona: "phantom",
       harnessIdleTimeoutMs: 1000,
-      harnessHardTimeoutMs: 1000,
+      harnessHardTimeoutMs: 1000, harnessStartupTimeoutMs: 1000,
       personasDir: "/tmp",
       memoryDbPath: ":memory:",
       configPath: "/tmp/c.toml",

--- a/tests/lib-modelCommand.test.ts
+++ b/tests/lib-modelCommand.test.ts
@@ -58,7 +58,7 @@ function makeConfig(overrides: Partial<Config["harnesses"]> = {}): Config {
   return {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 1000,
-    harnessHardTimeoutMs: 1000,
+    harnessHardTimeoutMs: 1000, harnessStartupTimeoutMs: 1000,
     personasDir: dir,
     memoryDbPath: ":memory:",
     configPath,

--- a/tests/lib-personaBackfill.test.ts
+++ b/tests/lib-personaBackfill.test.ts
@@ -24,7 +24,7 @@ beforeEach(async () => {
   config = {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 600_000,
-    harnessHardTimeoutMs: 600_000,
+    harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir: join(workdir, "personas"),
     memoryDbPath: join(workdir, "memory.sqlite"),
     configPath: join(workdir, "config.toml"),

--- a/tests/lib-personaDefault.test.ts
+++ b/tests/lib-personaDefault.test.ts
@@ -28,7 +28,7 @@ class CaptureStream {
 function makeConfig(personasDir: string, defaultPersona = "phantom"): Config {
   return {
     defaultPersona,
-    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000,
+    harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
     personasDir,
     memoryDbPath: join(personasDir, "..", "memory.sqlite"),
     configPath: join(personasDir, "..", "config.toml"),

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -67,7 +67,7 @@ function baseConfig(): Config {
   return {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 1000,
-    harnessHardTimeoutMs: 1000,
+    harnessHardTimeoutMs: 1000, harnessStartupTimeoutMs: 1000,
     personasDir: "/tmp",
     memoryDbPath: ":memory:",
     configPath: "/tmp/c.toml",


### PR DESCRIPTION
Fixes the claude-only Windows/VSCode turn wedges tracked in #360.

## Root cause (verified against Megan's v1.1.247 logs)

A foreground `claude --print` turn blocks its MCP `initialize` handshake on the loopback `phantombot mcp proxy` subprocess it spawns as its MCP server. Under Windows SQLite lock contention the proxy can stall opening its store, so the handshake never resolves — claude emits **nothing**, and the turn burns the full 300s idle window before failing over.

**Pi never spawns a proxy** (built-in tools) — that's the claude-vs-pi differentiator, and why swapping Megan to pi "fixed" it: the orchestrator already auto-falls-through to pi on the wedge, so the manual swap just skipped the 5-minute wait.

This reframes the issue away from the original "harden Windows process reaping" hypothesis. Megan's logs show **zero** Job-Object / orphan / reparent signatures — the harness isn't leaving orphans, it's synchronously hanging on init.

## The fix (two parts)

**1. Startup timeout (`harnessStartupTimeoutMs`, default 60s).**
A new `KillCoordinator` timer bounding time-to-first-stdout-byte, distinct from the idle timer (which only bites once output has begun). Cleared on the first stdout byte via `firstOutput()`. A turn wedged before any output now fails over in ~60s instead of 300s. New recoverable `KillCause` `"startup"`. Wired through every foreground path; configurable via `PHANTOMBOT_HARNESS_STARTUP_TIMEOUT_MS` / `harness_startup_timeout_s`. The default is deliberately generous so a healthy-but-slow cold start under the *same* load that triggers the wedge is never false-killed.

**2. `mcpMode:"none"` on the durable-facts and threat-judge transports.**
Both are persona-less, tool-less completions that never need MCP, but they set `toolsMode:"none"` **without** `mcpMode:"none"` — so the claude harness took the foreground branch and spawned the proxy anyway. Setting `mcpMode:"none"` runs them with zero MCP servers, matching the intended contract and keeping background extraction *and* every untrusted-input screen off the proxy-spawn path.

## Deliberately NOT included (per the #360 discussion)

- **Idle-budget decay down the chain** — redundant once startup fails fast.
- **Canned chain-exhaust message** — a hardcoded English string with no i18n support on the app. Surface the structured error and let fallthrough do its job instead.

## Tests

Startup-timer unit tests (fires on silence, cancelled by first output, disabled when unset), `killCauseToErrorChunk` `"startup"` branch, and a `runHarnessProcess` integration test proving the recoverable error surfaces fast. `tsc --noEmit` clean; existing suites green (the 5 unrelated failures on `main` — gemini-chain migration + `acquireRunLock`/memory-store-concurrent sandbox file-lock — pre-date this branch).

## Honest caveat

Megan's box is healthy now (proxy answers `initialize` in ~347ms), so the "proxy stalled under lock contention" step is strong inference from the co-timed `database is locked` error storm, not a captured proxy-init failure. The startup timeout is the right mitigation regardless of the exact stall source — it bounds *any* pre-output wedge.
