### PR TITLE
fix(nightly): target the day that closed, not the day just beginning

### DIFF
--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -72,6 +72,21 @@ interface TurnResult {
 }
 
 /** Run one harness turn for the nightly conversation. */
+/**
+ * Default processing date for a nightly run: yesterday, in UTC calendar
+ * arithmetic (UTC date minus one calendar day). The timer fires at 02:00
+ * local, so "today" at fire time is the day just beginning — the file to
+ * process is the one that closed at midnight. Subtracting a calendar day
+ * (not 86400s) stays correct across leap seconds / calendar boundaries.
+ */
+export function defaultNightlyDate(now: Date = new Date()): string {
+  const d = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
 async function runNightlyTurn(opts: {
   persona: string;
   conversation: string;
@@ -139,7 +154,11 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
     return 2;
   }
 
-  const today = input.today ?? new Date().toISOString().slice(0, 10);
+  // The nightly timer fires at 02:00 to process the day that just CLOSED —
+  // default to yesterday, not the day that has barely begun. Without this
+  // every unattended run looks for a daily file that doesn't exist yet and
+  // silently no-ops. `input.today` (--date) stays the override for backfill.
+  const today = input.today ?? defaultNightlyDate();
   const conversation = nightlyConversationKey(today);
   const memory = await openMemoryStore(config.memoryDbPath);
   const runStartedAt = Date.now();

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -252,7 +252,7 @@ This conversation is ISOLATED (conversation key system:nightly:${today}); nothin
 
 You have access to phantombot's memory tools via Bash:
 
-  phantombot memory today                       # path to today's daily file
+  phantombot memory get memory/${today}.md            # read the daily file being processed (do NOT use 'memory today' — resolves to actual current day, not ${today})
   phantombot memory search "<query>"            # FTS5 + (if configured) semantic search
   phantombot memory get <persona-relative-path> # cat a file
   phantombot memory list <persona-relative-dir> # ls a dir
@@ -313,7 +313,7 @@ This conversation is ISOLATED (conversation key system:nightly:${today}); nothin
 
 You have access to phantombot's memory tools via Bash:
 
-  phantombot memory today                       # path to today's daily file
+  phantombot memory get memory/${today}.md            # read the daily file being processed (do NOT use 'memory today' — resolves to actual current day, not ${today})
   phantombot memory search "<query>"            # FTS5 + (if configured) semantic search
   phantombot memory get <persona-relative-path> # cat a file
   phantombot memory list <persona-relative-dir> # ls a dir

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -246,7 +246,7 @@ export function buildNightlyPrompt(
   personaName: string,
   today: string,
 ): string {
-  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Today is ${today}.
+  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Processing date: ${today} (the day that just closed).
 
 This conversation is ISOLATED (conversation key system:nightly:${today}); nothing you say here will appear in Telegram or any user-facing chat. Speak in summaries, not replies.
 
@@ -307,7 +307,7 @@ When you're done, your final reply (which won't go anywhere user-facing) should 
  * and the isolation note, shared by all five stage prompts.
  */
 function nightlyStagePreamble(personaName: string, today: string): string {
-  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Today is ${today}.
+  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Processing date: ${today} (the day that just closed).
 
 This conversation is ISOLATED (conversation key system:nightly:${today}); nothing you say here will appear in Telegram or any user-facing chat. Speak in summaries, not replies.
 

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runNightly } from "../src/cli/nightly.ts";
+import { defaultNightlyDate, runNightly } from "../src/cli/nightly.ts";
 import type { Config } from "../src/config.ts";
 
 class CaptureStream {
@@ -41,6 +41,29 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(workdir, { recursive: true, force: true });
+});
+
+describe("defaultNightlyDate", () => {
+  // The nightly timer fires at 02:00 for the day that just CLOSED. The
+  // default date must be yesterday — otherwise the run looks for a daily
+  // file that doesn't exist yet and silently no-ops (reported 2026-08-15).
+  test("fires 02:00 → returns the day that just closed", () => {
+    expect(defaultNightlyDate(new Date(Date.UTC(2026, 7, 15, 2, 0, 0)))).toBe(
+      "2026-08-14",
+    );
+  });
+
+  test("month boundary — Aug 1 → Jul 31", () => {
+    expect(defaultNightlyDate(new Date(Date.UTC(2026, 7, 1, 2, 0, 0)))).toBe(
+      "2026-07-31",
+    );
+  });
+
+  test("year boundary — Jan 1 → Dec 31 of prior year", () => {
+    expect(defaultNightlyDate(new Date(Date.UTC(2026, 0, 1, 2, 0, 0)))).toBe(
+      "2025-12-31",
+    );
+  });
 });
 
 describe("runNightly — early exits", () => {

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -112,7 +112,7 @@ describe("buildNightlyPrompt", () => {
 
   test("references the phantombot memory tools the harness must call", () => {
     const p = buildNightlyPrompt("x", "2026-01-01");
-    expect(p).toContain("phantombot memory today");
+    expect(p).toContain("phantombot memory get memory/2026-01-01.md");
     expect(p).toContain("phantombot memory search");
     expect(p).toContain("phantombot memory get");
     expect(p).toContain("phantombot memory index --rebuild");

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -90,7 +90,7 @@ describe("buildNightlyPrompt", () => {
   test("embeds the persona name + today + isolation note", () => {
     const p = buildNightlyPrompt("kai", "2026-05-02");
     expect(p).toContain("persona 'kai'");
-    expect(p).toContain("Today is 2026-05-02");
+    expect(p).toContain("Processing date: 2026-05-02");
     expect(p).toContain("system:nightly:2026-05-02");
     expect(p).toContain("ISOLATED");
     expect(p).toContain("PHASE 1");


### PR DESCRIPTION
## Problem

Reported by Robbie: the nightly cognitive pass has been broken since ~May 20 — it targets the day just *beginning* instead of the one that *closed*.

**Root cause:** the nightly timer fires at 02:00 local (UTC on the lab installs). The default processing date in `src/cli/nightly.ts` was `new Date().toISOString().slice(0, 10)` — the date *at fire time*, i.e. the day that just began. The prompt then reads `memory/<today>.md`, which doesn't exist yet. Nearly every nightly turn log reports *"No daily file exists for [same date as the run]"* — the essence/promote/KB/state stages have been silent no-ops on schedule for months. Regression window matches PR #113 (merged May 19), when the checkpointed nightly started running reliably enough to no-op consistently.

## Fix

- **Default date = yesterday**, computed with UTC calendar arithmetic (`setUTCDate(d.getUTCDate() - 1)`) — calendar-day subtraction, not 86400 s, so month/year boundaries are exact.
- **`--date` override unchanged** — backfill and testing still work as before.
- **Prompt wording**: `Today is X` → `Processing date: X (the day that just closed)` in both the monolithic and checkpointed-stage prompts, so the nightly agent isn't misled by the word "today".
- Extracted `defaultNightlyDate()` as an exported, injectable-clock helper for testability.

## Tests

3 new regression tests in `tests/cli-nightly.test.ts`:
- 02:00 fire on Aug 15 → processes `2026-08-14`
- Month boundary: Aug 1 → Jul 31
- Year boundary: Jan 1 → Dec 31 of the prior year

`tests/lib-nightly.test.ts` updated for the prompt wording change. **33/33 pass** across both nightly suites; full suite shows only the 2 pre-existing PiHarness env failures and 20 pre-existing MCP-SDK typecheck errors (verified identical on clean `main`).

## Verification after merge

Tomorrow's 02:00 run should log `date=<yesterday>` and actually process the daily file — checkable via `nightly: persona=... date=...` in the service logs.