### PR TITLE
feat(nightly): idempotent sweep, two concurrent stages, event-driven trigger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,14 +183,19 @@ If you add a new untrusted entry point (a new inbound channel, a new `ask`-style
 
 Phantombot ships on **Linux (systemd --user)**, **macOS (launchd, per-user LaunchAgents)**, and **Windows (per-user Task Scheduler logon task plus three periodic tasks)**. `lib/platform.ts` is the single router that decides which backend to talk to; each backend sits behind a common `ServiceControl` surface with an injectable runner so tests never touch the real service manager. Windows uses `InteractiveToken` and the current user's SID, so installation needs no password or elevation; installation preserves healthy existing task definitions and only repairs missing/stale entries. Windows `start`/`restart` re-enable the task and use a hidden native detached launch for SSH/terminal control because Task Scheduler cannot `/Run` an interactive-token task from a non-interactive session. `windowsJob.ts` assigns harness children to kill-on-close Job Objects.
 
-On Linux, `phantombot install` creates **four** systemd-user units:
+On Linux, `phantombot install` creates **three** systemd-user units:
 
 | Unit | Cadence | What it does |
 |---|---|---|
 | `phantombot.service` | always-on | `phantombot run` — Telegram listener |
 | `phantombot-heartbeat.timer` → `.service` | every 30 min | mechanical maintenance, no LLM |
-| `phantombot-nightly.timer` → `.service` | daily 02:00 | cognitive distillation, LLM |
 | `phantombot-tick.timer` → `.service` | every 1 min | fires due scheduled tasks |
+
+There is deliberately no nightly unit. The cognitive pass is event-driven —
+`run` fires a sweep at startup, and the heartbeat fires one when it notices the
+calendar day changed since its last fire. A clock would miss the day entirely on
+any box that sleeps at 02:00. Installs that predate this have their
+`phantombot-nightly.timer` stopped, disabled and deleted on the next heartbeat.
 
 Every service has **two `EnvironmentFile=` lines**:
 

--- a/README.md
+++ b/README.md
@@ -1512,17 +1512,22 @@ the ledger's hash stable. Once both join, phantombot refreshes the search index
 itself (incremental FTS + embeddings), so a new KB note is searchable without
 the model having to remember to ask.
 
-Because the ledger decides what to process, the pass is idempotent: re-running
-it with nothing pending costs nothing, and a machine that was asleep at 02:00
-just sweeps a longer backlog on its next run (the `run` daemon fires one at
-startup). There is no `--resume` and no catch-up mode. Useful flags:
+The sweep has **no timer**. It is triggered by two events instead: `run` fires
+one at startup, and the heartbeat fires one the first time it runs on a new
+calendar day (the previous day's file has closed by then). Rollover *detection*
+rather than a file-creation watch, because a daily file is created lazily on the
+first capture — on a quiet day it may never exist, and a creation hook would
+starve. Because the ledger decides what to process, both triggers are safe to
+fire redundantly: re-running with nothing pending costs nothing, and a machine
+that was off for a week sweeps the backlog when it comes back. There is no
+`--resume` and no catch-up mode. Useful flags:
 `--date <YYYY-MM-DD>` to reprocess one day, `--max-dates N` to change the
 per-run cap (default 10), `--force` to take over a stuck in-flight marker.
 
 `/status` shows a `dreaming:` line — `OK (nothing pending)`,
 `RUNNING (2/5 dates, on 2026-06-02)`, `WARN (2 dates pending …)` or `ERR`.
-Health is backlog-driven, not schedule-driven: a missed 02:00 with nothing
-pending is still OK. `phantombot doctor` reports the same signal (plus capture
+Health is backlog-driven, not schedule-driven: nothing pending is OK no matter
+when the last sweep ran. `phantombot doctor` reports the same signal (plus capture
 health, timers and connectors) but never runs the nightly itself.
 
 ## Maintenance
@@ -1539,8 +1544,7 @@ Installed user units:
 |---|---|---|
 | `phantombot.service` | Always on | Telegram listener |
 | `phantombot-tick.timer` | Every minute | Scheduled task runner |
-| `phantombot-heartbeat.timer` | Every 30 minutes | Mechanical maintenance |
-| `phantombot-nightly.timer` | Daily | LLM-backed memory distillation |
+| `phantombot-heartbeat.timer` | Every 30 minutes | Mechanical maintenance + fires the nightly sweep on day rollover |
 
 Update commands:
 

--- a/README.md
+++ b/README.md
@@ -1493,17 +1493,37 @@ Environment overrides: `PHANTOMBOT_RETRIEVAL_CROSS_ENABLED`,
 
 ### Nightly and Doctor
 
-The nightly distillation is checkpointed in five stages:
+Every `phantombot nightly` run is a **sweep**. It lists the daily files, diffs
+them against the ledger in `memory/.nightly-state.json` (mtime + size, then
+content hash) and processes every date that is new, that grew since it was
+processed, or whose last pass didn't finish:
 
 ```text
-essence -> promote -> kb -> compress -> state
+sweep (code) -> per date: distill ‖ kb -> index refresh (code) -> ledger (code)
 ```
 
-If it times out or the machine restarts, `phantombot nightly --resume`
-continues from the checkpoint.
+* `distill` files the day's captures into the drawers (people / decisions /
+  lessons / commitments / norms) and maintains MEMORY.md's `## Recent`.
+* `kb` extracts durable knowledge into `kb/` — reconcile, create, sweep inbox.
 
-`phantombot doctor` checks memory health and can auto-repair stale, failed, or
-partial nightly runs.
+The two stages run **concurrently**: they read the same daily file and write
+disjoint targets. Neither writes back to the daily file, which is what keeps
+the ledger's hash stable. Once both join, phantombot refreshes the search index
+itself (incremental FTS + embeddings), so a new KB note is searchable without
+the model having to remember to ask.
+
+Because the ledger decides what to process, the pass is idempotent: re-running
+it with nothing pending costs nothing, and a machine that was asleep at 02:00
+just sweeps a longer backlog on its next run (the `run` daemon fires one at
+startup). There is no `--resume` and no catch-up mode. Useful flags:
+`--date <YYYY-MM-DD>` to reprocess one day, `--max-dates N` to change the
+per-run cap (default 10), `--force` to take over a stuck in-flight marker.
+
+`/status` shows a `dreaming:` line — `OK (nothing pending)`,
+`RUNNING (2/5 dates, on 2026-06-02)`, `WARN (2 dates pending …)` or `ERR`.
+Health is backlog-driven, not schedule-driven: a missed 02:00 with nothing
+pending is still OK. `phantombot doctor` reports the same signal (plus capture
+health, timers and connectors) but never runs the nightly itself.
 
 ## Maintenance
 

--- a/README.md
+++ b/README.md
@@ -1521,13 +1521,21 @@ starve. Because the ledger decides what to process, both triggers are safe to
 fire redundantly: re-running with nothing pending costs nothing, and a machine
 that was off for a week sweeps the backlog when it comes back. There is no
 `--resume` and no catch-up mode. Useful flags:
-`--date <YYYY-MM-DD>` to reprocess one day, `--max-dates N` to change the
-per-run cap (default 10), `--force` to take over a stuck in-flight marker.
+`--date <YYYY-MM-DD>` to reprocess one day, `--max-dates N` to bound a manual
+run, `--force` to take over a stuck in-flight marker.
+
+A sweep is **uncapped by default**: it drains the entire backlog in one pass,
+so a first run after months of history is one long night rather than a queue
+that reappears every morning. The in-flight marker stops the rollover trigger
+from starting a second sweep on top of a running one.
 
 `/status` shows a `dreaming:` line — `OK (nothing pending)`,
 `RUNNING (2/5 dates, on 2026-06-02)`, `WARN (2 dates pending …)` or `ERR`.
 Health is backlog-driven, not schedule-driven: nothing pending is OK no matter
-when the last sweep ran. `phantombot doctor` reports the same signal (plus capture
+when the last sweep ran, and a backlog of *any* depth is only a WARN while it
+drains. It turns into ERR when a sweep errored, when the in-flight marker went
+stale, or when dates are pending and no sweep has run for over 24h — a backlog
+nobody is picking up. `phantombot doctor` reports the same signal (plus capture
 health, timers and connectors) but never runs the nightly itself.
 
 ## Maintenance

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 | `src/persona/builder.ts` | Concatenates persona pieces + (deferred) retrieved memory + invocation context into a system prompt string. | `loader.ts` |
 | `src/memory/store.ts` | bun:sqlite wrapper. `turns` table (`appendTurn`, `recentTurns`, …) + `capture_log` table (`appendCapture`, `lastCaptureAt`, `countCapturesSince`, turn counters for the nudge/doctor). | `bun:sqlite` |
 | `src/lib/nightly.ts` | Two-stage model + prompt bodies, the `.nightly-state.json` ledger (`sweepDailyFiles`, `dateRecord`), and `nightlyHealth` for `/status` + doctor. | filesystem |
+| `src/lib/nightlyTrigger.ts` | When the sweep runs: `dayRolledOver` (heartbeat trigger) + `spawnNightlySweep` (detached fire, also used by `run` at startup). | `node:child_process` |
 | `src/lib/indexRefresh.ts` | `refreshPersonaIndex`: incremental FTS + embedding refresh, called in code by the nightly after both stages join. | `lib/memoryIndex`, `lib/embedJob` |
 | `src/cli/doctor.ts` | `phantombot doctor`: reports the nightly ledger (read-only) + `capture_log`, repairs units/timers/connectors. | `memory/store`, `lib/nightly` |
 | `src/importer/openclaw.ts` | Walks an OpenClaw agent dir; copies recognized markdown into the personas dir. | filesystem |
@@ -128,15 +129,16 @@ Three properties worth knowing when touching this code:
 3. **The nightly is a sweep, and the sweep is the idempotency mechanism.** Each
    run diffs the daily files against a ledger in `.nightly-state.json`
    (mtime + size, then content hash) and processes whatever is new, grew, or
-   half-finished. Per date it runs exactly two harness turns — `distill`
+   half-finished. It is triggered by startup and by the heartbeat detecting a
+   calendar-day rollover — there is no nightly timer. Per date it runs exactly
+   two harness turns — `distill`
    (drawers + MEMORY.md) and `kb` — **concurrently**, because their write
    targets are disjoint; neither may write back to the daily file, or the hash
    would change and the date would reprocess forever. The index refresh that
    used to live in the KB prompt now runs in code after both stages join
    (`refreshPersonaIndex`), which both guarantees it and orders it after the
    writes. There is no `--resume` and no catch-up mode: a half-done date is just
-   a date the ledger doesn't call done, and `run` fires a sweep at startup for
-   machines that are off at 02:00. `doctor` reports this state; it no longer
+   a date the ledger doesn't call done. `doctor` reports this state; it no longer
    repairs it, so the job has one owner.
 
 ## Open design questions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,8 +35,9 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 | `src/persona/loader.ts` | Reads BOOT.md / SOUL.md / IDENTITY.md (required) + MEMORY.md / tools.md / AGENTS.md (optional). | filesystem |
 | `src/persona/builder.ts` | Concatenates persona pieces + (deferred) retrieved memory + invocation context into a system prompt string. | `loader.ts` |
 | `src/memory/store.ts` | bun:sqlite wrapper. `turns` table (`appendTurn`, `recentTurns`, …) + `capture_log` table (`appendCapture`, `lastCaptureAt`, `countCapturesSince`, turn counters for the nudge/doctor). | `bun:sqlite` |
-| `src/lib/nightly.ts` | Nightly stage list, per-stage prompt bodies, `.nightly-progress.json` checkpoint read/write, `pendingNightlyStages`. | filesystem |
-| `src/cli/doctor.ts` | `phantombot doctor`: reads nightly state/progress + `capture_log`, decides if repair is needed, spawns detached `nightly --resume`. | `memory/store`, `lib/nightly` |
+| `src/lib/nightly.ts` | Two-stage model + prompt bodies, the `.nightly-state.json` ledger (`sweepDailyFiles`, `dateRecord`), and `nightlyHealth` for `/status` + doctor. | filesystem |
+| `src/lib/indexRefresh.ts` | `refreshPersonaIndex`: incremental FTS + embedding refresh, called in code by the nightly after both stages join. | `lib/memoryIndex`, `lib/embedJob` |
+| `src/cli/doctor.ts` | `phantombot doctor`: reports the nightly ledger (read-only) + `capture_log`, repairs units/timers/connectors. | `memory/store`, `lib/nightly` |
 | `src/importer/openclaw.ts` | Walks an OpenClaw agent dir; copies recognized markdown into the personas dir. | filesystem |
 | `src/orchestrator/turn.ts` | `runTurn`: persona → memory → harness chain → persist. The one function every entry point calls. | `loader`, `builder`, `memory`, `fallback` |
 | `src/orchestrator/fallback.ts` | `runWithFallback`: tries each harness in order, advances on recoverable error, terminates on success or terminal error. Pre-spawn skip when `maxPayloadBytes` is too small. | `harnesses/*` |
@@ -124,12 +125,19 @@ Three properties worth knowing when touching this code:
 2. **The 30-turn nudge is mechanical.** `src/channels/telegram.ts` counts user turns
    since the last `capture_log` row; at every multiple of `CAPTURE_NUDGE_INTERVAL`
    (30) it stacks a fixed reminder onto the next system prompt. No LLM decides this.
-3. **The nightly is checkpointed and resumable.** It is decomposed into five
-   idempotent stages (`essence` → `promote` → `kb` → `compress` → `state`), each a
-   bounded harness turn. `.nightly-progress.json` is written after every stage;
-   `--resume` skips completed stages. A stage timeout costs one stage, not the night.
-   `phantombot doctor` (also wired into the `run` startup catch-up) detects a
-   missed/failed/partial nightly and repairs it by spawning a detached `nightly --resume`.
+3. **The nightly is a sweep, and the sweep is the idempotency mechanism.** Each
+   run diffs the daily files against a ledger in `.nightly-state.json`
+   (mtime + size, then content hash) and processes whatever is new, grew, or
+   half-finished. Per date it runs exactly two harness turns — `distill`
+   (drawers + MEMORY.md) and `kb` — **concurrently**, because their write
+   targets are disjoint; neither may write back to the daily file, or the hash
+   would change and the date would reprocess forever. The index refresh that
+   used to live in the KB prompt now runs in code after both stages join
+   (`refreshPersonaIndex`), which both guarantees it and orders it after the
+   writes. There is no `--resume` and no catch-up mode: a half-done date is just
+   a date the ledger doesn't call done, and `run` fires a sweep at startup for
+   machines that are off at 02:00. `doctor` reports this state; it no longer
+   repairs it, so the job has one owner.
 
 ## Open design questions
 

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -750,7 +750,8 @@ async function handleStatus(
     (probes.telegram ? `telegram: ${probes.telegram}\n` : "") +
     (probes.acp ? `acp:     ${probes.acp}\n` : "") +
     (probes.memory ? `memory:  ${probes.memory}\n` : "") +
-    (probes.voice ? `voice:   ${probes.voice}\n` : "");
+    (probes.voice ? `voice:   ${probes.voice}\n` : "") +
+    (probes.dreaming ? `dreaming: ${probes.dreaming}\n` : "");
 
   return {
     reply:

--- a/src/channels/statusProbes.ts
+++ b/src/channels/statusProbes.ts
@@ -23,7 +23,10 @@
  * production callers omit `deps` and get the real implementations.
  */
 
-import type { Config } from "../config.ts";
+import { existsSync } from "node:fs";
+
+import { type Config, personaDir } from "../config.ts";
+import { nightlyHealth as realNightlyHealth } from "../lib/nightly.ts";
 import { truncateLine } from "../lib/format.ts";
 import { timeoutSignal } from "../lib/fetchTimeout.ts";
 import { telegramGetMe as realTelegramGetMe } from "../lib/telegramApi.ts";
@@ -64,6 +67,11 @@ export interface StatusProbeLines {
   memory?: string;
   /** e.g. "elevenlabs onwK…03F9 OK" or "openai nova ERR (…)" */
   voice?: string;
+  /**
+   * Nightly distillation health, e.g. "OK (nothing pending)",
+   * "RUNNING (2/5 dates, on 2026-06-02)" or "WARN (2 dates pending, …)".
+   */
+  dreaming?: string;
 }
 
 /**
@@ -77,6 +85,7 @@ export interface StatusProbeDeps {
   geminiEmbed?: typeof realGeminiEmbed;
   reconcileEditorConnectors?: typeof realReconcileEditorConnectors;
   isPhantombotBinary?: typeof realIsPhantombotBinary;
+  nightlyHealth?: typeof realNightlyHealth;
   env?: Record<string, string | undefined>;
   /** Override the shared probe deadline (ms). Production omits it; tests use
    *  a tiny value to exercise the cap without waiting the real 5s. */
@@ -183,7 +192,36 @@ async function probeVoice(
 }
 
 /**
- * Run all four live probes concurrently and return their one-line summaries.
+ * Nightly ("dreaming") health, read straight off the ledger + the daily files
+ * on disk. No LLM, no network, and it never does any of the nightly's work —
+ * it only reports what the last sweep left behind and what is still pending.
+ *
+ * Deliberately schedule-blind: a laptop that sweeps at 09:15 on boot is just
+ * as healthy as a server that sweeps at 02:00, provided nothing is pending.
+ */
+async function probeDreaming(
+  config: Config | undefined,
+  persona: string,
+  health: typeof realNightlyHealth,
+): Promise<string | undefined> {
+  if (!config) return undefined;
+  const dir = personaDir(config, persona);
+  if (!existsSync(dir)) return undefined;
+  const h = await health(dir);
+  switch (h.status) {
+    case "running":
+      return `RUNNING (${h.detail})`;
+    case "warning":
+      return `WARN (${h.detail})`;
+    case "error":
+      return `ERR (${h.detail})`;
+    default:
+      return `OK (${h.detail})`;
+  }
+}
+
+/**
+ * Run all live probes concurrently and return their one-line summaries.
  * Any probe that throws or has no config surface is omitted (undefined).
  */
 export async function gatherStatusProbes(
@@ -199,6 +237,7 @@ export async function gatherStatusProbes(
   const env = deps.env ?? process.env;
   const validateEl = deps.validateElevenLabsKey ?? realValidateElevenLabsKey;
   const validateOa = deps.validateOpenAIKey ?? realValidateOpenAIKey;
+  const nightly = deps.nightlyHealth ?? realNightlyHealth;
 
   // One shared deadline for the whole fan-out. Threaded into every client that
   // accepts a signal (cancels the socket) AND raced in settle() below (hard cap
@@ -221,7 +260,7 @@ export async function gatherStatusProbes(
     }
   };
 
-  const [telegram, memory, voice] = await Promise.all([
+  const [telegram, memory, voice, dreaming] = await Promise.all([
     settle(probeTelegram(config, persona, getMe, deadline)),
     settle(probeMemory(config, embed, deadline)),
     settle(
@@ -232,6 +271,7 @@ export async function gatherStatusProbes(
         signal: deadline,
       }),
     ),
+    settle(probeDreaming(config, persona, nightly)),
   ]);
   // ACP probe is synchronous local file reads — no need to race it.
   let acp: string | undefined;
@@ -241,5 +281,5 @@ export async function gatherStatusProbes(
     acp = undefined;
   }
 
-  return { telegram, acp, memory, voice };
+  return { telegram, acp, memory, voice, dreaming };
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2,23 +2,20 @@
  * `phantombot doctor` — memory-subsystem health check + auto-repair.
  *
  * Reads signals that already exist on disk and in `memory.sqlite`:
- *   - `.nightly-state.json`    — last run timestamp + status
- *   - `.nightly-progress.json` — an in-flight / partial checkpoint
- *   - `capture_log`            — was anything captured in the last 24h?
+ *   - `.nightly-state.json` — the sweep ledger: which dates are distilled,
+ *     which are pending, and whether a sweep is in flight right now
+ *   - `capture_log`         — was anything captured in the last 24h?
  *
- * It answers the three questions the issue author could only guess at:
- * did the last nightly run, did it succeed, and is capture actually
- * firing. When the nightly is stale, failed, or left a partial
- * checkpoint, doctor spawns `phantombot nightly --resume` as a detached
- * background process — which, thanks to the checkpointed nightly, picks
- * up exactly where the last run stopped.
+ * The nightly section is READ-ONLY. Doctor used to spawn its own
+ * `nightly --resume` when the last run looked stale, which meant two owners
+ * for the same job. The nightly is now idempotent — every run sweeps whatever
+ * is unprocessed — so there is exactly one owner (the timer, plus the startup
+ * sweep in `run`) and doctor just reports what the ledger says.
  *
- * Invoked manually, from the startup catch-up in `run`, and safe to
- * wire into any mechanical scheduler (it never runs an LLM in-process —
- * repair is a detached child).
+ * Invoked manually, at startup from `run`, and safe to wire into any
+ * mechanical scheduler — it never runs an LLM.
  */
 
-import { spawn } from "node:child_process";
 import { defineCommand } from "citty";
 import { existsSync, readFileSync } from "node:fs";
 import { basename } from "node:path";
@@ -34,11 +31,9 @@ import {
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import {
-  CATCHUP_WINDOW_MS,
-  loadNightlyProgress,
   loadNightlyState,
-  type NightlyProgress,
-  type NightlyState,
+  type NightlyHealth,
+  nightlyHealth,
 } from "../lib/nightly.ts";
 import {
   ensureRoutingExtension,
@@ -96,21 +91,22 @@ export interface DoctorReport {
     last_run?: string;
     last_status?: string;
     /**
-     * Error messages from the last run, if any. Persisted in
+     * Error messages from the last sweep, if any. Persisted in
      * `.nightly-state.json` but historically dropped here, so a failing
      * stage was invisible to `doctor` (it only showed `last_status`).
      */
     errors?: string[];
-    /** Hours since the last run, or null if it never ran. */
+    /** Hours since the last sweep, or null if it never ran. */
     age_hours: number | null;
-    stale: boolean;
-    /** A partial/in-progress checkpoint, if one is parked on disk. */
-    checkpoint?: {
-      date: string;
-      status: NightlyProgress["status"];
-      completed_stages: string[];
-      last_error?: string;
-    };
+    /**
+     * Ledger-derived health: ok / running / warning / error. Backlog is the
+     * only truth here — a missed 02:00 with nothing pending is still `ok`.
+     */
+    health: NightlyHealth["status"];
+    detail: string;
+    /** Daily files still awaiting a pass. */
+    backlog: number;
+    oldest_pending?: string;
   };
   capture: {
     window_hours: number;
@@ -121,7 +117,7 @@ export interface DoctorReport {
   };
   /**
    * Embeddings / semantic-search status. Purely INFORMATIONAL — this never
-   * feeds `repair_needed` or the exit code. Embeddings are optional: with no
+   * feeds the exit code. Embeddings are optional: with no
    * provider, memory search still works on keyword (FTS5/BM25) matching. We
    * surface the easy-to-miss "running keyword-only" state so an operator can
    * SEE that vector search is off (and how to turn it on) without it ever
@@ -211,22 +207,23 @@ export interface DoctorReport {
    * settings.
    */
   editorConnectors?: EditorConnectorResult[];
-  repair_needed: boolean;
-  repair_reason?: string;
-  repair_triggered: boolean;
 }
 
 export interface RunDoctorInput {
   config?: Config;
   persona?: string;
-  /** Spawn `nightly --resume` when repair is warranted. Default true. */
+  /**
+   * Perform the repairs doctor still owns (systemd units/timers, the managed
+   * Pi extension, editor connectors). Default true. The nightly is NOT among
+   * them any more — it repairs itself by sweeping.
+   */
   repair?: boolean;
   /** Emit machine-readable JSON instead of the human summary. */
   json?: boolean;
   out?: WriteSink;
   err?: WriteSink;
-  /** Test seam — override the repair spawn. */
-  spawnRepair?: (persona: string) => void;
+  /** Test seam — override the nightly health read. */
+  nightlyHealth?: typeof nightlyHealth;
   /**
    * Test seam for the systemd check. Pass `false` to skip the check
    * (the default outside Linux). Pass a function to substitute a fake —
@@ -276,56 +273,6 @@ export interface RunDoctorInput {
     | ((repair: boolean) => DoctorReport["editorConnectors"]);
 }
 
-function decideRepair(
-  state: NightlyState,
-  progress: NightlyProgress | null,
-  ageHours: number | null,
-): { needed: boolean; reason?: string } {
-  if (progress && progress.status !== "complete") {
-    return {
-      needed: true,
-      reason:
-        `partial nightly checkpoint for ${progress.date} ` +
-        `(${progress.completed_stages.length} stage(s) done` +
-        (progress.last_error ? `; last error: ${progress.last_error}` : "") +
-        ")",
-    };
-  }
-  if (!state.last_run || ageHours === null) {
-    return { needed: true, reason: "no record of any nightly run" };
-  }
-  if (state.last_status === "error" || state.last_status === "partial") {
-    return {
-      needed: true,
-      reason: `last nightly status was '${state.last_status}'`,
-    };
-  }
-  if (ageHours * 3_600_000 > CATCHUP_WINDOW_MS) {
-    return {
-      needed: true,
-      reason: `last nightly ran ${Math.round(ageHours)}h ago (>${
-        CATCHUP_WINDOW_MS / 3_600_000
-      }h)`,
-    };
-  }
-  return { needed: false };
-}
-
-/** Spawn a detached `phantombot nightly --resume` that outlives this process. */
-function defaultSpawnRepair(persona: string): void {
-  const entry = process.argv[1] ?? "";
-  const dev = entry.endsWith(".ts") || entry.endsWith(".js");
-  const args = dev
-    ? [entry, "nightly", "--resume", "--persona", persona]
-    : ["nightly", "--resume", "--persona", persona];
-  const child = spawn(process.execPath, args, {
-    detached: true,
-    stdio: "ignore",
-  });
-  child.unref();
-  log.info("doctor: spawned background nightly --resume", { persona });
-}
-
 export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
@@ -340,7 +287,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   }
 
   const state = await loadNightlyState(dir);
-  const progress = await loadNightlyProgress(dir);
+  const health = await (input.nightlyHealth ?? nightlyHealth)(dir, { state });
 
   const lastRunMs = state.last_run ? Date.parse(state.last_run) : NaN;
   const ageHours = Number.isNaN(lastRunMs)
@@ -370,14 +317,6 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   const embProvider = config.embeddings.provider;
   const semanticSearch =
     embProvider === "gemini" && !!config.embeddings.gemini?.apiKey;
-
-  const { needed, reason } = decideRepair(state, progress, ageHours);
-
-  let repairTriggered = false;
-  if (needed && repair) {
-    (input.spawnRepair ?? defaultSpawnRepair)(persona);
-    repairTriggered = true;
-  }
 
   // Timer "last fired" check — catches the long-uptime failure mode
   // where systemd thinks a timer is active but it hasn't fired in
@@ -510,18 +449,11 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
         ? { errors: state.errors }
         : {}),
       age_hours: ageHours === null ? null : Math.round(ageHours * 10) / 10,
-      stale: needed,
-      ...(progress
-        ? {
-            checkpoint: {
-              date: progress.date,
-              status: progress.status,
-              completed_stages: progress.completed_stages,
-              ...(progress.last_error
-                ? { last_error: progress.last_error }
-                : {}),
-            },
-          }
+      health: health.status,
+      detail: health.detail,
+      backlog: health.backlog,
+      ...(health.oldest_pending
+        ? { oldest_pending: health.oldest_pending }
         : {}),
     },
     capture: {
@@ -539,9 +471,6 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     ...(harnessReport ? { harnesses: harnessReport } : {}),
     ...(piExtensionReport ? { piExtension: piExtensionReport } : {}),
     ...(editorConnectors ? { editorConnectors } : {}),
-    repair_needed: needed,
-    repair_reason: reason,
-    repair_triggered: repairTriggered,
   };
 
   const systemdBroken =
@@ -578,7 +507,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   const editorConnectorsBroken =
     !!editorConnectors && editorConnectors.some(editorConnectorBroken);
   const exitCode =
-    needed && !repairTriggered
+    health.status === "error"
       ? 1
       : systemdBroken
         ? 1
@@ -600,32 +529,27 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   // Human summary.
   const tick = (ok: boolean) => (ok ? "ok" : "WARN");
   out.write(`phantombot doctor — persona '${persona}'\n`);
-  // A non-ok status is a warning even when the run isn't stale: a stage
-  // can fail today yet still be "recent", which previously slipped past
-  // the staleness-only marker.
-  const statusBad =
-    state.last_status === "error" || state.last_status === "partial";
+  // Health comes off the ledger, not the clock: a box that slept through
+  // 02:00 but has nothing pending is healthy.
+  const marker =
+    health.status === "ok"
+      ? "ok"
+      : health.status === "running"
+        ? "RUNNING"
+        : health.status === "warning"
+          ? "WARN"
+          : "ERR";
   out.write(
-    `  nightly: ${tick(!needed && !statusBad)} — ` +
+    `  nightly: ${marker} — ${health.detail}` +
       (state.last_run
-        ? `last run ${state.last_run} (${report.nightly.age_hours}h ago), status '${
-            state.last_status ?? "unknown"
-          }'`
-        : "never run") +
+        ? ` (last sweep ${state.last_run}, ${report.nightly.age_hours}h ago)`
+        : "") +
       "\n",
   );
   if (state.errors && state.errors.length > 0) {
     for (const e of state.errors) {
       out.write(`    error: ${e}\n`);
     }
-  }
-  if (progress) {
-    out.write(
-      `  checkpoint: ${progress.status} for ${progress.date} — ` +
-        `done [${progress.completed_stages.join(", ") || "none"}]` +
-        (progress.last_error ? ` — ${progress.last_error}` : "") +
-        "\n",
-    );
   }
   out.write(
     `  capture: ${tick(!dryDay)} — ${captures} capture(s), ${userTurns} ` +
@@ -642,15 +566,11 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       : "  embeddings: semantic (vector) search off — OKF field-weighted BM25 " +
         "+ link-graph expansion active. Optional: add Gemini with `phantombot embedding`\n",
   );
-  if (needed) {
-    out.write(`  repair: ${reason}\n`);
+  if (health.backlog > 0) {
     out.write(
-      repairTriggered
-        ? "  → spawned background `nightly --resume`\n"
-        : "  → run `phantombot nightly --resume` to repair\n",
+      `  → ${health.backlog} date(s) pending; the next \`phantombot nightly\` ` +
+        "sweep picks them up automatically\n",
     );
-  } else {
-    out.write("  repair: not needed\n");
   }
 
   if (systemdReport) {
@@ -971,7 +891,7 @@ export default defineCommand({
   meta: {
     name: "doctor",
     description:
-      "Memory health check — reports nightly/capture status and auto-repairs a stale or partial nightly by resuming it in the background.",
+      "Memory health check — reports nightly sweep backlog, capture health, timers and connectors. The nightly repairs itself by sweeping; doctor only reports it.",
   },
   args: {
     persona: {
@@ -981,8 +901,8 @@ export default defineCommand({
     repair: {
       type: "boolean",
       description:
-        "Spawn a background `nightly --resume` when repair is warranted. " +
-        "Pass --no-repair to only report.",
+        "Repair drifted systemd units, timers, the Pi extension and editor " +
+        "connectors. Pass --no-repair to only report.",
       default: true,
     },
     json: {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -9,8 +9,8 @@
  * The nightly section is READ-ONLY. Doctor used to spawn its own
  * `nightly --resume` when the last run looked stale, which meant two owners
  * for the same job. The nightly is now idempotent — every run sweeps whatever
- * is unprocessed — so there is exactly one owner (the timer, plus the startup
- * sweep in `run`) and doctor just reports what the ledger says.
+ * is unprocessed — so the sweep owns itself, triggered by day rollover from
+ * the heartbeat and by `run` at startup, and doctor just reports the ledger.
  *
  * Invoked manually, at startup from `run`, and safe to wire into any
  * mechanical scheduler — it never runs an LLM.

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -58,9 +58,6 @@ import {
   HEARTBEAT_TIMER_NAME,
   heartbeatServicePath,
   heartbeatTimerPath,
-  NIGHTLY_TIMER_NAME,
-  nightlyServicePath,
-  nightlyTimerPath,
   phantombotUnitTargets,
   PHANTOMBOT_SERVICE_PATH,
   type SystemctlRunner,
@@ -786,8 +783,6 @@ async function defaultCheckSystemd(
       name: basename(heartbeatServicePath()),
     },
     { path: heartbeatTimerPath(), name: basename(heartbeatTimerPath()) },
-    { path: nightlyServicePath(), name: basename(nightlyServicePath()) },
-    { path: nightlyTimerPath(), name: basename(nightlyTimerPath()) },
     { path: tickServicePath(), name: basename(tickServicePath()) },
     { path: tickTimerPath(), name: basename(tickTimerPath()) },
   ];
@@ -819,7 +814,9 @@ async function defaultCheckSystemd(
         forceRearmTimers: staleTimers,
       });
       repaired =
-        heal.rewrote.length > 0 || heal.repairedTimers.length > 0;
+        heal.rewrote.length > 0 ||
+        heal.repairedTimers.length > 0 ||
+        heal.removedRetired.length > 0;
     } catch (e) {
       log.warn("doctor: systemd heal failed", {
         error: (e as Error).message,
@@ -874,11 +871,10 @@ async function listInactiveTimers(
   systemctl: SystemctlRunner,
 ): Promise<string[]> {
   const out: string[] = [];
-  for (const t of [
-    HEARTBEAT_TIMER_NAME,
-    NIGHTLY_TIMER_NAME,
-    TICK_TIMER_NAME,
-  ]) {
+  // Two timers, not three: the nightly timer is retired (the sweep runs on
+  // startup and on the heartbeat's day-rollover check), so an absent one is
+  // correct rather than a fault to repair.
+  for (const t of [HEARTBEAT_TIMER_NAME, TICK_TIMER_NAME]) {
     const r = await systemctl.run(["--user", "is-active", t]);
     if (r.exitCode !== 0 || r.stdout.trim() !== "active") {
       out.push(t);

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -2,7 +2,12 @@
  * `phantombot heartbeat` — short, mechanical maintenance pass.
  *
  * Runs every 30 minutes via systemd timer (installed by `phantombot install`).
- * No LLM call. See src/lib/heartbeat.ts for what it does.
+ * No LLM call. See src/lib/heartbeat.ts for the memory work it does.
+ *
+ * It is also the clock the nightly hangs off: when the calendar day changes
+ * between two fires, yesterday's daily file has closed, so the heartbeat spawns
+ * a detached nightly sweep. That (plus the startup sweep in `run`) is why there
+ * is no phantombot-nightly.timer any more.
  */
 
 import { defineCommand } from "citty";
@@ -15,6 +20,11 @@ import { runHeartbeat } from "../lib/heartbeat.ts";
 import { MemoryIndex } from "../lib/memoryIndex.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
+import {
+  dayRolledOver,
+  type NightlyTriggerReason,
+  spawnNightlySweep,
+} from "../lib/nightlyTrigger.ts";
 import { currentPlatform } from "../lib/platform.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { flushDueConversationTurns } from "../orchestrator/turnIndexer.ts";
@@ -28,7 +38,10 @@ import {
   BunSchtasksRunner,
   ensureTasksCurrent,
 } from "../lib/taskScheduler.ts";
-import { recordHeartbeatFired } from "../lib/timerHealth.ts";
+import {
+  loadHeartbeatLastFired,
+  recordHeartbeatFired,
+} from "../lib/timerHealth.ts";
 import { VERSION } from "../version.ts";
 
 // Delegates to the shared resolver in config.ts so the memory-index path
@@ -62,6 +75,14 @@ export interface RunHeartbeatCliInput {
    * real embedder from config and run runEmbedJob against the note index.
    */
   embedNotes?: false | (() => Promise<EmbedNotesResult | null>);
+  /**
+   * Test seam for the day-rollover nightly trigger. Pass `false` to skip the
+   * check entirely, or a function to capture the spawn without forking a real
+   * process. Production passes undefined → {@link spawnNightlySweep}.
+   */
+  triggerNightly?:
+    | false
+    | ((persona: string, reason: NightlyTriggerReason) => void);
 }
 
 /** Outcome of the heartbeat's incremental note-embed pass. */
@@ -178,6 +199,34 @@ export async function runHeartbeatCli(
     }
   }
 
+  // Day-rollover trigger — this is what replaced the 02:00 nightly timer.
+  // The heartbeat already fires every 30 min and already knows what day it is,
+  // so it is the natural place to notice that the calendar day changed since
+  // the last fire: the moment it does, yesterday's daily file is closed and
+  // can be distilled. Read the PREVIOUS marker before recordHeartbeatFired()
+  // overwrites it. Worst-case latency is one heartbeat interval, and firing
+  // redundantly is free — the sweep is ledger-driven and no-ops when nothing
+  // is pending. Wrapped in try/catch: a spawn failure must not fail the
+  // heartbeat, and the next startup sweeps the same backlog anyway.
+  let rolloverLine = "";
+  if (input.triggerNightly !== false) {
+    try {
+      const prev = loadHeartbeatLastFired(new Date()).iso;
+      if (dayRolledOver(prev)) {
+        (input.triggerNightly ?? spawnNightlySweep)(persona, "rollover");
+        rolloverLine = ", day rolled over → nightly sweep";
+        log.info("heartbeat: day rolled over, spawned nightly sweep", {
+          persona,
+          previousFire: prev,
+        });
+      }
+    } catch (e) {
+      log.warn("heartbeat: rollover check threw unexpectedly", {
+        error: (e as Error).message,
+      });
+    }
+  }
+
   // Record the fire AFTER the primary work succeeded. Doctor uses
   // this marker's mtime to flag a dead heartbeat timer.
   await recordHeartbeatFired();
@@ -191,7 +240,7 @@ export async function runHeartbeatCli(
   out.write(
     `heartbeat ok: promoted ${r.promoted.length}, ` +
       `stale ${r.staleRecent.length}, ` +
-      `indexed ${r.indexedFiles}${noteEmbedLine}${updateLine}\n`,
+      `indexed ${r.indexedFiles}${noteEmbedLine}${updateLine}${rolloverLine}\n`,
   );
   return 0;
 }
@@ -278,7 +327,7 @@ export default defineCommand({
   meta: {
     name: "heartbeat",
     description:
-      "Mechanical 30-min maintenance: promote tagged daily-file lines to drawers, scan ## Recent for staleness, refresh FTS index, flush due conversation-turn tails, and embed newly-written notes. No LLM call.",
+      "Mechanical 30-min maintenance: promote tagged daily-file lines to drawers, scan ## Recent for staleness, refresh FTS index, flush due conversation-turn tails, embed newly-written notes, and fire the nightly sweep when the calendar day has rolled over. No LLM call.",
   },
   args: {
     persona: {

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -1,45 +1,53 @@
 /**
- * `phantombot nightly` — runs the cognitive distillation pass.
+ * `phantombot nightly` — the cognitive distillation pass.
  *
- * The pass is CHECKPOINTED: it is decomposed into five idempotent stages
- * (essence → promote → kb → compress → state), each run as its own
- * harness turn. After every completed stage phantombot writes
- * `.nightly-progress.json`. If a stage times out — or the box powers off
- * mid-run — the next invocation with `--resume` (or the startup catch-up,
- * or `phantombot doctor`) skips the finished stages and continues. A
- * timeout therefore costs at most one stage, never the whole night.
+ * Every invocation is a SWEEP. Phantombot lists the daily files, diffs them
+ * against the ledger in `memory/.nightly-state.json` (mtime, then content
+ * hash), and processes every date that is new, that grew since it was
+ * processed, or whose last pass didn't finish. Running it twice in a row
+ * costs nothing; a box that slept through 02:00 just sweeps a longer backlog
+ * on the next run. That is why there is no `--resume`, no `--catch-up` and no
+ * repair path in `doctor` — one owner, one code path.
  *
- * Conversation key is `system:nightly:<YYYY-MM-DD>` so every stage is
- * isolated from Telegram chats and shares context across stages.
+ * Per date: TWO harness turns run CONCURRENTLY (`distill` → drawers +
+ * MEMORY.md, `kb` → kb/). They read the same daily file and write disjoint
+ * targets, so there is no shared writer and no lock. Neither writes back to
+ * the daily file — that keeps the ledger's hash stable. Once both join, the
+ * driver refreshes the search index IN CODE (see refreshPersonaIndex), which
+ * is both guaranteed and correctly ordered after the writes.
  *
- * If the persona ships a `nightly-prompt.md` override, that custom
- * prompt is run as a single monolithic turn (no checkpointing) — the
- * override owns the phase contract, so phantombot can't safely split it.
+ * Conversation key is `system:nightly:<YYYY-MM-DD>` so stages are isolated
+ * from Telegram chats and share context per date.
  *
- * Schedule: runs daily at 02:00 local via systemd timer. Manual
- * invocation works the same.
+ * If the persona ships a `nightly-prompt.md` override, that custom prompt is
+ * run as a single monolithic turn per date — the override owns the contract,
+ * so phantombot can't safely split it.
  */
 
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
-import { type Config, loadConfig, personaDir } from "../config.ts";
+import { type Config, loadConfig, memoryIndexPath, personaDir } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
 import type { Harness } from "../harnesses/types.ts";
 import { resolveHarnessBinsForConfig } from "../lib/harnessAvailability.ts";
+import { refreshPersonaIndex } from "../lib/indexRefresh.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import {
   buildNightlyPromptForPersona,
   buildNightlyStagePrompt,
-  clearNightlyProgress,
+  dateRecord,
+  loadNightlyState,
+  NIGHTLY_STAGES,
   type NightlyStage,
   nightlyConversationKey,
-  type NightlyProgress,
-  pendingNightlyStages,
-  saveNightlyProgress,
+  type PendingDate,
+  pendingForDate,
+  STALE_RUN_MS,
   saveNightlyState,
+  sweepDailyFiles,
 } from "../lib/nightly.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
@@ -48,45 +56,50 @@ const NIGHTLY_SUFFIX =
   "You are operating in NIGHTLY MAINTENANCE MODE. " +
   "Skip pleasantries. Do work, write files, report briefly.";
 
-// Per-stage timeouts. A single stage is far smaller than the old
-// monolithic pass, so the hard cap can be tighter; idle stays at 5 min
-// to tolerate long thinking between tool calls.
+// Per-stage timeouts. A stage is one bounded job, so the hard cap can be
+// tight; idle stays at 5 min to tolerate long thinking between tool calls.
 const STAGE_IDLE_TIMEOUT_MS = 5 * 60_000;
 const STAGE_HARD_TIMEOUT_MS = 20 * 60_000;
+
+/**
+ * Dates processed per invocation. A first sweep on a persona with months of
+ * unprocessed history would otherwise run for hours and overlap the next
+ * night's run; capping keeps each pass bounded and lets the backlog drain
+ * over consecutive runs (and stay visible in `/status`).
+ */
+export const MAX_DATES_PER_RUN = 10;
 
 export interface RunNightlyInput {
   config?: Config;
   persona?: string;
-  /** Override "today" — useful for backfill or testing. ISO YYYY-MM-DD. */
+  /** Process ONE specific date (YYYY-MM-DD), ledger state ignored. */
   today?: string;
-  /** Resume from `.nightly-progress.json` instead of starting fresh. */
-  resume?: boolean;
+  /** Cap dates processed this run. Default {@link MAX_DATES_PER_RUN}. */
+  maxDates?: number;
+  /** Run even if another sweep holds the in-flight marker. */
+  force?: boolean;
   out?: WriteSink;
   err?: WriteSink;
+  /** Test seam — override the clock. */
+  now?: Date;
+  /** Test seam — run a stage without a real harness. */
+  runStage?: (args: {
+    persona: string;
+    date: string;
+    stage: NightlyStage | "override";
+    prompt: string;
+  }) => Promise<TurnResult>;
+  /** Test seam — skip the real index refresh. */
+  refreshIndex?: (personaDir: string) => Promise<void>;
 }
 
-interface TurnResult {
+export interface TurnResult {
   finalReply: string;
   errored?: string;
   durationMs: number;
 }
 
 /** Run one harness turn for the nightly conversation. */
-/**
- * Default processing date for a nightly run: yesterday, in UTC calendar
- * arithmetic (UTC date minus one calendar day). The timer fires at 02:00
- * local, so "today" at fire time is the day just beginning — the file to
- * process is the one that closed at midnight. Subtracting a calendar day
- * (not 86400s) stays correct across leap seconds / calendar boundaries.
- */
-export function defaultNightlyDate(now: Date = new Date()): string {
-  const d = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-  );
-  d.setUTCDate(d.getUTCDate() - 1);
-  return d.toISOString().slice(0, 10);
-}
-
 async function runNightlyTurn(opts: {
   persona: string;
   conversation: string;
@@ -117,7 +130,7 @@ async function runNightlyTurn(opts: {
       origin: "internal",
       // Nightly needs no MCP; running MCP-free stops an unauthenticated remote
       // connector from wedging the --print startup and killing a stage on the
-      // idle timeout (essence "timed out with no output"). See HarnessRequest.mcpMode.
+      // idle timeout. See HarnessRequest.mcpMode.
       mcpMode: "none",
     })) {
       if (chunk.type === "text") finalReply += chunk.text;
@@ -133,6 +146,7 @@ async function runNightlyTurn(opts: {
 export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
+  const now = input.now ?? new Date();
 
   let config = input.config ?? (await loadConfig());
   const persona = input.persona ?? config.defaultPersona;
@@ -146,156 +160,223 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
   // long-running `run` daemon does. Without this the nightly oneshot relied
   // solely on the systemd unit's narrow Environment=PATH and a PATH-relative
   // `pi` could fail with `exit 127` every night (issue #181 §1).
-  ({ config } = await resolveHarnessBinsForConfig(config, { err }));
+  if (!input.runStage) {
+    ({ config } = await resolveHarnessBinsForConfig(config, { err }));
+  }
 
-  const harnesses = buildHarnessChain(config, err);
-  if (harnesses.length === 0) {
+  const harnesses = input.runStage ? [] : buildHarnessChain(config, err);
+  if (!input.runStage && harnesses.length === 0) {
     err.write("no harnesses configured\n");
     return 2;
   }
 
-  // The nightly timer fires at 02:00 to process the day that just CLOSED —
-  // default to yesterday, not the day that has barely begun. Without this
-  // every unattended run looks for a daily file that doesn't exist yet and
-  // silently no-ops. `input.today` (--date) stays the override for backfill.
-  const today = input.today ?? defaultNightlyDate();
-  const conversation = nightlyConversationKey(today);
-  const memory = await openMemoryStore(config.memoryDbPath);
-  const runStartedAt = Date.now();
+  const state = await loadNightlyState(dir);
 
-  try {
-    // A persona-provided override owns the whole phase contract; we
-    // can't safely chunk it, so run it as one monolithic turn.
-    if (existsSync(join(dir, "nightly-prompt.md"))) {
+  // Single-sweep lock. A long backlog can outlive the gap to the next timer
+  // fire; two sweeps on the same dates would double-file drawers. A marker
+  // older than STALE_RUN_MS is a crashed run, not a live one, so it's taken
+  // over rather than obeyed.
+  if (state.current && !input.force) {
+    const beat = Date.parse(state.current.updated_at ?? state.current.started_at);
+    const alive = !Number.isNaN(beat) && now.getTime() - beat <= STALE_RUN_MS;
+    if (alive) {
       out.write(
-        `nightly: persona='${persona}' date=${today} conversation=${conversation} (override prompt — monolithic, no checkpointing)\n`,
+        `nightly: a sweep is already in flight (on ${state.current.date}, ` +
+          `started ${state.current.started_at}) — skipping. Use --force to override.\n`,
       );
-      const prompt = await buildNightlyPromptForPersona(dir, persona, today);
-      const r = await runNightlyTurn({
-        persona,
-        conversation,
-        userMessage: prompt,
-        agentDir: dir,
-        harnesses,
-        memory,
-      });
-      if (r.errored) log.error("nightly: override turn failed", { error: r.errored });
-      await saveNightlyState(dir, {
-        last_run: new Date().toISOString(),
-        last_status: r.errored ? "error" : "ok",
-        ...(r.errored ? { errors: [r.errored] } : {}),
-      });
-      out.write(
-        `nightly ${r.errored ? "FAILED" : "ok"}: ${r.durationMs}ms` +
-          (r.errored ? ` — ${r.errored}` : "") +
-          `\n`,
-      );
-      return r.errored ? 1 : 0;
-    }
-
-    // Checkpointed path: run each pending stage, checkpoint after each.
-    const stages = await pendingNightlyStages(dir, today, input.resume ?? false);
-    const allStages: NightlyStage[] = [
-      "essence",
-      "promote",
-      "kb",
-      "compress",
-      "state",
-    ];
-    const completed = allStages.filter((s) => !stages.includes(s));
-
-    out.write(
-      `nightly: persona='${persona}' date=${today} conversation=${conversation}\n`,
-    );
-    if (stages.length === 0) {
-      out.write("nightly: all stages already complete for today — nothing to do\n");
       return 0;
     }
-    if (completed.length > 0) {
-      out.write(
-        `nightly: resuming — ${completed.length} stage(s) already done [${completed.join(", ")}], ${stages.length} remaining\n`,
-      );
+    out.write(
+      `nightly: taking over a stalled sweep (last beat ${state.current.updated_at}) \n`,
+    );
+  }
+
+  // Which dates to process. `--date` is an explicit override for one day
+  // (backfill / debugging); otherwise sweep everything unprocessed or changed.
+  let queue: PendingDate[];
+  if (input.today) {
+    const one = await pendingForDate(dir, input.today);
+    if (!one) {
+      err.write(`no daily file for ${input.today} — nothing to process\n`);
+      return 2;
     }
-
-    const progress: NightlyProgress = {
-      date: today,
-      started_at: new Date(runStartedAt).toISOString(),
-      updated_at: new Date().toISOString(),
-      completed_stages: [...completed],
-      status: "in_progress",
-    };
-    await saveNightlyProgress(dir, progress);
-
-    for (const stage of stages) {
-      out.write(`nightly: stage '${stage}' starting\n`);
-      const prompt = buildNightlyStagePrompt(persona, today, stage);
-      const r = await runNightlyTurn({
-        persona,
-        conversation,
-        userMessage: prompt,
-        agentDir: dir,
-        harnesses,
-        memory,
-      });
-
-      if (r.errored) {
-        // Checkpoint stays at the last good stage; status -> partial so
-        // resume / doctor pick up exactly here next time.
-        progress.status = "partial";
-        progress.last_error = `stage '${stage}': ${r.errored}`;
-        progress.updated_at = new Date().toISOString();
-        await saveNightlyProgress(dir, progress);
-        await saveNightlyState(dir, {
-          last_run: new Date().toISOString(),
-          last_status: "partial",
-          errors: [`stage '${stage}': ${r.errored}`],
-        });
-        log.error("nightly: stage failed — checkpoint saved", {
-          persona,
-          date: today,
-          stage,
-          error: r.errored,
-          completed: progress.completed_stages,
-        });
-        out.write(
-          `nightly PARTIAL: stage '${stage}' failed after ${r.durationMs}ms — ${r.errored}\n` +
-            `nightly: ${progress.completed_stages.length}/${allStages.length} stages done; rerun with --resume to continue\n`,
-        );
-        return 1;
+    queue = [one];
+  } else {
+    const sweep = await sweepDailyFiles(
+      dir,
+      state,
+      now.toISOString().slice(0, 10),
+    );
+    // Files that were touched but not changed: refresh the ledger's mtime so
+    // the next sweep takes the cheap stat-only path again. No turns spent.
+    if (sweep.touched.length > 0) {
+      const patch: Record<string, ReturnType<typeof dateRecord>> = {};
+      for (const t of sweep.touched) {
+        const prev = state.processed?.[t.date];
+        if (prev) patch[t.date] = { ...prev, mtime_ms: t.mtime_ms, size: t.size };
       }
-
-      progress.completed_stages.push(stage);
-      progress.updated_at = new Date().toISOString();
-      await saveNightlyProgress(dir, progress);
-      out.write(`nightly: stage '${stage}' ok (${r.durationMs}ms)\n`);
+      await saveNightlyState(dir, { processed: patch });
     }
+    queue = sweep.pending;
+  }
 
-    // Every stage done — clear the checkpoint and stamp success.
-    progress.status = "complete";
-    await clearNightlyProgress(dir);
+  const cap = input.maxDates ?? MAX_DATES_PER_RUN;
+  const deferred = Math.max(0, queue.length - cap);
+  if (deferred > 0) queue = queue.slice(0, cap);
+
+  if (queue.length === 0) {
+    out.write(`nightly: persona='${persona}' — nothing pending\n`);
     await saveNightlyState(dir, {
-      last_run: new Date().toISOString(),
+      last_run: now.toISOString(),
       last_status: "ok",
-    });
-    const totalMs = Date.now() - runStartedAt;
-    out.write(`nightly ok: ${allStages.length} stages, ${totalMs}ms total\n`);
-    log.info("nightly: complete", {
-      persona,
-      date: today,
-      durationMs: totalMs,
-      stages: allStages.length,
+      current: null,
     });
     return 0;
-  } finally {
-    await memory.close();
   }
+
+  out.write(
+    `nightly: persona='${persona}' — ${queue.length} date(s) to process ` +
+      `[${queue.map((q) => `${q.date}:${q.reason}`).join(", ")}]` +
+      (deferred > 0 ? ` (+${deferred} deferred to the next run)` : "") +
+      `\n`,
+  );
+
+  const monolithic = existsSync(join(dir, "nightly-prompt.md"));
+  const memory = input.runStage ? null : await openMemoryStore(config.memoryDbPath);
+  const startedAt = new Date().toISOString();
+  const errors: string[] = [];
+
+  try {
+    for (const [i, pending] of queue.entries()) {
+      const conversation = nightlyConversationKey(pending.date);
+      await saveNightlyState(dir, {
+        current: {
+          date: pending.date,
+          index: i + 1,
+          total: queue.length,
+          started_at: startedAt,
+          updated_at: new Date().toISOString(),
+          pid: process.pid,
+        },
+      });
+
+      const runOne = async (
+        stage: NightlyStage | "override",
+        prompt: string,
+      ): Promise<TurnResult> =>
+        input.runStage
+          ? await input.runStage({ persona, date: pending.date, stage, prompt })
+          : await runNightlyTurn({
+              persona,
+              conversation,
+              userMessage: prompt,
+              agentDir: dir,
+              harnesses,
+              memory: memory!,
+            });
+
+      const stagesDone: NightlyStage[] = [];
+      let dateError: string | undefined;
+      const t0 = Date.now();
+
+      if (monolithic) {
+        const prompt = await buildNightlyPromptForPersona(
+          dir,
+          persona,
+          pending.date,
+        );
+        const r = await runOne("override", prompt);
+        if (r.errored) dateError = `override: ${r.errored}`;
+        else stagesDone.push(...NIGHTLY_STAGES);
+      } else {
+        // The two stages write to disjoint targets (drawers+MEMORY.md vs kb/),
+        // so they run concurrently. Nothing between them needs ordering — the
+        // one thing that did, the index refresh, now happens after the join.
+        const results = await Promise.all(
+          NIGHTLY_STAGES.map(async (stage) => ({
+            stage,
+            r: await runOne(
+              stage,
+              buildNightlyStagePrompt(persona, pending.date, stage),
+            ),
+          })),
+        );
+        for (const { stage, r } of results) {
+          if (r.errored) {
+            const msg = `stage '${stage}' (${pending.date}): ${r.errored}`;
+            dateError ??= msg;
+            errors.push(msg);
+            log.error("nightly: stage failed", {
+              persona,
+              date: pending.date,
+              stage,
+              error: r.errored,
+            });
+          } else {
+            stagesDone.push(stage);
+          }
+        }
+      }
+
+      // Index refresh in code — guaranteed, once, after both stages joined.
+      // A failure here is reported but never marks the date unprocessed: the
+      // distillation itself succeeded and the next refresh picks the files up.
+      if (input.refreshIndex) {
+        await input.refreshIndex(dir);
+      } else {
+        const ix = await refreshPersonaIndex({
+          config,
+          personaDir: dir,
+          indexPath: memoryIndexPath(persona),
+        });
+        if (ix.error) err.write(`nightly: index refresh failed — ${ix.error}\n`);
+      }
+
+      await saveNightlyState(dir, {
+        processed: {
+          [pending.date]: dateRecord(pending, stagesDone, dateError),
+        },
+      });
+      if (dateError) {
+        if (!errors.includes(dateError)) errors.push(dateError);
+        out.write(
+          `nightly: ${pending.date} PARTIAL (${stagesDone.length}/${NIGHTLY_STAGES.length} stages, ` +
+            `${Date.now() - t0}ms) — ${dateError}\n`,
+        );
+      } else {
+        out.write(`nightly: ${pending.date} ok (${Date.now() - t0}ms)\n`);
+      }
+    }
+  } finally {
+    await memory?.close();
+  }
+
+  const failed = errors.length > 0;
+  await saveNightlyState(dir, {
+    last_run: new Date().toISOString(),
+    last_status: failed ? "partial" : "ok",
+    ...(failed ? { errors } : { errors: [] }),
+    current: null,
+  });
+  out.write(
+    `nightly ${failed ? "FINISHED WITH ERRORS" : "ok"}: ${queue.length} date(s)` +
+      (deferred > 0 ? `, ${deferred} deferred` : "") +
+      `\n`,
+  );
+  log.info("nightly: sweep complete", {
+    persona,
+    dates: queue.length,
+    deferred,
+    errors: errors.length,
+  });
+  return failed ? 1 : 0;
 }
 
 export default defineCommand({
   meta: {
     name: "nightly",
     description:
-      "Run the cognitive distillation pass — promote, KB-feed, compress. Checkpointed into resumable stages; isolated conversation; manual or via the systemd timer.",
+      "Run the cognitive distillation sweep — every unprocessed or changed daily file is distilled into the drawers, MEMORY.md and the KB. Idempotent: re-running with nothing pending does nothing.",
   },
   args: {
     persona: {
@@ -304,20 +385,26 @@ export default defineCommand({
     },
     date: {
       type: "string",
-      description: "Override today's date (YYYY-MM-DD); useful for backfill.",
-    },
-    resume: {
-      type: "boolean",
       description:
-        "Resume from .nightly-progress.json — skip stages already completed today.",
+        "Process only this date (YYYY-MM-DD), regardless of ledger state.",
+    },
+    "max-dates": {
+      type: "string",
+      description: `Cap dates processed this run (default ${MAX_DATES_PER_RUN}).`,
+    },
+    force: {
+      type: "boolean",
+      description: "Run even if another sweep holds the in-flight marker.",
       default: false,
     },
   },
   async run({ args }) {
+    const max = args["max-dates"] ? Number(args["max-dates"]) : undefined;
     process.exitCode = await runNightly({
       persona: args.persona ? String(args.persona) : undefined,
       today: args.date ? String(args.date) : undefined,
-      resume: Boolean(args.resume),
+      maxDates: Number.isFinite(max) ? max : undefined,
+      force: Boolean(args.force),
     });
   },
 });

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -61,20 +61,18 @@ const NIGHTLY_SUFFIX =
 const STAGE_IDLE_TIMEOUT_MS = 5 * 60_000;
 const STAGE_HARD_TIMEOUT_MS = 20 * 60_000;
 
-/**
- * Dates processed per invocation. A first sweep on a persona with months of
- * unprocessed history would otherwise run for hours and overlap the next
- * night's run; capping keeps each pass bounded and lets the backlog drain
- * over consecutive runs (and stay visible in `/status`).
- */
-export const MAX_DATES_PER_RUN = 10;
-
 export interface RunNightlyInput {
   config?: Config;
   persona?: string;
   /** Process ONE specific date (YYYY-MM-DD), ledger state ignored. */
   today?: string;
-  /** Cap dates processed this run. Default {@link MAX_DATES_PER_RUN}. */
+  /**
+   * Cap dates processed this run. Unset means NO cap: a sweep drains the whole
+   * backlog in one pass. A months-deep first sweep is a long run, but it is a
+   * one-off, the in-flight marker keeps the rollover trigger from starting a
+   * second one on top of it, and a half-drained backlog that reappears every
+   * night is worse than one long night. Set it only to bound a manual run.
+   */
   maxDates?: number;
   /** Run even if another sweep holds the in-flight marker. */
   force?: boolean;
@@ -220,8 +218,11 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
     queue = sweep.pending;
   }
 
-  const cap = input.maxDates ?? MAX_DATES_PER_RUN;
-  const deferred = Math.max(0, queue.length - cap);
+  // No cap by default — the sweep drains the whole backlog. `--max-dates`
+  // bounds a manual run; anything it leaves behind stays pending in the ledger.
+  const cap = input.maxDates;
+  const deferred =
+    cap !== undefined && cap > 0 ? Math.max(0, queue.length - cap) : 0;
   if (deferred > 0) queue = queue.slice(0, cap);
 
   if (queue.length === 0) {
@@ -390,7 +391,8 @@ export default defineCommand({
     },
     "max-dates": {
       type: "string",
-      description: `Cap dates processed this run (default ${MAX_DATES_PER_RUN}).`,
+      description:
+        "Cap dates processed this run (default: no cap — drain the backlog).",
     },
     force: {
       type: "boolean",

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -5,7 +5,7 @@
  * against the ledger in `memory/.nightly-state.json` (mtime, then content
  * hash), and processes every date that is new, that grew since it was
  * processed, or whose last pass didn't finish. Running it twice in a row
- * costs nothing; a box that slept through 02:00 just sweeps a longer backlog
+ * costs nothing; a box that was off for a week just sweeps a longer backlog
  * on the next run. That is why there is no `--resume`, no `--catch-up` and no
  * repair path in `doctor` — one owner, one code path.
  *

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -75,6 +75,7 @@ import {
 import { openMemoryStore } from "../memory/store.ts";
 import { VERSION } from "../version.ts";
 import { runDoctor } from "./doctor.ts";
+import { spawn } from "node:child_process";
 import { ensureRoutingExtension } from "../lib/piExtensionProvision.ts";
 import { reconcileEditorConnectors } from "../connectors/acp/autoInstall.ts";
 
@@ -449,11 +450,8 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   }
   out.write("Ctrl-C to stop.\n");
 
-  // Startup catch-up: `doctor` checks for a stale, failed, or partially
-  // checkpointed nightly and, if found, spawns a detached
-  // `nightly --resume` that picks up from the last good stage. This
-  // covers machines powered off during the 02:00 window. Don't await —
-  // doctor's repair is a detached child, so this returns immediately.
+  // Startup health check — read-only for the nightly (it repairs itself by
+  // sweeping); still repairs drifted units/timers/connectors. Don't await.
   // Runs against the admin persona for the same reason as notify above.
   const doctorPersona =
     adminListener?.persona ?? phantomchatPersonas[0]?.persona ?? defaultPersona;
@@ -466,6 +464,16 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         error: (e as Error).message,
       }),
   );
+
+  // Startup nightly sweep — the whole story for boxes that are off at 02:00.
+  // The nightly is idempotent (it processes whatever the ledger says is
+  // unprocessed or changed, and no-ops when nothing is), so this is safe to
+  // fire on every start: an always-on server finds nothing pending and exits
+  // in milliseconds; a laptop booted at 09:15 distils the days it missed.
+  // Detached, so a long backlog sweep outlives neither this promise nor the
+  // daemon's own lifecycle concerns, and a crash there can never take the
+  // channel loop with it.
+  spawnStartupNightly(doctorPersona);
 
   // Self-provision the managed Pi capability-routing extension: when a routable
   // capability (image and/or coding model) is configured, stamp the embedded
@@ -920,6 +928,34 @@ export async function runRun(input: RunInput = {}): Promise<number> {
     lock.release();
   }
   return 0;
+}
+
+/**
+ * Fire a detached `phantombot nightly` for the given persona.
+ *
+ * Detached + unref'd on purpose: a first sweep over a long backlog can run for
+ * many minutes, and it must not hold the daemon's event loop or die with a
+ * restart. The nightly holds its own in-flight marker, so a start-restart-start
+ * cycle cannot stack two sweeps on the same dates.
+ */
+export function spawnStartupNightly(persona: string): void {
+  const entry = process.argv[1] ?? "";
+  const dev = entry.endsWith(".ts") || entry.endsWith(".js");
+  const args = dev
+    ? [entry, "nightly", "--persona", persona]
+    : ["nightly", "--persona", persona];
+  try {
+    const child = spawn(process.execPath, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    log.info("run: spawned startup nightly sweep", { persona });
+  } catch (e) {
+    log.warn("run: could not spawn startup nightly sweep", {
+      error: (e as Error).message,
+    });
+  }
 }
 
 export default defineCommand({

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -75,7 +75,7 @@ import {
 import { openMemoryStore } from "../memory/store.ts";
 import { VERSION } from "../version.ts";
 import { runDoctor } from "./doctor.ts";
-import { spawn } from "node:child_process";
+import { spawnNightlySweep } from "../lib/nightlyTrigger.ts";
 import { ensureRoutingExtension } from "../lib/piExtensionProvision.ts";
 import { reconcileEditorConnectors } from "../connectors/acp/autoInstall.ts";
 
@@ -465,7 +465,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
       }),
   );
 
-  // Startup nightly sweep — the whole story for boxes that are off at 02:00.
+  // Startup nightly sweep — one of the two triggers that replaced the timer.
   // The nightly is idempotent (it processes whatever the ledger says is
   // unprocessed or changed, and no-ops when nothing is), so this is safe to
   // fire on every start: an always-on server finds nothing pending and exits
@@ -931,31 +931,15 @@ export async function runRun(input: RunInput = {}): Promise<number> {
 }
 
 /**
- * Fire a detached `phantombot nightly` for the given persona.
+ * Fire a detached `phantombot nightly` for the given persona at startup.
  *
- * Detached + unref'd on purpose: a first sweep over a long backlog can run for
- * many minutes, and it must not hold the daemon's event loop or die with a
- * restart. The nightly holds its own in-flight marker, so a start-restart-start
- * cycle cannot stack two sweeps on the same dates.
+ * Thin alias over the shared trigger (see src/lib/nightlyTrigger.ts) — startup
+ * is one of the two events that replace the retired 02:00 timer; the heartbeat's
+ * day-rollover check is the other. The nightly holds its own in-flight marker,
+ * so a start-restart-start cycle cannot stack two sweeps on the same dates.
  */
 export function spawnStartupNightly(persona: string): void {
-  const entry = process.argv[1] ?? "";
-  const dev = entry.endsWith(".ts") || entry.endsWith(".js");
-  const args = dev
-    ? [entry, "nightly", "--persona", persona]
-    : ["nightly", "--persona", persona];
-  try {
-    const child = spawn(process.execPath, args, {
-      detached: true,
-      stdio: "ignore",
-    });
-    child.unref();
-    log.info("run: spawned startup nightly sweep", { persona });
-  } catch (e) {
-    log.warn("run: could not spawn startup nightly sweep", {
-      error: (e as Error).message,
-    });
-  }
+  spawnNightlySweep(persona, "startup");
 }
 
 export default defineCommand({

--- a/src/lib/indexRefresh.ts
+++ b/src/lib/indexRefresh.ts
@@ -1,0 +1,83 @@
+/**
+ * Refresh a persona's search index in CODE.
+ *
+ * Two passes over memory/ + kb/: fill the SQLite FTS5 table from any file
+ * whose mtime moved, then embed the chunks whose text sha changed. Nothing
+ * else in the system does this — a KB note written by the nightly is
+ * invisible to `memory search` until it runs.
+ *
+ * This used to be a line inside the nightly's KB PROMPT
+ * ("run `phantombot memory index --rebuild` at the end"), i.e. deterministic
+ * work behind a probabilistic trigger: if the model forgot, or the turn died,
+ * the index silently lagged a day. Two wins from moving it here:
+ *
+ *   - it is guaranteed to run, exactly once, AFTER both concurrent stages
+ *     have joined — which is precisely the write/index race that made the
+ *     stages unsafe to parallelise; and
+ *   - it uses `refreshStale`, not `rebuild`. `rebuild` drops the tables and
+ *     re-embeds EVERY file with force, which on a mature persona means
+ *     re-embedding hundreds of unchanged daily files every single night.
+ */
+
+import type { Config } from "../config.ts";
+import { defaultEmbedder, runEmbedJob } from "./embedJob.ts";
+import { log } from "./logger.ts";
+import { MemoryIndex } from "./memoryIndex.ts";
+
+export interface RefreshPersonaIndexInput {
+  config: Config;
+  /** Persona working directory (contains memory/ and kb/). */
+  personaDir: string;
+  /** Path to the persona's index db. */
+  indexPath: string;
+  /** Skip the embedding pass (FTS only). */
+  noEmbed?: boolean;
+}
+
+export interface RefreshPersonaIndexResult {
+  indexed: number;
+  removed: number;
+  embedded: number;
+  embedFailed: number;
+  /** Non-fatal failure message, if the refresh could not complete. */
+  error?: string;
+}
+
+/**
+ * Never throws: a failed index refresh must not fail the work that produced
+ * the files. The error is logged and returned for the caller to report.
+ */
+export async function refreshPersonaIndex(
+  input: RefreshPersonaIndexInput,
+): Promise<RefreshPersonaIndexResult> {
+  const result: RefreshPersonaIndexResult = {
+    indexed: 0,
+    removed: 0,
+    embedded: 0,
+    embedFailed: 0,
+  };
+  let ix: MemoryIndex | undefined;
+  try {
+    ix = await MemoryIndex.open(input.indexPath);
+    const fts = await ix.refreshStale(input.personaDir);
+    result.indexed = fts.indexed;
+    result.removed = fts.removed;
+
+    if (input.noEmbed) return result;
+    const embedder = defaultEmbedder(input.config);
+    if (!embedder) return result; // keyword-only install: valid, not a fault
+    const r = await runEmbedJob({
+      personaDir: input.personaDir,
+      index: ix,
+      embedder,
+    });
+    result.embedded = r.embedded;
+    result.embedFailed = r.failed;
+  } catch (e) {
+    result.error = (e as Error).message;
+    log.warn("index refresh failed (non-fatal)", { error: result.error });
+  } finally {
+    ix?.close();
+  }
+  return result;
+}

--- a/src/lib/launchd.ts
+++ b/src/lib/launchd.ts
@@ -11,7 +11,6 @@
  *
  *   ~/Library/LaunchAgents/dev.phantombot.phantombot.plist
  *   ~/Library/LaunchAgents/dev.phantombot.heartbeat.plist
- *   ~/Library/LaunchAgents/dev.phantombot.nightly.plist
  *   ~/Library/LaunchAgents/dev.phantombot.tick.plist
  *
  * Logs go to ~/Library/Logs/phantombot/<unit>.{out,err}.log (no journald
@@ -34,6 +33,12 @@ import type { WriteSink } from "./io.ts";
 
 export const PHANTOMBOT_PLIST_LABEL = "dev.phantombot.phantombot";
 export const HEARTBEAT_PLIST_LABEL = "dev.phantombot.heartbeat";
+/**
+ * RETIRED label. The nightly no longer runs on a clock (startup + the
+ * heartbeat's day-rollover check trigger it now — see nightlyTrigger.ts), so
+ * this plist is never generated. The label survives only so an upgrade can
+ * bootout and delete what an older install left in the gui domain.
+ */
 export const NIGHTLY_PLIST_LABEL = "dev.phantombot.nightly";
 export const TICK_PLIST_LABEL = "dev.phantombot.tick";
 
@@ -64,6 +69,7 @@ export function heartbeatPlistPath(): string {
   return join(launchAgentsDir(), `${HEARTBEAT_PLIST_LABEL}.plist`);
 }
 
+/** Path of the retired nightly plist (kept for cleanup only). */
 export function nightlyPlistPath(): string {
   return join(launchAgentsDir(), `${NIGHTLY_PLIST_LABEL}.plist`);
 }
@@ -211,16 +217,6 @@ export function generateHeartbeatPlist(binPath: string): string {
   });
 }
 
-/** Generate the nightly plist — fires daily at 02:00. */
-export function generateNightlyPlist(binPath: string): string {
-  return generatePlist({
-    label: NIGHTLY_PLIST_LABEL,
-    binPath,
-    args: ["nightly"],
-    startCalendar: { Hour: 2, Minute: 0 },
-  });
-}
-
 /**
  * Generate the tick plist — fires every 60 seconds.
  *
@@ -291,7 +287,7 @@ export interface InstallLaunchdOptions {
 }
 
 /**
- * Write the four plists, then bootstrap each into the user's gui domain.
+ * Write the three plists, then bootstrap each into the user's gui domain.
  *
  * `bootstrap` is the modern install verb (replaces `load`). It both loads
  * the unit and starts it (for KeepAlive=true) or schedules it (for
@@ -318,11 +314,6 @@ export async function installPhantombotPlists(
       path: hbPath,
       label: HEARTBEAT_PLIST_LABEL,
       body: generateHeartbeatPlist(opts.binPath),
-    },
-    {
-      path: ngPath,
-      label: NIGHTLY_PLIST_LABEL,
-      body: generateNightlyPlist(opts.binPath),
     },
     {
       path: tkPath,
@@ -357,8 +348,18 @@ export async function installPhantombotPlists(
       return { installed: false };
     }
   }
+
+  // Upgrade cleanup: an install from before the nightly timer was retired
+  // still has the 02:00 agent loaded. Bootout + delete it so it can't fire a
+  // duplicate sweep. Guarded on the plist existing, so a fresh Mac issues no
+  // extra launchctl call at all.
+  if (existsSync(ngPath)) {
+    await opts.launchctl.run(["bootout", `${domain}/${NIGHTLY_PLIST_LABEL}`]);
+    await unlink(ngPath);
+    opts.out.write(`removed retired plist: ${ngPath}\n`);
+  }
   opts.out.write(
-    `bootstrapped ${PHANTOMBOT_PLIST_LABEL} + heartbeat + nightly + tick into ${domain}\n`,
+    `bootstrapped ${PHANTOMBOT_PLIST_LABEL} + heartbeat + tick into ${domain}\n`,
   );
   return { installed: true };
 }

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -1,36 +1,110 @@
 /**
  * Nightly cognitive pass.
  *
- * Runs the harness once per day in an isolated conversation
- * (`system:nightly:<YYYY-MM-DD>`) so it can never bleed into Telegram
- * chats. The harness gets the full persona BOOT.md + a focused
- * distillation directive, plus access to phantombot's memory CLI tools
- * (search / get / list / today / index) via its native Bash tool.
+ * Every run is a SWEEP: phantombot lists the daily files on disk, compares
+ * each one against the ledger in `memory/.nightly-state.json` (mtime + content
+ * hash), and processes every date that has never been processed or has grown
+ * since it was. There is no catch-up mode, no resume flag and no separate
+ * repair path — a box that was asleep at 02:00 simply sweeps a longer backlog
+ * the next time the pass runs, and a re-run with nothing pending is free.
  *
- * Phases the harness is instructed to run (from the OpenClaw spec):
+ * Each pending date is processed by exactly TWO harness turns, run
+ * CONCURRENTLY because they write to disjoint targets:
  *
- *   1. Day essence — read today's daily file, write a 2-3 line summary
- *      header at the top.
- *   2. Promote — anything tagged or worth keeping into the structured
- *      drawers (people / decisions / lessons / commitments).
- *   3. KB feed — for each durable concept, `phantombot memory search`
- *      first to dedup, then update an existing note OR create a new
- *      atomic note with frontmatter and [[wikilinks]]. Sweep kb/inbox/.
- *   4. Compress — trim MEMORY.md if bloating; clear ## Recent items
- *      that have been distilled.
- *   5. State — write a summary to memory/.nightly-state.json so the
- *      next run knows what was done.
+ *   1. distill — file the day's captures the heartbeat missed into the
+ *      structured drawers (people / decisions / lessons / commitments) and
+ *      maintain MEMORY.md's "## Recent" orientation layer.
+ *   2. kb      — extract durable knowledge into kb/: reconcile against
+ *      existing notes, create new atomic notes, sweep kb/inbox/.
  *
- * Phantombot just spawns this run; the cognitive work is the harness's
- * own. No phantombot-side judgment about what to keep, distill, or link.
+ * Neither stage writes back to the daily file — that is what keeps the
+ * ledger's hash stable, so "hash changed" means "genuinely more content".
+ *
+ * The search-index refresh that used to be a line in the KB prompt is now
+ * done by the driver in code after both stages join (see
+ * `refreshPersonaIndex`): deterministic work does not belong behind a
+ * probabilistic trigger, and doing it once after the join closes the race
+ * between the KB writes and the drawer writes.
+ *
+ * Conversation key is `system:nightly:<YYYY-MM-DD>` so the pass can never
+ * bleed into Telegram chats, and both stages for a date share context.
  */
 
 import { existsSync } from "node:fs";
-import { readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "./logger.ts";
 
 const NIGHTLY_PROMPT_OVERRIDE = "nightly-prompt.md";
+
+/** Daily files are named strictly `YYYY-MM-DD.md` under `memory/`. */
+const DAILY_FILE_RE = /^(\d{4}-\d{2}-\d{2})\.md$/;
+
+/**
+ * A sweep that hasn't touched its `current` block in this long is treated as
+ * dead (crashed process, powered-off box) rather than running. Generous: one
+ * date is two concurrent turns, each capped at the stage hard timeout.
+ */
+export const STALE_RUN_MS = 45 * 60_000;
+
+/**
+ * Backlog above this many unprocessed dates is an error, not a warning —
+ * something has been swallowing runs, not just a night missed.
+ */
+export const BACKLOG_WARN_MAX = 3;
+
+// ---------------------------------------------------------------------------
+// Stage model
+// ---------------------------------------------------------------------------
+
+/**
+ * The two stages of a nightly pass. Split by OUTPUT target, not input: both
+ * read the same daily file, `distill` writes drawers + MEMORY.md and `kb`
+ * writes kb/. Kept separate (rather than merged into one cheaper turn)
+ * because the KB stage's search-read-reconcile work degrades badly when it
+ * shares a turn with mechanical filing.
+ */
+export type NightlyStage = "distill" | "kb";
+
+export const NIGHTLY_STAGES: readonly NightlyStage[] = [
+  "distill",
+  "kb",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Ledger
+// ---------------------------------------------------------------------------
+
+/** What the ledger remembers about one processed date. */
+export interface NightlyDateRecord {
+  /** mtime of the daily file at the moment it was processed. */
+  mtime_ms: number;
+  /** Byte size when processed — paired with mtime for the cheap skip path. */
+  size: number;
+  /** sha256 of the daily file's bytes when processed (hex). */
+  hash: string;
+  /** Stages that completed for this date. */
+  stages_done: NightlyStage[];
+  completed_at: string;
+  status: "ok" | "partial" | "error";
+  /** First stage error, if the date didn't fully succeed. */
+  error?: string;
+}
+
+/** Progress marker for a sweep that is running right now. Feeds `/status`. */
+export interface NightlyCurrent {
+  /** Date being processed at this instant. */
+  date: string;
+  /** 1-based position of that date within this sweep. */
+  index: number;
+  /** Total dates this sweep intends to process. */
+  total: number;
+  started_at: string;
+  /** Refreshed as each date starts — drives stale-run detection. */
+  updated_at: string;
+  pid?: number;
+}
 
 export interface NightlyState {
   last_run?: string;
@@ -39,6 +113,10 @@ export interface NightlyState {
   kb_notes_updated?: number;
   kb_notes_created?: number;
   errors?: string[];
+  /** date (YYYY-MM-DD) → what was done for it. The idempotency ledger. */
+  processed?: Record<string, NightlyDateRecord>;
+  /** Set while a sweep is in flight; cleared when it finishes. */
+  current?: NightlyCurrent | null;
 }
 
 export function nightlyConversationKey(date: string): string {
@@ -49,137 +127,12 @@ export function nightlyStatePath(personaDir: string): string {
   return join(personaDir, "memory", ".nightly-state.json");
 }
 
-// ---------------------------------------------------------------------------
-// Checkpointed nightly — stage model
-// ---------------------------------------------------------------------------
-
-/**
- * The nightly pass decomposed into idempotent stages. Each stage is one
- * bounded harness turn; phantombot checkpoints after every completed
- * stage to `.nightly-progress.json`. A run that times out (or the box
- * powering off) loses at most the in-flight stage — the next run resumes
- * from the checkpoint instead of redoing the whole night.
- *
- * Order matters: `essence` and `promote` read the daily file, `kb`
- * synthesises (the long pole), `compress` trims MEMORY.md, `state`
- * records counts.
- */
-export type NightlyStage =
-  | "essence"
-  | "promote"
-  | "kb"
-  | "compress"
-  | "state";
-
-export const NIGHTLY_STAGES: readonly NightlyStage[] = [
-  "essence",
-  "promote",
-  "kb",
-  "compress",
-  "state",
-] as const;
-
-export interface NightlyProgress {
-  /** ISO date (YYYY-MM-DD) this checkpoint belongs to. */
-  date: string;
-  started_at: string;
-  updated_at: string;
-  /** Stages finished successfully, in completion order. */
-  completed_stages: NightlyStage[];
-  status: "in_progress" | "partial" | "complete";
-  /** Message from the stage that failed/timed out, if any. */
-  last_error?: string;
+/** Absolute path of one daily file. The filename IS the primary key. */
+export function dailyFilePath(personaDir: string, date: string): string {
+  return join(personaDir, "memory", `${date}.md`);
 }
 
-export function nightlyProgressPath(personaDir: string): string {
-  return join(personaDir, "memory", ".nightly-progress.json");
-}
-
-/** Read the current checkpoint. Returns null if none exists. */
-export async function loadNightlyProgress(
-  personaDir: string,
-): Promise<NightlyProgress | null> {
-  const p = nightlyProgressPath(personaDir);
-  if (!existsSync(p)) return null;
-  try {
-    return JSON.parse(await readFile(p, "utf8")) as NightlyProgress;
-  } catch (e) {
-    log.warn("nightly: progress file unreadable; treating as absent", {
-      error: (e as Error).message,
-    });
-    return null;
-  }
-}
-
-export async function saveNightlyProgress(
-  personaDir: string,
-  progress: NightlyProgress,
-): Promise<void> {
-  await writeFile(
-    nightlyProgressPath(personaDir),
-    JSON.stringify(progress, null, 2) + "\n",
-    "utf8",
-  );
-}
-
-/** Remove the checkpoint — called once all stages complete. */
-export async function clearNightlyProgress(
-  personaDir: string,
-): Promise<void> {
-  const p = nightlyProgressPath(personaDir);
-  if (!existsSync(p)) return;
-  try {
-    await rm(p);
-  } catch (e) {
-    log.warn("nightly: could not clear progress file", {
-      error: (e as Error).message,
-    });
-  }
-}
-
-/**
- * Given a persona dir and the date being processed, return the stages
- * still to run. Honors an existing checkpoint ONLY when it belongs to
- * the same date — a stale checkpoint from a previous day is ignored so
- * we always start a fresh day clean.
- */
-export async function pendingNightlyStages(
-  personaDir: string,
-  today: string,
-  resume: boolean,
-): Promise<NightlyStage[]> {
-  if (!resume) return [...NIGHTLY_STAGES];
-  const progress = await loadNightlyProgress(personaDir);
-  if (!progress || progress.date !== today) return [...NIGHTLY_STAGES];
-  const done = new Set(progress.completed_stages);
-  return NIGHTLY_STAGES.filter((s) => !done.has(s));
-}
-
-/**
- * Catch-up window: if the last nightly run was more than this many
- * milliseconds ago, a startup catch-up is warranted. Default: 24 hours.
- */
-export const CATCHUP_WINDOW_MS = 24 * 60 * 60 * 1000;
-
-/**
- * Should a catch-up nightly run at startup?
- *
- * Returns `true` when the persona has no record of a previous nightly
- * run OR the last run was more than {@link CATCHUP_WINDOW_MS} ago.
- * Designed for users who shut down their machine overnight and miss
- * the 02:00 scheduled run.
- */
-export async function shouldRunCatchupNightly(
-  personaDir: string,
-): Promise<boolean> {
-  const state = await loadNightlyState(personaDir);
-  if (!state.last_run) return true;
-  const lastRun = Date.parse(state.last_run);
-  if (Number.isNaN(lastRun)) return true;
-  return Date.now() - lastRun > CATCHUP_WINDOW_MS;
-}
-
-/** Read the previous nightly state. Returns {} if no prior run. */
+/** Read the ledger. Returns {} if no prior run (or an unreadable file). */
 export async function loadNightlyState(
   personaDir: string,
 ): Promise<NightlyState> {
@@ -195,13 +148,22 @@ export async function loadNightlyState(
   }
 }
 
-/** Update the previous nightly state with a fresh run record. */
+/**
+ * Merge a patch into the ledger and write it back. `processed` is merged
+ * key-by-key so a patch carrying one date never drops the rest of history;
+ * `current: null` explicitly clears the in-flight marker.
+ */
 export async function saveNightlyState(
   personaDir: string,
   patch: Partial<NightlyState>,
 ): Promise<void> {
   const cur = await loadNightlyState(personaDir);
-  const next = { ...cur, ...patch };
+  const next: NightlyState = {
+    ...cur,
+    ...patch,
+    processed: { ...(cur.processed ?? {}), ...(patch.processed ?? {}) },
+  };
+  if (patch.current === null) delete next.current;
   await writeFile(
     nightlyStatePath(personaDir),
     JSON.stringify(next, null, 2) + "\n",
@@ -209,12 +171,279 @@ export async function saveNightlyState(
   );
 }
 
+// ---------------------------------------------------------------------------
+// Sweep
+// ---------------------------------------------------------------------------
+
+/** A daily file the sweep has decided needs (re)processing. */
+export interface PendingDate {
+  date: string;
+  path: string;
+  mtime_ms: number;
+  size: number;
+  hash: string;
+  /** Why it's pending: never seen, content grew, or last pass didn't finish. */
+  reason: "new" | "changed" | "incomplete";
+}
+
+export interface SweepResult {
+  /** Dates needing harness turns, oldest first. */
+  pending: PendingDate[];
+  /**
+   * Dates whose file was touched (mtime moved) but whose CONTENT is
+   * unchanged — the ledger's mtime is refreshed for free, no turn spent.
+   */
+  touched: Array<{ date: string; mtime_ms: number; size: number }>;
+  /** Every date file seen on disk, oldest first. */
+  seen: string[];
+}
+
+async function sha256File(path: string): Promise<string> {
+  return createHash("sha256").update(await readFile(path)).digest("hex");
+}
+
+/**
+ * Reconcile the daily files on disk against the ledger.
+ *
+ * `before` is exclusive: the day still being written to (today) is never
+ * swept, because the drawers would be filed from a half-finished file and
+ * the hash would change minutes later anyway.
+ *
+ * Cost control: a date whose ledger mtime still matches `stat` is skipped
+ * without reading the file at all, so a ten-year archive costs one `readdir`
+ * plus N `stat`s. Only files whose mtime moved get hashed — and a hash that
+ * matches means the file was merely touched, not changed.
+ */
+export async function sweepDailyFiles(
+  personaDir: string,
+  state: NightlyState,
+  before: string,
+): Promise<SweepResult> {
+  const memDir = join(personaDir, "memory");
+  const pending: PendingDate[] = [];
+  const touched: Array<{ date: string; mtime_ms: number; size: number }> = [];
+  const seen: string[] = [];
+  if (!existsSync(memDir)) return { pending, touched, seen };
+
+  const entries = (await readdir(memDir))
+    .map((f) => ({ file: f, m: DAILY_FILE_RE.exec(f) }))
+    .filter((e): e is { file: string; m: RegExpExecArray } => e.m !== null)
+    .map((e) => e.m[1]!)
+    .filter((d) => d < before)
+    .sort();
+
+  const ledger = state.processed ?? {};
+  for (const date of entries) {
+    seen.push(date);
+    const path = join(memDir, `${date}.md`);
+    let mtimeMs: number;
+    let size: number;
+    try {
+      const st = await stat(path);
+      mtimeMs = Math.floor(st.mtimeMs);
+      size = st.size;
+    } catch {
+      continue; // vanished between readdir and stat — nothing to process
+    }
+    const rec = ledger[date];
+    const done =
+      rec !== undefined &&
+      rec.status === "ok" &&
+      NIGHTLY_STAGES.every((s) => rec.stages_done.includes(s));
+
+    // Fast path: mtime AND size both unchanged. Size is the belt to mtime's
+    // braces — an append landing inside the same millisecond as the last
+    // stat still moves the size, so a late capture can't hide from the sweep.
+    if (done && rec.mtime_ms === mtimeMs && rec.size === size) continue;
+
+    let hash: string;
+    try {
+      hash = await sha256File(path);
+    } catch (e) {
+      log.warn("nightly: daily file unreadable during sweep", {
+        date,
+        error: (e as Error).message,
+      });
+      continue;
+    }
+    if (done && rec.hash === hash) {
+      touched.push({ date, mtime_ms: mtimeMs, size });
+      continue;
+    }
+    pending.push({
+      date,
+      path,
+      mtime_ms: mtimeMs,
+      size,
+      hash,
+      reason: rec === undefined ? "new" : done ? "changed" : "incomplete",
+    });
+  }
+  return { pending, touched, seen };
+}
+
+/**
+ * Build a {@link PendingDate} for ONE explicit date, ignoring the ledger.
+ * Backs `nightly --date` (backfill / debugging), which must reprocess a day
+ * on demand without walking the whole archive. Returns null if there's no
+ * daily file for that date.
+ */
+export async function pendingForDate(
+  personaDir: string,
+  date: string,
+): Promise<PendingDate | null> {
+  const path = dailyFilePath(personaDir, date);
+  if (!existsSync(path)) return null;
+  try {
+    const st = await stat(path);
+    return {
+      date,
+      path,
+      mtime_ms: Math.floor(st.mtimeMs),
+      size: st.size,
+      hash: await sha256File(path),
+      reason: "new",
+    };
+  } catch (e) {
+    log.warn("nightly: daily file unreadable", {
+      date,
+      error: (e as Error).message,
+    });
+    return null;
+  }
+}
+
+/** Build the ledger entry for a date the driver has just finished. */
+export function dateRecord(
+  p: PendingDate,
+  stagesDone: NightlyStage[],
+  error?: string,
+): NightlyDateRecord {
+  return {
+    mtime_ms: p.mtime_ms,
+    size: p.size,
+    hash: p.hash,
+    stages_done: stagesDone,
+    completed_at: new Date().toISOString(),
+    status: error ? (stagesDone.length > 0 ? "partial" : "error") : "ok",
+    ...(error ? { error } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Health — the `/status` "dreaming:" line and `doctor`'s nightly section
+// ---------------------------------------------------------------------------
+
+export type NightlyHealthStatus = "ok" | "running" | "warning" | "error";
+
+export interface NightlyHealth {
+  status: NightlyHealthStatus;
+  /** One short line, e.g. "2/5 dates, on 2026-06-02". */
+  detail: string;
+  /** Dates still needing a pass. */
+  backlog: number;
+  /** Oldest pending date, when there is one. */
+  oldest_pending?: string;
+  last_run?: string;
+}
+
+/**
+ * Judge nightly health from the ledger + what's on disk.
+ *
+ * Deliberately schedule-agnostic: an always-on box that sweeps at 02:00 and a
+ * laptop that sweeps at 09:15 on boot both read `ok` as long as nothing is
+ * pending. Backlog is the only truth — "the timer didn't fire in its window"
+ * is not a fault if there was nothing to do.
+ */
+export async function nightlyHealth(
+  personaDir: string,
+  opts: { now?: Date; state?: NightlyState } = {},
+): Promise<NightlyHealth> {
+  const now = opts.now ?? new Date();
+  const state = opts.state ?? (await loadNightlyState(personaDir));
+  const sweep = await sweepDailyFiles(
+    personaDir,
+    state,
+    now.toISOString().slice(0, 10),
+  );
+  const backlog = sweep.pending.length;
+  const oldest = sweep.pending[0]?.date;
+  const base = {
+    backlog,
+    ...(oldest ? { oldest_pending: oldest } : {}),
+    ...(state.last_run ? { last_run: state.last_run } : {}),
+  };
+
+  const cur = state.current;
+  if (cur) {
+    const beat = Date.parse(cur.updated_at ?? cur.started_at);
+    const stalled = Number.isNaN(beat) || now.getTime() - beat > STALE_RUN_MS;
+    if (!stalled) {
+      return {
+        ...base,
+        status: "running",
+        detail: `${cur.index}/${cur.total} dates, on ${cur.date}`,
+      };
+    }
+    return {
+      ...base,
+      status: "error",
+      detail: `sweep stalled on ${cur.date} since ${cur.updated_at ?? cur.started_at}`,
+    };
+  }
+
+  const failed = Object.entries(state.processed ?? {})
+    .filter(([, r]) => r.status === "error" || r.status === "partial")
+    .map(([d]) => d)
+    .sort();
+
+  if (backlog > BACKLOG_WARN_MAX) {
+    return {
+      ...base,
+      status: "error",
+      detail: `${backlog} dates unprocessed (oldest ${oldest})`,
+    };
+  }
+  if (state.last_status === "error") {
+    return {
+      ...base,
+      status: "error",
+      detail: `last sweep errored${state.errors?.[0] ? ` — ${state.errors[0]}` : ""}`,
+    };
+  }
+  if (backlog > 0) {
+    return {
+      ...base,
+      status: "warning",
+      detail: `${backlog} date${backlog === 1 ? "" : "s"} pending (oldest ${oldest})`,
+    };
+  }
+  if (failed.length > 0) {
+    return {
+      ...base,
+      status: "warning",
+      detail: `${failed.length} date(s) processed with errors (${failed.slice(-1)[0]})`,
+    };
+  }
+  return {
+    ...base,
+    status: "ok",
+    detail: state.last_run
+      ? `nothing pending (last sweep ${state.last_run})`
+      : "nothing pending",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Prompts
+// ---------------------------------------------------------------------------
+
 /**
  * If a persona dir contains a `nightly-prompt.md` file, use it as the
  * template (with `{{persona}}` and `{{today}}` substitutions); otherwise
- * fall back to the built-in `buildNightlyPrompt`. Lets users customize
- * the nightly directive per-persona (e.g. add a "summarize calendar
- * before phase 3" step) without forking phantombot.
+ * fall back to the built-in {@link buildNightlyPrompt}. The override owns the
+ * whole contract, so the driver runs it as ONE monolithic turn per date
+ * instead of the two-stage split.
  */
 export async function buildNightlyPromptForPersona(
   personaDir: string,
@@ -238,141 +467,104 @@ export async function buildNightlyPromptForPersona(
   return buildNightlyPrompt(personaName, today);
 }
 
-/**
- * Build the user-message that starts the nightly turn. Embeds the
- * persona name, today's date, and the 5-phase contract.
- */
-export function buildNightlyPrompt(
-  personaName: string,
-  today: string,
-): string {
-  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Processing date: ${today} (the day that just closed).
+/** Shared preamble: what is being processed, isolation note, tools. */
+function nightlyPreamble(personaName: string, today: string): string {
+  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Processing date: ${today} (a day that has closed).
 
 This conversation is ISOLATED (conversation key system:nightly:${today}); nothing you say here will appear in Telegram or any user-facing chat. Speak in summaries, not replies.
 
 You have access to phantombot's memory tools via Bash:
 
-  phantombot memory get memory/${today}.md            # read the daily file being processed (do NOT use 'memory today' — resolves to actual current day, not ${today})
+  phantombot memory get memory/${today}.md      # the daily file being processed (do NOT use 'memory today' — that resolves to the real current day, not ${today})
   phantombot memory search "<query>"            # FTS5 + (if configured) semantic search
   phantombot memory get <persona-relative-path> # cat a file
   phantombot memory list <persona-relative-dir> # ls a dir
-  phantombot memory index --rebuild             # full reindex (FTS + embeddings)
-
-You also have your normal Read / Write / Edit tools — use them on files inside this persona's working directory (\`agentDir\`). The structured drawers are under memory/ and the KB vault under kb/. The four templates in kb/templates/ are scaffolds for atomic-note / runbook / decision / postmortem.
-
-Run these five phases IN ORDER. Be brief in any text you write to MEMORY.md or drawers — long form goes in KB notes:
-
-PHASE 1 — Day essence
-  Read today's daily file (memory/${today}.md). If it exists, prepend a 2-3 line "Day essence" section summarising what mattered today. Skip if the file doesn't exist or is empty.
-
-PHASE 2 — Promote to drawers
-  Re-read the daily file. For each promote-able item that the heartbeat hasn't already filed:
-    - People / relationships  → memory/people.md
-    - Decisions with rationale → memory/decisions.md
-    - Mistakes and learnings   → memory/lessons.md
-    - Deadlines / obligations  → memory/commitments.md
-  Append under a "## ${today}" header. Don't duplicate items the heartbeat already promoted.
-
-PHASE 3 — Feed the KB
-  Re-read the daily file for durable knowledge (procedures, configs, runbooks, concepts, decisions worth keeping).
-  For each candidate:
-    a) phantombot memory search "<topic>" to check for existing coverage
-    b) If a note already covers the area, open it and RECONCILE it against today's knowledge — don't just append:
-       - ADDS (new case, edge case, link): update in place.
-       - CONTRADICTS / INVALIDATES it (a fact changed, something was decommissioned, an old assumption proved wrong): do NOT silently overwrite, and do NOT leave the stale claim standing beside the new one. Rewrite the note so its body states the CURRENT truth, bump \`updated:\`, and append a dated line under a "## Changelog" section recording what was invalidated — "${today}: was X → now Y, because Z". The old belief survives as history; it just stops being served as current truth.
-       - The whole subject is DECOMMISSIONED / no longer real: set frontmatter \`status: obsolete\` with a dated one-line reason (and a [[wikilink]] to any replacement) instead of deleting — recall must know it's dead, not silently lose it.
-    c) Otherwise create a new atomic note in the right kb/<category>/ subdir using one of kb/templates/ as a starting point. Frontmatter required: type, tags, created, updated. Link related notes with [[wikilinks]].
-  Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
-  Run \`phantombot memory index --rebuild\` at the end so new notes have embeddings.
-
-PHASE 4 — Maintain MEMORY.md
-  MEMORY.md is the always-in-context orientation layer — MAINTAIN it (fill AND trim), don't only trim.
-    - FILL: read MEMORY.md; if there is no "## Recent" section, add one. From today's daily file and what you promoted/distilled above, add a few SHORT orientation bullets (one line each) for durable, still-relevant facts worth having in context every turn. Summarise and point to the KB note / drawer that holds the detail — don't paste whole entries.
-    - TRIM: keep MEMORY.md short. Remove "## Recent" bullets that are now stale or fully distilled to a permanent home (leave a pointer if useful). If a section bloated into long-form prose, move detail into the relevant KB note(s) and leave a short pointer.
-
-PHASE 5 — State report
-  Write your summary to memory/.nightly-state.json (overwrite). Include:
-    last_run         (ISO 8601 timestamp)
-    last_status      ("ok" | "partial" | "error")
-    items_promoted   (count from phase 2)
-    kb_notes_updated (count from phase 3, existing-note edits)
-    kb_notes_created (count from phase 3, new-note writes)
-    errors           (array of strings — anything that went wrong; empty array on full success)
-
-When you're done, your final reply (which won't go anywhere user-facing) should be a brief sentence acknowledging completion. Phantombot will log it.`;
-}
-
-/**
- * Common preamble for every checkpointed nightly stage — the tools list
- * and the isolation note, shared by all five stage prompts.
- */
-function nightlyStagePreamble(personaName: string, today: string): string {
-  return `You are running your nightly cognitive maintenance pass for persona '${personaName}'. Processing date: ${today} (the day that just closed).
-
-This conversation is ISOLATED (conversation key system:nightly:${today}); nothing you say here will appear in Telegram or any user-facing chat. Speak in summaries, not replies.
-
-You have access to phantombot's memory tools via Bash:
-
-  phantombot memory get memory/${today}.md            # read the daily file being processed (do NOT use 'memory today' — resolves to actual current day, not ${today})
-  phantombot memory search "<query>"            # FTS5 + (if configured) semantic search
-  phantombot memory get <persona-relative-path> # cat a file
-  phantombot memory list <persona-relative-dir> # ls a dir
-  phantombot memory index --rebuild             # full reindex (FTS + embeddings)
 
 You also have your normal Read / Write / Edit tools — use them on files inside this persona's working directory. The structured drawers are under memory/ and the KB vault under kb/.
 
-This nightly run is CHECKPOINTED: you are executing exactly ONE stage. Do only the stage described below, then stop with a one-line completion note. Do not run other phases — phantombot drives them as separate turns.`;
+Two rules that apply to every stage:
+  - NEVER write to memory/${today}.md. Daily files are append-only inputs; phantombot tracks them by content hash and an edit here makes the day look unprocessed forever.
+  - Do NOT run \`phantombot memory index\`. Phantombot refreshes the index itself in code once your stage and its sibling have both finished.`;
 }
 
-/** Per-stage instruction body. Mirrors the phases of {@link buildNightlyPrompt}. */
+/** Per-stage instruction body. */
 const NIGHTLY_STAGE_BODY: Record<NightlyStage, (today: string) => string> = {
-  essence: (today) => `STAGE: DAY ESSENCE
-Read today's daily file (memory/${today}.md). If it exists and is non-empty, prepend a 2-3 line "Day essence" section summarising what mattered today. If the file is missing or empty, do nothing and say so.`,
-  promote: (today) => `STAGE: PROMOTE TO DRAWERS
-Re-read the daily file (memory/${today}.md). For each promote-able item the heartbeat has not already filed:
-  - People / relationships   → memory/people.md
-  - Decisions with rationale → memory/decisions.md
-  - Mistakes and learnings   → memory/lessons.md
-  - Deadlines / obligations  → memory/commitments.md
-Append under a "## ${today}" header. Do not duplicate items the heartbeat already promoted.`,
-  kb: (today) => `STAGE: FEED THE KB
-Re-read today's daily file for durable knowledge (procedures, configs, runbooks, concepts, decisions worth keeping). For each candidate:
-  a) phantombot memory search "<topic>" to check for existing coverage
+  distill: (today) => `STAGE: DISTILL (drawers + MEMORY.md)
+
+You are running ONE of two concurrent stages. Yours writes to the structured
+drawers and MEMORY.md — nothing else. A sibling turn is handling kb/ right
+now, so do not touch kb/ files.
+
+1. Read the daily file (memory/${today}.md). If it is missing or empty, say so
+   and make no edits.
+2. FILE the promote-able items the heartbeat has not already picked up:
+     - People / relationships   → memory/people.md
+     - Decisions with rationale → memory/decisions.md
+     - Mistakes and learnings   → memory/lessons.md
+     - Deadlines / obligations  → memory/commitments.md
+     - What is ROUTINE in your owner's world → memory/norms.md
+   Append under a "## ${today}" header. Do not duplicate what is already filed —
+   read the drawer first.
+3. MAINTAIN MEMORY.md — the always-in-context orientation layer. Fill AND trim:
+     - FILL: add a few SHORT one-line bullets under "## Recent" for durable,
+       still-relevant facts worth having in context every turn. Summarise and
+       point at the drawer or KB note holding the detail; never paste entries.
+     - TRIM: remove "## Recent" bullets that are stale or now have a permanent
+       home. If a section has bloated into prose, move the detail into a KB
+       note and leave a one-line pointer.
+Finish with a one-line summary of what you filed.`,
+
+  kb: (today) => `STAGE: KB (durable knowledge)
+
+You are running ONE of two concurrent stages. Yours writes to kb/ — nothing
+else. A sibling turn is filing drawers and MEMORY.md right now, so do not
+touch memory/ files.
+
+Read the daily file (memory/${today}.md) for durable knowledge (procedures,
+configs, runbooks, concepts, decisions worth keeping). For each candidate:
+  a) \`phantombot memory search "<topic>"\` to check for existing coverage.
   b) If a note already covers the area, open it and RECONCILE — don't just append:
      - ADDS (new case, edge case, link): update in place.
-     - CONTRADICTS / INVALIDATES it (fact changed, thing decommissioned, old assumption wrong): rewrite the body to the CURRENT truth, bump \`updated:\`, and append a dated line under a "## Changelog" section — "${today}: was X → now Y, because Z". Don't leave the stale claim standing beside the new one; the old belief lives on only as changelog history.
-     - Whole subject DECOMMISSIONED: set frontmatter \`status: obsolete\` with a dated reason (+ [[wikilink]] to any replacement) instead of deleting.
-  c) Otherwise create a new atomic note in the right kb/<category>/ subdir from a kb/templates/ scaffold. Frontmatter required: type, tags, created, updated. Link related notes with [[wikilinks]].
-Then sweep kb/inbox/: file each stub into the right category, or delete if no longer relevant.
-Finish with \`phantombot memory index --rebuild\` so new notes get embeddings.`,
-  compress: (today) => `STAGE: COMPRESS / MAINTAIN MEMORY.md
-MEMORY.md is the always-in-context orientation layer. Your job here is to MAINTAIN it — both fill and trim — not just trim.
-  1. Read MEMORY.md (use your Read tool). If it has no "## Recent" section, add one.
-  2. FILL: from today's daily file (memory/${today}.md) and the items you promoted/distilled in earlier stages, add a few SHORT orientation bullets under "## Recent" — only durable, still-relevant facts worth having in context every turn (current focus, active projects, fresh standing facts). One line each. Do not copy whole entries; summarise and link to the KB note or drawer that holds the detail.
-  3. TRIM: MEMORY.md must stay short. Remove "## Recent" bullets that are now stale or have a permanent home in a drawer/KB note (leave a short pointer if useful). If any section has bloated into long-form prose, move that detail into the relevant KB note and leave a one-line pointer.
-If today's daily file is missing or empty and nothing has changed, say so and make no edits.`,
-  state: (today) => `STAGE: STATE REPORT
-Write memory/.nightly-state.json (overwrite). Include:
-  last_run         (ISO 8601 timestamp — now)
-  last_status      ("ok" | "partial" | "error")
-  items_promoted   (count of items promoted in the PROMOTE stage)
-  kb_notes_updated (existing-note edits from the KB stage)
-  kb_notes_created (new notes from the KB stage)
-  errors           (array of strings; empty array on full success)
-Use \`phantombot memory get\`/your Read tool to recall counts from this conversation's earlier stages. Phantombot also patches last_run/last_status itself, so an approximate count is fine — date ${today}.`,
+     - CONTRADICTS / INVALIDATES it (a fact changed, something was decommissioned,
+       an old assumption proved wrong): rewrite the body so it states the CURRENT
+       truth, bump \`updated:\`, and append a dated line under a "## Changelog"
+       section — "${today}: was X → now Y, because Z". Don't leave the stale claim
+       standing beside the new one; the old belief survives only as history.
+     - Whole subject DECOMMISSIONED: set frontmatter \`status: obsolete\` with a
+       dated one-line reason (+ [[wikilink]] to any replacement) instead of deleting.
+  c) Otherwise create a new atomic note in the right kb/<category>/ subdir from a
+     kb/templates/ scaffold. Frontmatter required: type, tags, created, updated.
+     Link related notes with [[wikilinks]].
+Then sweep kb/inbox/: file each stub into the right category, or delete it if it
+is no longer relevant.
+Finish with a one-line summary of notes created / updated.`,
 };
 
-/**
- * Build the user-message for ONE checkpointed nightly stage. Used by the
- * resumable nightly driver, which runs each stage as a separate harness
- * turn and checkpoints between them.
- */
+/** Build the user-message for ONE nightly stage. */
 export function buildNightlyStagePrompt(
   personaName: string,
   today: string,
   stage: NightlyStage,
 ): string {
-  return `${nightlyStagePreamble(personaName, today)}
+  return `${nightlyPreamble(personaName, today)}
 
 ${NIGHTLY_STAGE_BODY[stage](today)}`;
+}
+
+/**
+ * Monolithic prompt — used only for the persona-override path, where a custom
+ * `nightly-prompt.md` is absent but the override machinery still asks for a
+ * single-turn prompt. Same two jobs, one turn.
+ */
+export function buildNightlyPrompt(
+  personaName: string,
+  today: string,
+): string {
+  return `${nightlyPreamble(personaName, today)}
+
+Run BOTH stages below, in order, in this single turn.
+
+${NIGHTLY_STAGE_BODY.distill(today)}
+
+${NIGHTLY_STAGE_BODY.kb(today)}`;
 }

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -49,10 +49,12 @@ const DAILY_FILE_RE = /^(\d{4}-\d{2}-\d{2})\.md$/;
 export const STALE_RUN_MS = 45 * 60_000;
 
 /**
- * Backlog above this many unprocessed dates is an error, not a warning —
- * something has been swallowing runs, not just a night missed.
+ * A backlog is work queued, not a fault — however deep it is, it reads as a
+ * warning while it drains. It only turns into an error once it is STAGNANT:
+ * dates are pending and no sweep has run in this long, which means the thing
+ * that triggers sweeps is broken rather than merely behind.
  */
-export const BACKLOG_WARN_MAX = 3;
+export const BACKLOG_STAGNANT_MS = 24 * 60 * 60_000;
 
 // ---------------------------------------------------------------------------
 // Stage model
@@ -397,13 +399,6 @@ export async function nightlyHealth(
     .map(([d]) => d)
     .sort();
 
-  if (backlog > BACKLOG_WARN_MAX) {
-    return {
-      ...base,
-      status: "error",
-      detail: `${backlog} dates unprocessed (oldest ${oldest})`,
-    };
-  }
   if (state.last_status === "error") {
     return {
       ...base,
@@ -412,6 +407,20 @@ export async function nightlyHealth(
     };
   }
   if (backlog > 0) {
+    // Deep backlog is not itself a fault — a sweep drains it whole, so it is
+    // simply work in the queue. The fault case is a backlog nobody is picking
+    // up: pending dates and no sweep within BACKLOG_STAGNANT_MS.
+    // A ledger with no `last_run` is a fresh install, not a stuck one — the
+    // startup trigger stamps it within a minute of the process coming up, so
+    // "never swept" is a warning and only an OLD sweep is an error.
+    const last = state.last_run ? Date.parse(state.last_run) : NaN;
+    if (!Number.isNaN(last) && now.getTime() - last > BACKLOG_STAGNANT_MS) {
+      return {
+        ...base,
+        status: "error",
+        detail: `${backlog} date${backlog === 1 ? "" : "s"} pending, no sweep since ${state.last_run}`,
+      };
+    }
     return {
       ...base,
       status: "warning",

--- a/src/lib/nightlyTrigger.ts
+++ b/src/lib/nightlyTrigger.ts
@@ -1,0 +1,99 @@
+/**
+ * When the nightly sweep gets triggered.
+ *
+ * There is no 02:00 timer any more. A clock is the wrong trigger for a pass
+ * whose job is "distil the day that just closed": a box asleep at 02:00 misses
+ * it entirely, and a box in a different timezone from its daily files runs it
+ * against the wrong day. Two event-driven triggers replace it, both of which
+ * are things that ALREADY happen:
+ *
+ *   1. startup   — `phantombot run` fires a detached sweep (covers laptops and
+ *                  anything that was powered off).
+ *   2. rollover  — the 30-min heartbeat notices that the calendar day has
+ *                  changed since its previous fire, which means yesterday's
+ *                  daily file is now closed, and fires a detached sweep.
+ *
+ * Rollover DETECTION rather than a file-creation watch: a daily file is written
+ * lazily on the first capture of the day, so on a quiet day it may never be
+ * created at all — a creation hook would silently starve, leaving yesterday
+ * unprocessed forever. The day changing is unconditional.
+ *
+ * Both triggers are safe to fire redundantly: the sweep is ledger-driven and
+ * idempotent, no-ops in milliseconds when nothing is pending, and holds an
+ * in-flight marker so two sweeps can't double-file the same drawers.
+ */
+
+import { spawn } from "node:child_process";
+
+import { log } from "./logger.ts";
+
+/** Why a sweep was fired. Logged, and useful in tests. */
+export type NightlyTriggerReason = "startup" | "rollover" | "manual";
+
+/**
+ * The calendar day used for daily-file NAMING, so rollover detection and the
+ * files it is detecting rollover FOR agree on where the boundary is.
+ *
+ * That basis is currently UTC (`memory capture` names the file from
+ * `toISOString()`), which means "the day" closes at 01:00/02:00 local in
+ * Europe — a known wart, tracked separately. What matters here is that this
+ * helper and the daily-file writer use the SAME wrong-or-right boundary; a
+ * mismatch would fire the sweep while the day it is about to process is still
+ * being appended to.
+ */
+export function dailyFileDate(at: Date = new Date()): string {
+  return at.toISOString().slice(0, 10);
+}
+
+/**
+ * Has the calendar day rolled over between the previous heartbeat fire and
+ * now? `prevIso` is the timestamp recorded by the last fire; `undefined` (no
+ * marker — first heartbeat ever, or a wiped state dir) is deliberately NOT a
+ * rollover: startup already fired a sweep, and guessing here would double up.
+ *
+ * A clock stepped backwards (NTP correction, a restored VM snapshot) yields a
+ * previous date in the future, which is also not a rollover — we compare for
+ * strict "the recorded day is older than today".
+ */
+export function dayRolledOver(
+  prevIso: string | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!prevIso) return false;
+  const prev = Date.parse(prevIso);
+  if (Number.isNaN(prev)) return false;
+  return dailyFileDate(new Date(prev)) < dailyFileDate(now);
+}
+
+/**
+ * Fire a detached `phantombot nightly` for the given persona.
+ *
+ * Detached + unref'd on purpose: a first sweep over a long backlog can run for
+ * many minutes, and it must not hold its parent's event loop (the daemon's
+ * channel loop, or a heartbeat process that is supposed to exit in seconds) or
+ * die when that parent does.
+ */
+export function spawnNightlySweep(
+  persona: string,
+  reason: NightlyTriggerReason,
+): void {
+  const entry = process.argv[1] ?? "";
+  const dev = entry.endsWith(".ts") || entry.endsWith(".js");
+  const args = dev
+    ? [entry, "nightly", "--persona", persona]
+    : ["nightly", "--persona", persona];
+  try {
+    const child = spawn(process.execPath, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    log.info("nightly: spawned sweep", { persona, reason });
+  } catch (e) {
+    log.warn("nightly: could not spawn sweep", {
+      persona,
+      reason,
+      error: (e as Error).message,
+    });
+  }
+}

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -15,8 +15,20 @@ import type { WriteSink } from "./io.ts";
 export const PHANTOMBOT_UNIT_NAME = "phantombot.service";
 export const HEARTBEAT_SERVICE_NAME = "phantombot-heartbeat.service";
 export const HEARTBEAT_TIMER_NAME = "phantombot-heartbeat.timer";
+/**
+ * RETIRED units. The nightly no longer runs on a clock — it is triggered by
+ * startup and by the heartbeat noticing the calendar day rolled over (see
+ * src/lib/nightlyTrigger.ts), so a 02:00 timer would only ever duplicate work
+ * on a box that happened to be awake. These names survive solely so upgrades
+ * can stop, disable and delete what a previous install left behind.
+ */
 export const NIGHTLY_SERVICE_NAME = "phantombot-nightly.service";
 export const NIGHTLY_TIMER_NAME = "phantombot-nightly.timer";
+export const RETIRED_TIMER_NAMES = [NIGHTLY_TIMER_NAME] as const;
+export const RETIRED_UNIT_NAMES = [
+  NIGHTLY_TIMER_NAME,
+  NIGHTLY_SERVICE_NAME,
+] as const;
 export const TICK_SERVICE_NAME = "phantombot-tick.service";
 export const TICK_TIMER_NAME = "phantombot-tick.timer";
 
@@ -56,10 +68,12 @@ export function heartbeatTimerPath(): string {
   return join(homedir(), ".config", "systemd", "user", HEARTBEAT_TIMER_NAME);
 }
 
+/** Path of the retired nightly service (kept for cleanup only). */
 export function nightlyServicePath(): string {
   return join(homedir(), ".config", "systemd", "user", NIGHTLY_SERVICE_NAME);
 }
 
+/** Path of the retired nightly timer (kept for cleanup only). */
 export function nightlyTimerPath(): string {
   return join(homedir(), ".config", "systemd", "user", NIGHTLY_TIMER_NAME);
 }
@@ -167,45 +181,6 @@ Description=Phantombot heartbeat timer (every 30 min)
 
 [Timer]
 OnCalendar=*:0/30
-AccuracySec=1min
-Persistent=true
-
-[Install]
-WantedBy=timers.target
-`;
-}
-
-/** Generate the nightly oneshot service body. */
-export function generateNightlyService(binPath: string): string {
-  const exec = [binPath, "nightly"].map(quoteArg).join(" ");
-  return `[Unit]
-Description=Phantombot nightly — cognitive distillation pass
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=${exec}
-# A sweep processes up to MAX_DATES_PER_RUN (10) days per run, each two
-# concurrent harness turns, so the cap has to clear a full backlog pass.
-# Being killed mid-sweep is survivable (unfinished dates stay pending) but it
-# leaves a stale in-flight marker that /status reports as ERR until the next
-# run takes over — so give it room.
-TimeoutStartSec=5400
-Environment="PATH=${PHANTOMBOT_SERVICE_PATH}"
-${ENVIRONMENT_FILE_LINES}
-StandardOutput=journal
-StandardError=journal
-`;
-}
-
-/** Generate the nightly timer body — fires daily at 02:00 local. */
-export function generateNightlyTimer(): string {
-  return `[Unit]
-Description=Phantombot nightly timer (daily 02:00)
-
-[Timer]
-OnCalendar=*-*-* 02:00:00
 AccuracySec=1min
 Persistent=true
 
@@ -519,10 +494,14 @@ export interface PhantombotUnitPathOverrides {
   unitPath?: string;
   heartbeatServicePath?: string;
   heartbeatTimerPath?: string;
-  nightlyServicePath?: string;
-  nightlyTimerPath?: string;
   tickServicePath?: string;
   tickTimerPath?: string;
+  /**
+   * Where the RETIRED nightly units would live. Not generated any more — only
+   * consulted so cleanup can delete them out of a tmpdir under test.
+   */
+  nightlyServicePath?: string;
+  nightlyTimerPath?: string;
 }
 
 /**
@@ -552,18 +531,6 @@ export function phantombotUnitTargets(
       path: overrides.heartbeatTimerPath ?? heartbeatTimerPath(),
       content: generateHeartbeatTimer(),
       unit: HEARTBEAT_TIMER_NAME,
-      isTimer: true,
-    },
-    {
-      path: overrides.nightlyServicePath ?? nightlyServicePath(),
-      content: generateNightlyService(binPath),
-      unit: NIGHTLY_SERVICE_NAME,
-      isTimer: false,
-    },
-    {
-      path: overrides.nightlyTimerPath ?? nightlyTimerPath(),
-      content: generateNightlyTimer(),
-      unit: NIGHTLY_TIMER_NAME,
       isTimer: true,
     },
     {
@@ -658,12 +625,59 @@ export interface EnsureUnitsCurrentResult {
   backups: string[];
   /** Timer unit names that were re-enabled and/or restarted to repair them. */
   repairedTimers: string[];
+  /** Retired unit files removed from disk (upgrade cleanup). Usually empty. */
+  removedRetired: string[];
+}
+
+/**
+ * Stop, disable and delete the units phantombot no longer installs.
+ *
+ * Upgrade path only: an install from before the nightly timer was retired
+ * still has `phantombot-nightly.timer` armed at 02:00. Leaving it would fire a
+ * redundant (harmless but confusing) sweep forever, and `doctor` would keep
+ * reporting a timer that no template claims. Best-effort throughout — a
+ * systemctl that fails on an already-absent unit is expected, not an error.
+ * Returns the basenames actually deleted, so callers only log on real cleanup.
+ */
+export async function removeRetiredUnits(
+  systemctl: SystemctlRunner,
+  paths: readonly string[] = [nightlyTimerPath(), nightlyServicePath()],
+): Promise<string[]> {
+  const present = paths.filter((p) => existsSync(p));
+  // Nothing on disk → nothing systemd can run, so skip the IPC entirely. This
+  // is the case on every install from this version onward, which matters
+  // because the heal path runs on every heartbeat.
+  if (present.length === 0) return [];
+
+  for (const unit of RETIRED_TIMER_NAMES) {
+    await systemctl.run(["--user", "stop", unit]);
+    await systemctl.run(["--user", "disable", unit]);
+  }
+  const removed: string[] = [];
+  for (const path of present) {
+    try {
+      await unlink(path);
+      removed.push(basename(path));
+    } catch {
+      // Read-only dir or a racing uninstall — nothing we can do, and the
+      // stale unit is inert once disabled above.
+    }
+  }
+  return removed;
 }
 
 export async function ensureSystemdUnitsCurrent(
   opts: EnsureUnitsCurrentOptions,
 ): Promise<EnsureUnitsCurrentResult> {
   const targets = phantombotUnitTargets(opts.binPath, opts);
+
+  // Sweep away units we no longer install (currently the 02:00 nightly timer)
+  // before reconciling the ones we do. Cheap, and it means a box heals itself
+  // on the next heartbeat instead of needing a reinstall.
+  const removedRetired = await removeRetiredUnits(opts.systemctl, [
+    opts.nightlyTimerPath ?? nightlyTimerPath(),
+    opts.nightlyServicePath ?? nightlyServicePath(),
+  ]);
 
   const rewrote: string[] = [];
   const backups: string[] = [];
@@ -689,7 +703,7 @@ export async function ensureSystemdUnitsCurrent(
     rewrote.push(basename(t.path));
     if (t.isTimer) rewroteTimerUnits.add(t.unit);
   }
-  if (rewrote.length > 0) {
+  if (rewrote.length > 0 || removedRetired.length > 0) {
     await opts.systemctl.run(["--user", "daemon-reload"]);
   }
 
@@ -733,7 +747,7 @@ export async function ensureSystemdUnitsCurrent(
     repairedTimers.push(t.unit);
   }
 
-  return { rewrote, backups, repairedTimers };
+  return { rewrote, backups, repairedTimers, removedRetired };
 }
 
 export interface InstallOptions {
@@ -770,14 +784,21 @@ export async function installPhantombotUnit(
     opts.out.write(`wrote ${t.unit}: ${t.path}\n`);
   }
 
+  // Reinstalling over an older layout: drop the retired 02:00 nightly timer.
+  const removedRetired = await removeRetiredUnits(opts.systemctl, [
+    opts.nightlyTimerPath ?? nightlyTimerPath(),
+    opts.nightlyServicePath ?? nightlyServicePath(),
+  ]);
+  for (const name of removedRetired) {
+    opts.out.write(`removed retired unit: ${name}\n`);
+  }
+
   for (const args of [
     ["--user", "daemon-reload"],
     ["--user", "enable", PHANTOMBOT_UNIT_NAME],
     ["--user", "start", PHANTOMBOT_UNIT_NAME],
     ["--user", "enable", HEARTBEAT_TIMER_NAME],
     ["--user", "start", HEARTBEAT_TIMER_NAME],
-    ["--user", "enable", NIGHTLY_TIMER_NAME],
-    ["--user", "start", NIGHTLY_TIMER_NAME],
     ["--user", "enable", TICK_TIMER_NAME],
     ["--user", "start", TICK_TIMER_NAME],
   ]) {
@@ -790,7 +811,7 @@ export async function installPhantombotUnit(
     }
   }
   opts.out.write(
-    "enabled and started phantombot.service + heartbeat.timer + nightly.timer + tick.timer\n",
+    "enabled and started phantombot.service + heartbeat.timer + tick.timer\n",
   );
   return { installed: true };
 }

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -186,7 +186,12 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 ExecStart=${exec}
-TimeoutStartSec=2700
+# A sweep processes up to MAX_DATES_PER_RUN (10) days per run, each two
+# concurrent harness turns, so the cap has to clear a full backlog pass.
+# Being killed mid-sweep is survivable (unfinished dates stay pending) but it
+# leaves a stale in-flight marker that /status reports as ERR until the next
+# run takes over — so give it room.
+TimeoutStartSec=5400
 Environment="PATH=${PHANTOMBOT_SERVICE_PATH}"
 ${ENVIRONMENT_FILE_LINES}
 StandardOutput=journal

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -29,7 +29,6 @@
  *
  *   \Phantombot\phantombot-<persona>   — always-on `phantombot run`   (keep-alive)
  *   \Phantombot\heartbeat-<persona>    — `phantombot heartbeat`       (every 30 min)
- *   \Phantombot\nightly-<persona>      — `phantombot nightly`         (daily 02:00)
  *   \Phantombot\tick-<persona>         — `phantombot tick`            (every 60 s)
  *
  * Keep-alive without a supervisor: Task Scheduler has no true "restart on
@@ -115,6 +114,12 @@ export const LEGACY_TASK_NAMES = [
 export interface TaskNames {
   main: string;
   heartbeat: string;
+  /**
+   * RETIRED. No longer registered — the nightly is triggered by startup and by
+   * the heartbeat's day-rollover check (see src/lib/nightlyTrigger.ts). The
+   * name is still resolved so install/heal/uninstall can delete the 02:00 task
+   * an older install left behind.
+   */
   nightly: string;
   tick: string;
   /**
@@ -144,7 +149,9 @@ export function taskNames(persona: string): TaskNames {
     // `all` intentionally omits the login task: it is conditionally
     // registered (password mode only), so heal/ownership sweeps address it
     // explicitly rather than assuming it always exists.
-    all: [main, heartbeat, nightly, tick],
+    // `nightly` is absent on purpose: it is retired, and everything that
+    // consumes `all` is describing the set we actively register and heal.
+    all: [main, heartbeat, tick],
   };
 }
 
@@ -268,7 +275,7 @@ export function bootSchemaNeedsMigration(installedVersion: number): boolean {
 }
 
 /** Short label used for the per-task log filenames. */
-type TaskLabel = "phantombot" | "heartbeat" | "nightly" | "tick" | "login";
+type TaskLabel = "phantombot" | "heartbeat" | "tick" | "login";
 
 function logsDir(): string {
   return join(xdgDataHome(), "phantombot", "logs");
@@ -481,7 +488,6 @@ function generateTaskXml(opts: TaskXmlOptions): string {
  * "active immediately" and the repetition interval takes over from there.
  */
 const START_BOUNDARY = "2020-01-01T00:00:00";
-const NIGHTLY_BOUNDARY = "2020-01-01T02:00:00";
 
 function repeatingTimeTrigger(interval: string): string {
   return (
@@ -589,37 +595,6 @@ export function generateHeartbeatTaskXml(
     args: ["heartbeat"],
     triggersXml: repeatingTimeTrigger("PT30M"),
     executionTimeLimit: "PT1H",
-    logon,
-  });
-}
-
-/** Generate the nightly task XML — fires daily at 02:00. */
-export function generateNightlyTaskXml(
-  sid: string,
-  binPath: string,
-  persona: string,
-  logon: TaskLogon = { mode: "interactive" },
-): string {
-  const triggers =
-    "    <CalendarTrigger>\n" +
-    "      <Enabled>true</Enabled>\n" +
-    `      <StartBoundary>${NIGHTLY_BOUNDARY}</StartBoundary>\n` +
-    "      <ScheduleByDay>\n" +
-    "        <DaysInterval>1</DaysInterval>\n" +
-    "      </ScheduleByDay>\n" +
-    "    </CalendarTrigger>\n";
-  return generateTaskXml({
-    uri: taskNames(persona).nightly,
-    description: `phantombot nightly (daily at 02:00) [${persona}]`,
-    sid,
-    persona,
-    label: "nightly",
-    binPath,
-    args: ["nightly"],
-    triggersXml: triggers,
-    // Matches the systemd unit's TimeoutStartSec: a sweep can process up to
-    // MAX_DATES_PER_RUN days in one run.
-    executionTimeLimit: "PT1H30M",
     logon,
   });
 }
@@ -1131,12 +1106,6 @@ function allTaskSpecs(
       logon,
     },
     {
-      name: taskNames(persona).nightly,
-      label: "nightly",
-      xml: generateNightlyTaskXml(sid, binPath, persona, logon),
-      logon,
-    },
-    {
       name: taskNames(persona).tick,
       label: "tick",
       xml: generateTickTaskXml(sid, binPath, persona, logon),
@@ -1296,10 +1265,13 @@ export async function installPhantombotTasks(
     priorSchemaVersion,
   );
 
+  // Note: this also sweeps the retired 02:00 nightly task, since install
+  // delegates the whole register/heal step to ensureTasksCurrent.
   const r = await ensureTasksCurrent({
     binPath: opts.binPath,
     persona: opts.persona,
     sid,
+    accountName: opts.accountName,
     xmlDir,
     schtasks: opts.schtasks,
     // A (re)install must apply the chosen mode + credential even when the
@@ -1359,8 +1331,8 @@ export async function installPhantombotTasks(
 
   opts.out.write(
     logon.mode === "password"
-      ? `registered ${taskNames(opts.persona).main} + heartbeat + nightly + tick + login-fallback\n`
-      : `registered ${taskNames(opts.persona).main} + heartbeat + nightly + tick\n`,
+      ? `registered ${taskNames(opts.persona).main} + heartbeat + tick + login-fallback\n`
+      : `registered ${taskNames(opts.persona).main} + heartbeat + tick\n`,
   );
   return { installed: true };
 }
@@ -1558,6 +1530,11 @@ export interface EnsureTasksCurrentOptions {
   schtasks: SchtasksRunner;
   /** Test seam for the password-mode action patcher. */
   patchAction?: PatchActionFn;
+  /**
+   * Override the current `COMPUTER\\user` account name (tests). Used only to
+   * prove ownership before deleting the retired nightly task.
+   */
+  accountName?: string;
 }
 
 /**
@@ -1720,6 +1697,19 @@ export async function ensureTasksCurrent(
         stderr: r.stderr.trim() || r.stdout.trim(),
       });
     }
+  }
+
+  // Retired 02:00 nightly task: delete it if an older install registered one.
+  // Unconditional and cheap (`/Query` on an absent task is a fast non-zero),
+  // and it means a Windows box heals itself on the next heartbeat rather than
+  // firing a duplicate sweep until someone reinstalls.
+  const retired = taskNames(persona).nightly;
+  const owner: TaskOwner = {
+    sid,
+    username: opts.accountName ?? currentUserName(),
+  };
+  if ((await deleteTaskIfOwned(opts.schtasks, retired, owner)) === "deleted") {
+    log.info("taskScheduler: removed retired nightly task", { task: retired });
   }
 
   return { rewrote, failed };

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -617,7 +617,9 @@ export function generateNightlyTaskXml(
     binPath,
     args: ["nightly"],
     triggersXml: triggers,
-    executionTimeLimit: "PT1H",
+    // Matches the systemd unit's TimeoutStartSec: a sweep can process up to
+    // MAX_DATES_PER_RUN days in one run.
+    executionTimeLimit: "PT1H30M",
     logon,
   });
 }

--- a/tests/channels-statusProbes.test.ts
+++ b/tests/channels-statusProbes.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   gatherStatusProbes,
   type StatusProbeDeps,
@@ -13,6 +16,7 @@ function cfg(partial: {
   telegramPersonas?: Record<string, { token: string }>;
   embeddings?: Config["embeddings"];
   voice?: Config["voice"];
+  personasDir?: string;
 }): Config {
   return {
     channels: {
@@ -21,6 +25,7 @@ function cfg(partial: {
     },
     embeddings: partial.embeddings ?? { provider: "none" },
     voice: partial.voice ?? { provider: "none" },
+    personasDir: partial.personasDir,
   } as unknown as Config;
 }
 
@@ -38,6 +43,11 @@ function stubDeps(over: Partial<StatusProbeDeps> = {}): StatusProbeDeps {
     }),
     reconcileEditorConnectors: () => [],
     isPhantombotBinary: () => false,
+    nightlyHealth: async () => ({
+      status: "ok" as const,
+      detail: "nothing pending",
+      backlog: 0,
+    }),
     env: {},
     ...over,
   };
@@ -344,5 +354,68 @@ describe("gatherStatusProbes — resilience", () => {
       }),
     );
     expect(r.memory).toBe("gemini embeddings OK");
+  });
+});
+
+// The "dreaming" line reports the nightly sweep's health off its ledger — no
+// LLM, no network, and it never does any of the nightly's work. It exists so a
+// silently-skipped or stalled distillation is visible from /status instead of
+// only from `doctor`.
+describe("gatherStatusProbes — dreaming", () => {
+  let personas: string;
+
+  beforeEach(async () => {
+    personas = await mkdtemp(join(tmpdir(), "phantombot-probe-"));
+    await mkdir(join(personas, "phantom", "memory"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(personas, { recursive: true, force: true });
+  });
+
+  const cases: Array<[string, "ok" | "running" | "warning" | "error", string]> = [
+    ["ok", "ok", "OK (nothing pending)"],
+    ["running", "running", "RUNNING (2/5 dates, on 2026-06-02)"],
+    ["warning", "warning", "WARN (2 dates pending, oldest 2026-06-02)"],
+    ["error", "error", "ERR (sweep stalled on 2026-06-02)"],
+  ];
+
+  for (const [name, status, expected] of cases) {
+    test(`renders ${name} as "${expected}"`, async () => {
+      const detail = expected.replace(/^[A-Z]+ \(/, "").replace(/\)$/, "");
+      const r = await gatherStatusProbes(
+        cfg({ personasDir: personas }),
+        "phantom",
+        stubDeps({
+          nightlyHealth: async () => ({ status, detail, backlog: 0 }),
+        }),
+      );
+      expect(r.dreaming).toBe(expected);
+    });
+  }
+
+  test("omits the line when the persona dir does not exist", async () => {
+    const r = await gatherStatusProbes(
+      cfg({ personasDir: join(personas, "nope") }),
+      "phantom",
+      stubDeps(),
+    );
+    expect(r.dreaming).toBeUndefined();
+  });
+
+  // Same contract as every other probe: a throwing subsystem drops its line,
+  // it never breaks /status.
+  test("a throwing health read drops the line instead of failing /status", async () => {
+    const r = await gatherStatusProbes(
+      cfg({ personasDir: personas, telegram: { token: "T" } }),
+      "phantom",
+      stubDeps({
+        nightlyHealth: async () => {
+          throw new Error("ledger on fire");
+        },
+      }),
+    );
+    expect(r.dreaming).toBeUndefined();
+    expect(r.telegram).toBeDefined();
   });
 });

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -112,10 +112,29 @@ describe("runDoctor", () => {
     expect(out.text).toContain("2 date(s) pending");
   });
 
-  test("a large backlog → ERR and exit 1", async () => {
+  // Depth alone never fails doctor — a backfill is queued work, and one sweep
+  // takes the whole queue.
+  test("a large backlog is still WARN and exit 0", async () => {
     for (const d of ["01", "02", "03", "04", "05"]) {
       await writeDaily(`2026-05-${d}`);
     }
+    await writeState({
+      last_run: new Date(Date.now() - 60 * 60_000).toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out });
+    expect(code).toBe(0);
+    expect(out.text).toMatch(/nightly: WARN/);
+    expect(out.text).toContain("5 date(s) pending");
+  });
+
+  test("a backlog with no sweep for over a day → ERR and exit 1", async () => {
+    await writeDaily("2026-05-01");
+    await writeState({
+      last_run: new Date(Date.now() - 30 * 60 * 60_000).toISOString(),
+      last_status: "ok",
+    });
     const out = new CaptureStream();
     const code = await runDoctor({ config, out });
     expect(code).toBe(1);

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -53,10 +53,11 @@ async function writeState(obj: unknown): Promise<void> {
     "utf8",
   );
 }
-async function writeProgress(obj: unknown): Promise<void> {
+/** Write a daily file the sweep will see as unprocessed. */
+async function writeDaily(date: string): Promise<void> {
   await writeFile(
-    join(personaMemoryDir, ".nightly-progress.json"),
-    JSON.stringify(obj),
+    join(personaMemoryDir, `${date}.md`),
+    `notes for ${date}`,
     "utf8",
   );
 }
@@ -74,123 +75,115 @@ describe("runDoctor", () => {
     expect(err.text).toContain("not found");
   });
 
-  test("no nightly record → repair needed and spawned", async () => {
-    const spawned: string[] = [];
-    const out = new CaptureStream();
-    const code = await runDoctor({
-      config,
-      out,
-      spawnRepair: (p) => spawned.push(p),
-    });
-    expect(spawned).toEqual(["phantom"]);
-    expect(out.text).toContain("never run");
-    expect(code).toBe(0); // repair was triggered
-  });
-
-  test("fresh ok nightly → repair not needed", async () => {
+  // Doctor no longer owns nightly repair: the nightly is idempotent and
+  // sweeps whatever is pending on its own schedule (plus on startup). Doctor
+  // reads the ledger and reports — one owner for the job, not two.
+  test("nothing pending → nightly ok, exit 0", async () => {
     await writeState({
       last_run: new Date().toISOString(),
       last_status: "ok",
     });
-    const spawned: string[] = [];
     const out = new CaptureStream();
-    const code = await runDoctor({
-      config,
-      out,
-      spawnRepair: (p) => spawned.push(p),
-    });
-    expect(spawned).toEqual([]);
+    const code = await runDoctor({ config, out });
     expect(code).toBe(0);
-    expect(out.text).toContain("repair: not needed");
+    expect(out.text).toMatch(/nightly: ok/);
+    expect(out.text).toContain("nothing pending");
   });
 
-  test("stale nightly (>24h) → repair needed", async () => {
+  // Backlog is the only truth — a box that slept through 02:00 and swept on
+  // boot is healthy, however long ago that was.
+  test("a long-idle sweep with an empty backlog is still ok", async () => {
     await writeState({
-      last_run: new Date(Date.now() - 30 * 3_600_000).toISOString(),
+      last_run: new Date(Date.now() - 30 * 24 * 3_600_000).toISOString(),
       last_status: "ok",
     });
-    const spawned: string[] = [];
-    await runDoctor({ config, out: new CaptureStream(), spawnRepair: (p) => spawned.push(p) });
-    expect(spawned).toEqual(["phantom"]);
-  });
-
-  test("partial checkpoint → repair needed, reason names the checkpoint", async () => {
-    await writeState({
-      last_run: new Date().toISOString(),
-      last_status: "partial",
-    });
-    await writeProgress({
-      date: "2026-05-18",
-      started_at: "x",
-      updated_at: "x",
-      completed_stages: ["essence", "promote"],
-      status: "partial",
-    });
-    const spawned: string[] = [];
     const out = new CaptureStream();
-    await runDoctor({ config, out, spawnRepair: (p) => spawned.push(p) });
-    expect(spawned).toEqual(["phantom"]);
-    expect(out.text).toContain("checkpoint");
-    expect(out.text).toContain("2026-05-18");
+    expect(await runDoctor({ config, out })).toBe(0);
+    expect(out.text).toMatch(/nightly: ok/);
   });
 
-  test("no-repair mode reports but never spawns; exits 1 when repair needed", async () => {
-    const spawned: string[] = [];
-    const code = await runDoctor({
-      config,
-      repair: false,
-      out: new CaptureStream(),
-      spawnRepair: (p) => spawned.push(p),
-    });
-    expect(spawned).toEqual([]);
-    expect(code).toBe(1);
-  });
-
-  test("surfaces the nightly errors array (human + json) and flags WARN on non-ok status", async () => {
-    // A fresh run (not stale) that still recorded a failing stage. Status
-    // is non-ok and errors is populated — both must reach the operator.
-    await writeState({
-      last_run: new Date().toISOString(),
-      last_status: "partial",
-      errors: ["stage 'essence': pi exited with code 127"],
-    });
+  test("a small backlog → WARN, exit 0, and points at the next sweep", async () => {
+    await writeDaily("2026-05-01");
+    await writeDaily("2026-05-02");
     const out = new CaptureStream();
-    await runDoctor({ config, out, spawnRepair: () => {} });
-    expect(out.text).toContain("pi exited with code 127");
-    // Non-ok status downgrades the nightly line to WARN even when recent.
+    const code = await runDoctor({ config, out });
+    expect(code).toBe(0);
     expect(out.text).toMatch(/nightly: WARN/);
+    expect(out.text).toContain("2 date(s) pending");
+  });
+
+  test("a large backlog → ERR and exit 1", async () => {
+    for (const d of ["01", "02", "03", "04", "05"]) {
+      await writeDaily(`2026-05-${d}`);
+    }
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out });
+    expect(code).toBe(1);
+    expect(out.text).toMatch(/nightly: ERR/);
+  });
+
+  test("an in-flight sweep is reported as RUNNING with progress", async () => {
+    const now = new Date().toISOString();
+    await writeState({
+      last_run: now,
+      last_status: "ok",
+      current: {
+        date: "2026-05-02",
+        index: 2,
+        total: 5,
+        started_at: now,
+        updated_at: now,
+      },
+    });
+    const out = new CaptureStream();
+    expect(await runDoctor({ config, out })).toBe(0);
+    expect(out.text).toContain("nightly: RUNNING — 2/5 dates, on 2026-05-02");
+  });
+
+  test("surfaces the nightly errors array (human + json)", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "error",
+      errors: ["stage 'kb' (2026-05-01): pi exited with code 127"],
+    });
+    const out = new CaptureStream();
+    await runDoctor({ config, out });
+    expect(out.text).toContain("pi exited with code 127");
+    expect(out.text).toMatch(/nightly: ERR/);
 
     const jsonOut = new CaptureStream();
-    await runDoctor({ config, json: true, out: jsonOut, spawnRepair: () => {} });
+    await runDoctor({ config, json: true, out: jsonOut });
     const report = JSON.parse(jsonOut.text);
     expect(report.nightly.errors).toEqual([
-      "stage 'essence': pi exited with code 127",
+      "stage 'kb' (2026-05-01): pi exited with code 127",
     ]);
+    expect(report.nightly.health).toBe("error");
   });
 
-  test("omits the errors field when the last run was clean", async () => {
+  test("omits the errors field when the last sweep was clean", async () => {
     await writeState({
       last_run: new Date().toISOString(),
       last_status: "ok",
     });
     const out = new CaptureStream();
-    await runDoctor({ config, json: true, out, spawnRepair: () => {} });
-    const report = JSON.parse(out.text);
-    expect(report.nightly.errors).toBeUndefined();
+    await runDoctor({ config, json: true, out });
+    expect(JSON.parse(out.text).nightly.errors).toBeUndefined();
   });
 
-  test("json mode emits a parseable report", async () => {
+  test("json mode emits a parseable report with ledger-derived health", async () => {
+    await writeDaily("2026-05-01");
     await writeState({
       last_run: new Date().toISOString(),
       last_status: "ok",
     });
     const out = new CaptureStream();
-    await runDoctor({ config, json: true, out, spawnRepair: () => {} });
+    await runDoctor({ config, json: true, out });
     const report = JSON.parse(out.text);
     expect(report.persona).toBe("phantom");
-    expect(report.repair_needed).toBe(false);
     expect(report.capture).toBeDefined();
-    expect(report.nightly.last_status).toBe("ok");
+    expect(report.nightly.health).toBe("warning");
+    expect(report.nightly.backlog).toBe(1);
+    expect(report.nightly.oldest_pending).toBe("2026-05-01");
   });
 });
 

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { rmrf } from "./fixtures/rmrf.ts";
 import { runHeartbeatCli } from "../src/cli/heartbeat.ts";
 import type { Config } from "../src/config.ts";
@@ -54,6 +54,17 @@ beforeEach(async () => {
 afterEach(async () => {
   await rmrf(workdir);
 });
+
+/**
+ * Write the heartbeat's last-fired marker with an explicit timestamp, so a
+ * test can model "the previous fire was yesterday" without waiting a day.
+ * Same format `recordHeartbeatFired` writes.
+ */
+async function writeMarker(at: Date): Promise<void> {
+  const p = heartbeatMarkerPath();
+  await mkdir(dirname(p), { recursive: true });
+  await writeFile(p, `ISO=${at.toISOString()} runs=1\n`, "utf8");
+}
 
 describe("runHeartbeatCli", () => {
   test("happy path returns 0 and prints summary", async () => {
@@ -128,6 +139,75 @@ describe("runHeartbeatCli", () => {
       },
     });
     // Primary work still completes and exit is 0; the heal failure is logged but swallowed.
+    expect(code).toBe(0);
+    expect(out.text).toContain("heartbeat ok");
+  });
+
+  test("a day boundary since the last fire spawns the nightly sweep", async () => {
+    // This is the replacement for the 02:00 timer: the heartbeat sees that the
+    // previous fire was recorded on an earlier calendar day, which means
+    // yesterday's daily file has closed, and fires a detached sweep.
+    await writeMarker(new Date(Date.now() - 36 * 3_600_000));
+    const spawned: Array<[string, string]> = [];
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+      triggerNightly: (persona, reason) => spawned.push([persona, reason]),
+    });
+    expect(code).toBe(0);
+    expect(spawned).toEqual([["phantom", "rollover"]]);
+    expect(out.text).toContain("day rolled over");
+  });
+
+  test("a fire earlier the same day does not spawn a sweep", async () => {
+    await writeMarker(new Date());
+    const spawned: string[] = [];
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+      triggerNightly: (persona) => spawned.push(persona),
+    });
+    expect(code).toBe(0);
+    expect(spawned).toEqual([]);
+    expect(out.text).not.toContain("day rolled over");
+  });
+
+  test("first-ever heartbeat (no marker) does not spawn a sweep", async () => {
+    // `run` already fires a startup sweep; guessing here would double up.
+    const spawned: string[] = [];
+    const code = await runHeartbeatCli({
+      config,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+      triggerNightly: (persona) => spawned.push(persona),
+    });
+    expect(code).toBe(0);
+    expect(spawned).toEqual([]);
+  });
+
+  test("a spawn failure does not break the heartbeat", async () => {
+    await writeMarker(new Date(Date.now() - 36 * 3_600_000));
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+      triggerNightly: () => {
+        throw new Error("fork failed");
+      },
+    });
     expect(code).toBe(0);
     expect(out.text).toContain("heartbeat ok");
   });

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -212,8 +212,6 @@ describe("runInstall (linux/systemd)", () => {
       "--user start phantombot.service",
       "--user enable phantombot-heartbeat.timer",
       "--user start phantombot-heartbeat.timer",
-      "--user enable phantombot-nightly.timer",
-      "--user start phantombot-nightly.timer",
       "--user enable phantombot-tick.timer",
       "--user start phantombot-tick.timer",
     ]);
@@ -245,15 +243,14 @@ describe("runInstall (darwin/launchd)", () => {
       platform: "darwin",
     });
     expect(code).toBe(0);
-    // bootouts of nothing × 4, then bootstrap each plist × 4. We check the
-    // verb sequence rather than full strings so test stays readable.
+    // bootouts of nothing × 3, then bootstrap each plist × 3 (the retired
+    // nightly agent is neither written nor bootstrapped). We check the verb
+    // sequence rather than full strings so the test stays readable.
     const verbs = lc.calls.map((c) => c[0]);
     expect(verbs).toEqual([
       "bootout",
       "bootout",
       "bootout",
-      "bootout",
-      "bootstrap",
       "bootstrap",
       "bootstrap",
       "bootstrap",
@@ -329,9 +326,9 @@ describe("runInstall (windows/schtasks)", () => {
       platform: "windows",
     });
     expect(code).toBe(0);
-    // Four /Create imports, one per task.
+    // Three /Create imports, one per live task.
     const creates = st.calls.filter((c) => c[0] === "/Create");
-    expect(creates.length).toBe(4);
+    expect(creates.length).toBe(3);
     expect(out.text).toContain("registered");
     expect(out.text).toContain("while logged in");
   });
@@ -400,7 +397,8 @@ describe("runUninstall (windows/schtasks)", () => {
     const out = new CaptureStream();
     const st = new FakeSchtasks();
     const sid = "S-1-5-21-1-2-3-1001";
-    // 4 persona-scoped tasks + 4 legacy pre-rename names, all owned by us.
+    // 3 live + 1 retired persona-scoped task, plus 4 legacy pre-rename names,
+    // all owned by us. Uninstall must clear the retired nightly task too.
     const names = [
       "phantombot-testbot",
       "heartbeat-testbot",
@@ -535,7 +533,7 @@ describe("runInstall (windows) logged-off prompt flow", () => {
     });
     expect(code).toBe(0);
     const creates = st.calls.filter((c) => c[0] === "/Create");
-    expect(creates.length).toBe(4);
+    expect(creates.length).toBe(3);
     for (const c of creates) {
       expect(c).not.toContain("/RU");
       expect(c).not.toContain("/RP");
@@ -569,8 +567,8 @@ describe("runInstall (windows) logged-off prompt flow", () => {
     expect(code).toBe(0);
     expect(askedPassword).toBe(true);
     const creates = st.calls.filter((c) => c[0] === "/Create");
-    // 4 password tasks + the interactive login-fallback twin.
-    expect(creates.length).toBe(5);
+    // 3 password tasks + the interactive login-fallback twin.
+    expect(creates.length).toBe(4);
     for (const c of creates.filter((c) => !c.some((a) => a.includes("login-testbot")))) {
       expect(c).toContain("/RU");
       expect(c).toContain("MEGAN-PC\\megan");
@@ -626,8 +624,8 @@ describe("runInstall (windows) logged-off prompt flow", () => {
     expect(code).toBe(0);
     expect(prompted).toBe(false);
     const creates = st.calls.filter((c) => c[0] === "/Create");
-    // 4 password tasks + the interactive login-fallback twin.
-    expect(creates.length).toBe(5);
+    // 3 password tasks + the interactive login-fallback twin.
+    expect(creates.length).toBe(4);
     for (const c of creates.filter((c) => !c.some((a) => a.includes("login-testbot")))) {
       expect(c).toContain("/RP");
     }
@@ -684,7 +682,7 @@ describe("runInstall (windows) logged-off prompt flow", () => {
     const pwCreates = st.calls.filter(
       (c) => c[0] === "/Create" && !c.some((a) => a.includes("login-testbot")),
     );
-    expect(pwCreates.length).toBe(4);
+    expect(pwCreates.length).toBe(3);
     // The reused vault password was applied via /RP.
     for (const c of pwCreates) {
       expect(c).toContain("/RP");
@@ -751,7 +749,7 @@ describe("runInstall (windows) logged-off prompt flow", () => {
     const pwCreates = st.calls.filter(
       (c) => c[0] === "/Create" && !c.some((a) => a.includes("login-testbot")),
     );
-    expect(pwCreates.length).toBe(4);
+    expect(pwCreates.length).toBe(3);
     for (const c of pwCreates) expect(c).toContain("migrated-pw");
     // The interactive login-fallback twin is registered too.
     expect(st.calls.some((c) => c.some((a) => a.includes("login-testbot")))).toBe(

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { defaultNightlyDate, runNightly } from "../src/cli/nightly.ts";
+import { MAX_DATES_PER_RUN, runNightly } from "../src/cli/nightly.ts";
+import {
+  loadNightlyState,
+  NIGHTLY_STAGES,
+  type NightlyStage,
+} from "../src/lib/nightly.ts";
 import type { Config } from "../src/config.ts";
 
 class CaptureStream {
@@ -17,11 +22,13 @@ class CaptureStream {
 }
 
 let workdir: string;
+let personaDir: string;
 let config: Config;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-ngcli-"));
-  await mkdir(join(workdir, "personas", "phantom"), { recursive: true });
+  personaDir = join(workdir, "personas", "phantom");
+  await mkdir(join(personaDir, "memory"), { recursive: true });
   config = {
     defaultPersona: "phantom",
     harnessIdleTimeoutMs: 600_000, harnessHardTimeoutMs: 600_000, harnessStartupTimeoutMs: 600_000,
@@ -43,28 +50,42 @@ afterEach(async () => {
   await rm(workdir, { recursive: true, force: true });
 });
 
-describe("defaultNightlyDate", () => {
-  // The nightly timer fires at 02:00 for the day that just CLOSED. The
-  // default date must be yesterday — otherwise the run looks for a daily
-  // file that doesn't exist yet and silently no-ops (reported 2026-08-15).
-  test("fires 02:00 → returns the day that just closed", () => {
-    expect(defaultNightlyDate(new Date(Date.UTC(2026, 7, 15, 2, 0, 0)))).toBe(
-      "2026-08-14",
-    );
-  });
+async function daily(date: string, body = `notes for ${date}`): Promise<void> {
+  await writeFile(join(personaDir, "memory", `${date}.md`), body, "utf8");
+}
 
-  test("month boundary — Aug 1 → Jul 31", () => {
-    expect(defaultNightlyDate(new Date(Date.UTC(2026, 7, 1, 2, 0, 0)))).toBe(
-      "2026-07-31",
-    );
-  });
+interface StageCall {
+  date: string;
+  stage: NightlyStage | "override";
+  prompt: string;
+  startedAt: number;
+  endedAt: number;
+}
 
-  test("year boundary — Jan 1 → Dec 31 of prior year", () => {
-    expect(defaultNightlyDate(new Date(Date.UTC(2026, 0, 1, 2, 0, 0)))).toBe(
-      "2025-12-31",
-    );
-  });
-});
+/**
+ * Drive runNightly with fake stages. `fail` marks stage/date pairs that should
+ * report an error; `delayMs` keeps a stage in flight long enough to observe
+ * concurrency.
+ */
+function harness(opts: { fail?: string[]; delayMs?: number } = {}) {
+  const calls: StageCall[] = [];
+  const runStage = async (a: {
+    date: string;
+    stage: NightlyStage | "override";
+    prompt: string;
+  }) => {
+    const startedAt = Date.now();
+    if (opts.delayMs) await new Promise((r) => setTimeout(r, opts.delayMs));
+    calls.push({ ...a, startedAt, endedAt: Date.now() });
+    const key = `${a.date}:${a.stage}`;
+    return opts.fail?.includes(key)
+      ? { finalReply: "", errored: "boom", durationMs: 1 }
+      : { finalReply: "done", durationMs: 1 };
+  };
+  return { calls, runStage };
+}
+
+const now = new Date("2026-05-10T02:00:00Z");
 
 describe("runNightly — early exits", () => {
   test("missing persona → exit 2", async () => {
@@ -88,5 +109,292 @@ describe("runNightly — early exits", () => {
     });
     expect(code).toBe(2);
     expect(err.text).toContain("no harnesses");
+  });
+});
+
+describe("runNightly — the sweep", () => {
+  test("processes every pending date, oldest first, two stages each", async () => {
+    await daily("2026-05-01");
+    await daily("2026-05-02");
+    const h = harness();
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config,
+      now,
+      out,
+      runStage: h.runStage,
+      refreshIndex: async () => {},
+    });
+    expect(code).toBe(0);
+    expect(h.calls.length).toBe(4);
+    expect(h.calls.map((c) => c.date)).toEqual([
+      "2026-05-01",
+      "2026-05-01",
+      "2026-05-02",
+      "2026-05-02",
+    ]);
+    expect(new Set(h.calls.map((c) => c.stage))).toEqual(
+      new Set(NIGHTLY_STAGES),
+    );
+  });
+
+  // The whole point of the ledger: no flags, no catch-up mode — a second run
+  // with nothing new spends zero turns.
+  test("a second run with nothing changed does no work", async () => {
+    await daily("2026-05-01");
+    const first = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: first.runStage, refreshIndex: async () => {},
+    });
+    const second = harness();
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config, now, out,
+      runStage: second.runStage, refreshIndex: async () => {},
+    });
+    expect(code).toBe(0);
+    expect(second.calls).toEqual([]);
+    expect(out.text).toContain("nothing pending");
+  });
+
+  // A day keeps receiving captures after its pass; growth must re-queue it.
+  test("a daily file that grew after processing is swept again", async () => {
+    await daily("2026-05-01");
+    const first = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: first.runStage, refreshIndex: async () => {},
+    });
+    await daily("2026-05-01", "notes for 2026-05-01 plus a late capture");
+    const second = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: second.runStage, refreshIndex: async () => {},
+    });
+    expect(second.calls.map((c) => c.date)).toEqual([
+      "2026-05-01",
+      "2026-05-01",
+    ]);
+  });
+
+  // Disjoint write targets (drawers+MEMORY.md vs kb/) is what licenses this.
+  test("the two stages for a date run concurrently, not in sequence", async () => {
+    await daily("2026-05-01");
+    const h = harness({ delayMs: 60 });
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(h.calls.length).toBe(2);
+    const [a, b] = h.calls;
+    // Overlap: the second stage started before the first one finished.
+    expect(Math.max(a!.startedAt, b!.startedAt)).toBeLessThan(
+      Math.min(a!.endedAt, b!.endedAt),
+    );
+  });
+
+  test("the index refresh runs in code once per date, after both stages", async () => {
+    await daily("2026-05-01");
+    const h = harness();
+    const refreshes: number[] = [];
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage,
+      refreshIndex: async () => {
+        refreshes.push(Date.now());
+      },
+    });
+    expect(refreshes.length).toBe(1);
+    expect(refreshes[0]!).toBeGreaterThanOrEqual(
+      Math.max(...h.calls.map((c) => c.endedAt)),
+    );
+  });
+
+  test("today is never swept — only days that have closed", async () => {
+    await daily("2026-05-09");
+    await daily("2026-05-10"); // == `now`
+    const h = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(new Set(h.calls.map((c) => c.date))).toEqual(
+      new Set(["2026-05-09"]),
+    );
+  });
+});
+
+describe("runNightly — ledger", () => {
+  test("records mtime, size, hash and stages per processed date", async () => {
+    await daily("2026-05-01");
+    const h = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    const rec = (await loadNightlyState(personaDir)).processed?.["2026-05-01"];
+    expect(rec?.status).toBe("ok");
+    expect(rec?.stages_done.sort()).toEqual([...NIGHTLY_STAGES].sort());
+    expect(rec?.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(rec?.size).toBeGreaterThan(0);
+  });
+
+  test("clears the in-flight marker when the sweep finishes", async () => {
+    await daily("2026-05-01");
+    const h = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect((await loadNightlyState(personaDir)).current).toBeUndefined();
+  });
+
+  // One stage failing must not throw away the other's work, and must leave the
+  // date pending so the next sweep retries it — resume with no resume flag.
+  test("a failed stage → partial record, exit 1, and the date stays pending", async () => {
+    await daily("2026-05-01");
+    const h = harness({ fail: ["2026-05-01:kb"] });
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config, now, out,
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(code).toBe(1);
+    const rec = (await loadNightlyState(personaDir)).processed?.["2026-05-01"];
+    expect(rec?.status).toBe("partial");
+    expect(rec?.stages_done).toEqual(["distill"]);
+    expect(out.text).toContain("PARTIAL");
+
+    const retry = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: retry.runStage, refreshIndex: async () => {},
+    });
+    expect(retry.calls.length).toBe(2);
+  });
+});
+
+describe("runNightly — bounds and locking", () => {
+  test("caps dates per run and defers the rest to the next sweep", async () => {
+    for (let d = 1; d <= 5; d++) {
+      await daily(`2026-05-0${d}`);
+    }
+    const h = harness();
+    const out = new CaptureStream();
+    await runNightly({
+      config, now, out, maxDates: 2,
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(new Set(h.calls.map((c) => c.date))).toEqual(
+      new Set(["2026-05-01", "2026-05-02"]),
+    );
+    expect(out.text).toContain("+3 deferred");
+  });
+
+  test("the default cap is MAX_DATES_PER_RUN", async () => {
+    for (let d = 1; d <= MAX_DATES_PER_RUN + 2; d++) {
+      await daily(`2026-04-${String(d).padStart(2, "0")}`);
+    }
+    const h = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(new Set(h.calls.map((c) => c.date)).size).toBe(MAX_DATES_PER_RUN);
+  });
+
+  // Two overlapping sweeps would double-file the same drawers.
+  test("a live in-flight marker makes the run skip", async () => {
+    await daily("2026-05-01");
+    const { saveNightlyState } = await import("../src/lib/nightly.ts");
+    await saveNightlyState(personaDir, {
+      current: {
+        date: "2026-05-01",
+        index: 1,
+        total: 1,
+        started_at: now.toISOString(),
+        updated_at: now.toISOString(),
+      },
+    });
+    const h = harness();
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config, now, out,
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(code).toBe(0);
+    expect(h.calls).toEqual([]);
+    expect(out.text).toContain("already in flight");
+  });
+
+  // …but a marker left by a crashed process must not block the sweep forever.
+  test("a stale in-flight marker is taken over", async () => {
+    await daily("2026-05-01");
+    const { saveNightlyState } = await import("../src/lib/nightly.ts");
+    await saveNightlyState(personaDir, {
+      current: {
+        date: "2026-05-01",
+        index: 1,
+        total: 1,
+        started_at: "2026-05-09T02:00:00Z",
+        updated_at: "2026-05-09T02:00:00Z",
+      },
+    });
+    const h = harness();
+    const out = new CaptureStream();
+    await runNightly({
+      config, now, out,
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(h.calls.length).toBe(2);
+    expect(out.text).toContain("stalled sweep");
+  });
+});
+
+describe("runNightly — --date override", () => {
+  test("reprocesses one date regardless of the ledger", async () => {
+    await daily("2026-05-01");
+    const first = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: first.runStage, refreshIndex: async () => {},
+    });
+    const again = harness();
+    const code = await runNightly({
+      config, now, today: "2026-05-01", out: new CaptureStream(),
+      runStage: again.runStage, refreshIndex: async () => {},
+    });
+    expect(code).toBe(0);
+    expect(again.calls.length).toBe(2);
+  });
+
+  test("a date with no daily file → exit 2", async () => {
+    const err = new CaptureStream();
+    const code = await runNightly({
+      config, now, today: "2026-05-01", out: new CaptureStream(), err,
+      runStage: harness().runStage, refreshIndex: async () => {},
+    });
+    expect(code).toBe(2);
+    expect(err.text).toContain("no daily file");
+  });
+});
+
+describe("runNightly — persona override prompt", () => {
+  test("nightly-prompt.md runs as one monolithic turn per date", async () => {
+    await daily("2026-05-01");
+    await writeFile(
+      join(personaDir, "nightly-prompt.md"),
+      "custom {{persona}} {{today}}",
+      "utf8",
+    );
+    const h = harness();
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(h.calls.length).toBe(1);
+    expect(h.calls[0]!.stage).toBe("override");
+    expect(h.calls[0]!.prompt).toBe("custom phantom 2026-05-01");
   });
 });

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { MAX_DATES_PER_RUN, runNightly } from "../src/cli/nightly.ts";
+import { runNightly } from "../src/cli/nightly.ts";
 import {
   loadNightlyState,
   NIGHTLY_STAGES,
@@ -276,7 +276,7 @@ describe("runNightly — ledger", () => {
 });
 
 describe("runNightly — bounds and locking", () => {
-  test("caps dates per run and defers the rest to the next sweep", async () => {
+  test("--max-dates bounds a manual run and defers the rest", async () => {
     for (let d = 1; d <= 5; d++) {
       await daily(`2026-05-0${d}`);
     }
@@ -292,16 +292,20 @@ describe("runNightly — bounds and locking", () => {
     expect(out.text).toContain("+3 deferred");
   });
 
-  test("the default cap is MAX_DATES_PER_RUN", async () => {
-    for (let d = 1; d <= MAX_DATES_PER_RUN + 2; d++) {
+  // No default cap: a backlog left half-drained comes back every night and
+  // keeps /status yellow, so one pass takes the whole queue.
+  test("with no --max-dates the sweep drains the entire backlog", async () => {
+    for (let d = 1; d <= 25; d++) {
       await daily(`2026-04-${String(d).padStart(2, "0")}`);
     }
     const h = harness();
+    const out = new CaptureStream();
     await runNightly({
-      config, now, out: new CaptureStream(),
+      config, now, out,
       runStage: h.runStage, refreshIndex: async () => {},
     });
-    expect(new Set(h.calls.map((c) => c.date)).size).toBe(MAX_DATES_PER_RUN);
+    expect(new Set(h.calls.map((c) => c.date)).size).toBe(25);
+    expect(out.text).not.toContain("deferred");
   });
 
   // Two overlapping sweeps would double-file the same drawers.

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -575,7 +575,12 @@ describe("runUpdate post-swap systemd heal", () => {
       refreshCompletions: false,
       healSystemdUnits: async (bin) => {
         called.push(bin);
-        return { rewrote: [], backups: [], repairedTimers: [] };
+        return {
+          rewrote: [],
+          backups: [],
+          repairedTimers: [],
+          removedRetired: [],
+        };
       },
     });
     expect(code).toBe(0);
@@ -601,6 +606,7 @@ describe("runUpdate post-swap systemd heal", () => {
         rewrote: ["phantombot-tick.timer", "phantombot.service"],
         backups: [],
         repairedTimers: ["phantombot-tick.timer"],
+        removedRetired: [],
       }),
     });
     expect(code).toBe(0);

--- a/tests/lib-indexRefresh.test.ts
+++ b/tests/lib-indexRefresh.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { refreshPersonaIndex } from "../src/lib/indexRefresh.ts";
+import type { Config } from "../src/config.ts";
+
+let workdir: string;
+let personaDir: string;
+let indexPath: string;
+let config: Config;
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-ixref-"));
+  personaDir = join(workdir, "persona");
+  indexPath = join(workdir, "index.sqlite");
+  await mkdir(join(personaDir, "memory"), { recursive: true });
+  await mkdir(join(personaDir, "kb", "concepts"), { recursive: true });
+  config = { embeddings: { provider: "none" } } as unknown as Config;
+});
+
+afterEach(async () => {
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("refreshPersonaIndex", () => {
+  // This is the work that used to sit in the nightly's KB PROMPT ("run
+  // `phantombot memory index --rebuild` at the end") — deterministic work
+  // behind a probabilistic trigger. In code it is guaranteed, ordered after
+  // both stages' writes, and runs exactly once.
+  test("indexes memory/ and kb/ files", async () => {
+    await writeFile(
+      join(personaDir, "memory", "2026-05-01.md"),
+      "a decision about proxies",
+      "utf8",
+    );
+    await writeFile(
+      join(personaDir, "kb", "concepts", "proxy.md"),
+      "# Proxy\nnotes",
+      "utf8",
+    );
+    const r = await refreshPersonaIndex({ config, personaDir, indexPath });
+    expect(r.error).toBeUndefined();
+    expect(r.indexed).toBe(2);
+  });
+
+  // refreshStale, not rebuild: `rebuild` drops the tables and re-embeds every
+  // file with force on every run — hundreds of unchanged dailies a night.
+  test("a second call re-indexes nothing when no file changed", async () => {
+    await writeFile(join(personaDir, "memory", "2026-05-01.md"), "x", "utf8");
+    await refreshPersonaIndex({ config, personaDir, indexPath });
+    const second = await refreshPersonaIndex({ config, personaDir, indexPath });
+    expect(second.indexed).toBe(0);
+    expect(second.error).toBeUndefined();
+  });
+
+  test("a changed file is picked up on the next call", async () => {
+    const p = join(personaDir, "memory", "2026-05-01.md");
+    await writeFile(p, "x", "utf8");
+    await refreshPersonaIndex({ config, personaDir, indexPath });
+    await writeFile(p, "x and more", "utf8");
+    expect(
+      (await refreshPersonaIndex({ config, personaDir, indexPath })).indexed,
+    ).toBe(1);
+  });
+
+  // A failed refresh must never fail the distillation that produced the files:
+  // the writes already landed, and the next refresh picks them up.
+  test("an unusable index path is reported, not thrown", async () => {
+    // A directory where the db file should be: sqlite can't open it.
+    const r = await refreshPersonaIndex({
+      config,
+      personaDir,
+      indexPath: join(personaDir, "memory"),
+    });
+    expect(r.error).toBeDefined();
+    expect(r.indexed).toBe(0);
+  });
+
+  // Keyword-only installs (no embeddings provider) are a valid configuration,
+  // not a fault — FTS still refreshes.
+  test("no embeddings provider → FTS only, no error", async () => {
+    await writeFile(join(personaDir, "memory", "2026-05-01.md"), "x", "utf8");
+    const r = await refreshPersonaIndex({ config, personaDir, indexPath });
+    expect(r.embedded).toBe(0);
+    expect(r.error).toBeUndefined();
+  });
+});

--- a/tests/lib-launchd.test.ts
+++ b/tests/lib-launchd.test.ts
@@ -5,13 +5,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   generateHeartbeatPlist,
-  generateNightlyPlist,
   generatePhantombotPlist,
   generateTickPlist,
   installPhantombotPlists,
@@ -130,17 +130,6 @@ describe("companion plists carry the right schedule", () => {
     expect(plist).not.toContain("<key>KeepAlive</key>");
   });
 
-  test("nightly fires daily at 02:00 (calendar-based)", () => {
-    const plist = generateNightlyPlist("/usr/local/bin/phantombot");
-    expect(plist).toContain(`<string>${NIGHTLY_PLIST_LABEL}</string>`);
-    expect(plist).toContain("<string>nightly</string>");
-    expect(plist).toContain("<key>StartCalendarInterval</key>");
-    expect(plist).toContain("<key>Hour</key>");
-    expect(plist).toContain("<integer>2</integer>");
-    expect(plist).toContain("<key>Minute</key>");
-    expect(plist).toContain("<integer>0</integer>");
-  });
-
   test("tick fires every 60 seconds", () => {
     const plist = generateTickPlist("/usr/local/bin/phantombot");
     expect(plist).toContain(`<string>${TICK_PLIST_LABEL}</string>`);
@@ -151,7 +140,7 @@ describe("companion plists carry the right schedule", () => {
 });
 
 describe("installPhantombotPlists", () => {
-  test("writes all four plists then bootstraps each into the gui domain", async () => {
+  test("writes the three live plists then bootstraps each into the gui domain", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     const lc = new FakeLaunchctl();
@@ -168,36 +157,63 @@ describe("installPhantombotPlists", () => {
     });
     expect(result.installed).toBe(true);
 
-    // All four files exist on disk with sane bodies.
-    for (const path of [mainPath, hbPath, ngPath, tkPath]) {
+    // The retired nightly plist is never written.
+    expect(existsSync(ngPath)).toBe(false);
+    // Every live plist exists on disk with a sane body.
+    for (const path of [mainPath, hbPath, tkPath]) {
       const body = await readFile(path, "utf8");
       expect(body).toContain('<?xml version="1.0"');
       expect(body).toContain("<key>Label</key>");
     }
 
-    // The launchctl call sequence is: bootout(label) × 4 (idempotent
-    // pre-cleanup), then bootstrap(plist) × 4.
+    // The launchctl call sequence is: bootout(label) × 3 (idempotent
+    // pre-cleanup), then bootstrap(plist) × 3. Nothing for the retired
+    // nightly agent, because its plist isn't on disk.
     const sequence = lc.calls.map((c) => c.join(" "));
     expect(sequence).toEqual([
       `bootout gui/501/${PHANTOMBOT_PLIST_LABEL}`,
       `bootout gui/501/${HEARTBEAT_PLIST_LABEL}`,
-      `bootout gui/501/${NIGHTLY_PLIST_LABEL}`,
       `bootout gui/501/${TICK_PLIST_LABEL}`,
       `bootstrap gui/501 ${mainPath}`,
       `bootstrap gui/501 ${hbPath}`,
-      `bootstrap gui/501 ${ngPath}`,
       `bootstrap gui/501 ${tkPath}`,
     ]);
     expect(out.text).toContain("bootstrapped");
+  });
+
+  test("boots out and deletes a nightly plist left by an older install", async () => {
+    // Upgrade path: the retired 02:00 agent is still loaded and on disk.
+    // Install must unload and delete it, or macOS keeps firing a duplicate
+    // sweep every night.
+    await Bun.write(ngPath, "<plist>old nightly</plist>");
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const lc = new FakeLaunchctl();
+    const result = await installPhantombotPlists({
+      binPath: "/Users/andrew/.local/bin/phantombot",
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      launchctl: lc,
+      out,
+      err,
+    });
+    expect(result.installed).toBe(true);
+    expect(existsSync(ngPath)).toBe(false);
+    expect(lc.calls.map((c) => c.join(" "))).toContain(
+      `bootout gui/501/${NIGHTLY_PLIST_LABEL}`,
+    );
+    expect(out.text).toContain("removed retired plist");
   });
 
   test("fails install (and reports) when bootstrap returns non-zero", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     const lc = new FakeLaunchctl();
-    // 4 bootouts succeed; first bootstrap fails.
+    // 3 bootouts succeed; first bootstrap fails.
     lc.responses = [
-      { exitCode: 0, stdout: "", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" },
@@ -250,7 +266,6 @@ describe("uninstallPhantombotPlists", () => {
       `bootout gui/501/${PHANTOMBOT_PLIST_LABEL}`,
     ]);
     // All plists removed.
-    const { existsSync } = await import("node:fs");
     expect(existsSync(mainPath)).toBe(false);
     expect(existsSync(hbPath)).toBe(false);
     expect(existsSync(ngPath)).toBe(false);

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   buildNightlyPrompt,
   buildNightlyPromptForPersona,
+  BACKLOG_STAGNANT_MS,
   buildNightlyStagePrompt,
   dailyFilePath,
   dateRecord,
@@ -283,7 +284,7 @@ describe("nightlyHealth", () => {
     expect((await nightlyHealth(workdir, { now })).status).toBe("ok");
   });
 
-  test("1–3 pending dates → warning", async () => {
+  test("pending dates → warning", async () => {
     await daily("2026-05-01");
     await daily("2026-05-02");
     const h = await nightlyHealth(workdir, { now });
@@ -293,11 +294,41 @@ describe("nightlyHealth", () => {
     expect(h.detail).toContain("2 dates pending");
   });
 
-  test("more than 3 pending dates → error", async () => {
-    for (const d of ["01", "02", "03", "04"]) await daily(`2026-05-${d}`);
+  // Depth is not a fault: one sweep drains the whole queue, so a months-deep
+  // backfill reads as work-in-progress, not as a broken nightly.
+  test("a deep backlog is still only a warning while sweeps are running", async () => {
+    for (let d = 1; d <= 20; d++) {
+      await daily(`2026-04-${String(d).padStart(2, "0")}`);
+    }
+    await saveNightlyState(workdir, {
+      last_run: new Date(now.getTime() - 60 * 60_000).toISOString(),
+      last_status: "ok",
+    });
+    const h = await nightlyHealth(workdir, { now });
+    expect(h.status).toBe("warning");
+    expect(h.backlog).toBe(20);
+  });
+
+  // The real fault is a backlog nobody is picking up — the trigger is dead.
+  test("pending dates with no sweep for over a day → error", async () => {
+    await daily("2026-05-01");
+    await saveNightlyState(workdir, {
+      last_run: new Date(now.getTime() - BACKLOG_STAGNANT_MS - 60_000).toISOString(),
+      last_status: "ok",
+    });
     const h = await nightlyHealth(workdir, { now });
     expect(h.status).toBe("error");
-    expect(h.detail).toContain("4 dates unprocessed");
+    expect(h.detail).toContain("no sweep since");
+  });
+
+  // A fresh install has a backlog and no last_run; that is queued work, not a
+  // stuck trigger — `run` stamps last_run within a minute of starting.
+  test("a never-swept ledger with a backlog → warning, not error", async () => {
+    for (let d = 1; d <= 12; d++) {
+      await daily(`2026-04-${String(d).padStart(2, "0")}`);
+    }
+    const h = await nightlyHealth(workdir, { now });
+    expect(h.status).toBe("warning");
   });
 
   test("an in-flight sweep with a fresh beat → running with progress", async () => {

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -1,23 +1,23 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildNightlyPrompt,
   buildNightlyPromptForPersona,
   buildNightlyStagePrompt,
-  CATCHUP_WINDOW_MS,
-  clearNightlyProgress,
-  loadNightlyProgress,
+  dailyFilePath,
+  dateRecord,
   loadNightlyState,
   NIGHTLY_STAGES,
-  type NightlyProgress,
+  type NightlyState,
   nightlyConversationKey,
+  nightlyHealth,
   nightlyStatePath,
-  pendingNightlyStages,
-  saveNightlyProgress,
+  pendingForDate,
   saveNightlyState,
-  shouldRunCatchupNightly,
+  STALE_RUN_MS,
+  sweepDailyFiles,
 } from "../src/lib/nightly.ts";
 
 let workdir: string;
@@ -31,6 +31,21 @@ afterEach(async () => {
   await rm(workdir, { recursive: true, force: true });
 });
 
+/** Write a daily file and return its recorded mtime (ms, floored). */
+async function daily(date: string, body = `notes for ${date}`): Promise<void> {
+  await writeFile(dailyFilePath(workdir, date), body, "utf8");
+}
+
+/** Mark a date as fully processed in the ledger, matching what's on disk. */
+async function markProcessed(date: string): Promise<void> {
+  const sweep = await sweepDailyFiles(workdir, await loadNightlyState(workdir), "9999-12-31");
+  const p = sweep.pending.find((x) => x.date === date);
+  if (!p) throw new Error(`no pending entry for ${date}`);
+  await saveNightlyState(workdir, {
+    processed: { [date]: dateRecord(p, [...NIGHTLY_STAGES]) },
+  });
+}
+
 describe("nightlyConversationKey", () => {
   test("uses system:nightly:<date> namespace", () => {
     expect(nightlyConversationKey("2026-05-02")).toBe(
@@ -39,10 +54,20 @@ describe("nightlyConversationKey", () => {
   });
 });
 
-describe("nightlyStatePath", () => {
-  test("returns memory/.nightly-state.json under the persona dir", () => {
+describe("nightlyStatePath / dailyFilePath", () => {
+  test("state lives at memory/.nightly-state.json", () => {
     expect(nightlyStatePath("/tmp/persona")).toBe(
       "/tmp/persona/memory/.nightly-state.json",
+    );
+  });
+
+  // The filename IS the primary key: six call sites build it from the date,
+  // and index paths + [[memory/…]] wikilinks point at it. Nothing may rename
+  // a daily file (e.g. to a "_processed_" prefix) — captures written after a
+  // pass would recreate the un-prefixed name and orphan the processed half.
+  test("daily files are memory/<date>.md, never renamed", () => {
+    expect(dailyFilePath("/tmp/persona", "2026-08-16")).toBe(
+      "/tmp/persona/memory/2026-08-16.md",
     );
   });
 });
@@ -64,122 +89,362 @@ describe("loadNightlyState / saveNightlyState", () => {
     expect(r.items_promoted).toBe(5);
   });
 
-  test("save merges into existing state", async () => {
+  // The ledger is the whole idempotency mechanism: a patch carrying one date
+  // must never clobber the rest of history, or every prior date reprocesses.
+  test("processed entries merge key-by-key instead of replacing", async () => {
     await saveNightlyState(workdir, {
-      last_run: "2026-05-01T02:00:00Z",
-      items_promoted: 3,
+      processed: {
+        "2026-05-01": {
+          mtime_ms: 1,
+          size: 1,
+          hash: "a",
+          stages_done: [...NIGHTLY_STAGES],
+          completed_at: "x",
+          status: "ok",
+        },
+      },
     });
     await saveNightlyState(workdir, {
-      last_run: "2026-05-02T02:00:00Z",
-      last_status: "ok",
+      processed: {
+        "2026-05-02": {
+          mtime_ms: 2,
+          size: 1,
+          hash: "b",
+          stages_done: [...NIGHTLY_STAGES],
+          completed_at: "y",
+          status: "ok",
+        },
+      },
     });
     const r = await loadNightlyState(workdir);
-    expect(r.last_run).toBe("2026-05-02T02:00:00Z");
-    expect(r.last_status).toBe("ok");
-    // items_promoted from the first save is preserved.
-    expect(r.items_promoted).toBe(3);
+    expect(Object.keys(r.processed ?? {}).sort()).toEqual([
+      "2026-05-01",
+      "2026-05-02",
+    ]);
   });
 
-  test("malformed JSON falls back to {} (logs warn but doesn't throw)", async () => {
-    await writeFile(nightlyStatePath(workdir), "not json", "utf8");
-    expect(await loadNightlyState(workdir)).toEqual({});
+  test("current: null clears the in-flight marker", async () => {
+    await saveNightlyState(workdir, {
+      current: {
+        date: "2026-05-02",
+        index: 1,
+        total: 1,
+        started_at: "x",
+        updated_at: "x",
+      },
+    });
+    await saveNightlyState(workdir, { current: null });
+    expect((await loadNightlyState(workdir)).current).toBeUndefined();
   });
 });
 
-describe("buildNightlyPrompt", () => {
-  test("embeds the persona name + today + isolation note", () => {
-    const p = buildNightlyPrompt("kai", "2026-05-02");
-    expect(p).toContain("persona 'kai'");
-    expect(p).toContain("Processing date: 2026-05-02");
-    expect(p).toContain("system:nightly:2026-05-02");
-    expect(p).toContain("ISOLATED");
-    expect(p).toContain("PHASE 1");
-    expect(p).toContain("PHASE 5");
+describe("sweepDailyFiles", () => {
+  test("every daily file is pending on a virgin ledger, oldest first", async () => {
+    await daily("2026-05-01");
+    await daily("2026-05-03");
+    await daily("2026-05-02");
+    const r = await sweepDailyFiles(workdir, {}, "2026-06-01");
+    expect(r.pending.map((p) => p.date)).toEqual([
+      "2026-05-01",
+      "2026-05-02",
+      "2026-05-03",
+    ]);
+    expect(r.pending.every((p) => p.reason === "new")).toBe(true);
   });
 
-  test("references all five phases in order", () => {
-    const p = buildNightlyPrompt("x", "2026-01-01");
-    const phase1 = p.indexOf("PHASE 1");
-    const phase5 = p.indexOf("PHASE 5");
-    expect(phase1).toBeGreaterThan(0);
-    expect(phase5).toBeGreaterThan(phase1);
-    for (let i = 2; i <= 4; i++) {
-      const idx = p.indexOf(`PHASE ${i}`);
-      expect(idx).toBeGreaterThan(phase1);
-      expect(idx).toBeLessThan(phase5);
+  // The point of the ledger: a second sweep with nothing new does no work.
+  test("a processed, unchanged date is skipped", async () => {
+    await daily("2026-05-01");
+    await markProcessed("2026-05-01");
+    const r = await sweepDailyFiles(workdir, await loadNightlyState(workdir), "2026-06-01");
+    expect(r.pending).toEqual([]);
+    expect(r.seen).toEqual(["2026-05-01"]);
+  });
+
+  // A day can keep receiving captures AFTER its pass (the heartbeat and
+  // `memory capture` both append). Content growth must re-queue it — this is
+  // the case a "rename to _processed_" scheme could never see.
+  test("a date whose content grew after processing is pending again", async () => {
+    await daily("2026-05-01");
+    await markProcessed("2026-05-01");
+    await writeFile(dailyFilePath(workdir, "2026-05-01"), "more content", "utf8");
+    const r = await sweepDailyFiles(workdir, await loadNightlyState(workdir), "2026-06-01");
+    expect(r.pending.map((p) => p.date)).toEqual(["2026-05-01"]);
+    expect(r.pending[0]!.reason).toBe("changed");
+  });
+
+  // mtime moved but bytes identical (a touch, a restore, a copy): no turn is
+  // spent, the ledger's mtime is just refreshed so the cheap path resumes.
+  test("a touched-but-identical file is 'touched', not pending", async () => {
+    await daily("2026-05-01");
+    await markProcessed("2026-05-01");
+    const future = new Date(Date.now() + 10_000);
+    await utimes(dailyFilePath(workdir, "2026-05-01"), future, future);
+    const r = await sweepDailyFiles(workdir, await loadNightlyState(workdir), "2026-06-01");
+    expect(r.pending).toEqual([]);
+    expect(r.touched.map((t) => t.date)).toEqual(["2026-05-01"]);
+  });
+
+  // Today is still being written to. Distilling it would file drawers from a
+  // half-finished file, and its hash would change minutes later anyway.
+  test("the boundary date is exclusive — today is never swept", async () => {
+    await daily("2026-05-01");
+    await daily("2026-05-02");
+    const r = await sweepDailyFiles(workdir, {}, "2026-05-02");
+    expect(r.pending.map((p) => p.date)).toEqual(["2026-05-01"]);
+  });
+
+  test("non-daily files in memory/ are ignored", async () => {
+    await daily("2026-05-01");
+    await writeFile(join(workdir, "memory", "decisions.md"), "x", "utf8");
+    await writeFile(join(workdir, "memory", "2026-05.md"), "x", "utf8");
+    const r = await sweepDailyFiles(workdir, {}, "2026-06-01");
+    expect(r.pending.map((p) => p.date)).toEqual(["2026-05-01"]);
+  });
+
+  // A pass that half-finished (one stage errored) is recorded as partial, so
+  // resume is automatic — it is simply a date the ledger doesn't call done.
+  test("a partially processed date is pending with reason 'incomplete'", async () => {
+    await daily("2026-05-01");
+    const sweep = await sweepDailyFiles(workdir, {}, "2026-06-01");
+    await saveNightlyState(workdir, {
+      processed: {
+        "2026-05-01": dateRecord(sweep.pending[0]!, ["distill"], "kb blew up"),
+      },
+    });
+    const r = await sweepDailyFiles(workdir, await loadNightlyState(workdir), "2026-06-01");
+    expect(r.pending.map((p) => p.reason)).toEqual(["incomplete"]);
+  });
+
+  test("missing memory dir yields an empty sweep", async () => {
+    const empty = await mkdtemp(join(tmpdir(), "phantombot-nightly-empty-"));
+    try {
+      expect(await sweepDailyFiles(empty, {}, "2026-06-01")).toEqual({
+        pending: [],
+        touched: [],
+        seen: [],
+      });
+    } finally {
+      await rm(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("pendingForDate", () => {
+  test("returns an entry for an existing daily file, ledger ignored", async () => {
+    await daily("2026-05-01");
+    await markProcessed("2026-05-01");
+    const p = await pendingForDate(workdir, "2026-05-01");
+    expect(p?.date).toBe("2026-05-01");
+    expect(p?.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("returns null when there is no daily file", async () => {
+    expect(await pendingForDate(workdir, "2026-05-09")).toBeNull();
+  });
+});
+
+describe("dateRecord", () => {
+  test("all stages, no error → ok", async () => {
+    await daily("2026-05-01");
+    const p = (await sweepDailyFiles(workdir, {}, "2026-06-01")).pending[0]!;
+    const rec = dateRecord(p, [...NIGHTLY_STAGES]);
+    expect(rec.status).toBe("ok");
+    expect(rec.hash).toBe(p.hash);
+    expect(rec.mtime_ms).toBe(p.mtime_ms);
+  });
+
+  test("some stages + error → partial; no stages + error → error", async () => {
+    await daily("2026-05-01");
+    const p = (await sweepDailyFiles(workdir, {}, "2026-06-01")).pending[0]!;
+    expect(dateRecord(p, ["distill"], "boom").status).toBe("partial");
+    expect(dateRecord(p, [], "boom").status).toBe("error");
+  });
+});
+
+describe("nightlyHealth", () => {
+  const now = new Date("2026-05-10T09:00:00Z");
+
+  test("nothing pending → ok", async () => {
+    await daily("2026-05-01");
+    await markProcessed("2026-05-01");
+    const h = await nightlyHealth(workdir, { now });
+    expect(h.status).toBe("ok");
+    expect(h.backlog).toBe(0);
+  });
+
+  // Explicitly schedule-blind: a laptop asleep at 02:00 that swept on boot is
+  // just as healthy as a server that swept on the timer. Backlog is the truth.
+  test("a long-idle ledger with nothing pending is still ok", async () => {
+    await saveNightlyState(workdir, {
+      last_run: "2026-01-01T02:00:00Z",
+      last_status: "ok",
+    });
+    expect((await nightlyHealth(workdir, { now })).status).toBe("ok");
+  });
+
+  test("1–3 pending dates → warning", async () => {
+    await daily("2026-05-01");
+    await daily("2026-05-02");
+    const h = await nightlyHealth(workdir, { now });
+    expect(h.status).toBe("warning");
+    expect(h.backlog).toBe(2);
+    expect(h.oldest_pending).toBe("2026-05-01");
+    expect(h.detail).toContain("2 dates pending");
+  });
+
+  test("more than 3 pending dates → error", async () => {
+    for (const d of ["01", "02", "03", "04"]) await daily(`2026-05-${d}`);
+    const h = await nightlyHealth(workdir, { now });
+    expect(h.status).toBe("error");
+    expect(h.detail).toContain("4 dates unprocessed");
+  });
+
+  test("an in-flight sweep with a fresh beat → running with progress", async () => {
+    await daily("2026-05-01");
+    await saveNightlyState(workdir, {
+      current: {
+        date: "2026-05-01",
+        index: 2,
+        total: 5,
+        started_at: "2026-05-10T08:55:00Z",
+        updated_at: "2026-05-10T08:59:00Z",
+      },
+    });
+    const h = await nightlyHealth(workdir, { now });
+    expect(h.status).toBe("running");
+    expect(h.detail).toBe("2/5 dates, on 2026-05-01");
+  });
+
+  // A crashed sweep leaves its marker behind. Without staleness detection
+  // /status would report RUNNING forever and the backlog would look attended.
+  test("an in-flight marker older than STALE_RUN_MS → error", async () => {
+    await daily("2026-05-01");
+    await saveNightlyState(workdir, {
+      current: {
+        date: "2026-05-01",
+        index: 1,
+        total: 1,
+        started_at: "2026-05-10T07:00:00Z",
+        updated_at: new Date(now.getTime() - STALE_RUN_MS - 1000).toISOString(),
+      },
+    });
+    const h = await nightlyHealth(workdir, { now });
+    expect(h.status).toBe("error");
+    expect(h.detail).toContain("stalled");
+  });
+
+  test("last sweep errored → error even with an empty backlog", async () => {
+    const state: NightlyState = {
+      last_run: "2026-05-10T02:00:00Z",
+      last_status: "error",
+      errors: ["stage 'kb' (2026-05-01): timed out"],
+    };
+    await saveNightlyState(workdir, state);
+    const h = await nightlyHealth(workdir, { now });
+    expect(h.status).toBe("error");
+    expect(h.detail).toContain("timed out");
+  });
+
+  test("a date recorded partial → warning once its backlog is drained", async () => {
+    // File processed with one stage failing, then reprocessed successfully is
+    // the happy path; a lingering partial record with no pending work is the
+    // "it finished, but not cleanly" state.
+    await saveNightlyState(workdir, {
+      last_status: "ok",
+      processed: {
+        "2026-05-01": {
+          mtime_ms: 1,
+          size: 1,
+          hash: "a",
+          stages_done: ["distill"],
+          completed_at: "2026-05-02T02:00:00Z",
+          status: "partial",
+          error: "kb blew up",
+        },
+      },
+    });
+    expect((await nightlyHealth(workdir, { now })).status).toBe("warning");
+  });
+});
+
+describe("buildNightlyStagePrompt", () => {
+  test("there are exactly two stages: distill and kb", () => {
+    expect([...NIGHTLY_STAGES]).toEqual(["distill", "kb"]);
+  });
+
+  test("embeds persona, date and the isolation note", () => {
+    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "distill");
+    expect(p).toContain("persona 'robbie'");
+    expect(p).toContain("system:nightly:2026-05-18");
+  });
+
+  // The daily file is the ledger's hash input. A stage that writes to it (the
+  // old "day essence" header did) makes the date look changed forever, so the
+  // pass would re-run that day on every single sweep.
+  test("every stage is told never to write to the daily file", () => {
+    for (const s of NIGHTLY_STAGES) {
+      const p = buildNightlyStagePrompt("robbie", "2026-05-18", s);
+      expect(p).toContain("NEVER write to memory/2026-05-18.md");
     }
   });
 
-  test("references the phantombot memory tools the harness must call", () => {
-    const p = buildNightlyPrompt("x", "2026-01-01");
-    expect(p).toContain("phantombot memory get memory/2026-01-01.md");
-    expect(p).toContain("phantombot memory search");
-    expect(p).toContain("phantombot memory get");
-    expect(p).toContain("phantombot memory index --rebuild");
-  });
-});
-
-describe("shouldRunCatchupNightly", () => {
-  test("returns true when no state file exists", async () => {
-    expect(await shouldRunCatchupNightly(workdir)).toBe(true);
+  // Index refresh is deterministic work; it now runs in code after the join.
+  // Leaving it in the prompt would race the sibling stage's writes.
+  test("no stage asks the model to run the index", () => {
+    for (const s of NIGHTLY_STAGES) {
+      const p = buildNightlyStagePrompt("robbie", "2026-05-18", s);
+      expect(p).not.toContain("memory index --rebuild");
+      expect(p).toContain("Do NOT run `phantombot memory index`");
+    }
   });
 
-  test("returns true when last_run is more than 24h ago", async () => {
-    const old = new Date(Date.now() - CATCHUP_WINDOW_MS - 60_000);
-    await saveNightlyState(workdir, {
-      last_run: old.toISOString(),
-    });
-    expect(await shouldRunCatchupNightly(workdir)).toBe(true);
+  test("the stages declare disjoint write targets so they can run concurrently", () => {
+    const distill = buildNightlyStagePrompt("robbie", "2026-05-18", "distill");
+    const kb = buildNightlyStagePrompt("robbie", "2026-05-18", "kb");
+    expect(distill).toContain("do not touch kb/");
+    expect(kb).toContain("do not\ntouch memory/ files");
   });
 
-  test("returns false when last_run is within the last 24h", async () => {
-    const recent = new Date(Date.now() - 60_000); // 1 minute ago
-    await saveNightlyState(workdir, {
-      last_run: recent.toISOString(),
-    });
-    expect(await shouldRunCatchupNightly(workdir)).toBe(false);
+  test("distill fills AND trims MEMORY.md, and files the drawers", () => {
+    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "distill");
+    expect(p).toContain("memory/decisions.md");
+    expect(p).toContain("memory/commitments.md");
+    expect(p).toContain("FILL");
+    expect(p).toContain("TRIM");
+    expect(p).toContain("## Recent");
   });
 
-  test("returns true when last_run is unparseable", async () => {
-    // Write malformed last_run directly (bypass saveNightlyState which uses Date.toISOString)
-    await writeFile(
-      nightlyStatePath(workdir),
-      JSON.stringify({ last_run: "not-a-date" }, null, 2) + "\n",
-      "utf8",
-    );
-    expect(await shouldRunCatchupNightly(workdir)).toBe(true);
+  // The KB stage must RECONCILE, not append: a note that became wrong has to
+  // stop being served as current truth while surviving as changelog history.
+  test("kb instructs supersession, not just append", () => {
+    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "kb");
+    expect(p).toContain("RECONCILE");
+    expect(p).toMatch(/CONTRADICTS|INVALIDATES/);
+    expect(p).toContain("## Changelog");
+    expect(p).toContain("status: obsolete");
+    expect(p).toContain("2026-05-18: was X → now Y");
   });
 
-  test("returns false exactly at the window boundary", async () => {
-    // Pin Date.now() so the boundary check is deterministic — without this,
-    // elapsed time between the two Date.now() calls (here vs inside
-    // shouldRunCatchupNightly) pushes `now - lastRun` past CATCHUP_WINDOW_MS
-    // and the strict `>` comparison flips true.
-    const fixedNow = Date.now();
-    const origNow = Date.now;
-    Date.now = () => fixedNow;
-    try {
-      const atBoundary = new Date(fixedNow - CATCHUP_WINDOW_MS);
-      await saveNightlyState(workdir, {
-        last_run: atBoundary.toISOString(),
-      });
-      // Exactly at boundary: still within window (strictly greater than)
-      expect(await shouldRunCatchupNightly(workdir)).toBe(false);
-    } finally {
-      Date.now = origNow;
+  test("no stage mentions the removed day-essence header", () => {
+    for (const s of NIGHTLY_STAGES) {
+      expect(
+        buildNightlyStagePrompt("robbie", "2026-05-18", s),
+      ).not.toContain("Day essence");
     }
   });
 });
 
 describe("buildNightlyPromptForPersona — override", () => {
-  test("returns the built-in prompt when no override file exists", async () => {
+  test("falls back to the built-in monolithic prompt with both stages", async () => {
     const built = await buildNightlyPromptForPersona(
       workdir,
       "kai",
       "2026-05-02",
     );
-    expect(built).toContain("PHASE 5");
     expect(built).toContain("persona 'kai'");
+    expect(built).toContain("STAGE: DISTILL");
+    expect(built).toContain("STAGE: KB");
   });
 
   test("uses the override file with {{persona}} / {{today}} substitution", async () => {
@@ -188,135 +453,13 @@ describe("buildNightlyPromptForPersona — override", () => {
       "Hey {{persona}}, today is {{today}}. Do the thing.",
       "utf8",
     );
-    const built = await buildNightlyPromptForPersona(
-      workdir,
-      "robbie",
-      "2026-05-02",
-    );
-    expect(built).toBe("Hey robbie, today is 2026-05-02. Do the thing.");
-  });
-});
-
-describe("nightly checkpoint — progress file", () => {
-  test("loadNightlyProgress returns null when no file exists", async () => {
-    expect(await loadNightlyProgress(workdir)).toBeNull();
+    expect(
+      await buildNightlyPromptForPersona(workdir, "robbie", "2026-05-02"),
+    ).toBe("Hey robbie, today is 2026-05-02. Do the thing.");
   });
 
-  test("save then load round-trips", async () => {
-    const progress: NightlyProgress = {
-      date: "2026-05-18",
-      started_at: "2026-05-18T02:00:00.000Z",
-      updated_at: "2026-05-18T02:03:00.000Z",
-      completed_stages: ["essence", "promote"],
-      status: "in_progress",
-    };
-    await saveNightlyProgress(workdir, progress);
-    expect(await loadNightlyProgress(workdir)).toEqual(progress);
-  });
-
-  test("clearNightlyProgress removes the file", async () => {
-    await saveNightlyProgress(workdir, {
-      date: "2026-05-18",
-      started_at: "x",
-      updated_at: "x",
-      completed_stages: [],
-      status: "in_progress",
-    });
-    await clearNightlyProgress(workdir);
-    expect(await loadNightlyProgress(workdir)).toBeNull();
-  });
-
-  test("clearNightlyProgress is a no-op when there is no file", async () => {
-    await clearNightlyProgress(workdir); // must not throw
-    expect(await loadNightlyProgress(workdir)).toBeNull();
-  });
-});
-
-describe("pendingNightlyStages", () => {
-  test("returns every stage when resume is false", async () => {
-    expect(await pendingNightlyStages(workdir, "2026-05-18", false)).toEqual([
-      ...NIGHTLY_STAGES,
-    ]);
-  });
-
-  test("returns every stage when resume is true but no checkpoint", async () => {
-    expect(await pendingNightlyStages(workdir, "2026-05-18", true)).toEqual([
-      ...NIGHTLY_STAGES,
-    ]);
-  });
-
-  test("skips completed stages when checkpoint matches today", async () => {
-    await saveNightlyProgress(workdir, {
-      date: "2026-05-18",
-      started_at: "x",
-      updated_at: "x",
-      completed_stages: ["essence", "promote"],
-      status: "partial",
-    });
-    expect(await pendingNightlyStages(workdir, "2026-05-18", true)).toEqual([
-      "kb",
-      "compress",
-      "state",
-    ]);
-  });
-
-  test("ignores a stale checkpoint from a different date", async () => {
-    await saveNightlyProgress(workdir, {
-      date: "2026-05-17",
-      started_at: "x",
-      updated_at: "x",
-      completed_stages: ["essence", "promote", "kb"],
-      status: "partial",
-    });
-    expect(await pendingNightlyStages(workdir, "2026-05-18", true)).toEqual([
-      ...NIGHTLY_STAGES,
-    ]);
-  });
-});
-
-describe("buildNightlyStagePrompt", () => {
-  test("embeds persona, date and the isolation/checkpoint notes", () => {
-    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "essence");
-    expect(p).toContain("persona 'robbie'");
-    expect(p).toContain("2026-05-18");
-    expect(p).toContain("CHECKPOINTED");
-    expect(p).toContain("system:nightly:2026-05-18");
-  });
-
-  test("each stage carries its own distinct instruction body", () => {
-    const bodies = NIGHTLY_STAGES.map((s) =>
-      buildNightlyStagePrompt("robbie", "2026-05-18", s),
-    );
-    expect(bodies[0]).toContain("DAY ESSENCE");
-    expect(bodies[1]).toContain("PROMOTE TO DRAWERS");
-    expect(bodies[2]).toContain("FEED THE KB");
-    expect(bodies[3]).toContain("MAINTAIN MEMORY.md");
-    expect(bodies[4]).toContain("STATE REPORT");
-  });
-
-  // Issue #181 §4: MEMORY.md was never populated because the old stage only
-  // ever TRIMMED. The maintain stage must also instruct the agent to FILL the
-  // "## Recent" orientation section, otherwise MEMORY.md stays at template.
-  test("the MEMORY.md stage instructs filling, not only trimming", () => {
-    const body = buildNightlyStagePrompt("robbie", "2026-05-18", "compress");
-    expect(body).toContain("FILL");
-    expect(body).toContain("## Recent");
-    expect(body).toMatch(/maintain/i);
-    // and still keeps the trim half
-    expect(body).toContain("TRIM");
-  });
-
-  // The KB stage used to be purely additive ("open and update it"), so a note
-  // that became WRONG (subject decommissioned / assumption invalidated) kept the
-  // stale claim standing next to the new one. It must now RECONCILE: rewrite to
-  // current truth, leave a dated changelog trail, and mark dead subjects obsolete.
-  test("the KB stage instructs supersession, not just append", () => {
-    const body = buildNightlyStagePrompt("robbie", "2026-05-18", "kb");
-    expect(body).toContain("RECONCILE");
-    expect(body).toMatch(/CONTRADICTS|INVALIDATES/);
-    expect(body).toContain("## Changelog");
-    expect(body).toContain("status: obsolete");
-    // the changelog instruction is dated with the run's date (today binding)
-    expect(body).toContain("2026-05-18: was X → now Y");
+  test("buildNightlyPrompt runs both stages in one turn", () => {
+    const p = buildNightlyPrompt("robbie", "2026-05-18");
+    expect(p).toContain("Run BOTH stages below");
   });
 });

--- a/tests/lib-nightlyTrigger.test.ts
+++ b/tests/lib-nightlyTrigger.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for day-rollover detection — the trigger that replaced the 02:00
+ * nightly timer.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { dailyFileDate, dayRolledOver } from "../src/lib/nightlyTrigger.ts";
+
+describe("dailyFileDate", () => {
+  test("uses the same basis the daily-file writer uses (UTC)", () => {
+    // `memory capture` names files from toISOString(), so rollover detection
+    // has to agree with that boundary or it would fire while the day it is
+    // about to process is still being appended to.
+    const at = new Date("2026-06-01T23:30:00Z");
+    expect(dailyFileDate(at)).toBe("2026-06-01");
+    expect(dailyFileDate(new Date("2026-06-02T00:00:00Z"))).toBe("2026-06-02");
+  });
+});
+
+describe("dayRolledOver", () => {
+  test("true when the previous fire was on an earlier day", () => {
+    expect(
+      dayRolledOver("2026-06-01T23:45:00Z", new Date("2026-06-02T00:15:00Z")),
+    ).toBe(true);
+  });
+
+  test("false within the same day, even 23 hours apart", () => {
+    expect(
+      dayRolledOver("2026-06-01T00:30:00Z", new Date("2026-06-01T23:30:00Z")),
+    ).toBe(false);
+  });
+
+  test("false with no marker — startup already swept, don't double up", () => {
+    expect(dayRolledOver(undefined, new Date("2026-06-02T00:15:00Z"))).toBe(
+      false,
+    );
+  });
+
+  test("false on an unparseable marker rather than firing blind", () => {
+    expect(dayRolledOver("not-a-date", new Date("2026-06-02T00:15:00Z"))).toBe(
+      false,
+    );
+  });
+
+  test("false when the clock stepped backwards (NTP fix, restored snapshot)", () => {
+    // Previous fire recorded in the future: nothing has closed, so nothing to
+    // distil. Firing here would process a day that is still open.
+    expect(
+      dayRolledOver("2026-06-03T10:00:00Z", new Date("2026-06-02T09:00:00Z")),
+    ).toBe(false);
+  });
+
+  test("true across a multi-day gap (box was powered off for a week)", () => {
+    expect(
+      dayRolledOver("2026-05-26T09:00:00Z", new Date("2026-06-02T09:00:00Z")),
+    ).toBe(true);
+  });
+});

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -192,8 +193,6 @@ describe("installPhantombotUnit", () => {
       ["--user", "start", "phantombot.service"],
       ["--user", "enable", "phantombot-heartbeat.timer"],
       ["--user", "start", "phantombot-heartbeat.timer"],
-      ["--user", "enable", "phantombot-nightly.timer"],
-      ["--user", "start", "phantombot-nightly.timer"],
       ["--user", "enable", "phantombot-tick.timer"],
       ["--user", "start", "phantombot-tick.timer"],
     ]);
@@ -278,13 +277,11 @@ describe("ensureSystemdUnitsCurrent", () => {
     expect(r.rewrote).toEqual([]);
     expect(r.backups).toEqual([]);
     expect(r.repairedTimers).toEqual([]);
-    // No daemon-reload, no enable, no start — only the 6 inspect calls
-    // (is-enabled + is-active for each of the 3 timers).
+    // No daemon-reload, no enable, no start — only the 4 inspect calls
+    // (is-enabled + is-active for each of the 2 timers).
     expect(sys.calls).toEqual([
       ["--user", "is-enabled", "phantombot-heartbeat.timer"],
       ["--user", "is-active", "phantombot-heartbeat.timer"],
-      ["--user", "is-enabled", "phantombot-nightly.timer"],
-      ["--user", "is-active", "phantombot-nightly.timer"],
       ["--user", "is-enabled", "phantombot-tick.timer"],
       ["--user", "is-active", "phantombot-tick.timer"],
     ]);
@@ -302,10 +299,6 @@ describe("ensureSystemdUnitsCurrent", () => {
       { exitCode: 1, stdout: "disabled\n", stderr: "" },
       { exitCode: 3, stdout: "inactive\n", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" },
-      // nightly
-      { exitCode: 1, stdout: "disabled\n", stderr: "" },
-      { exitCode: 3, stdout: "inactive\n", stderr: "" },
-      { exitCode: 0, stdout: "", stderr: "" },
       // tick
       { exitCode: 1, stdout: "disabled\n", stderr: "" },
       { exitCode: 3, stdout: "inactive\n", stderr: "" },
@@ -320,8 +313,6 @@ describe("ensureSystemdUnitsCurrent", () => {
       [
         "phantombot-heartbeat.service",
         "phantombot-heartbeat.timer",
-        "phantombot-nightly.service",
-        "phantombot-nightly.timer",
         "phantombot-tick.service",
         "phantombot-tick.timer",
         "phantombot.service",
@@ -330,7 +321,6 @@ describe("ensureSystemdUnitsCurrent", () => {
     expect(r.backups).toEqual([]); // nothing pre-existing to back up
     expect(r.repairedTimers).toEqual([
       "phantombot-heartbeat.timer",
-      "phantombot-nightly.timer",
       "phantombot-tick.timer",
     ]);
     // Verify each canonical body landed on disk.
@@ -388,9 +378,6 @@ describe("ensureSystemdUnitsCurrent", () => {
       isEnabledActive(),
       { exitCode: 3, stdout: "inactive\n", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" },
-      // nightly OK
-      isEnabledActive(),
-      isActiveActive(),
       // tick OK
       isEnabledActive(),
       isActiveActive(),
@@ -431,9 +418,6 @@ describe("ensureSystemdUnitsCurrent", () => {
       isEnabledActive(),
       isActiveActive(),
       { exitCode: 0, stdout: "", stderr: "" }, // restart
-      // nightly OK, not in the force set → left alone
-      isEnabledActive(),
-      isActiveActive(),
       // tick OK, not in the force set → left alone
       isEnabledActive(),
       isActiveActive(),
@@ -485,9 +469,6 @@ describe("ensureSystemdUnitsCurrent", () => {
       isEnabledActive(),
       isActiveActive(),
       { exitCode: 0, stdout: "", stderr: "" }, // restart
-      // nightly: unchanged, enabled + active → left alone
-      isEnabledActive(),
-      isActiveActive(),
       // tick: unchanged, enabled + active → left alone
       isEnabledActive(),
       isActiveActive(),
@@ -505,11 +486,6 @@ describe("ensureSystemdUnitsCurrent", () => {
       "--user",
       "restart",
       "phantombot-heartbeat.timer",
-    ]);
-    expect(sys.calls).not.toContainEqual([
-      "--user",
-      "restart",
-      "phantombot-nightly.timer",
     ]);
     expect(sys.calls).not.toContainEqual([
       "--user",
@@ -534,9 +510,6 @@ describe("ensureSystemdUnitsCurrent", () => {
       isEnabledActive(),
       { exitCode: 3, stdout: "inactive\n", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" }, // enable --now
-      // nightly OK
-      isEnabledActive(),
-      isActiveActive(),
       // tick OK
       isEnabledActive(),
       isActiveActive(),
@@ -559,6 +532,68 @@ describe("ensureSystemdUnitsCurrent", () => {
       "restart",
       "phantombot-heartbeat.timer",
     ]);
+  });
+
+  test("never generates the retired nightly units", () => {
+    const targets = phantombotUnitTargets("/usr/local/bin/phantombot");
+    expect(targets.map((t) => t.unit)).toEqual([
+      "phantombot.service",
+      "phantombot-heartbeat.service",
+      "phantombot-heartbeat.timer",
+      "phantombot-tick.service",
+      "phantombot-tick.timer",
+    ]);
+  });
+
+  test("tears down a nightly timer left behind by an older install", async () => {
+    // The upgrade case: unit files from a pre-retirement install are on disk
+    // and the timer is armed at 02:00. The heal must stop + disable + delete
+    // it, or the box keeps firing a redundant sweep forever.
+    const bin = "/usr/local/bin/phantombot";
+    await writeFile(ngServicePath, "[Service]\nExecStart=old nightly\n", "utf8");
+    await writeFile(ngTimerPath, "[Timer]\nOnCalendar=*-*-* 02:00:00\n", "utf8");
+    const sys = new FakeSystemctl();
+
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+    });
+
+    expect(r.removedRetired.sort()).toEqual([
+      "phantombot-nightly.service",
+      "phantombot-nightly.timer",
+    ]);
+    expect(existsSync(ngTimerPath)).toBe(false);
+    expect(existsSync(ngServicePath)).toBe(false);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "stop",
+      "phantombot-nightly.timer",
+    ]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "disable",
+      "phantombot-nightly.timer",
+    ]);
+    // The removal itself justifies a daemon-reload even if no unit drifted.
+    expect(sys.calls).toContainEqual(["--user", "daemon-reload"]);
+  });
+
+  test("costs zero systemctl calls when no retired unit is on disk", async () => {
+    // This runs on EVERY heartbeat, so the common case (nothing to clean up)
+    // must not talk to systemd at all.
+    const bin = "/usr/local/bin/phantombot";
+    const sys = new FakeSystemctl();
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+    });
+    expect(r.removedRetired).toEqual([]);
+    expect(
+      sys.calls.filter((c) => c.some((a) => a.includes("nightly"))),
+    ).toEqual([]);
   });
 });
 

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -17,7 +17,6 @@ import {
   defaultTaskSchedulerServiceControl,
   ensureTasksCurrent,
   generateHeartbeatTaskXml,
-  generateNightlyTaskXml,
   generatePhantombotTaskXml,
   generateTickTaskXml,
   daemonKillOrder,
@@ -247,15 +246,6 @@ describe("companion task schedules", () => {
     expect(xml).not.toContain("<RestartOnFailure>");
   });
 
-  test("nightly fires daily at 02:00 (calendar trigger)", () => {
-    const xml = generateNightlyTaskXml(SID, BIN, PERSONA);
-    expect(xml).toContain(`<URI>${NAMES.nightly}</URI>`);
-    expect(xml).toContain("<CalendarTrigger>");
-    expect(xml).toContain("<ScheduleByDay>");
-    expect(xml).toContain("<DaysInterval>1</DaysInterval>");
-    expect(xml).toContain("2020-01-01T02:00:00");
-  });
-
   test("tick repeats every minute", () => {
     const xml = generateTickTaskXml(SID, BIN, PERSONA);
     expect(xml).toContain(`<URI>${NAMES.tick}</URI>`);
@@ -272,7 +262,7 @@ describe("XML escaping", () => {
 });
 
 describe("installPhantombotTasks", () => {
-  test("imports all four tasks with /F, in main→companions order", async () => {
+  test("imports the three live tasks with /F, in main→companions order", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     const st = new FakeSchtasks();
@@ -296,10 +286,11 @@ describe("installPhantombotTasks", () => {
       `/Create /TN ${NAMES.main} /XML ${join(workdir, "phantombot-task-phantombot.xml")} /F`,
       `/Query /TN ${NAMES.heartbeat} /XML`,
       `/Create /TN ${NAMES.heartbeat} /XML ${join(workdir, "phantombot-task-heartbeat.xml")} /F`,
-      `/Query /TN ${NAMES.nightly} /XML`,
-      `/Create /TN ${NAMES.nightly} /XML ${join(workdir, "phantombot-task-nightly.xml")} /F`,
       `/Query /TN ${NAMES.tick} /XML`,
       `/Create /TN ${NAMES.tick} /XML ${join(workdir, "phantombot-task-tick.xml")} /F`,
+      // The retired 02:00 nightly task is swept on every register pass, so an
+      // upgrade can't leave a duplicate sweep armed. Absent here → probe only.
+      `/Query /TN ${NAMES.nightly} /XML`,
       // Pre-rename legacy tasks are cleaned up so an upgrade never
       // double-supervises the daemon — each is ownership-checked via its
       // exported XML before the delete.
@@ -431,7 +422,6 @@ describe("installPhantombotTasks", () => {
     expect(created).toEqual([
       NAMES.main,
       NAMES.heartbeat,
-      NAMES.nightly,
       NAMES.tick,
     ]);
   });
@@ -442,7 +432,9 @@ describe("uninstallPhantombotTasks", () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
     const st = new FakeSchtasks();
-    for (const name of [...NAMES.all, ...LEGACY_TASK_NAMES]) {
+    // NAMES.nightly is seeded explicitly: it is no longer part of NAMES.all
+    // (retired), but uninstall must still remove one an older install left.
+    for (const name of [...NAMES.all, NAMES.nightly, ...LEGACY_TASK_NAMES]) {
       st.registry[name] = principalXml(SID);
     }
     const result = await uninstallPhantombotTasks({ persona: PERSONA, sid: SID, schtasks: st, out, err });
@@ -560,7 +552,7 @@ describe("uninstallPhantombotTasks", () => {
     // deleting the persona marker.
     const out = new CaptureStream();
     const st = new FakeSchtasks();
-    for (const name of NAMES.all) {
+    for (const name of [...NAMES.all, NAMES.nightly]) {
       st.registry[name] = passwordPrincipalXml("MEGAN\\megan");
     }
     const result = await uninstallPhantombotTasks({
@@ -573,7 +565,9 @@ describe("uninstallPhantombotTasks", () => {
     });
     expect(result.removed).toBe(true);
     expect(st.calls.filter((c) => c[0] === "/Delete").length).toBe(4);
-    for (const name of NAMES.all) expect(st.registry[name]).toBeUndefined();
+    for (const name of [...NAMES.all, NAMES.nightly]) {
+      expect(st.registry[name]).toBeUndefined();
+    }
   });
 
   test("missing tasks are skipped quietly — no deletes, not fatal", async () => {
@@ -598,7 +592,6 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
     return {
       [NAMES.main]: generatePhantombotTaskXml(SID, bin, PERSONA),
       [NAMES.heartbeat]: generateHeartbeatTaskXml(SID, bin, PERSONA),
-      [NAMES.nightly]: generateNightlyTaskXml(SID, bin, PERSONA),
       [NAMES.tick]: generateTickTaskXml(SID, bin, PERSONA),
     };
   }
@@ -670,13 +663,11 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
     expect(r.rewrote).toEqual([
       NAMES.main,
       NAMES.heartbeat,
-      NAMES.nightly,
       NAMES.tick,
     ]);
     expect(st.created()).toEqual([
       NAMES.main,
       NAMES.heartbeat,
-      NAMES.nightly,
       NAMES.tick,
     ]);
   });
@@ -731,7 +722,6 @@ describe("ensureTasksCurrent (heartbeat self-heal)", () => {
     expect(r.rewrote).toEqual([
       NAMES.main,
       NAMES.heartbeat,
-      NAMES.nightly,
       NAMES.tick,
     ]);
     // The launcher is written back so the re-registered tasks can actually run.
@@ -1143,11 +1133,11 @@ describe("password logon mode (run when logged off)", () => {
     });
     expect(result.installed).toBe(true);
     const creates = st.calls.filter((c) => c[0] === "/Create");
-    // 4 password tasks + the interactive login-fallback twin = 5 registrations.
-    expect(creates.length).toBe(5);
+    // 3 password tasks + the interactive login-fallback twin = 4 registrations.
+    expect(creates.length).toBe(4);
     const loginCreate = creates.find((c) => c.includes(NAMES.login))!;
     const passwordCreates = creates.filter((c) => !c.includes(NAMES.login));
-    expect(passwordCreates.length).toBe(4);
+    expect(passwordCreates.length).toBe(3);
     for (const c of passwordCreates) {
       expect(c).toContain("/RU");
       expect(c).toContain(ACCOUNT);
@@ -1182,10 +1172,6 @@ describe("password logon mode (run when logged off)", () => {
         username: ACCOUNT,
       }),
       [NAMES.heartbeat]: generateHeartbeatTaskXml(SID, BIN, PERSONA, {
-        mode: "password",
-        username: ACCOUNT,
-      }),
-      [NAMES.nightly]: generateNightlyTaskXml(SID, BIN, PERSONA, {
         mode: "password",
         username: ACCOUNT,
       }),
@@ -1261,15 +1247,10 @@ describe("password logon mode (run when logged off)", () => {
       schtasks: st,
       patchAction: async () => ({ ok: true }),
     });
-    // The 4 password tasks can't be recreated without the credential; the
+    // The 3 password tasks can't be recreated without the credential; the
     // interactive login-fallback twin needs none, so it IS restored.
     expect(r.rewrote).toEqual([NAMES.login]);
-    expect(r.failed).toEqual([
-      NAMES.main,
-      NAMES.heartbeat,
-      NAMES.nightly,
-      NAMES.tick,
-    ]);
+    expect(r.failed).toEqual([NAMES.main, NAMES.heartbeat, NAMES.tick]);
   });
 
   test("legacy (pre persona-rename) tasks are removed on install", async () => {
@@ -1595,7 +1576,7 @@ describe("#309 cold-start recovery: `phantombot install` restores a fully-wiped 
     }
   }
 
-  test("all tasks deleted → interactive install re-registers the four-task set", async () => {
+  test("all tasks deleted → interactive install re-registers the three-task set", async () => {
     const st = new ColdStartFake();
     const result = await installPhantombotTasks({
       binPath: BIN,
@@ -1610,7 +1591,6 @@ describe("#309 cold-start recovery: `phantombot install` restores a fully-wiped 
     expect(st.created()).toEqual([
       NAMES.main,
       NAMES.heartbeat,
-      NAMES.nightly,
       NAMES.tick,
     ]);
   });
@@ -1632,7 +1612,6 @@ describe("#309 cold-start recovery: `phantombot install` restores a fully-wiped 
     expect(st.created()).toEqual([
       NAMES.main,
       NAMES.heartbeat,
-      NAMES.nightly,
       NAMES.tick,
       NAMES.login,
     ]);


### PR DESCRIPTION
## What

Collapses the nightly cognitive pass from **five sequential LLM stages to two, run in parallel**, and makes the whole pass idempotent against a ledger.

| | before | after |
|---|---|---|
| LLM turns / day | 5 sequential | 2 concurrent |
| recovery paths | `--resume`, doctor spawn, startup catch-up | none — every run sweeps what's pending |
| index refresh | a line in the KB *prompt* (`--rebuild`, every file re-embedded) | in code after the join (`refreshStale`) |
| daily files | mutated (essence header prepended) | read-only inputs |

## Why each stage went

- **essence** — every turn is embedded now; a 3-line day summary adds nothing search doesn't, and it *mutated the file the ledger hashes*, which would make every processed date look changed forever.
- **promote** — merged into `distill`; the 30-min heartbeat already does mechanical promotion, the nightly only mops up.
- **compress** — merged into `distill` (same output targets: drawers + MEMORY.md).
- **state** — was never cognitive work; the driver already writes the state file in code.
- **kb** — kept as its own turn. It's the only stage doing search → read → reconcile, and it reliably goes shallow when bundled with mechanical filing.

`distill` and `kb` write disjoint targets (drawers + MEMORY.md vs `kb/`), so they run concurrently with no lock. The one thing that *did* need ordering — the index refresh — now runs in code once both join.

## The sweep

`.nightly-state.json` gains a ledger: `date → {mtime, size, hash, stages_done, status}`. Every run reconciles the daily files against it and processes anything new, grown, or half-finished.

- No `--resume`, no `--catch-up`, no doctor repair spawn. A half-done date is just a date the ledger doesn't call done, so resume is automatic.
- Cheap: a date whose mtime+size match is skipped without reading the file. Only files that moved get hashed; a hash that matches means "touched, not changed" and costs no turn.
- A day that gains captures *after* its pass gets reprocessed — something a "rename to `_processed_`" scheme structurally can't see (and which would also break `memory capture`, whose writes are keyed on `memory/<date>.md`).
- Triggered by events, not a clock (see below), and both triggers are safe to fire redundantly.

Daily files are untouched: no renames, no prefixes, no deletion.

## No more 02:00 timer

The nightly unit is **deleted from all three backends** (systemd, launchd, Windows Task Scheduler). A clock is the wrong trigger for a pass whose job is "distil the day that just closed" — a box asleep at 02:00 misses it entirely. Two events that already happen replace it:

1. **startup** — `phantombot run` fires a detached sweep (laptops, anything that was powered off).
2. **day rollover** — the 30-min heartbeat reads its own last-fired marker before overwriting it; when the calendar day has changed since the previous fire, yesterday's daily file has closed, so it spawns a sweep. Worst-case latency is one heartbeat interval.

Rollover *detection*, not a file-creation watch: a daily file is created lazily on the first capture of the day, so on a quiet day it may never exist at all and a creation hook would silently starve. The day changing is unconditional. `dailyFileDate` deliberately uses the same (UTC) basis as the daily-file writer, so the trigger can't fire while the day it is about to process is still being appended to.

Upgrade path: the retired unit names survive only as a cleanup list. The heal path (every heartbeat) stops, disables and deletes `phantombot-nightly.timer` / the launchd agent / the scheduled task if an older install left one armed — guarded on the unit being present, so a current install costs zero extra IPC. `doctor` no longer expects or repairs it.

## `/status`

```
dreaming: OK (nothing pending)
dreaming: RUNNING (2/5 dates, on 2026-06-02)
dreaming: WARN (2 dates pending, oldest 2026-06-02)
dreaming: ERR (1 date pending, no sweep since 2026-05-28T02:00:00Z)
```

Backlog is the only truth — **schedule is irrelevant**. A laptop that swept on boot at 09:15 reports OK, as long as nothing is pending. A crashed sweep leaves an in-flight marker that goes stale after 45 min and reports ERR rather than RUNNING forever. `doctor` reports the same signal, read-only.

**Depth is not a fault.** A backlog of any size is queued work, and one sweep takes the whole queue, so it reads WARN while it drains — a backfill shouldn't make `/status` scream for a week. ERR is reserved for a backlog that is *stagnant*: dates pending and no sweep in over 24h, meaning the trigger is dead rather than merely behind. A never-swept ledger stays WARN, since that's a fresh install and `run` stamps `last_run` within a minute of coming up.

## Bounds and safety

- **No per-run cap.** A sweep drains the entire backlog in one pass — a first run over months of history is one long night rather than a queue that reappears every morning. `--max-dates N` bounds a manual run; whatever it leaves stays pending in the ledger.
- In-flight marker prevents two sweeps double-filing the same drawers; a stale one is taken over, not obeyed (`--force` to override).
- `--date <YYYY-MM-DD>` still reprocesses one day on demand.

## Tests

`bun test` green (2809 pass / 0 fail), `tsc --noEmit` clean. New coverage: sweep semantics (new / changed / touched / incomplete / today-excluded), ledger merge, health state machine including the stalled-marker case, deep-backlog-is-WARN, stagnant-backlog-is-ERR and never-swept-is-WARN, stage concurrency, index-refresh ordering and its failure path, uncapped drain plus `--max-dates` bounding, the in-flight lock, prompt invariants (no stage writes the daily file, no stage runs the index), and the rollover trigger — fires across a day boundary, stays quiet within a day, stays quiet with no marker (startup already swept) or a backwards clock step, and a spawn failure never fails the heartbeat. Backend suites assert the retired unit is never generated and that a leftover one is torn down.
