### PR TITLE
test(config): isolate PHANTOMBOT_GEMINI_API_KEY from the env snapshot

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -42,6 +42,10 @@ const ENV_KEYS = [
   "PHANTOMBOT_CODING_MODEL",
   "PHANTOMBOT_CODEX_BIN",
   "PHANTOMBOT_CODEX_MODEL",
+  // buildEmbeddingsConfig() prefers this over the TOML [embeddings.gemini]
+  // api_key, so a real key in a developer's shell silently overrides the
+  // fixture and breaks the embedding assertions below.
+  "PHANTOMBOT_GEMINI_API_KEY",
   "PHANTOMBOT_RETRIEVAL_ENABLED",
   "PHANTOMBOT_RETRIEVAL_LIMIT",
   "PHANTOMBOT_RETRIEVAL_MAX_TOKENS",


### PR DESCRIPTION
Fixes #373.

## Root cause

`tests/config.test.ts` snapshots and clears a list of env vars (`ENV_KEYS`) in `beforeEach` so every test starts from a clean environment. `PHANTOMBOT_GEMINI_API_KEY` was missing from that list.

`buildEmbeddingsConfig()` (`src/config.ts:1232`) prefers the env key over the TOML `[embeddings.gemini] api_key`:

```ts
const envApiKey = process.env.PHANTOMBOT_GEMINI_API_KEY;
const tomlApiKey = asString(tomlGemini.api_key);
const apiKey = envApiKey ?? tomlApiKey;
```

So on a machine with a real key exported, *"migrates a legacy Gemini CLI chain without touching embeddings"* reads the ambient key instead of the `"embedding-key"` fixture and fails `expect(c.embeddings.gemini?.apiKey).toBe("embedding-key")`. CI has no key set, hence green there.

## One correction to the issue

The issue names the variable `GEMINI_API_KEY`, but that is **not** the one that breaks the test — nothing in `src/config.ts` reads it (bare `GEMINI_API_KEY` only appears in `src/lib/piModels.ts` as provider *metadata*). Verified by isolating each:

```
$ env -u PHANTOMBOT_GEMINI_API_KEY GEMINI_API_KEY=AIzaFAKE bun test tests/config.test.ts
 55 pass, 0 fail          # bare var is harmless

$ env -u GEMINI_API_KEY PHANTOMBOT_GEMINI_API_KEY=AIzaFAKE bun test tests/config.test.ts
 54 pass, 1 fail          # this is the real trigger
```

The `PHANTOMBOT_`-prefixed var is what needs isolating.

## Fix

Add `PHANTOMBOT_GEMINI_API_KEY` to `ENV_KEYS`, with a comment on why. This reuses the file's existing snapshot/clear/restore mechanism rather than adding a bespoke fixture, so it also restores the developer's real key afterwards.

## Verification

| | before | after |
|---|---|---|
| `PHANTOMBOT_GEMINI_API_KEY=AIzaFAKE bun test tests/config.test.ts` | 54 pass, **1 fail** | **55 pass, 0 fail** |
| clean env, same file | 55 pass, 0 fail | 55 pass, 0 fail |
| full suite w/ key set | 2681 pass, **1 fail** | **2682 pass, 2 skip, 0 fail** (167 files) |
| `bun tsc --noEmit` | — | clean (exit 0) |

A full-suite run with the key set confirms this was the only test in the repo affected by the leak.