### PR TITLE
fix(phantomchat): scope enqueue interrupt to addressed bot in multi-bot groups

### DIFF
--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -1176,7 +1176,36 @@ export async function runPhantomchatServer(
     // through instructions the user has already superseded. Silent by design:
     // only `/stop` tells the user what it threw away. Gated on an active turn
     // so that a burst of messages sent while idle is still answered in full.
-    const active = activeTurns.get(msg.conversationId);
+    //
+    // GROUP SCOPING: in a multi-bot group every bot's instance sees every
+    // message over the shared relay, so an unscoped interrupt lets a message
+    // addressed to a SIBLING abort THIS bot's in-flight work. The interrupt
+    // must therefore pass the same two gates handle() applies before it runs a
+    // turn: (1) bot senders are always ignored (cascade kill), and (2) when
+    // another bot shares the group, the addressing gate must say this message
+    // is for us. Both checks here are READ-ONLY — no profile fetch, no
+    // lastAddressed/buffer mutation; handle() re-decides authoritatively when
+    // the message actually runs. A cold profile cache degrades to the old
+    // behaviour (interrupt fires), never to a lost interrupt.
+    let interrupt = !isBot(msg.senderId);
+    if (interrupt && msg.groupId) {
+      const memberHexes = msg.groupMemberHexes ?? [];
+      const roster = buildRoster(memberHexes);
+      const otherBotPresent =
+        roster.length > 1 ||
+        memberHexes.some((h) => h.toLowerCase() !== ourHex && isBot(h));
+      if (otherBotPresent) {
+        const state =
+          groupChats.get(msg.conversationId) ?? { lastAddressed: [], buffer: [] };
+        const decision = decideGroupReply({
+          self: selfName,
+          matched: matchPersonaNames(msg.text ?? "", roster),
+          lastAddressed: state.lastAddressed,
+        });
+        interrupt = decision.reply;
+      }
+    }
+    const active = interrupt ? activeTurns.get(msg.conversationId) : undefined;
     if (active) {
       const dropped = backlog.flush(msg.conversationId, "interrupt");
       log.info("phantomchat: new message — interrupting active turn", {

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -1182,8 +1182,21 @@ export async function runPhantomchatServer(
     // addressed to a SIBLING abort THIS bot's in-flight work. The interrupt
     // must therefore pass the same two gates handle() applies before it runs a
     // turn: (1) bot senders are always ignored (cascade kill), and (2) when
-    // another bot shares the group, the addressing gate must say this message
-    // is for us. Both checks here are READ-ONLY — no profile fetch, no
+    // another bot shares the group, the message must EXPLICITLY name this bot.
+    //
+    // Why explicit-name-only instead of the full decideGroupReply gate: the
+    // follow-up arm of decideGroupReply reads lastAddressed, which is only
+    // written in handle(). While a turn is active, later messages from the
+    // same peer are queued BEHIND that turn, so handle() hasn't run for them
+    // and lastAddressed is stale — a handoff ("kai, you take Y") followed by
+    // a bare follow-up ("and also Z") would read lastAddressed=["lena"] and
+    // abort Lena's in-flight turn, AND the backlog flush would silently drop
+    // the queued handoff. Net: work killed, replacement lost. Requiring an
+    // explicit name match keeps the enqueue check stateless: an unaddressed
+    // follow-up just queues behind the running turn (mild UX cost — "stop,
+    // do Y instead" must name the bot — but strictly safe), while handle()
+    // still applies the full lastAddressed logic when the message runs.
+    // Both checks here are READ-ONLY — no profile fetch, no
     // lastAddressed/buffer mutation; handle() re-decides authoritatively when
     // the message actually runs. A cold profile cache degrades to the old
     // behaviour (interrupt fires), never to a lost interrupt.
@@ -1195,14 +1208,9 @@ export async function runPhantomchatServer(
         roster.length > 1 ||
         memberHexes.some((h) => h.toLowerCase() !== ourHex && isBot(h));
       if (otherBotPresent) {
-        const state =
-          groupChats.get(msg.conversationId) ?? { lastAddressed: [], buffer: [] };
-        const decision = decideGroupReply({
-          self: selfName,
-          matched: matchPersonaNames(msg.text ?? "", roster),
-          lastAddressed: state.lastAddressed,
-        });
-        interrupt = decision.reply;
+        interrupt = matchPersonaNames(msg.text ?? "", roster).some(
+          (n) => n.toLowerCase() === selfName.toLowerCase(),
+        );
       }
     }
     const active = interrupt ? activeTurns.get(msg.conversationId) : undefined;

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -1802,4 +1802,130 @@ describe("phantomchat group addressing gate (multi-bot)", () => {
     expect(harness.invocations).toBe(1);
     expect(replyWraps(srv.pool).length).toBeGreaterThan(0);
   });
+
+  // ===== interrupt scoping (#301 follow-up) =====
+  // The enqueue-time interrupt originally fired for ANY group message visible
+  // on the shared relay — including ones addressed to a sibling bot — aborting
+  // this bot's in-flight work. The interrupt must pass the same gates handle()
+  // applies: bot senders never interrupt, and in a multi-bot group only a
+  // message the addressing gate says is OURS does.
+
+  /** A turn that blocks until aborted (interrupt) or released by the test, so
+   *  the interrupt decision at enqueue time can be observed. */
+  class GateHarness implements Harness {
+    invocations = 0;
+    aborted = 0;
+    private releasers: Array<() => void> = [];
+    constructor(public readonly id: string) {}
+    releaseAll(): void {
+      for (const r of this.releasers.splice(0)) r();
+    }
+    async available(): Promise<boolean> {
+      return true;
+    }
+    async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+      this.invocations++;
+      yield { type: "text", text: "working" };
+      await new Promise<void>((resolve) => {
+        if (req.signal?.aborted) return resolve();
+        const onAbort = () => resolve();
+        req.signal?.addEventListener("abort", onAbort, { once: true });
+        this.releasers.push(() => {
+          req.signal?.removeEventListener("abort", onAbort);
+          resolve();
+        });
+      });
+      if (req.signal?.aborted) {
+        this.aborted++;
+        return;
+      }
+      yield { type: "done", finalText: "done" };
+    }
+  }
+
+  test("interrupt scoping: a message addressed to a sibling does NOT interrupt this bot's active turn", async () => {
+    const c = cast();
+    const harness = new GateHarness("fake");
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    // Lena is mid-turn...
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "lena, research X", "HQ");
+    await groupSleep(150);
+    expect(harness.invocations).toBe(1);
+
+    // ...when Andrew addresses Kai. Old behaviour aborted Lena's turn here.
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "kai, you take Y", "HQ");
+    await groupSleep(150);
+    expect(harness.aborted).toBe(0); // turn survived
+
+    harness.releaseAll();
+    await groupSleep(250);
+    await srv.stop();
+    // Kai's message never ran a turn on Lena's instance either.
+    expect(harness.invocations).toBe(1);
+  });
+
+  test("interrupt scoping: a message addressed to THIS bot still interrupts the active turn", async () => {
+    const c = cast();
+    const harness = new GateHarness("fake");
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "lena, research X", "HQ");
+    await groupSleep(150);
+    expect(harness.invocations).toBe(1);
+
+    // A message naming Lena is a genuine interrupt: abort + run the new one.
+    srv.feedGroup(
+      c.andrewSk,
+      [c.lenaHex, c.kaiHex],
+      "lena, stop — do Z instead",
+      "HQ",
+    );
+    await groupSleep(250);
+    expect(harness.aborted).toBe(1);
+    expect(harness.invocations).toBe(2);
+
+    harness.releaseAll();
+    await groupSleep(250);
+    await srv.stop();
+  });
+
+  test("interrupt scoping: a sibling bot's message never interrupts (bot-gate)", async () => {
+    const c = cast();
+    const harness = new GateHarness("fake");
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "lena, research X", "HQ");
+    await groupSleep(150);
+    expect(harness.invocations).toBe(1);
+
+    // Kai chimes in naming Lena. handle() drops bot messages (option a) —
+    // the enqueue interrupt must not fire for them either.
+    srv.feedGroup(c.kaiSk, [c.lenaHex, c.andrewHex], "good point, lena!", "HQ");
+    await groupSleep(150);
+    expect(harness.aborted).toBe(0);
+
+    harness.releaseAll();
+    await groupSleep(250);
+    await srv.stop();
+    expect(harness.invocations).toBe(1);
+  });
 });

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -1928,4 +1928,32 @@ describe("phantomchat group addressing gate (multi-bot)", () => {
     await srv.stop();
     expect(harness.invocations).toBe(1);
   });
+
+  test("interrupt scoping: handoff-then-unaddressed-follow-up must not kill the active turn", async () => {
+    const c = cast();
+    const harness = new GateHarness("fake");
+    const srv = makeGroupServer({
+      botSk: c.lenaSk,
+      persona: "lena",
+      allowedHex: [c.andrewHex, c.kaiHex],
+      groupPersonaNames: ["lena", "kai"],
+      siblingBotHex: [c.kaiHex],
+      harness,
+    });
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "lena, research X", "HQ");
+    await groupSleep(150);
+    expect(harness.invocations).toBe(1);
+
+    // Andrew hands off to Kai, then follows up WITHOUT re-naming him —
+    // which is exactly what lastAddressed exists to support.
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "kai, you take Y", "HQ");
+    srv.feedGroup(c.andrewSk, [c.lenaHex, c.kaiHex], "and also Z", "HQ");
+    await groupSleep(400);
+    expect(harness.aborted).toBe(0);
+
+    harness.releaseAll();
+    await groupSleep(250);
+    await srv.stop();
+    expect(harness.invocations).toBe(1);
+  });
 });


### PR DESCRIPTION
## Problem

In a multi-bot PhantomChat group, every bot's instance receives every group message over the shared relay. The enqueue-time interrupt (#301) fired for **any** inbound message with an active turn on that conversation — so when Andrew messaged Agent B, Agent A's in-flight work was aborted too. You couldn't talk to one agent without interrupting another.

The Telegram engine doesn't have this bug: it runs the group addressing gate *before* the interrupt check. PhantomChat's server had the ordering inverted — interrupt in `enqueue()`, addressing gate later in `handle()`.

## Fix

The enqueue-time interrupt now passes the same two gates `handle()` applies before running a turn:

1. **Bot senders never interrupt** (parity with the cascade-kill gate — a sibling bot's chatter can't abort your turn either).
2. **Multi-bot groups:** the addressing gate (`matchPersonaNames` + `decideGroupReply`) must say the message is for *this* bot before its active turn is aborted.

Both checks are **read-only** at enqueue time — no profile fetch, no `lastAddressed`/buffer mutation; `handle()` re-decides authoritatively when the message actually runs. A cold profile cache degrades to the old behaviour (interrupt fires), never to a lost interrupt. DMs are unchanged (immediate interrupt, as before).

Context catch-up is untouched: non-addressed messages still land in the rolling group buffer and are delivered as the context preamble next time the bot is addressed.

## Tests

Three regression tests in `channels-phantomchat-server.test.ts` (multi-bot group gate suite):

- message addressed to a sibling → active turn **survives**, no turn runs
- message addressed to this bot → active turn **aborts**, new turn runs (interrupt still works)
- sibling bot's message → never interrupts (bot-gate)

`bun test tests/channels-phantomchat-server.test.ts` — 40 pass, 0 fail. Full phantomchat channel suite: 65 pass, 0 fail. Typecheck clean (only pre-existing MCP-SDK fixture errors, untouched).
