### PR TITLE
fix(reset): /reset clears the context window, no longer deletes history

### DIFF
--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -21,11 +21,10 @@
  */
 
 import { stopNoteText } from "./core/backlog.ts";
-import { memoryIndexPath, type Config } from "../config.ts";
+import { type Config } from "../config.ts";
 import type { Harness } from "../harnesses/types.ts";
 import { formatElapsedSeconds, truncateLine } from "../lib/format.ts";
 import { log } from "../lib/logger.ts";
-import { MemoryIndex } from "../lib/memoryIndex.ts";
 import { defaultServiceControl, selfRestart } from "../lib/platform.ts";
 import type { ServiceControl } from "../lib/systemd.ts";
 import { runUpdateFlow } from "../lib/updateNotify.ts";
@@ -70,7 +69,7 @@ export interface SlashCommandContext {
   persona: string;
   /** Conversation key, e.g. "telegram:42". Used by /reset. */
   conversation: string;
-  /** Memory store for /reset's deleteConversation call. */
+  /** Memory store for /reset's context-watermark advance and /stop's note. */
   memory: MemoryStore;
   /**
    * The harness chain — mutable. /harness reorders this in place so the
@@ -168,7 +167,11 @@ export const TELEGRAM_BOT_COMMANDS: Array<{
     command: "stop",
     description: "Abort the current turn and drop anything queued behind it",
   },
-  { command: "reset", description: "Clear this chat's history" },
+  {
+    command: "reset",
+    description:
+      "Start a fresh context window here (history is kept and stays searchable)",
+  },
   { command: "status", description: "Show harness, uptime, context usage" },
   { command: "harness", description: "List or switch the active harness" },
   {
@@ -644,39 +647,27 @@ async function handleReset(
     stoppedNote = ` (and stopped an in-flight turn that was ${elapsedS}s in)`;
   }
 
-  const removed = await ctx.memory.deleteConversation(
+  // /reset clears the LIVE CONTEXT WINDOW — it does not destroy the record.
+  // It used to delete the turn rows AND their embeddings, which made a
+  // routine "clear this chat" command silently unrecoverable: one /reset on a
+  // long-running DM took 4,009 turns and every vector with it, and nothing
+  // else in the system had a durable copy. Now it advances a per-conversation
+  // watermark: nothing is replayed into the prompt, while the turns, the
+  // index, and durable facts all survive and stay retrievable.
+  const dropped = await ctx.memory.resetConversationContext(
     ctx.persona,
     ctx.conversation,
   );
-  let removedIndexedTurns = false;
-  if (ctx.config?.retrieval?.turnIndexing.enabled) {
-    let ix: MemoryIndex | undefined;
-    try {
-      ix = await MemoryIndex.open(memoryIndexPath(ctx.persona));
-      ix.deleteConversationTurns(ctx.persona, ctx.conversation);
-      removedIndexedTurns = true;
-    } catch (e) {
-      log.warn("commands: /reset failed to clear turn index", {
-        chatId: ctx.chatId,
-        persona: ctx.persona,
-        conversation: ctx.conversation,
-        error: (e as Error).message,
-      });
-    } finally {
-      ix?.close();
-    }
-  }
   log.info("commands: /reset", {
     chatId: ctx.chatId,
     persona: ctx.persona,
     conversation: ctx.conversation,
-    deletedTurns: removed,
-    removedIndexedTurns,
+    droppedFromWindow: dropped,
     abortedActiveTurn: Boolean(ctx.activeTurn),
   });
-  const noun = removed === 1 ? "turn" : "turns";
+  const noun = dropped === 1 ? "turn" : "turns";
   return {
-    reply: `reset: cleared ${removed} ${noun} from this chat${stoppedNote}`,
+    reply: `reset: cleared ${dropped} ${noun} from this chat's context — history kept, still searchable${stoppedNote}`,
   };
 }
 

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -256,6 +256,19 @@ export interface MemoryStore {
    */
   deleteConversation(persona: string, conversation: string): Promise<number>;
   /**
+   * NON-DESTRUCTIVE /reset: advance this conversation's live-context
+   * watermark to its newest turn, so `recentTurns` replays nothing until new
+   * turns arrive. Turns, their embeddings, durable facts and extractor state
+   * all SURVIVE — only the replayed window is cleared, which is what /reset
+   * is actually for. Returns the number of turns dropped out of the window
+   * (those above the previous watermark). Idempotent: a second reset with no
+   * new turns drops 0. The watermark is monotonic and never lowered.
+   */
+  resetConversationContext(
+    persona: string,
+    conversation: string,
+  ): Promise<number>;
+  /**
    * Delete the quarantined (embeddable=0) turns for a (persona,
    * conversation) pair; returns rows deleted. Called after a TRUSTED turn
    * succeeds (orchestrator/turn.ts): by then the held untrusted payload has
@@ -538,6 +551,20 @@ CREATE TABLE IF NOT EXISTS durable_fact_pending (
 );
 CREATE INDEX IF NOT EXISTS idx_durable_fact_pending_conv
   ON durable_fact_pending (persona, conversation, turn_id);
+
+-- Live-context watermark for /reset. A row means "replay only turns with
+-- id > reset_turn_id in this conversation's live history window". The turns
+-- themselves are NEVER deleted — /reset draws a line, it does not destroy the
+-- record, so retrieval, the turn index, and durable-fact extraction keep
+-- seeing the full history. Monotonic: the watermark only ever
+-- rises, so a reset can't un-hide turns an earlier reset already hid.
+CREATE TABLE IF NOT EXISTS conversation_reset (
+  persona       TEXT NOT NULL,
+  conversation  TEXT NOT NULL,
+  reset_turn_id INTEGER NOT NULL DEFAULT 0,
+  updated_at    TEXT NOT NULL,
+  PRIMARY KEY (persona, conversation)
+);
 `;
 
 interface RawDisplayRow {
@@ -583,6 +610,11 @@ class SqliteMemoryStore implements MemoryStore {
   private claimEvictedTxn;
   private commitExtractionTxn;
   private deleteConversationTxn;
+  private maxTurnIdStmt;
+  private getResetWatermarkStmt;
+  private countTurnsAboveWatermarkStmt;
+  private upsertResetWatermarkStmt;
+  private resetConversationContextTxn;
   private appendPairTxn;
   private closed = false;
 
@@ -670,11 +702,17 @@ class SqliteMemoryStore implements MemoryStore {
       "INSERT INTO turns (persona, conversation, role, text, created_at, embeddable, source) VALUES (?, ?, ?, ?, ?, ?, ?)",
     );
     // Inner query gets most-recent-N descending; outer flips back to chronological.
+    // The live-history window, floored at the /reset watermark: turns at or
+    // below it stay in the DB (and in the index, and in durable facts) but are
+    // no longer replayed into the prompt. COALESCE covers the common case of a
+    // conversation that has never been reset (no row → 0 → everything shows).
     this.recentStmt = db.prepare(
       `SELECT role, text FROM (
          SELECT id, role, text, created_at
          FROM turns
          WHERE persona = ? AND conversation = ?
+           AND id > COALESCE((SELECT reset_turn_id FROM conversation_reset
+                              WHERE persona = ? AND conversation = ?), 0)
          ORDER BY created_at DESC, id DESC
          LIMIT ?
        ) ORDER BY created_at ASC, id ASC`,
@@ -690,6 +728,13 @@ class SqliteMemoryStore implements MemoryStore {
          WHERE persona = ?
            AND conversation LIKE ? || '%'
            AND conversation IS NOT ?
+           -- Correlated (not bound): this spans MANY sibling conversations,
+           -- each with its own watermark. Without it, a sibling that was
+           -- /reset would leak its pre-reset turns back in through the
+           -- cross-conversation briefing window.
+           AND id > COALESCE((SELECT r.reset_turn_id FROM conversation_reset r
+                              WHERE r.persona = turns.persona
+                                AND r.conversation = turns.conversation), 0)
          ORDER BY created_at DESC, id DESC
          LIMIT ?
        ) ORDER BY created_at ASC, id ASC`,
@@ -1003,6 +1048,59 @@ class SqliteMemoryStore implements MemoryStore {
         return turns;
       },
     );
+    this.maxTurnIdStmt = db.prepare(
+      "SELECT COALESCE(MAX(id), 0) AS maxId FROM turns WHERE persona = ? AND conversation = ?",
+    );
+    this.getResetWatermarkStmt = db.prepare(
+      "SELECT reset_turn_id AS mark FROM conversation_reset WHERE persona = ? AND conversation = ?",
+    );
+    this.countTurnsAboveWatermarkStmt = db.prepare(
+      "SELECT COUNT(*) AS n FROM turns WHERE persona = ? AND conversation = ? AND id > ?",
+    );
+    // MAX(existing, new) keeps the watermark monotonic. Belt-and-braces: the
+    // txn already refuses to lower it, but a concurrent writer that inserted
+    // turns between our read and write must not be able to rewind it either.
+    this.upsertResetWatermarkStmt = db.prepare(
+      `INSERT INTO conversation_reset (persona, conversation, reset_turn_id, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT (persona, conversation) DO UPDATE SET
+         reset_turn_id = MAX(conversation_reset.reset_turn_id, excluded.reset_turn_id),
+         updated_at    = excluded.updated_at`,
+    );
+    // Non-destructive /reset. Deliberately touches NOTHING but the watermark:
+    // no turn deletes, no index deletes, and the durable-fact cursor/leases
+    // are left alone precisely BECAUSE the turns survive — wiping the cursor
+    // here would re-extract the entire history from the top on the next pass.
+    this.resetConversationContextTxn = db.transaction(
+      (persona: string, conversation: string, ts: string): number => {
+        const prev =
+          (
+            this.getResetWatermarkStmt.get(persona, conversation) as
+              | { mark: number }
+              | undefined
+          )?.mark ?? 0;
+        const max =
+          (
+            this.maxTurnIdStmt.get(persona, conversation) as {
+              maxId: number;
+            }
+          ).maxId;
+        const hidden = (
+          this.countTurnsAboveWatermarkStmt.get(
+            persona,
+            conversation,
+            prev,
+          ) as { n: number }
+        ).n;
+        this.upsertResetWatermarkStmt.run(
+          persona,
+          conversation,
+          Math.max(prev, max),
+          ts,
+        );
+        return hidden;
+      },
+    );
     // Atomic user+assistant pair insert. Both rows share the same
     // created_at; ordering tiebreaks on the autoincrement id, so the
     // user turn (inserted first) always sorts before the assistant turn.
@@ -1065,7 +1163,13 @@ class SqliteMemoryStore implements MemoryStore {
     conversation: string,
     n: number,
   ): Promise<Array<{ role: Role; text: string }>> {
-    return this.recentStmt.all(persona, conversation, n) as Array<{
+    return this.recentStmt.all(
+      persona,
+      conversation,
+      persona,
+      conversation,
+      n,
+    ) as Array<{
       role: Role;
       text: string;
     }>;
@@ -1359,6 +1463,17 @@ class SqliteMemoryStore implements MemoryStore {
     // transaction so a reset never leaks facts into the next conversation on the
     // same key. Returns the turn count for back-compat.
     return this.deleteConversationTxn(persona, conversation) as number;
+  }
+
+  async resetConversationContext(
+    persona: string,
+    conversation: string,
+  ): Promise<number> {
+    return this.resetConversationContextTxn(
+      persona,
+      conversation,
+      new Date().toISOString(),
+    ) as number;
   }
 
   async purgeQuarantined(

--- a/tests/channels-commands.test.ts
+++ b/tests/channels-commands.test.ts
@@ -181,7 +181,7 @@ describe("/stop", () => {
 // ---------------------------------------------------------------------------
 
 describe("/reset", () => {
-  test("deletes turns for the active conversation only", async () => {
+  test("clears the context window for the active conversation only", async () => {
     // Seed two conversations under the same persona.
     await memory.appendTurn({
       persona: "phantom",
@@ -214,6 +214,66 @@ describe("/reset", () => {
   test("reports zero gracefully when there's nothing to clear", async () => {
     const r = await handleSlashCommand("/reset", ctx());
     expect(r!.reply).toContain("0 turns");
+  });
+
+  // The regression this whole change exists for. /reset used to delete the
+  // turn rows AND their embeddings, so a routine "clear this chat" silently
+  // destroyed history nothing else held a durable copy of. It must now clear
+  // only the replayed window.
+  test("does NOT delete the underlying turns — history survives a reset", async () => {
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "user",
+      text: "remember me",
+    });
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "assistant",
+      text: "I will",
+    });
+
+    await handleSlashCommand("/reset", ctx());
+
+    // Live window: empty, as the user asked for.
+    expect(await memory.recentTurns("phantom", "telegram:42", 10)).toEqual([]);
+    // Durable record: fully intact, still retrievable.
+    const survivors = await memory.turnsAfterId("phantom", "telegram:42", 0);
+    expect(survivors.map((t) => t.text)).toEqual(["remember me", "I will"]);
+  });
+
+  test("turns after a reset are replayed again — the window refills", async () => {
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "user",
+      text: "before",
+    });
+    await handleSlashCommand("/reset", ctx());
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "user",
+      text: "after",
+    });
+
+    expect(await memory.recentTurns("phantom", "telegram:42", 10)).toEqual([
+      { role: "user", text: "after" },
+    ]);
+  });
+
+  test("a second reset with no new turns is a no-op, not a re-clear", async () => {
+    await memory.appendTurn({
+      persona: "phantom",
+      conversation: "telegram:42",
+      role: "user",
+      text: "once",
+    });
+    const first = await handleSlashCommand("/reset", ctx());
+    expect(first!.reply).toContain("1 turn ");
+    const second = await handleSlashCommand("/reset", ctx());
+    expect(second!.reply).toContain("0 turns");
   });
 
   test("singular noun for exactly one turn deleted", async () => {

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -387,3 +387,71 @@ describe("MemoryStore — concurrent open under a transient cross-process lock",
     }
   });
 });
+
+describe("MemoryStore.resetConversationContext (non-destructive /reset)", () => {
+  test("empties the live window but keeps every turn on disk", async () => {
+    await append("phantom", "c1", "user", "one");
+    await append("phantom", "c1", "assistant", "two");
+
+    const dropped = await store.resetConversationContext("phantom", "c1");
+    expect(dropped).toBe(2);
+
+    expect(await store.recentTurns("phantom", "c1", 10)).toEqual([]);
+    const rows = await store.turnsAfterId("phantom", "c1", 0);
+    expect(rows.map((r) => r.text)).toEqual(["one", "two"]);
+  });
+
+  test("only the reset conversation is affected", async () => {
+    await append("phantom", "c1", "user", "mine");
+    await append("phantom", "c2", "user", "theirs");
+
+    await store.resetConversationContext("phantom", "c1");
+
+    expect(await store.recentTurns("phantom", "c1", 10)).toEqual([]);
+    expect(await store.recentTurns("phantom", "c2", 10)).toEqual([
+      { role: "user", text: "theirs" },
+    ]);
+  });
+
+  test("turns appended after the reset replay normally", async () => {
+    await append("phantom", "c1", "user", "old");
+    await store.resetConversationContext("phantom", "c1");
+    await append("phantom", "c1", "user", "new");
+
+    expect(await store.recentTurns("phantom", "c1", 10)).toEqual([
+      { role: "user", text: "new" },
+    ]);
+  });
+
+  test("the watermark is monotonic — a later reset never un-hides earlier turns", async () => {
+    await append("phantom", "c1", "user", "a");
+    await store.resetConversationContext("phantom", "c1");
+    await append("phantom", "c1", "user", "b");
+    // Second reset hides "b" too; "a" must stay hidden, not come back.
+    expect(await store.resetConversationContext("phantom", "c1")).toBe(1);
+    expect(await store.recentTurns("phantom", "c1", 10)).toEqual([]);
+
+    await append("phantom", "c1", "user", "c");
+    expect(await store.recentTurns("phantom", "c1", 10)).toEqual([
+      { role: "user", text: "c" },
+    ]);
+  });
+
+  test("resetting an empty conversation reports 0 and is safe", async () => {
+    expect(await store.resetConversationContext("phantom", "nope")).toBe(0);
+    expect(await store.recentTurns("phantom", "nope", 10)).toEqual([]);
+  });
+
+  test("a reset sibling doesn't leak pre-reset turns into the prefix window", async () => {
+    await append("phantom", "phantomchat:group:a", "user", "hidden");
+    await append("phantom", "phantomchat:group:b", "user", "visible");
+    await store.resetConversationContext("phantom", "phantomchat:group:a");
+
+    const rows = await store.recentTurnsForConversationPrefix(
+      "phantom",
+      "phantomchat:group:",
+      10,
+    );
+    expect(rows.map((r) => r.text)).toEqual(["visible"]);
+  });
+});


### PR DESCRIPTION
## The problem

`/reset` was a **destructive** command wearing the name of a harmless one. `handleReset()` did two deletes:

```ts
await ctx.memory.deleteConversation(persona, conversation);  // the turn rows
ix.deleteConversationTurns(persona, conversation);           // their embeddings
```

Andrew ran a `/reset` on his Telegram DM expecting to clear the live context and see what survived in vector memory. Nothing survived — because reset had wiped the vectors in the same call:

```
"commands: /reset", conversation:"telegram:7995070089",
 deletedTurns:4009, removedIndexedTurns:true
```

4,009 turns and every embedding, unrecoverable. Nothing else in the system holds a durable copy of recent history, so a command people reach for casually ("clear this chat") is in practice "permanently destroy this thread's memory".

## The change

`/reset` now clears **only the live context window**. Nothing is deleted.

A per-conversation watermark:

```sql
CREATE TABLE IF NOT EXISTS conversation_reset (
  persona       TEXT NOT NULL,
  conversation  TEXT NOT NULL,
  reset_turn_id INTEGER NOT NULL DEFAULT 0,
  updated_at    TEXT NOT NULL,
  PRIMARY KEY (persona, conversation)
);
```

`recentTurns()` floors the replay window at that watermark. After a reset the prompt replays nothing; the turns, their embeddings, durable facts, and the extractor's cursor/leases all survive and stay retrievable through search.

### Details worth a reviewer's eye

- **Monotonic watermark.** Upsert uses `MAX(existing, new)`, so a later reset can never un-hide turns an earlier one hid — including if a concurrent writer inserts between the read and the write.
- **Sibling conversations.** `recentTurnsForConversationPrefix()` (the cross-conversation briefing window) applies the watermark **correlated per conversation** — without it, a reset chat would leak its pre-reset turns back in through the group briefing path.
- **Durable-fact cursor deliberately NOT cleared.** `deleteConversation()` clears it because the turns are actually gone. Here they aren't, so wiping the cursor would re-extract the entire history from the top on the next pass.
- **`deleteConversation()` is untouched** and still available for genuine deletion — it's just no longer what `/reset` calls. No `--hard` flag: Andrew's call was that reset should only ever mean "clear the window".
- **Migration:** `CREATE TABLE IF NOT EXISTS` runs in `SCHEMA` on every open, so existing DBs pick it up with no backfill. Conversations with no row read as watermark `0` — everything shows, exactly as before.
- **Truthful UX.** The reply is now `reset: cleared N turns from this chat's context — history kept, still searchable`, and the Telegram command description no longer promises to "Clear this chat's history".

## Tests

Store-level (`tests/memory.test.ts`): window empties while rows survive on disk; scoping to one conversation; post-reset turns replay again; monotonicity across two resets; empty-conversation no-op; the sibling-leak case.

Command-level (`tests/channels-commands.test.ts`): the **regression this exists for** — `/reset` does not delete the underlying turns; window refills with new turns; a second reset with nothing new reports 0.

Full suite: **2691 pass, 0 fail**. Typecheck clean.