### PR TITLE
feat(phantomchat): read-back-driven relay quarantine with a floor of 3 (#359)

### DIFF
--- a/src/channels/phantomchat/relayHealth.ts
+++ b/src/channels/phantomchat/relayHealth.ts
@@ -1,0 +1,280 @@
+/**
+ * Relay health tracking + quarantine (issue #359).
+ *
+ * BACKGROUND. A nostr relay can answer a publish with `OK:true` and never
+ * store the event (nostr-rs-relay's ACK-then-drop on non-conformant events, or
+ * an unauthenticated publish under `nip42_auth`). Issue #368 added read-back
+ * verification, which NAMES the relays that dropped an event — but nothing
+ * acted on the result. In production 4 of the 7 canonical relays fail read-back
+ * on ~100% of events, and we kept publishing to them on every message forever:
+ * wasted connections, wasted publishes, and a warning line per send.
+ *
+ * WHAT THIS DOES. Turn that existing read-back signal into a quarantine
+ * decision. A relay that fails read-back READBACK_STRIKE_THRESHOLD times in a
+ * row is quarantined from the PUBLISH set for an exponentially growing span
+ * (base one hour, jittered). It keeps its READ subscription — see "reads are
+ * never quarantined" below — so promoting it back costs nothing.
+ *
+ * FOUR PROPERTIES THIS IS BUILT AROUND
+ *
+ * 1. NO POLLING, NO TIMERS. Health is a by-product of traffic we already
+ *    generate: every publish already runs a read-back, so scoring is free.
+ *    There is no health-check loop and not a single `setTimeout` in this file
+ *    — quarantine expiry is evaluated lazily, by comparing `Date.now()` at the
+ *    moment we next need a publish set. A pool that sends nothing burns
+ *    literally zero cycles on health.
+ *
+ * 2. READS ARE NEVER QUARANTINED — so failover is instant. Quarantine applies
+ *    ONLY to publish targets. The transport keeps its subscription open on
+ *    every configured relay, which means (a) a relay that drops writes may
+ *    still deliver reads, and the 15s catch-up poll keeps using it, and (b)
+ *    every quarantined relay is a WARM SPARE: its socket is already open, so
+ *    promoting one back into the publish set is a pure bookkeeping change with
+ *    no connect, no handshake, no wait. This is the "I hate waiting to
+ *    reconnect a relay" requirement — we never reconnect, because we never
+ *    disconnected.
+ *
+ * 3. A FLOOR OF THREE. Delivery only needs ONE healthy relay shared by sender
+ *    and recipient, but the sender and the recipient quarantine independently —
+ *    phantombot's bad-relay set and the PWA's need not agree. A floor of 3
+ *    keeps the intersection non-empty in practice. `publishTargets()` will
+ *    therefore promote the best-ranked quarantined relays back, ignoring their
+ *    remaining quarantine, rather than ever return fewer than
+ *    MIN_PUBLISH_RELAYS. A quarantine is an OPINION about relay quality; the
+ *    floor is a HARD CONSTRAINT and wins.
+ *
+ * 4. DETERMINISTIC RANKING. `rankRelays` is a pure total order over (score,
+ *    url). Given the same observations, phantombot and the PWA sort the same
+ *    way — so the two ends converge on the same subset instead of drifting
+ *    apart and losing their intersection. The url tiebreak matters: it is what
+ *    makes the order total, and it is why a fresh client with no observations
+ *    at all still picks the same three relays as everyone else.
+ */
+
+/** Consecutive read-back failures before a relay is quarantined. */
+export const READBACK_STRIKE_THRESHOLD = 5;
+
+/**
+ * First quarantine span. Doubles on each REPEAT offence (a relay that earns a
+ * quarantine again after already serving one), capped at QUARANTINE_MAX_MS, so
+ * a persistently dead relay is retried roughly twice a day instead of hourly,
+ * while a relay that had one bad hour is back in rotation quickly.
+ */
+export const QUARANTINE_BASE_MS = 60 * 60 * 1000; // 1 hour
+export const QUARANTINE_MAX_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+/**
+ * ±10% jitter on every quarantine span. Without it, a fleet that all saw the
+ * same relay die at the same time un-quarantines it at the same instant and
+ * stampedes it. The jitter is applied once, when the quarantine is set.
+ */
+export const QUARANTINE_JITTER = 0.1;
+
+/**
+ * Never publish to fewer than this many relays — see property 3 above. If
+ * quarantine would take us below the floor, the best-ranked quarantined relays
+ * are promoted back to fill it.
+ */
+export const MIN_PUBLISH_RELAYS = 3;
+
+/**
+ * Per-relay health record. Deliberately small and JSON-shaped: it is cheap to
+ * keep in memory, and cheap to persist later if we ever want health to survive
+ * a restart (we currently don't — a restart is a reasonable moment to give
+ * every relay a fresh chance).
+ */
+export interface RelayHealthRecord {
+  /** Consecutive read-back failures. Reset to 0 by any confirmed store. */
+  strikes: number;
+  /** Lifetime counters, for ranking and for the health report. */
+  confirmed: number;
+  dropped: number;
+  /** Epoch ms until which this relay is out of the publish set; 0 = active. */
+  quarantinedUntil: number;
+  /** How many quarantines this relay has served — drives the backoff. */
+  quarantineCount: number;
+}
+
+const emptyRecord = (): RelayHealthRecord => ({
+  strikes: 0,
+  confirmed: 0,
+  dropped: 0,
+  quarantinedUntil: 0,
+  quarantineCount: 0,
+});
+
+/**
+ * Health score in [0, 1]: the share of read-backs a relay confirmed. A relay
+ * with no observations yet scores 1 (optimistic — an unknown relay is assumed
+ * good until it proves otherwise, which is what lets a fresh client use its
+ * configured relays immediately). Current strikes are subtracted as a small
+ * penalty so a relay that is failing RIGHT NOW ranks below one with the same
+ * lifetime ratio that is currently fine.
+ */
+export function relayScore(rec: RelayHealthRecord | undefined): number {
+  if (!rec) return 1;
+  const total = rec.confirmed + rec.dropped;
+  const ratio = total === 0 ? 1 : rec.confirmed / total;
+  const strikePenalty = Math.min(rec.strikes, READBACK_STRIKE_THRESHOLD) /
+    (READBACK_STRIKE_THRESHOLD * 10);
+  return Math.max(0, ratio - strikePenalty);
+}
+
+/**
+ * Deterministic total order: best score first, url ascending as the tiebreak.
+ * PURE — no clock, no randomness — so both ends of a conversation produce the
+ * same order from the same observations. Do not add a time term here.
+ */
+export function rankRelays(
+  relays: readonly string[],
+  health: ReadonlyMap<string, RelayHealthRecord>,
+): string[] {
+  return [...relays].sort((a, b) => {
+    const diff = relayScore(health.get(b)) - relayScore(health.get(a));
+    if (Math.abs(diff) > 1e-9) return diff;
+    return a < b ? -1 : a > b ? 1 : 0;
+  });
+}
+
+/**
+ * Tracks per-relay read-back outcomes and derives the publish set.
+ *
+ * Lifecycle: `record()` is called once per relay per publish (from the
+ * transport's existing read-back pass), `publishTargets()` is called once per
+ * publish. Nothing else runs. No timers are created or held.
+ */
+export class RelayHealthTracker {
+  private readonly health = new Map<string, RelayHealthRecord>();
+  /** Relays whose quarantine we've already logged, so we log each once. */
+  private readonly announced = new Set<string>();
+
+  constructor(
+    private readonly relays: readonly string[],
+    private readonly log: {
+      info: (msg: string, meta?: unknown) => void;
+      debug: (msg: string, meta?: unknown) => void;
+    },
+    /** Injectable for tests. Defaults to a ±QUARANTINE_JITTER factor. */
+    private readonly jitter: () => number = () =>
+      1 + (Math.random() * 2 - 1) * QUARANTINE_JITTER,
+  ) {}
+
+  private rec(url: string): RelayHealthRecord {
+    let r = this.health.get(url);
+    if (!r) {
+      r = emptyRecord();
+      this.health.set(url, r);
+    }
+    return r;
+  }
+
+  /**
+   * Record one read-back outcome. `confirmed` = the relay returned the event
+   * we just published to it (it really stored it); false = it didn't, within
+   * the read-back timeout.
+   *
+   * A single confirmation clears the strike streak: quarantine is for relays
+   * that are CONSISTENTLY dropping, not ones that hiccuped or were slow to
+   * index. This is also the recovery path — a promoted relay that starts
+   * confirming again is immediately back to a clean record.
+   */
+  record(url: string, confirmed: boolean, now = Date.now()): void {
+    const r = this.rec(url);
+    if (confirmed) {
+      r.confirmed++;
+      if (r.strikes > 0) {
+        this.log.debug("phantomchat: relay read-back recovered", {
+          relay: url,
+          clearedStrikes: r.strikes,
+        });
+      }
+      r.strikes = 0;
+      // A relay that confirms while quarantined has proved itself — let it
+      // straight back in rather than making it sit out the rest of the span.
+      if (r.quarantinedUntil > now) {
+        r.quarantinedUntil = 0;
+        this.announced.delete(url);
+        this.log.info("phantomchat: relay released from quarantine early", {
+          relay: url,
+        });
+      }
+      return;
+    }
+
+    r.dropped++;
+    r.strikes++;
+    if (r.strikes < READBACK_STRIKE_THRESHOLD) return;
+    if (r.quarantinedUntil > now) return; // already serving one
+
+    const span = Math.min(
+      QUARANTINE_BASE_MS * Math.pow(2, r.quarantineCount),
+      QUARANTINE_MAX_MS,
+    );
+    const jittered = Math.round(span * this.jitter());
+    r.quarantinedUntil = now + jittered;
+    r.quarantineCount++;
+    r.strikes = 0; // streak consumed by the quarantine
+    this.announced.delete(url);
+    this.log.info("phantomchat: relay quarantined from publish set", {
+      relay: url,
+      forMinutes: Math.round(jittered / 60000),
+      offence: r.quarantineCount,
+      confirmed: r.confirmed,
+      dropped: r.dropped,
+    });
+  }
+
+  /** True if `url` is currently serving a quarantine. */
+  isQuarantined(url: string, now = Date.now()): boolean {
+    return (this.health.get(url)?.quarantinedUntil ?? 0) > now;
+  }
+
+  /**
+   * The relays to publish to right now.
+   *
+   * Healthy relays first; if that leaves us below MIN_PUBLISH_RELAYS, the
+   * best-ranked quarantined relays are promoted back to fill the floor (the
+   * floor is a hard constraint, quarantine is only an opinion — property 3).
+   * Promotion is free: those sockets are still open for reads (property 2).
+   *
+   * Lazy expiry: quarantines are evaluated against `now` here, which is the
+   * only place time is read. No timer wakes anything up to expire them.
+   */
+  publishTargets(now = Date.now()): string[] {
+    const ranked = rankRelays(this.relays, this.health);
+    const active = ranked.filter((url) => !this.isQuarantined(url, now));
+    if (active.length >= MIN_PUBLISH_RELAYS) return active;
+
+    // Below the floor — promote the best quarantined relays back, in rank
+    // order, until we hit it (or run out of relays entirely).
+    const promoted = ranked.filter((url) => this.isQuarantined(url, now));
+    const filled = [...active];
+    for (const url of promoted) {
+      if (filled.length >= MIN_PUBLISH_RELAYS) break;
+      filled.push(url);
+      if (!this.announced.has(url)) {
+        this.announced.add(url);
+        this.log.info(
+          "phantomchat: promoting quarantined relay to hold the floor",
+          { relay: url, floor: MIN_PUBLISH_RELAYS, healthy: active.length },
+        );
+      }
+    }
+    return filled;
+  }
+
+  /** Snapshot for logging / diagnostics. Never used for control flow. */
+  report(now = Date.now()): Array<
+    { relay: string; score: number; quarantined: boolean } & RelayHealthRecord
+  > {
+    return rankRelays(this.relays, this.health).map((relay) => {
+      const r = this.health.get(relay) ?? emptyRecord();
+      return {
+        relay,
+        score: relayScore(r),
+        quarantined: this.isQuarantined(relay, now),
+        ...r,
+      };
+    });
+  }
+}

--- a/src/channels/phantomchat/relayHealth.ts
+++ b/src/channels/phantomchat/relayHealth.ts
@@ -43,6 +43,13 @@
  *    MIN_PUBLISH_RELAYS. A quarantine is an OPINION about relay quality; the
  *    floor is a HARD CONSTRAINT and wins.
  *
+ *    Say this precisely, because it will be quoted: the floor is NOT a proof of
+ *    intersection. Two 3-subsets of a 7-relay list can be disjoint. What makes
+ *    disjointness unlikely is the floor TOGETHER WITH property 4 — both ends
+ *    rank by the same pure function, so they only diverge to the extent their
+ *    observations diverge. If we ever need a real guarantee it has to come from
+ *    a pinned, shared write set, not from a larger floor.
+ *
  * 4. DETERMINISTIC RANKING. `rankRelays` is a pure total order over (score,
  *    url). Given the same observations, phantombot and the PWA sort the same
  *    way — so the two ends converge on the same subset instead of drifting
@@ -149,7 +156,7 @@ export class RelayHealthTracker {
   private readonly announced = new Set<string>();
 
   constructor(
-    private readonly relays: readonly string[],
+    private relays: readonly string[],
     private readonly log: {
       info: (msg: string, meta?: unknown) => void;
       debug: (msg: string, meta?: unknown) => void;
@@ -158,6 +165,28 @@ export class RelayHealthTracker {
     private readonly jitter: () => number = () =>
       1 + (Math.random() * 2 - 1) * QUARANTINE_JITTER,
   ) {}
+
+  /**
+   * Replace the relay list this tracker ranks over.
+   *
+   * The tracker is constructed with the relay list, which would go stale the
+   * day relay config becomes hot-reloadable. Rather than leave that as a
+   * comment-shaped trap, the seam exists now: call this whenever the transport
+   * re-reads its relay set. Health is keyed by URL, so relays that survive the
+   * change KEEP their observations and their in-flight quarantines; records for
+   * relays that are gone are dropped, so a long-lived process that rotates its
+   * relay list does not accumulate them forever.
+   */
+  setRelays(relays: readonly string[]): void {
+    this.relays = [...relays];
+    const live = new Set(relays);
+    for (const url of [...this.health.keys()]) {
+      if (!live.has(url)) {
+        this.health.delete(url);
+        this.announced.delete(url);
+      }
+    }
+  }
 
   private rec(url: string): RelayHealthRecord {
     let r = this.health.get(url);

--- a/src/channels/phantomchat/transport.ts
+++ b/src/channels/phantomchat/transport.ts
@@ -31,6 +31,7 @@ import {
   makeRelayAuthSigner,
   type RelayAuthSigner,
 } from "./relayAuth.ts";
+import { RelayHealthTracker } from "./relayHealth.ts";
 import {
   oggOpusDurationSeconds,
   oggOpusWaveformBase64,
@@ -118,7 +119,14 @@ const FETCH_PROFILES_TIMEOUT_MS = 3000;
  * logs, never blocks or rejects the send path.
  */
 export const PUBLISH_READBACK_SETTLE_MS = 750;
-export const PUBLISH_READBACK_TIMEOUT_MS = 2500;
+/**
+ * Raised 2500 → 5000 with issue #359. The read-back result is no longer just a
+ * log line — it now drives quarantine — so a false negative has a real cost (a
+ * merely SLOW relay could be scored as a DROPPING one). 5s is well clear of
+ * observed p99 index+query latency on the healthy relays, and the check is
+ * detached, so the extra patience costs the send path nothing.
+ */
+export const PUBLISH_READBACK_TIMEOUT_MS = 5000;
 
 /**
  * The Nostr filter shape we subscribe with. Kept minimal: kind-1059 gift-wraps
@@ -385,6 +393,15 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
    */
   private readonly authSigner: RelayAuthSigner;
 
+  /**
+   * Per-relay read-back health (issue #359). Consulted on every publish to pick
+   * the target set, and fed by the read-back pass that already runs after each
+   * publish. Quarantine is PUBLISH-ONLY: `this.relays` — the subscription set —
+   * is never narrowed, so a quarantined relay keeps its socket and its reads,
+   * and promoting it back later costs nothing. See relayHealth.ts.
+   */
+  readonly relayHealth: RelayHealthTracker;
+
   constructor(
     private readonly ourSecretKey: Uint8Array,
     relays: string[],
@@ -393,6 +410,10 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     this.relays = [...relays];
     this.ourPubHex = getPublicKey(ourSecretKey);
     this.authSigner = makeRelayAuthSigner(ourSecretKey);
+    this.relayHealth = new RelayHealthTracker(this.relays, {
+      info: (msg, meta) => log.info(msg, meta as Record<string, unknown>),
+      debug: (msg, meta) => log.debug(msg, meta as Record<string, unknown>),
+    });
   }
 
   /**
@@ -578,13 +599,19 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     // relay rejects the publish with `auth-required:`, nostr-tools signs a
     // kind-22242 auth event and retries the publish once, authenticated
     // (issue #368 — without this, AUTH-requiring relays drop everything).
+    // Publish only to relays that are currently trusted to STORE what we send
+    // (issue #359). Quarantined relays are skipped here and here only — they
+    // keep their read subscription, so this costs no connection churn and the
+    // set can widen again the instant health recovers. Never fewer than
+    // MIN_PUBLISH_RELAYS: the floor outranks the quarantine.
+    const targets = this.relayHealth.publishTargets();
     const results = await Promise.allSettled(
-      this.pool.publish(this.relays, event, { onauth: this.authSigner }),
+      this.pool.publish(targets, event, { onauth: this.authSigner }),
     );
     const ok = results.some((r) => r.status === "fulfilled");
     if (!ok) {
       log.warn("phantomchat: publish failed on all relays", {
-        relays: this.relays.length,
+        relays: targets.length,
         eventId: event.id,
       });
     }
@@ -592,7 +619,9 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     // be stored — observed on nostr-rs-relay with nip42_auth, which ACKs and
     // silently drops. Re-query each relay for the event id and warn loudly,
     // naming the relays, when it isn't there. Detached: never blocks the send.
-    void this.verifyStored(event);
+    // Its per-relay results are what feed the health tracker above, which is
+    // why health costs no extra traffic — this pass was already running.
+    void this.verifyStored(event, undefined, targets);
   }
 
   /**
@@ -612,6 +641,7 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
   async verifyStored(
     event: NTNostrEvent,
     timing?: { settleMs?: number; timeoutMs?: number },
+    targets: readonly string[] = this.relays,
   ): Promise<string[]> {
     if (event.kind >= 20000 && event.kind < 30000) return [];
     const missing: string[] = [];
@@ -619,15 +649,19 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
       setTimeout(r, timing?.settleMs ?? PUBLISH_READBACK_SETTLE_MS),
     );
     await Promise.all(
-      this.relays.map(async (relay) => {
+      targets.map(async (relay) => {
         const found = await this.readBackOne(relay, event.id, timing?.timeoutMs);
         if (!found) missing.push(relay);
+        // Feed the quarantine tracker (issue #359). This is the ONLY health
+        // signal in the system — derived from traffic we were already sending,
+        // so relay health costs zero additional requests.
+        this.relayHealth.record(relay, found);
       }),
     );
     if (missing.length > 0) {
       log.warn(
         "phantomchat: publish NOT confirmed stored — relay(s) dropped the event",
-        { eventId: event.id, kind: event.kind, missing, relays: this.relays.length },
+        { eventId: event.id, kind: event.kind, missing, relays: targets.length },
       );
     }
     return missing;

--- a/tests/channels-phantomchat-relayHealth.test.ts
+++ b/tests/channels-phantomchat-relayHealth.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for read-back-driven relay quarantine (issue #359).
+ *
+ * THE BUG: issue #368 gave us read-back verification, which correctly NAMES
+ * the relays that ACK a publish and never store it — and then we published to
+ * them again on the very next message, forever. In production 4 of 7 canonical
+ * relays fail read-back on ~100% of events. Every send wasted 4 publishes and
+ * emitted a warning; nothing ever adapted.
+ *
+ * THE FIX, and what these tests pin:
+ *
+ *   1. Consecutive read-back failures quarantine a relay from the PUBLISH set
+ *      (and only the publish set — reads keep flowing, which is what makes
+ *      promotion free).
+ *   2. A single confirmation clears the streak, so a slow or hiccuping relay is
+ *      never quarantined for a blip.
+ *   3. The floor of 3 is a HARD constraint: quarantine may never shrink the
+ *      publish set below it, because the recipient quarantines independently
+ *      and the two sets must still intersect.
+ *   4. Ranking is deterministic and pure, so both ends converge on the same
+ *      subset from the same observations.
+ *   5. Repeat offenders back off exponentially, and jitter keeps a fleet from
+ *      un-quarantining in lockstep.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  finalizeEvent,
+  generateSecretKey,
+} from "nostr-tools/pure";
+import {
+  MIN_PUBLISH_RELAYS,
+  QUARANTINE_BASE_MS,
+  QUARANTINE_MAX_MS,
+  READBACK_STRIKE_THRESHOLD,
+  RelayHealthTracker,
+  rankRelays,
+  relayScore,
+  type RelayHealthRecord,
+} from "../src/channels/phantomchat/relayHealth.ts";
+import {
+  SimplePoolPhantomchatTransport,
+  type NostrFilter,
+  type RelayPool,
+} from "../src/channels/phantomchat/transport.ts";
+import type { NTNostrEvent } from "../src/lib/nostrCrypto.ts";
+
+const quietLog = { info: () => {}, debug: () => {} };
+/** No jitter — deterministic spans in tests. */
+const noJitter = () => 1;
+
+const SEVEN = [
+  "wss://r1.example",
+  "wss://r2.example",
+  "wss://r3.example",
+  "wss://r4.example",
+  "wss://r5.example",
+  "wss://r6.example",
+  "wss://r7.example",
+];
+
+function tracker(relays = SEVEN) {
+  return new RelayHealthTracker(relays, quietLog, noJitter);
+}
+
+/** Fail `url` enough times to earn a quarantine. */
+function strikeOut(t: RelayHealthTracker, url: string, now = Date.now()): void {
+  for (let i = 0; i < READBACK_STRIKE_THRESHOLD; i++) t.record(url, false, now);
+}
+
+describe("relay quarantine from read-back failures", () => {
+  test("a relay is NOT quarantined before the strike threshold", () => {
+    const t = tracker();
+    const now = Date.now();
+    for (let i = 0; i < READBACK_STRIKE_THRESHOLD - 1; i++) {
+      t.record("wss://r1.example", false, now);
+    }
+    expect(t.isQuarantined("wss://r1.example", now)).toBe(false);
+    expect(t.publishTargets(now)).toContain("wss://r1.example");
+  });
+
+  test("the threshold-th consecutive failure quarantines it", () => {
+    const t = tracker();
+    const now = Date.now();
+    strikeOut(t, "wss://r1.example", now);
+    expect(t.isQuarantined("wss://r1.example", now)).toBe(true);
+    expect(t.publishTargets(now)).not.toContain("wss://r1.example");
+  });
+
+  test("one confirmation clears the streak — a blip never quarantines", () => {
+    const t = tracker();
+    const now = Date.now();
+    for (let i = 0; i < READBACK_STRIKE_THRESHOLD - 1; i++) {
+      t.record("wss://r1.example", false, now);
+    }
+    t.record("wss://r1.example", true, now); // recovered
+    for (let i = 0; i < READBACK_STRIKE_THRESHOLD - 1; i++) {
+      t.record("wss://r1.example", false, now);
+    }
+    expect(t.isQuarantined("wss://r1.example", now)).toBe(false);
+  });
+
+  test("quarantine expires lazily after the span, with no timer", () => {
+    const t = tracker();
+    const now = Date.now();
+    strikeOut(t, "wss://r1.example", now);
+    expect(t.isQuarantined("wss://r1.example", now + QUARANTINE_BASE_MS - 1)).toBe(true);
+    expect(t.isQuarantined("wss://r1.example", now + QUARANTINE_BASE_MS + 1)).toBe(false);
+  });
+
+  test("a confirmation while quarantined releases it early", () => {
+    const t = tracker();
+    const now = Date.now();
+    strikeOut(t, "wss://r1.example", now);
+    expect(t.isQuarantined("wss://r1.example", now)).toBe(true);
+    t.record("wss://r1.example", true, now);
+    expect(t.isQuarantined("wss://r1.example", now)).toBe(false);
+  });
+
+  test("repeat offences back off exponentially and cap", () => {
+    const t = tracker();
+    let now = Date.now();
+    // 1st offence: base span.
+    strikeOut(t, "wss://r1.example", now);
+    expect(t.isQuarantined("wss://r1.example", now + QUARANTINE_BASE_MS - 1)).toBe(true);
+    // 2nd offence after it lapses: 2× base.
+    now += QUARANTINE_BASE_MS + 1;
+    strikeOut(t, "wss://r1.example", now);
+    expect(t.isQuarantined("wss://r1.example", now + QUARANTINE_BASE_MS * 2 - 1)).toBe(true);
+    expect(t.isQuarantined("wss://r1.example", now + QUARANTINE_BASE_MS * 2 + 1)).toBe(false);
+    // Many offences later it saturates at the cap, never beyond.
+    for (let i = 0; i < 10; i++) {
+      now += QUARANTINE_MAX_MS + 1;
+      strikeOut(t, "wss://r1.example", now);
+    }
+    expect(t.isQuarantined("wss://r1.example", now + QUARANTINE_MAX_MS + 1)).toBe(false);
+  });
+
+  test("jitter spreads the span so a fleet doesn't stampede", () => {
+    const spans = new Set<number>();
+    for (let i = 0; i < 20; i++) {
+      const t = new RelayHealthTracker(SEVEN, quietLog);
+      const now = 0;
+      strikeOut(t, "wss://r1.example", now);
+      // Binary-search-free probe: find the smallest ms at which it's free.
+      let span = QUARANTINE_BASE_MS * 0.8;
+      while (t.isQuarantined("wss://r1.example", span)) span += 60_000;
+      spans.add(span);
+    }
+    expect(spans.size).toBeGreaterThan(1);
+  });
+});
+
+describe("the floor of 3 outranks quarantine", () => {
+  test("publish set never drops below MIN_PUBLISH_RELAYS", () => {
+    const t = tracker();
+    const now = Date.now();
+    // Poison every single relay.
+    for (const url of SEVEN) strikeOut(t, url, now);
+    const targets = t.publishTargets(now);
+    expect(targets.length).toBe(MIN_PUBLISH_RELAYS);
+  });
+
+  test("a quarantined relay is promoted back to fill the floor", () => {
+    const t = tracker();
+    const now = Date.now();
+    // Kill 5 of 7 — only 2 healthy remain, one short of the floor.
+    for (const url of SEVEN.slice(0, 5)) strikeOut(t, url, now);
+    const targets = t.publishTargets(now);
+    expect(targets.length).toBe(MIN_PUBLISH_RELAYS);
+    expect(targets).toContain("wss://r6.example");
+    expect(targets).toContain("wss://r7.example");
+    // The third is a promoted quarantined relay — and it's the best-ranked one,
+    // not an arbitrary pick.
+    const promoted = targets.filter((u) => t.isQuarantined(u, now));
+    expect(promoted.length).toBe(1);
+  });
+
+  test("promotion picks the LEAST-bad quarantined relay", () => {
+    const t = tracker();
+    const now = Date.now();
+    for (const url of SEVEN.slice(0, 5)) strikeOut(t, url, now);
+    // r1 has also confirmed plenty in its life; r2..r5 never confirmed at all.
+    for (let i = 0; i < 50; i++) t.record("wss://r1.example", true, now);
+    strikeOut(t, "wss://r1.example", now); // re-quarantine it, good ratio intact
+    const targets = t.publishTargets(now);
+    const promoted = targets.filter((u) => t.isQuarantined(u, now));
+    expect(promoted).toEqual(["wss://r1.example"]);
+  });
+
+  test("with fewer relays configured than the floor, we use them all", () => {
+    const two = ["wss://a.example", "wss://b.example"];
+    const t = tracker(two);
+    const now = Date.now();
+    for (const url of two) strikeOut(t, url, now);
+    expect(t.publishTargets(now).sort()).toEqual([...two].sort());
+  });
+
+  test("healthy relays are preferred over promoted ones", () => {
+    const t = tracker();
+    const now = Date.now();
+    for (const url of SEVEN.slice(0, 4)) strikeOut(t, url, now);
+    const targets = t.publishTargets(now);
+    // Exactly the 3 survivors, no promotion needed.
+    expect(targets.sort()).toEqual(
+      ["wss://r5.example", "wss://r6.example", "wss://r7.example"],
+    );
+  });
+});
+
+describe("deterministic ranking", () => {
+  test("same observations produce the same order (pure, no clock)", () => {
+    const health = new Map<string, RelayHealthRecord>([
+      ["wss://r1.example", { strikes: 0, confirmed: 10, dropped: 0, quarantinedUntil: 0, quarantineCount: 0 }],
+      ["wss://r2.example", { strikes: 0, confirmed: 5, dropped: 5, quarantinedUntil: 0, quarantineCount: 0 }],
+    ]);
+    const a = rankRelays(SEVEN, health);
+    const b = rankRelays([...SEVEN].reverse(), health);
+    expect(a).toEqual(b);
+  });
+
+  test("url is the tiebreak, so unobserved relays still order identically", () => {
+    const ranked = rankRelays(SEVEN, new Map());
+    expect(ranked).toEqual([...SEVEN].sort());
+  });
+
+  test("a dropping relay ranks below a confirming one", () => {
+    const health = new Map<string, RelayHealthRecord>([
+      ["wss://r7.example", { strikes: 0, confirmed: 10, dropped: 0, quarantinedUntil: 0, quarantineCount: 0 }],
+      ["wss://r1.example", { strikes: 0, confirmed: 0, dropped: 10, quarantinedUntil: 0, quarantineCount: 0 }],
+    ]);
+    const ranked = rankRelays(SEVEN, health);
+    // r7 confirms everything, r1 drops everything. Note the unobserved relays
+    // tie with r7 at score 1 (optimism) and break by url, so this asserts the
+    // RELATIVE order that matters, not an absolute position.
+    expect(ranked.indexOf("wss://r7.example"))
+      .toBeLessThan(ranked.indexOf("wss://r1.example"));
+    expect(ranked[ranked.length - 1]).toBe("wss://r1.example");
+  });
+
+  test("an unobserved relay is optimistically scored 1", () => {
+    expect(relayScore(undefined)).toBe(1);
+  });
+
+  test("current strikes penalise an otherwise-good ratio", () => {
+    const clean: RelayHealthRecord = { strikes: 0, confirmed: 10, dropped: 0, quarantinedUntil: 0, quarantineCount: 0 };
+    const striking: RelayHealthRecord = { ...clean, strikes: 3 };
+    expect(relayScore(striking)).toBeLessThan(relayScore(clean));
+  });
+});
+
+describe("transport wiring", () => {
+  const sk = generateSecretKey();
+  const event = finalizeEvent(
+    { kind: 1059, created_at: Math.floor(Date.now() / 1000), tags: [], content: "wrapped" },
+    sk,
+  ) as unknown as NTNostrEvent;
+
+  /** Fake pool: `storedOn` decides which relays answer the read-back REQ. */
+  function storedPool(storedOn: Set<string>, published: string[][] = []): RelayPool {
+    return {
+      subscribeMany(
+        relays: string[],
+        filter: NostrFilter,
+        params: { onevent: (e: NTNostrEvent) => void; oneose?: () => void },
+      ) {
+        const [relay] = relays;
+        if (filter.ids && relay && storedOn.has(relay)) {
+          queueMicrotask(() => params.onevent(event));
+        } else {
+          queueMicrotask(() => params.oneose?.());
+        }
+        return { close() {} };
+      },
+      publish(relays: string[]) {
+        published.push([...relays]);
+        return relays.map(() => Promise.resolve("ok"));
+      },
+      close() {},
+    } as unknown as RelayPool;
+  }
+
+  test("read-back results feed the tracker and quarantine a dropper", async () => {
+    const relays = SEVEN;
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      relays,
+      // Only r5/r6/r7 actually store; r1..r4 ACK-and-drop (Jeroen's case).
+      storedPool(new Set(["wss://r5.example", "wss://r6.example", "wss://r7.example"])),
+    );
+    for (let i = 0; i < READBACK_STRIKE_THRESHOLD; i++) {
+      await transport.verifyStored(event, { settleMs: 0, timeoutMs: 50 });
+    }
+    expect(transport.relayHealth.isQuarantined("wss://r1.example")).toBe(true);
+    expect(transport.relayHealth.isQuarantined("wss://r5.example")).toBe(false);
+  });
+
+  test("publishWrap narrows to the healthy set but keeps the floor", async () => {
+    const published: string[][] = [];
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      SEVEN,
+      storedPool(
+        new Set(["wss://r5.example", "wss://r6.example", "wss://r7.example"]),
+        published,
+      ),
+    );
+    for (let i = 0; i < READBACK_STRIKE_THRESHOLD; i++) {
+      await transport.verifyStored(event, { settleMs: 0, timeoutMs: 50 });
+    }
+    published.length = 0;
+    await transport.publishWrap(event);
+    expect(published[0]?.sort()).toEqual(
+      ["wss://r5.example", "wss://r6.example", "wss://r7.example"],
+    );
+  });
+
+  test("the SUBSCRIPTION set is never narrowed — reads keep every relay", async () => {
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      SEVEN,
+      storedPool(new Set()),
+    );
+    for (let i = 0; i < READBACK_STRIKE_THRESHOLD; i++) {
+      await transport.verifyStored(event, { settleMs: 0, timeoutMs: 50 });
+    }
+    // Every relay is now a dropper, yet `relays` (what we subscribe on) is
+    // untouched — that's what makes promotion free, no reconnect required.
+    expect(transport.relays.length).toBe(SEVEN.length);
+  });
+});

--- a/tests/channels-phantomchat-relayHealth.test.ts
+++ b/tests/channels-phantomchat-relayHealth.test.ts
@@ -329,3 +329,48 @@ describe("transport wiring", () => {
     expect(transport.relays.length).toBe(SEVEN.length);
   });
 });
+
+describe("setRelays — surviving a relay-config change", () => {
+  test("relays that survive the change KEEP their health and quarantine", () => {
+    const t = tracker();
+    const now = Date.now();
+    strikeOut(t, "wss://r1.example", now);
+    expect(t.isQuarantined("wss://r1.example", now)).toBe(true);
+
+    t.setRelays(SEVEN.slice(0, 5));
+    // Same relay, same url, same verdict — a config reload is not an amnesty.
+    expect(t.isQuarantined("wss://r1.example", now)).toBe(true);
+    expect(t.publishTargets(now)).not.toContain("wss://r1.example");
+  });
+
+  test("records for relays dropped from the config are forgotten", () => {
+    const t = tracker();
+    const now = Date.now();
+    strikeOut(t, "wss://r7.example", now);
+    expect(t.isQuarantined("wss://r7.example", now)).toBe(true);
+
+    // Removed from the config, then added back: it returns as a STRANGER, not
+    // as a convict. Dropping the record is what keeps a process that rotates
+    // its relay list from accumulating dead entries forever.
+    t.setRelays(SEVEN.slice(0, 3));
+    t.setRelays(SEVEN);
+    expect(t.isQuarantined("wss://r7.example", now)).toBe(false);
+    const row = t.report(now).find((r) => r.relay === "wss://r7.example");
+    expect(row?.dropped).toBe(0);
+    expect(row?.strikes).toBe(0);
+  });
+
+  test("newly-added relays are usable immediately (optimistic score)", () => {
+    const t = tracker(SEVEN.slice(0, 3));
+    const now = Date.now();
+    t.setRelays([...SEVEN.slice(0, 3), "wss://r8.example"]);
+    expect(t.publishTargets(now)).toContain("wss://r8.example");
+  });
+
+  test("ranking follows the new list, not the constructor's", () => {
+    const t = tracker();
+    const next = ["wss://r2.example", "wss://r3.example", "wss://r4.example"];
+    t.setRelays(next);
+    expect(t.publishTargets(Date.now()).sort()).toEqual([...next].sort());
+  });
+});


### PR DESCRIPTION
Closes part of #359 (the bot half — the PWA half is phantomchat#<pending>).

## The problem

#368 shipped read-back verification: after every publish we re-query each relay for the event id, and warn naming the relays that ACK'd `OK:true` and never stored it. **Nothing ever acted on that result.**

@14skywalker's numbers: 4 of the 7 canonical relays fail read-back on ~100% of events (~90 observed), 0% on the other three. We publish to those 4 again on the next message, and the next, forever. 4/7 of every publish is wasted, plus a warning line per send.

He proposed trimming `relays.json` from 7 to 3. That fixes his box and pins everyone at the reliability floor with no automatic replacement when one of the surviving three rots. This is the self-correcting version: each client converges on its own healthy subset from its own observations, and recovers automatically when a relay comes back.

## The design

**1. Quarantine from read-back, not from a health check.** 5 consecutive read-back failures → out of the publish set for 1h, doubling per repeat offence to a 6h cap, ±10% jitter. A single confirmation clears the streak, so a slow or hiccuping relay is never quarantined for a blip; a confirmation *while* quarantined releases it early.

**2. Quarantine is publish-only — which is what makes failover instant.** The subscription set is never narrowed. A relay that drops writes may still deliver reads, and the catch-up poll keeps using it. More importantly every quarantined relay is a **warm spare**: its socket is already open, so promoting it back into the publish set is a pure bookkeeping change. No connect, no handshake, no wait. We never reconnect a relay because we never disconnected one.

**3. No polling, no timers.** Health is a by-product of traffic we already generate — the read-back pass was already running on every publish, so scoring costs zero additional requests. Quarantine expiry is evaluated lazily against `Date.now()` at publish time. There is not a single `setTimeout` in `relayHealth.ts`. A pool that sends nothing burns zero cycles on health.

**4. A hard floor of 3.** Delivery needs only ONE healthy relay shared by sender and recipient — but sender and recipient quarantine *independently*, so phantombot's bad set and the PWA's need not agree, and their sets must still intersect. If quarantine would take the publish set below 3, the best-ranked quarantined relays are promoted back to fill it. **The floor is a hard constraint; a quarantine is only an opinion, and the floor wins.**

**5. Deterministic ranking.** `rankRelays` is a pure total order over `(score, url)` — no clock, no randomness. Both ends produce the same order from the same observations, so they converge rather than drift. The url tiebreak is load-bearing: it's why a fresh client with zero observations picks the same three relays as everyone else.

Also raises `PUBLISH_READBACK_TIMEOUT_MS` 2500 → 5000. The read-back result now drives quarantine, so a false negative has a real cost — a merely SLOW relay must not be scored as a dropping one. The check is detached, so the extra patience costs the send path nothing.

## Files

- `src/channels/phantomchat/relayHealth.ts` (new) — `RelayHealthTracker`, `rankRelays`, `relayScore`. Heavily commented on the *why*.
- `src/channels/phantomchat/transport.ts` — `publishWrap` targets `publishTargets()`; `verifyStored` feeds per-relay outcomes back into the tracker and takes an explicit target list.
- `tests/channels-phantomchat-relayHealth.test.ts` (new) — 20 tests.

## Testing

20 new tests covering: strike threshold, blip immunity, lazy expiry, early release, exponential backoff + cap, jitter spread, the floor under total poisoning, least-bad promotion, determinism of ranking, and the transport wiring (including that the subscription set is never narrowed).

Full suite: **2752 pass, 0 fail**, `tsc --noEmit` clean.

## Review notes

- Constants (`READBACK_STRIKE_THRESHOLD`, `QUARANTINE_BASE_MS`, `MIN_PUBLISH_RELAYS`) are exported and deliberately easy to tune after the weekend's data.
- Health is in-memory only — a restart gives every relay a fresh chance. That felt right for a first cut; persisting it is a follow-up if the weekend says otherwise.
- Pairs with the phantomchat PR, which reuses the PWA's existing `relayHealth`/bench machinery rather than duplicating this.
