### PR TITLE
phantomchat: NIP-42 relay AUTH + publish read-back verification (#368)

### DIFF
--- a/src/channels/phantomchat/relayAuth.ts
+++ b/src/channels/phantomchat/relayAuth.ts
@@ -1,0 +1,72 @@
+/**
+ * NIP-42 relay AUTH support for the phantomchat transport.
+ *
+ * THE PROBLEM (issue #368): a relay configured with `nip42_auth = true`
+ * (nostr-rs-relay) demands an authenticated session before it will store our
+ * publishes. Without NIP-42 support the relay answers our publish with
+ * `OK:true` and then silently DROPS the event — the turn completes cleanly,
+ * the recipient never sees the reply, and nothing in the logs says why. That
+ * is the worst failure class a transport can have: silent outbound message
+ * loss.
+ *
+ * THE FIX: nostr-tools 2.23.3 already carries the whole NIP-42 machinery —
+ * it just needs a signer. Two entry points consume the same signer:
+ *
+ *   1. `automaticallyAuth` on the SimplePool constructor: when a relay sends
+ *      an `["AUTH", <challenge>]` frame (on connect or mid-subscription),
+ *      nostr-tools builds the kind-22242 auth event (`makeAuthEvent(relayURL,
+ *      challenge)`) and hands it to this callback to sign.
+ *   2. The `onauth` param on `pool.publish(...)` / `pool.subscribeMany(...)`:
+ *      when a relay rejects a publish with `OK:false "auth-required: ..."` or
+ *      closes a subscription with `auth-required:`, nostr-tools authenticates
+ *      with this callback and then RETRIES the operation.
+ *
+ * Both paths converge here: the callback receives a fully-formed
+ * EventTemplate (kind 22242, `relay` + `challenge` tags already set) and only
+ * has to sign it with the persona's PhantomChat secret key.
+ *
+ * The signer is intentionally a pure function of the secret key — no relay
+ * allowlist. A relay that asks for AUTH gets it; the kind-22242 event is only
+ * ever sent to the relay that issued the challenge (nostr-tools enforces the
+ * `relay` tag match), so signing does not leak identity to third parties.
+ */
+
+import { finalizeEvent } from "nostr-tools/pure";
+import type { EventTemplate, VerifiedEvent } from "nostr-tools/core";
+
+import { log } from "../../lib/logger.ts";
+
+/**
+ * The signer shape nostr-tools expects for `onauth` / `automaticallyAuth`:
+ * given the auth EventTemplate, return the signed kind-22242 event.
+ */
+export type RelayAuthSigner = (event: EventTemplate) => Promise<VerifiedEvent>;
+
+/**
+ * Build the NIP-42 auth signer for a persona's PhantomChat secret key.
+ * Cheap and pure — safe to construct per pool and per transport.
+ */
+export function makeRelayAuthSigner(secretKey: Uint8Array): RelayAuthSigner {
+  return async (event: EventTemplate): Promise<VerifiedEvent> => {
+    const relayTag = event.tags.find((t) => t[0] === "relay")?.[1];
+    log.debug("phantomchat: answering relay AUTH challenge", {
+      kind: event.kind,
+      relay: relayTag,
+    });
+    return finalizeEvent(event, secretKey);
+  };
+}
+
+/**
+ * The `automaticallyAuth` option for the SimplePool constructor: return the
+ * persona's signer for every relay that challenges us. nostr-tools calls this
+ * once per relay at connect time; returning the signer installs it as
+ * `relay.onauth`, which answers both the connect-time AUTH challenge and any
+ * mid-session re-challenge.
+ */
+export function automaticallyAuthWith(
+  secretKey: Uint8Array,
+): (relayURL: string) => RelayAuthSigner {
+  const signer = makeRelayAuthSigner(secretKey);
+  return () => signer;
+}

--- a/src/channels/phantomchat/transport.ts
+++ b/src/channels/phantomchat/transport.ts
@@ -28,6 +28,10 @@ import {
 import { encryptFileBytes } from "./fileEncrypt.ts";
 import { uploadToBlossom } from "./blossomUpload.ts";
 import {
+  makeRelayAuthSigner,
+  type RelayAuthSigner,
+} from "./relayAuth.ts";
+import {
   oggOpusDurationSeconds,
   oggOpusWaveformBase64,
 } from "./oggOpusDuration.ts";
@@ -100,6 +104,23 @@ const FETCH_GIFTWRAPS_TIMEOUT_MS = 4000;
 const FETCH_PROFILES_TIMEOUT_MS = 3000;
 
 /**
+ * Publish read-back verification (issue #368). A relay can answer a publish
+ * with `OK:true` and still never store the event — observed in production on
+ * nostr-rs-relay with `nip42_auth = true`, where the unauthenticated publish
+ * was acknowledged and silently dropped. After each publish of a STORABLE
+ * event we therefore re-query each relay for the event id; a relay that
+ * doesn't return it gets named in a warning instead of failing silently.
+ *
+ * `PUBLISH_READBACK_SETTLE_MS` gives the relay a beat to index before we ask
+ * (avoids false positives on relays that store asynchronously);
+ * `PUBLISH_READBACK_TIMEOUT_MS` caps the per-relay query so a dead relay
+ * can't stall the check. The whole verification runs detached — it only ever
+ * logs, never blocks or rejects the send path.
+ */
+export const PUBLISH_READBACK_SETTLE_MS = 750;
+export const PUBLISH_READBACK_TIMEOUT_MS = 2500;
+
+/**
  * The Nostr filter shape we subscribe with. Kept minimal: kind-1059 gift-wraps
  * tagged to our pubkey, from roughly now. We deliberately set `since` to a
  * SMALL window (or omit it) because a gift-wrap's `created_at` is randomized up
@@ -107,11 +128,13 @@ const FETCH_PROFILES_TIMEOUT_MS = 3000;
  * messages. Dedup (by wrap id, then rumor id) is the real guard, not `since`.
  */
 export interface NostrFilter {
-  kinds: number[];
+  kinds?: number[];
   /** Recipient p-tag filter (gift-wrap subscriptions). Omitted for `authors`. */
   "#p"?: string[];
   /** Author filter — used by the kind-0 profile pull (`fetchProfiles`). */
   authors?: string[];
+  /** Event-id filter — used by the publish read-back check (issue #368). */
+  ids?: string[];
   since?: number;
 }
 
@@ -150,10 +173,29 @@ export interface RelayPool {
   subscribeMany(
     relays: string[],
     filter: NostrFilter,
-    params: { onevent: (event: NTNostrEvent) => void; oneose?: () => void },
+    params: {
+      onevent: (event: NTNostrEvent) => void;
+      oneose?: () => void;
+      /**
+       * NIP-42 signer for relays that close the subscription demanding AUTH
+       * (`auth-required:`). nostr-tools authenticates and re-subscribes. Optional
+       * so in-memory test fakes don't have to implement it; the real SimplePool
+       * passes it straight through.
+       */
+      onauth?: RelayAuthSigner;
+    },
   ): { close(): void };
-  /** Publish `event` to every relay. Returns one promise per relay. */
-  publish(relays: string[], event: NTNostrEvent): Promise<string>[];
+  /**
+   * Publish `event` to every relay. Returns one promise per relay. `onauth`
+   * is the NIP-42 signer used when a relay rejects the publish with
+   * `auth-required:` — nostr-tools then authenticates and retries the publish
+   * once. Optional for test fakes; the real SimplePool honours it.
+   */
+  publish(
+    relays: string[],
+    event: NTNostrEvent,
+    params?: { onauth?: RelayAuthSigner },
+  ): Promise<string>[];
   /**
    * Per-relay connection status: a Map of relay-url → connected?. nostr-tools'
    * SimplePool exposes this as `listConnectionStatus()`; a relay that has hard-
@@ -333,6 +375,16 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     | ((recipientHex: string, rumorId: string, text: string) => void)
     | null = null;
 
+  /**
+   * The NIP-42 signer for this persona (issue #368). Handed to the pool on
+   * every publish and subscription so a relay that demands AUTH — whether by
+   * rejecting the publish with `auth-required:` or by closing the REQ — gets
+   * a signed kind-22242 response and the operation is retried authenticated.
+   * Without this a `nip42_auth = true` relay silently drops everything we
+   * publish (it answers `OK:true` and never stores the event).
+   */
+  private readonly authSigner: RelayAuthSigner;
+
   constructor(
     private readonly ourSecretKey: Uint8Array,
     relays: string[],
@@ -340,6 +392,7 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
   ) {
     this.relays = [...relays];
     this.ourPubHex = getPublicKey(ourSecretKey);
+    this.authSigner = makeRelayAuthSigner(ourSecretKey);
   }
 
   /**
@@ -383,6 +436,10 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     // doc: nostr-tools wraps it into the per-relay filters array itself, and
     // double-wrapping produces a malformed REQ that delivers nothing.
     return this.pool.subscribeMany(this.relays, filter, {
+      // NIP-42: relays that gate reads behind AUTH close the REQ with
+      // `auth-required:` — the signer lets nostr-tools authenticate and
+      // re-subscribe instead of silently delivering nothing.
+      onauth: this.authSigner,
       onevent: (event) => {
         try {
           const result = onWrap(event);
@@ -438,6 +495,7 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
       // timeout, whichever comes first.
       const timer = setTimeout(finish, FETCH_GIFTWRAPS_TIMEOUT_MS);
       sub = this.pool.subscribeMany(this.relays, filter, {
+        onauth: this.authSigner,
         onevent: (event) => {
           events.push(event);
         },
@@ -472,6 +530,7 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
       };
       const timer = setTimeout(finish, FETCH_PROFILES_TIMEOUT_MS);
       sub = this.pool.subscribeMany(this.relays, filter, {
+        onauth: this.authSigner,
         onevent: (event) => {
           const author = (event.pubkey ?? "").toLowerCase();
           if (!author) return;
@@ -515,8 +574,13 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     // SimplePool.publish returns one promise per relay; a publish that fails on
     // some relays but lands on others is still a success from our side. We wait
     // on all of them (allSettled) so a single dead relay can't reject the send,
-    // and log if EVERY relay rejected.
-    const results = await Promise.allSettled(this.pool.publish(this.relays, event));
+    // and log if EVERY relay rejected. `onauth` is the NIP-42 signer: when a
+    // relay rejects the publish with `auth-required:`, nostr-tools signs a
+    // kind-22242 auth event and retries the publish once, authenticated
+    // (issue #368 — without this, AUTH-requiring relays drop everything).
+    const results = await Promise.allSettled(
+      this.pool.publish(this.relays, event, { onauth: this.authSigner }),
+    );
     const ok = results.some((r) => r.status === "fulfilled");
     if (!ok) {
       log.warn("phantomchat: publish failed on all relays", {
@@ -524,6 +588,95 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
         eventId: event.id,
       });
     }
+    // Read-back verification (issue #368): even an `OK:true` publish may never
+    // be stored — observed on nostr-rs-relay with nip42_auth, which ACKs and
+    // silently drops. Re-query each relay for the event id and warn loudly,
+    // naming the relays, when it isn't there. Detached: never blocks the send.
+    void this.verifyStored(event);
+  }
+
+  /**
+   * Read-back check for a freshly published event (issue #368). For every
+   * relay, query `{ids: [event.id]}` after a short settle delay; a relay that
+   * doesn't return the event within the timeout never stored it — warn and
+   * name it. Returns the list of relays where the event was NOT confirmed, so
+   * tests can assert directly. Never throws; a failed read-back is itself just
+   * a debug log (the relay may simply be slow, and the periodic catch-up poll
+   * remains the delivery backstop).
+   *
+   * Skipped for EPHEMERAL events (kinds 20000–29999, NIP-16 — typing ticks):
+   * relays don't store those by design, so a read-back would always "fail".
+   *
+   * `timing` overrides the settle delay / query timeout — tests only.
+   */
+  async verifyStored(
+    event: NTNostrEvent,
+    timing?: { settleMs?: number; timeoutMs?: number },
+  ): Promise<string[]> {
+    if (event.kind >= 20000 && event.kind < 30000) return [];
+    const missing: string[] = [];
+    await new Promise((r) =>
+      setTimeout(r, timing?.settleMs ?? PUBLISH_READBACK_SETTLE_MS),
+    );
+    await Promise.all(
+      this.relays.map(async (relay) => {
+        const found = await this.readBackOne(relay, event.id, timing?.timeoutMs);
+        if (!found) missing.push(relay);
+      }),
+    );
+    if (missing.length > 0) {
+      log.warn(
+        "phantomchat: publish NOT confirmed stored — relay(s) dropped the event",
+        { eventId: event.id, kind: event.kind, missing, relays: this.relays.length },
+      );
+    }
+    return missing;
+  }
+
+  /**
+   * One-shot `{ids: [id]}` query against a SINGLE relay for the read-back
+   * check. Resolves true the moment the relay returns the event; false on the
+   * hard timeout or any error. Querying per-relay (instead of one pooled REQ)
+   * is what lets the warning NAME the relay that dropped the event.
+   */
+  private readBackOne(
+    relay: string,
+    eventId: string,
+    timeoutMs?: number,
+  ): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      let sub: { close(): void } | undefined;
+      const finish = (found: boolean): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try {
+          sub?.close();
+        } catch {
+          // already torn down — nothing to do.
+        }
+        resolve(found);
+      };
+      const timer = setTimeout(
+        () => finish(false),
+        timeoutMs ?? PUBLISH_READBACK_TIMEOUT_MS,
+      );
+      try {
+        sub = this.pool.subscribeMany([relay], { ids: [eventId] }, {
+          onauth: this.authSigner,
+          onevent: () => finish(true),
+          oneose: () => finish(false),
+        });
+      } catch (e) {
+        log.debug("phantomchat: read-back query failed", {
+          relay,
+          eventId,
+          error: (e as Error).message,
+        });
+        finish(false);
+      }
+    });
   }
 
   /**

--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -44,6 +44,7 @@ import {
   loadConfig,
 } from "../config.ts";
 import { loadPhantomchatPersonaConfig } from "../channels/phantomchat/personaStore.ts";
+import { automaticallyAuthWith } from "../channels/phantomchat/relayAuth.ts";
 import { synthesize, ttsSupport } from "../lib/audio.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
@@ -77,6 +78,12 @@ const defaultPhantomchatSend: PhantomchatNotifySend = async ({
     "../channels/phantomchat/transport.ts"
   );
   const pool = new SimplePool();
+  // NIP-42 (issue #368): answer AUTH challenges so a notify to an
+  // auth-requiring relay isn't silently dropped. `automaticallyAuth` is a
+  // public AbstractSimplePool field read at relay-connect time — assigning it
+  // before the first publish is the supported path (the SimplePool constructor
+  // type only exposes enablePing/enableReconnect).
+  pool.automaticallyAuth = automaticallyAuthWith(secretKey);
   const transport = new SimplePoolPhantomchatTransport(
     secretKey,
     relays,

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -17,6 +17,7 @@ import { TELEGRAM_BOT_COMMANDS } from "../channels/commands.ts";
 import { createPhantomchatChannel } from "../channels/phantomchat/channel.ts";
 import { runPhantomchatServer } from "../channels/phantomchat/server.ts";
 import { SimplePoolPhantomchatTransport } from "../channels/phantomchat/transport.ts";
+import { automaticallyAuthWith } from "../channels/phantomchat/relayAuth.ts";
 import {
   listPhantomchatPersonas,
   cacheRelaysForPersona,
@@ -684,7 +685,17 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         // created_at is backdated up to 48h (NIP-59). Hard-drop recovery is
         // handled instead by the channel-layer self-heal watchdog, which re-arms
         // the subscription with our own correct wide `since`.
+        //
+        // automaticallyAuth: NIP-42 (issue #368). A relay that sends an AUTH
+        // challenge — on connect or mid-subscription — gets a signed kind-22242
+        // response from the persona's key. Without it, a `nip42_auth = true`
+        // relay silently drops every event we publish. (SimplePool's
+        // constructor type only exposes enablePing/enableReconnect, but
+        // `automaticallyAuth` is a public AbstractSimplePool field read at
+        // relay-connect time — assigning it here, before any ensureRelay call,
+        // is the supported path.)
         const pool = new SimplePool({ enablePing: true });
+        pool.automaticallyAuth = automaticallyAuthWith(identity.secretKey);
         const transport = new SimplePoolPhantomchatTransport(
           identity.secretKey,
           relays,

--- a/tests/channels-phantomchat-relayAuth.test.ts
+++ b/tests/channels-phantomchat-relayAuth.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for NIP-42 relay AUTH + publish read-back verification (issue #368).
+ *
+ * THE BUG: on a relay with `nip42_auth = true` (nostr-rs-relay), every bot
+ * publish was answered `OK:true` and then silently DROPPED — the turn
+ * completed cleanly, the recipient never saw the reply, and nothing failed
+ * loudly. Two layers pin the fix:
+ *
+ *   1. The signer (`makeRelayAuthSigner`) must produce a valid, verifiable
+ *      kind-22242 auth event from the persona key, and the transport must
+ *      hand it to the pool on EVERY publish/subscribe so nostr-tools can
+ *      answer `auth-required:` rejections and AUTH challenges.
+ *   2. The read-back check (`verifyStored`) must re-query each relay for a
+ *      freshly published event id and name the relays that never stored it —
+ *      catching the non-conformant `OK:true`-then-drop relays that AUTH
+ *      alone can't.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  verifyEvent,
+} from "nostr-tools/pure";
+import type { EventTemplate } from "nostr-tools/core";
+import {
+  automaticallyAuthWith,
+  makeRelayAuthSigner,
+} from "../src/channels/phantomchat/relayAuth.ts";
+import {
+  SimplePoolPhantomchatTransport,
+  type NostrFilter,
+  type RelayPool,
+} from "../src/channels/phantomchat/transport.ts";
+import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
+import type { RelayAuthSigner } from "../src/channels/phantomchat/relayAuth.ts";
+
+describe("NIP-42 relay auth signer", () => {
+  test("signs the auth event template with the persona key", async () => {
+    const sk = generateSecretKey();
+    const signer = makeRelayAuthSigner(sk);
+    // The shape nostr-tools hands us: makeAuthEvent(relayURL, challenge).
+    const template: EventTemplate = {
+      kind: 22242,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ["relay", "wss://relay.example"],
+        ["challenge", "abc123"],
+      ],
+      content: "",
+    };
+    const signed = await signer(template);
+    expect(signed.kind).toBe(22242);
+    expect(signed.pubkey).toBe(getPublicKey(sk));
+    expect(signed.tags).toContainEqual(["relay", "wss://relay.example"]);
+    expect(signed.tags).toContainEqual(["challenge", "abc123"]);
+    expect(verifyEvent(signed)).toBe(true);
+  });
+
+  test("automaticallyAuthWith returns a working signer for any relay", async () => {
+    const sk = generateSecretKey();
+    const factory = automaticallyAuthWith(sk);
+    const signer = factory("wss://any.relay");
+    expect(typeof signer).toBe("function");
+    const signed = await signer({
+      kind: 22242,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ["relay", "wss://any.relay"],
+        ["challenge", "xyz"],
+      ],
+      content: "",
+    });
+    expect(verifyEvent(signed)).toBe(true);
+  });
+});
+
+describe("transport wires the auth signer into pool operations", () => {
+  function capturePool(): {
+    pool: RelayPool;
+    publishParams: Array<{ onauth?: RelayAuthSigner } | undefined>;
+    subParams: Array<{ onauth?: RelayAuthSigner } | undefined>;
+  } {
+    const publishParams: Array<{ onauth?: RelayAuthSigner } | undefined> = [];
+    const subParams: Array<{ onauth?: RelayAuthSigner } | undefined> = [];
+    const pool: RelayPool = {
+      subscribeMany(_relays, _filter, params) {
+        subParams.push(params);
+        return { close() {} };
+      },
+      publish(_relays, _event, params) {
+        publishParams.push(params);
+        return [];
+      },
+      close() {},
+    };
+    return { pool, publishParams, subParams };
+  }
+
+  test("publishWrap hands the onauth signer to pool.publish", async () => {
+    const { pool, publishParams } = capturePool();
+    const sk = generateSecretKey();
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      ["wss://relay.example"],
+      pool,
+    );
+    const event = finalizeEvent(
+      {
+        kind: 1059,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [],
+        content: "x",
+      },
+      sk,
+    ) as unknown as NTNostrEvent;
+    await transport.publishWrap(event);
+    expect(publishParams.length).toBe(1);
+    expect(typeof publishParams[0]?.onauth).toBe("function");
+    // The wired signer must actually sign with OUR key.
+    const signed = await publishParams[0]!.onauth!({
+      kind: 22242,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [["relay", "wss://relay.example"], ["challenge", "c"]],
+      content: "",
+    });
+    expect(signed.pubkey).toBe(getPublicKey(sk));
+    expect(verifyEvent(signed)).toBe(true);
+  });
+
+  test("subscribeGiftWraps hands the onauth signer to subscribeMany", () => {
+    const { pool, subParams } = capturePool();
+    const sk = generateSecretKey();
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      ["wss://relay.example"],
+      pool,
+    );
+    transport.subscribeGiftWraps(getPublicKey(sk), () => {});
+    expect(subParams.length).toBe(1);
+    expect(typeof subParams[0]?.onauth).toBe("function");
+  });
+});
+
+describe("publish read-back verification (verifyStored)", () => {
+  const sk = generateSecretKey();
+  const event = finalizeEvent(
+    {
+      kind: 1059,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+      content: "wrapped",
+    },
+    sk,
+  ) as unknown as NTNostrEvent;
+
+  /** A fake pool whose per-relay "storage" decides read-back results. */
+  function storedPool(storedOn: Set<string>): RelayPool {
+    return {
+      subscribeMany(relays, filter: NostrFilter, params) {
+        // The read-back query is a one-relay {ids:[...]} REQ — answer it from
+        // the fake's storage set. Other REQs (none in these tests) get EOSE.
+        const [relay] = relays;
+        if (filter.ids && relay && storedOn.has(relay)) {
+          queueMicrotask(() => params.onevent(event));
+        } else {
+          queueMicrotask(() => params.oneose?.());
+        }
+        return { close() {} };
+      },
+      publish() {
+        return [];
+      },
+      close() {},
+    };
+  }
+
+  test("returns [] when every relay stored the event", async () => {
+    const relays = ["wss://a.example", "wss://b.example"];
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      relays,
+      storedPool(new Set(relays)),
+    );
+    const missing = await transport.verifyStored(event, {
+      settleMs: 0,
+      timeoutMs: 200,
+    });
+    expect(missing).toEqual([]);
+  });
+
+  test("names the relay that dropped the event", async () => {
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      ["wss://a.example", "wss://b.example"],
+      storedPool(new Set(["wss://a.example"])),
+    );
+    const missing = await transport.verifyStored(event, {
+      settleMs: 0,
+      timeoutMs: 200,
+    });
+    expect(missing).toEqual(["wss://b.example"]);
+  });
+
+  test("names relays that never answer (timeout)", async () => {
+    // A pool that never calls onevent/oneose for the read-back REQ — the
+    // timeout must turn that into "not stored", not a hang.
+    const silentPool: RelayPool = {
+      subscribeMany() {
+        return { close() {} };
+      },
+      publish() {
+        return [];
+      },
+      close() {},
+    };
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      ["wss://dead.example"],
+      silentPool,
+    );
+    const missing = await transport.verifyStored(event, {
+      settleMs: 0,
+      timeoutMs: 100,
+    });
+    expect(missing).toEqual(["wss://dead.example"]);
+  });
+
+  test("skips ephemeral events (typing ticks are never stored by design)", async () => {
+    const ephemeral = finalizeEvent(
+      {
+        kind: 20001,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [["p", getPublicKey(generateSecretKey())]],
+        content: "",
+      },
+      sk,
+    ) as unknown as NTNostrEvent;
+    // A pool that records whether ANY read-back subscription was attempted.
+    let queried = false;
+    const pool: RelayPool = {
+      subscribeMany() {
+        queried = true;
+        return { close() {} };
+      },
+      publish() {
+        return [];
+      },
+      close() {},
+    };
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      ["wss://a.example"],
+      pool,
+    );
+    const missing = await transport.verifyStored(ephemeral, {
+      settleMs: 0,
+      timeoutMs: 100,
+    });
+    expect(missing).toEqual([]);
+    expect(queried).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #368.

## Problem

On a relay with `nip42_auth = true` (nostr-rs-relay), every bot publish was answered `OK:true` and then **silently dropped** — the turn completed cleanly, the recipient never saw the reply, nothing failed loudly. Root cause confirmed in the issue: zero NIP-42 handling anywhere in `src/`, and SimplePool never answered relay AUTH challenges.

## Fix — one PR, two layers (per Andrew's call to ship together)

**1. NIP-42 AUTH.** nostr-tools 2.23.3 already carries the machinery; it only needed a signer. New `relayAuth.ts` exports `makeRelayAuthSigner(secretKey)`, which signs the kind-22242 auth event nostr-tools builds from the relay challenge. Wired at every point nostr-tools consumes it:

- `automaticallyAuth` on the pool (run.ts + the one-shot notify pool) — answers connect-time and mid-subscription `["AUTH", challenge]` frames. Assigned post-construction: SimplePool's constructor type only exposes `enablePing`/`enableReconnect`, but `automaticallyAuth` is a public AbstractSimplePool field read at relay-connect time.
- `onauth` on **every publish and subscription** in the transport — a relay that rejects with `OK:false auth-required:` or closes a REQ demanding auth gets an authenticated retry, handled inside nostr-tools.

**2. Publish read-back verification.** AUTH alone can't catch the non-conformant relay that ACKs and drops anyway (the exact behavior observed in production). After publishing a storable event, `verifyStored` re-queries **each relay individually** for the event id (750ms settle + 2.5s per-relay timeout) and logs a warning **naming the relays that never stored it**. Detached: never blocks or rejects the send path. Ephemeral kinds (20000–29999, typing ticks) are skipped — relays don't store those by design.

## Test plan

- 8 new tests (`tests/channels-phantomchat-relayAuth.test.ts`): signer produces a verifiable kind-22242 with the persona key; transport hands `onauth` to publish + subscribe; read-back returns [] when all relays stored the event, names the dropping relay, names a dead relay on timeout, and skips ephemeral events.
- Full suite: 2614 pass — the only 2 failures (`PiHarness routing (subprocess)`) are pre-existing on clean `main`, verified by running the full suite on both branches.
- `tsc --noEmit` clean on all touched files (remaining errors are the pre-existing MCP SDK resolution noise).

## Notes for reviewers

- The read-back adds one `{ids:[...]}` REQ per relay per published storable event, detached — no latency on the send path.
- `NostrFilter.kinds` became optional (read-back filter is `{ids}`-only); the one consumer that reads `filter.kinds` (channel test fake) already guarded for it.
- Dogfooding suggestion after merge: point one persona at an auth-requiring relay and confirm the `answering relay AUTH challenge` debug line plus clean read-backs.