### PR TITLE
logger: route all levels to stderr, keep stdout clean for ACP/MCP wire

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,5 +1,9 @@
 /**
- * Tiny structured logger. Writes JSON lines to stdout.
+ * Tiny structured logger. Writes JSON lines to stderr.
+ *
+ * ALL levels (debug, info, warn, error) go to stderr. stdout is a protocol
+ * channel for two entrypoints (ACP stdio server + MCP proxy) — any stray
+ * write there corrupts the JSON-RPC wire and the editor drops the connection.
  *
  * Replace with pino / winston / etc. if you outgrow this. The interface here
  * is intentionally narrow so the swap stays small.
@@ -37,9 +41,9 @@ function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): v
     msg,
     ...(fields ?? {}),
   };
-  // stderr for warn/error so log shippers can split if desired.
-  const stream = level === "warn" || level === "error" ? process.stderr : process.stdout;
-  stream.write(redactForLog(JSON.stringify(line)) + "\n");
+  // ALL levels go to stderr. stdout is a protocol channel for two entrypoints
+  // (ACP stdio server + MCP proxy) — any stray write there corrupts the wire.
+  process.stderr.write(redactForLog(JSON.stringify(line)) + "\n");
 }
 
 export const log = {

--- a/tests/cli-tick.test.ts
+++ b/tests/cli-tick.test.ts
@@ -51,20 +51,20 @@ function installFetchTrap(): { calls: FetchCall[]; restore: () => void } {
   return { calls, restore: () => { globalThis.fetch = original; } };
 }
 
-function captureStdout(): {
+function captureStream(which: "stdout" | "stderr"): {
   lines: string[];
   restore: () => void;
 } {
   const lines: string[] = [];
-  const original = process.stdout.write;
-  process.stdout.write = ((chunk: unknown) => {
+  const original = process[which].write;
+  process[which].write = ((chunk: unknown) => {
     lines.push(String(chunk));
     return true;
   }) as typeof process.stdout.write;
   return {
     lines,
     restore: () => {
-      process.stdout.write = original;
+      process[which].write = original;
     },
   };
 }
@@ -190,7 +190,7 @@ describe("runTick — normal task fire", () => {
       { type: "text", text: "partial " },
       { type: "done", finalText: "partial done" },
     ]);
-    const capture = captureStdout();
+    const capture = captureStream("stderr");
     const trap = installFetchTrap();
     try {
       await runTick({

--- a/tests/lib-logger.test.ts
+++ b/tests/lib-logger.test.ts
@@ -58,9 +58,9 @@ describe("logger redaction", () => {
     expect(String(line.error)).toContain("[REDACTED]");
   });
 
-  test("redacts a secret in the message itself (info → stdout)", () => {
+  test("redacts a secret in the message itself (info → stderr)", () => {
     log.info("loaded TELEGRAM_BOT_TOKEN=secret-value-123 from env");
-    const line = lastLine(out.lines);
+    const line = lastLine(err.lines);
     expect(String(line.msg)).not.toContain("secret-value-123");
     expect(String(line.msg)).toContain("[REDACTED]");
   });
@@ -86,7 +86,7 @@ describe("logger redaction", () => {
     // `"TELEGRAM_BOT_TOKEN":"secret-value-123"` — no free-text `=` for the
     // label rule to anchor on — so the sink must match the JSON key form.
     log.info("env", { TELEGRAM_BOT_TOKEN: "secret-value-123" });
-    const line = lastLine(out.lines);
+    const line = lastLine(err.lines);
     expect(JSON.stringify(line)).not.toContain("secret-value-123");
     expect(line.TELEGRAM_BOT_TOKEN).toBe("[REDACTED]");
   });
@@ -103,9 +103,22 @@ describe("logger redaction", () => {
 
   test("leaves a clean line untouched and parseable", () => {
     log.info("started", { chatId: 42, persona: "default" });
-    const line = lastLine(out.lines);
+    const line = lastLine(err.lines);
     expect(line.msg).toBe("started");
     expect(line.chatId).toBe(42);
     expect(line.persona).toBe("default");
+  });
+
+  test("stdout stays byte-clean across all log levels", () => {
+    log.info("inf", { k: 1 });
+    log.warn("wrn", { k: 2 });
+    log.error("err", { k: 3 });
+    // stdout must be completely empty - it's a protocol channel for ACP/MCP.
+    expect(out.lines.join("")).toBe("");
+    // stderr must have all three lines.
+    const raw = err.lines.join("");
+    expect(raw).toContain('"msg":"inf"');
+    expect(raw).toContain('"msg":"wrn"');
+    expect(raw).toContain('"msg":"err"');
   });
 });


### PR DESCRIPTION
## Root cause

The structured logger (`src/lib/logger.ts`) wrote `info`/`debug` to `process.stdout` and `warn`/`error` to `process.stderr`. Under the ACP stdio server, **stdout IS the JSON-RPC protocol channel** — so every `log.info()` call mid-turn dumped a stray non-JSON-RPC line onto the wire.

Zed couldn't route it (`-32600 Invalid request` / `id=Null`), which broke request/response correlation and caused the agent to re-issue the same tool call endlessly — the loop you see in the Zed agent panel.

## Proof

On Aug 5, Zed's `Transport parse error` payload contained the **literal phantombot log line** verbatim:

```
{"ts":"...","msg":"orchestrator: trying harness","harnessId":"pi",...}
```

This is a `log.info()` call from `src/orchestrator/fallback.ts:150` — info level → stdout → wire corruption.

## Why it only hits ACP/editor

The ACP server's own logging already used stderr correctly (`logErr` sink in `server.ts`). But the **global logger** used by the orchestrator, harnesses, harness runner, and process group didn't know it was running under ACP. On Telegram/phantomchat, stdout isn't a protocol channel, so the stray writes are harmless (captured by launchd/systemd to a log file).

## The fix

Route **all** levels (debug, info, warn, error) to stderr. stdout is now byte-clean for all log calls, safe for both ACP and MCP entrypoints where stdout is a protocol channel.

**2 files changed, 25 insertions, 8 deletions:**
- `src/lib/logger.ts` — one-line change: `process.stderr.write(...)` for all levels
- `tests/lib-logger.test.ts` — update 3 tests that asserted info→stdout, add regression test proving stdout stays empty

## Also explains

- **Why only Zed/VS Code hit it** — Telegram/phantomchat don't use stdout as a protocol channel
- **Why the `id=Null` frames appear** — phantombot's `jsonRpcError(null, ...)` fires on the corrupt lines it receives back from Zed's error response
- **Why `pi.invoke killed: aborted` correlates** — the idle-kill warn goes to stderr (correct), but the info-logs around it go to stdout (corrupting the wire)

## Not related to

- #360/#366 (MCP proxy handshake / Windows SQLite lock contention) — different bug
- Process reaping / orphaned children — the harness children use explicit pipes, not inherited stdio

CI: `tsc --noEmit` clean, logger + ACP test suites all pass (42/42).