### PR TITLE
fix(nightly): scope harness turns to the persona dir, ending the macOS TCC re-prompt loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ phantombot/
 - **Env bootstrap** (`lib/envBootstrap.ts`) self-sources the `.env` files at startup (required on macOS, no-op on Linux) and re-sources before each harness spawn so `phantombot env set` takes effect mid-session.
 - **Tick fires scheduled tasks** (`src/cli/tick.ts`); 1-minute systemd timer; lockfile prevents overlap; missed runs are skipped, not piled up.
 - **Heartbeat is mechanical** (no LLM); **nightly is cognitive** (LLM-driven distillation).
+- **`workingDir` is REQUIRED on every `runTurn` call** (#387) — the harness subprocess cwd, deliberately with no default. Interactive surfaces (telegram, phantomchat, ask, tick, reactions) pass `homedir()`, because the owner asks for work on repos all over their home dir. Machine-driven background turns (nightly) pass the **persona dir**. This used to silently default to `homedir()` and every background caller took the default, so nightly stages woke up in `$HOME` unable to see their own `memory/` from cwd — and went hunting for it. On macOS those recursive walks cross `~/Library/Containers`, tripping the TCC `kTCCServiceSystemPolicyAppData` prompt ("phantombot would like to access data from other apps") once per spawned date. If you add a `runTurn` caller, decide which tree it may treat as home and say so explicitly.
 
 ## Channel layer (core + adapters)
 
@@ -196,6 +197,16 @@ There is deliberately no nightly unit. The cognitive pass is event-driven —
 calendar day changed since its last fire. A clock would miss the day entirely on
 any box that sleeps at 02:00. Installs that predate this have their
 `phantombot-nightly.timer` stopped, disabled and deleted on the next heartbeat.
+
+A nightly stage is deliberately the **narrowest turn phantombot runs**: no MCP
+(`mcpMode: "none"`), cwd pinned to the persona dir, and a positive tool grant of
+`NIGHTLY_TOOLS` = `Bash,Read,Write,Edit` (`toolsMode: { allow }`, #387). The
+allowlist exists to drop claude's native `Glob`/`Grep`, whose parallel workers
+recursively walk the tree from cwd; a stage searches through
+`phantombot memory search` (an index query), never a filesystem walk. Note the
+grant is claude-only — pi and codex have no positive-grant flag and ignore it —
+so treat it as defence-in-depth, **not** a trust boundary. `toolsMode: "none"`
+is the real boundary, and it's reserved for the threat judge.
 
 Every service has **two `EnvironmentFile=` lines**:
 

--- a/README.md
+++ b/README.md
@@ -1524,6 +1524,17 @@ that was off for a week sweeps the backlog when it comes back. There is no
 `--date <YYYY-MM-DD>` to reprocess one day, `--max-dates N` to bound a manual
 run, `--force` to take over a stuck in-flight marker.
 
+A stage runs **scoped to the persona directory**. Its working directory is the
+persona dir (not your home dir), it runs with no MCP servers, and it is granted
+exactly four tools — `Bash`, `Read`, `Write`, `Edit`. That is the whole job: read
+the day's file, write `memory/` and `kb/`, and search through
+`phantombot memory search`. It never needs to walk your filesystem, and it is no
+longer able to. Before this, stages ran from `$HOME` and would go looking for
+their own `memory/` directory; on macOS that search crossed
+`~/Library/Containers` and made the system ask *"phantombot would like to access
+data from other apps"* over and over — once for every date in the backlog. If
+you see that prompt, you are on a build older than #387.
+
 A sweep is **uncapped by default**: it drains the entire backlog in one pass,
 so a first run after months of history is one long night rather than a queue
 that reappears every morning. The in-flight marker stops the rollover trigger

--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -17,6 +17,7 @@
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
 import {
@@ -1264,6 +1265,10 @@ async function processChatMessage(
       conversation: conversationKey,
       userMessage: msg.text,
       agentDir: input.agentDir,
+      // Interactive surface: the owner asks for work on repos all over their
+      // home dir, so home stays the cwd. Explicit since #387 removed the
+      // silent homedir() default in runTurn.
+      workingDir: homedir(),
       harnesses,
       memory: input.memory,
       idleTimeoutMs: input.config.harnessIdleTimeoutMs,

--- a/src/channels/core/reactions.ts
+++ b/src/channels/core/reactions.ts
@@ -37,6 +37,7 @@
  * history. See {@link RecentOutbound}.
  */
 
+import { homedir } from "node:os";
 import type { Harness } from "../../harnesses/types.ts";
 import { log } from "../../lib/logger.ts";
 import type { MemoryStore } from "../../memory/store.ts";
@@ -284,6 +285,10 @@ export async function runReactionTurn(
       conversation: input.conversation,
       userMessage: envelope,
       agentDir: input.agentDir,
+      // Interactive surface: the owner asks for work on repos all over their
+      // home dir, so home stays the cwd. Explicit since #387 removed the
+      // silent homedir() default in runTurn.
+      workingDir: homedir(),
       harnesses: input.harnesses,
       memory: input.memory,
       idleTimeoutMs: input.idleTimeoutMs,

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -22,6 +22,7 @@
  *     surfaced as `senderId`), never on the envelope `from` field.
  */
 
+import { homedir } from "node:os";
 import type { Config } from "../../config.ts";
 import { DEFAULT_CHATTINESS, DEFAULT_TELEGRAM_STREAMING } from "../../config.ts";
 import type { Harness } from "../../harnesses/types.ts";
@@ -875,6 +876,10 @@ export async function runPhantomchatServer(
         conversation: conversationKey,
         userMessage,
         agentDir: input.agentDir,
+        // Interactive surface: the owner asks for work on repos all over their
+        // home dir, so home stays the cwd. Explicit since #387 removed the
+        // silent homedir() default in runTurn.
+        workingDir: homedir(),
         harnesses,
         memory: input.memory,
         idleTimeoutMs: input.config.harnessIdleTimeoutMs,

--- a/src/cli/ask.ts
+++ b/src/cli/ask.ts
@@ -28,6 +28,7 @@
 
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 
 import { type Config, loadConfig, personaDir } from "../config.ts";
 import { buildHarnessChain } from "../harnesses/buildChain.ts";
@@ -151,6 +152,10 @@ export async function runAsk(input: RunAskInput): Promise<number> {
       conversation,
       userMessage: prompt,
       agentDir,
+      // Interactive surface: the owner asks for work on repos all over their
+      // home dir, so home stays the cwd. Explicit since #387 removed the
+      // silent homedir() default in runTurn.
+      workingDir: homedir(),
       harnesses,
       memory,
       idleTimeoutMs: config.harnessIdleTimeoutMs,

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -52,6 +52,23 @@ import {
 import { openMemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
 
+/**
+ * Positive tool grant for nightly stages (#387).
+ *
+ * A stage reads and writes files under `memory/` and `kb/` and shells out to
+ * `phantombot memory …`; that is the whole job. Granting exactly those four
+ * drops claude's native Glob/Grep, whose parallel workers recursively walk
+ * the tree from cwd — the mechanism that turned one mis-rooted stage into a
+ * barrage of macOS TCC "access data from other apps" prompts. Search is still
+ * available, but through `phantombot memory search` (FTS5 + semantic), which
+ * queries an index instead of stat-ing the filesystem.
+ *
+ * Defence-in-depth on top of the cwd fix, not a substitute for it: claude
+ * honours this, pi/codex ignore it (no positive-grant flag), and Bash remains
+ * unconstrained because the memory CLI needs it.
+ */
+export const NIGHTLY_TOOLS = ["Bash", "Read", "Write", "Edit"];
+
 const NIGHTLY_SUFFIX =
   "You are operating in NIGHTLY MAINTENANCE MODE. " +
   "Skip pleasantries. Do work, write files, report briefly.";
@@ -98,7 +115,7 @@ export interface TurnResult {
 }
 
 /** Run one harness turn for the nightly conversation. */
-async function runNightlyTurn(opts: {
+export async function runNightlyTurn(opts: {
   persona: string;
   conversation: string;
   userMessage: string;
@@ -115,6 +132,15 @@ async function runNightlyTurn(opts: {
       conversation: opts.conversation,
       userMessage: opts.userMessage,
       agentDir: opts.agentDir,
+      // Spawn the stage INSIDE the persona dir, not the user's home (#387).
+      // A stage's whole job is `memory/` and `kb/`; waking it up in $HOME
+      // meant those were invisible from cwd, so the agent went looking for
+      // them — 79 `find` calls in one sweep, 7 of them rooted at `/`, plus
+      // claude's own parallel Glob walk. On macOS that walk crosses
+      // ~/Library/Containers and re-triggers the TCC "access data from other
+      // apps" prompt on every spawned date. Correct cwd removes the reason
+      // to search at all.
+      workingDir: opts.agentDir,
       harnesses: opts.harnesses,
       memory: opts.memory,
       idleTimeoutMs: STAGE_IDLE_TIMEOUT_MS,
@@ -130,6 +156,7 @@ async function runNightlyTurn(opts: {
       // connector from wedging the --print startup and killing a stage on the
       // idle timeout. See HarnessRequest.mcpMode.
       mcpMode: "none",
+      toolsMode: { allow: NIGHTLY_TOOLS },
     })) {
       if (chunk.type === "text") finalReply += chunk.text;
       if (chunk.type === "done") finalReply = chunk.finalText;

--- a/src/cli/tick.ts
+++ b/src/cli/tick.ts
@@ -34,6 +34,7 @@
 import { defineCommand } from "citty";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { homedir } from "node:os";
 import { spawn } from "node:child_process";
 
 import { type Config, loadConfig, personaDir, xdgStateHome } from "../config.ts";
@@ -189,6 +190,10 @@ export async function runTick(input: RunTickInput = {}): Promise<number> {
             conversation,
             userMessage: promptText,
             agentDir,
+            // Interactive surface: the owner asks for work on repos all over their
+            // home dir, so home stays the cwd. Explicit since #387 removed the
+            // silent homedir() default in runTurn.
+            workingDir: homedir(),
             harnesses,
             memory,
             idleTimeoutMs: config.harnessIdleTimeoutMs,

--- a/src/harnesses/claude.ts
+++ b/src/harnesses/claude.ts
@@ -217,7 +217,7 @@ export class ClaudeHarness implements Harness {
 
   private buildArgs(
     systemPrompt: string,
-    toolsMode?: "none",
+    toolsMode?: "none" | { allow: string[] },
     // When set (Windows), the persona system prompt is passed by FILE
     // (`--system-prompt-file`) instead of inline (`--system-prompt <text>`)
     // to stay under the command-line length limit.
@@ -279,6 +279,16 @@ export class ClaudeHarness implements Harness {
     // is moot when there are no tools to permit — belt and suspenders.)
     if (toolsMode === "none") {
       args.push("--tools", "");
+    } else if (toolsMode && toolsMode.allow.length > 0) {
+      // Positive tool grant for background turns with a known job (#387).
+      // `--tools "Bash,Edit,Read"` replaces the built-in set with exactly
+      // these — same positive-grant shape as `--tools ""`, so it doesn't rot
+      // as new tools ship. Nightly uses it to drop Glob/Grep: claude's native
+      // search tools fan out across parallel workers and walk the tree from
+      // cwd, which is what turned one confused stage into a barrage of macOS
+      // TCC prompts. The stage has `phantombot memory search` (FTS +
+      // semantic) and knows its own paths, so it never needed a tree walk.
+      args.push("--tools", toolsMode.allow.join(","));
     }
     // MCP isolation — EVERY claude turn runs `--strict-mcp-config`, which tells
     // claude to use ONLY the servers in `--mcp-config` and ignore ~/.claude.json

--- a/src/harnesses/codex.ts
+++ b/src/harnesses/codex.ts
@@ -92,7 +92,7 @@ export class CodexHarness implements Harness {
     });
   }
 
-  private buildArgs(toolsMode?: "none"): string[] {
+  private buildArgs(toolsMode?: "none" | { allow: string[] }): string[] {
     const args = [
       "exec",
       "--json",

--- a/src/harnesses/types.ts
+++ b/src/harnesses/types.ts
@@ -100,8 +100,16 @@ export interface HarnessRequest {
    * PRIMARY in the turn's chain — it never assumes a specific binary (e.g.
    * claude) is installed. A user who installs only one of the four supported
    * harnesses still gets screening on that one. Optional; normal turns omit.
+   *
+   * `{ allow: [...] }` is the narrower sibling: a POSITIVE grant of exactly
+   * the named built-in tools, for background turns whose job is known up
+   * front (nightly). Unlike `"none"` this has no cross-harness equivalent —
+   * only claude exposes a positive tool grant (`--tools "Bash,Edit,Read"`),
+   * so pi/codex IGNORE the allowlist and run their normal surface. It is
+   * therefore defence-in-depth, never a security boundary; never rely on it
+   * to contain untrusted input (that's what `"none"` is for).
    */
-  toolsMode?: "none";
+  toolsMode?: "none" | { allow: string[] };
   /**
    * MCP capability mode. Omitted = the harness's normal turn, which loads
    * every MCP server the CLI is configured with (including the user's remote

--- a/src/orchestrator/turn.ts
+++ b/src/orchestrator/turn.ts
@@ -21,7 +21,6 @@
  * to catch them and present cleanly.
  */
 
-import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { runWithFallback } from "./fallback.ts";
@@ -48,15 +47,29 @@ export interface TurnInput {
   /** Path to the persona directory (BOOT.md / SOUL.md / IDENTITY.md etc. live here). */
   agentDir: string;
   /**
-   * cwd for harness subprocesses. Defaults to the running user's home
-   * dir. Set to `agentDir` (or anything else) to scope down. Affects:
+   * cwd for harness subprocesses. REQUIRED — there is deliberately no
+   * default (see #387). Affects:
    *   - pi:     where relative-path tools resolve (no sandbox).
-   *   - claude: same + the "trusted dir" framing for the workspace.
+   *   - claude: same + the "trusted dir" framing for the workspace, AND
+   *             the root that Glob/Grep walk when the agent searches.
    *   - gemini: the *workspace sandbox root* — gemini hard-rejects tool
    *             calls that touch paths outside cwd + its temp dir.
    * Persona files load via absolute paths regardless of this setting.
+   *
+   * This used to silently default to `homedir()`, which meant a background
+   * turn woke up in `$HOME` unable to see its own `memory/` — so its file
+   * search walked the whole home tree looking for them. On macOS that walk
+   * crosses `~/Library/Containers` and trips the TCC
+   * `kTCCServiceSystemPolicyAppData` prompt ("phantombot would like to
+   * access data from other apps"), once per spawned process. A default
+   * nobody passes is a default nobody audits: make every call site say
+   * which tree this turn is allowed to treat as home.
+   *
+   *   - Interactive/chat surfaces pass `homedir()` — the owner asks for work
+   *     on repos all over their home dir, so scoping those down is wrong.
+   *   - Machine-driven background turns (nightly) pass the persona dir.
    */
-  workingDir?: string;
+  workingDir: string;
   /** Harness chain in priority order; first that succeeds wins. */
   harnesses: Harness[];
   /** Open memory store; runTurn appends to it on success. */
@@ -79,6 +92,14 @@ export interface TurnInput {
    * non-interactive `--print` startup handshake. See HarnessRequest.mcpMode.
    */
   mcpMode?: "none";
+  /**
+   * Restrict the harness's built-in tool surface for this turn. Omitted =
+   * the normal full surface. `{ allow: [...] }` is a positive grant used by
+   * background turns whose job is known up front (nightly); claude honours
+   * it, pi/codex ignore it. See HarnessRequest.toolsMode — and note it is
+   * defence-in-depth, NOT a trust boundary.
+   */
+  toolsMode?: { allow: string[] };
   /**
    * Append PRE_TOOL_NARRATION_INSTRUCTION to the system prompt — asks
    * the model to say one short sentence before each tool call so
@@ -343,7 +364,7 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
       history,
       persona: input.persona,
       conversation: input.conversation,
-      workingDir: input.workingDir ?? homedir(),
+      workingDir: input.workingDir,
       // Harness temp files land under the persona's own dir, not the shared
       // system /tmp (issue #365) — per-persona isolation + survives a full /tmp.
       tmpBaseDir: join(input.agentDir, "tmp"),
@@ -351,6 +372,7 @@ export async function* runTurn(input: TurnInput): AsyncGenerator<HarnessChunk> {
       hardTimeoutMs: input.hardTimeoutMs,
       startupTimeoutMs: input.startupTimeoutMs,
       mcpMode: input.mcpMode,
+      toolsMode: input.toolsMode,
       signal: input.signal,
     },
     { onToolCall: auditSink },

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { runNightly } from "../src/cli/nightly.ts";
+import { NIGHTLY_TOOLS, runNightly, runNightlyTurn } from "../src/cli/nightly.ts";
+import type {
+  Harness,
+  HarnessChunk,
+  HarnessRequest,
+} from "../src/harnesses/types.ts";
+import { openMemoryStore } from "../src/memory/store.ts";
 import {
   loadNightlyState,
   NIGHTLY_STAGES,
@@ -400,5 +406,70 @@ describe("runNightly — persona override prompt", () => {
     expect(h.calls.length).toBe(1);
     expect(h.calls[0]!.stage).toBe("override");
     expect(h.calls[0]!.prompt).toBe("custom phantom 2026-05-01");
+  });
+});
+
+// #387 — the macOS TCC re-prompt loop.
+//
+// A nightly stage's whole job lives in the persona dir, but runTurn used to
+// default the harness cwd to homedir() and every background caller took the
+// default. So stages woke up in $HOME, couldn't see their own memory/ from
+// cwd, and went looking: 79 `find` invocations in a single sweep on Matt's
+// box, 7 of them rooted at `/`, alongside claude's own parallel Glob walk.
+// On macOS those walks cross ~/Library/Containers, which trips the TCC
+// kTCCServiceSystemPolicyAppData prompt ("phantombot would like to access
+// data from other apps") — once per spawned date, so a 110-date backlog
+// became a barrage.
+//
+// These pin the two halves of the fix at the point they're wired, because
+// the runStage seam used by the sweep tests bypasses runTurn entirely and so
+// can never observe either.
+describe("runNightlyTurn — harness scoping (#387)", () => {
+  class CaptureHarness implements Harness {
+    readonly id = "capture";
+    seen: HarnessRequest | undefined;
+    async available(): Promise<boolean> {
+      return true;
+    }
+    async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
+      this.seen = req;
+      yield { type: "done", finalText: "ok" };
+    }
+  }
+
+  async function runOnce(): Promise<CaptureHarness> {
+    await writeFile(join(personaDir, "BOOT.md"), "# persona", "utf8");
+    const memory = await openMemoryStore(":memory:");
+    const harness = new CaptureHarness();
+    try {
+      await runNightlyTurn({
+        persona: "phantom",
+        conversation: "system:nightly:2026-05-10",
+        userMessage: "distill",
+        agentDir: personaDir,
+        harnesses: [harness],
+        memory,
+      });
+    } finally {
+      await memory.close();
+    }
+    return harness;
+  }
+
+  test("spawns the stage in the persona dir, never the user's home", async () => {
+    const harness = await runOnce();
+    expect(harness.seen?.workingDir).toBe(personaDir);
+    expect(harness.seen?.workingDir).not.toBe(homedir());
+  });
+
+  test("grants only the tools a stage needs — no tree-walking search tools", async () => {
+    const harness = await runOnce();
+    expect(harness.seen?.toolsMode).toEqual({ allow: NIGHTLY_TOOLS });
+    const allowed = NIGHTLY_TOOLS;
+    // Bash stays: the stage drives `phantombot memory …` through it.
+    expect(allowed).toContain("Bash");
+    // Glob/Grep are the walkers that trip TCC. They must not be granted.
+    expect(allowed).not.toContain("Glob");
+    expect(allowed).not.toContain("Grep");
   });
 });

--- a/tests/harnesses-claude.test.ts
+++ b/tests/harnesses-claude.test.ts
@@ -515,6 +515,42 @@ describe("ClaudeHarness subprocess invocation passes injected settings", () => {
     expect(texts).not.toContain("--tools");
   });
 
+  // #387: nightly stages get a POSITIVE tool grant so claude's native
+  // Glob/Grep — whose parallel workers recursively walk the tree from cwd,
+  // tripping the macOS TCC AppData prompt once per spawn — are simply not on
+  // the menu. Search still exists for the stage, via `phantombot memory
+  // search` (an index query) rather than a filesystem walk.
+  test("toolsMode allowlist passes --tools with exactly the named tools", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });
+    const chunks = await collect(
+      h.invoke(newRequest({ toolsMode: { allow: ["Bash", "Read", "Write", "Edit"] } })),
+    );
+    const texts = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    expect(texts).toContain("--tools");
+    expect(texts).toContain("Bash,Read,Write,Edit");
+    // The whole point: the tree-walking search tools are absent from the grant.
+    expect(texts).not.toContain("Glob");
+    expect(texts).not.toContain("Grep");
+  });
+
+  test("an EMPTY toolsMode allowlist is ignored rather than silently disabling every tool", async () => {
+    process.env.FAKE_CLAUDE_MODE = "argv";
+    const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });
+    const chunks = await collect(h.invoke(newRequest({ toolsMode: { allow: [] } })));
+    const texts = chunks
+      .filter((c): c is Extract<HarnessChunk, { type: "text" }> => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    // `--tools ""` means ZERO tools. An empty allowlist almost certainly means
+    // a caller built the list wrong, and silently running a tool-less nightly
+    // would look like a hang, so fall through to the normal surface instead.
+    expect(texts).not.toContain("--tools");
+  });
+
   test("mcpMode 'none' (background/nightly) runs MCP-free via --strict-mcp-config + empty --mcp-config", async () => {
     process.env.FAKE_CLAUDE_MODE = "argv";
     const h = new ClaudeHarness({ bin: FAKE_CLAUDE, model: "test", fallbackModel: "" });

--- a/tests/orchestrator-turn.test.ts
+++ b/tests/orchestrator-turn.test.ts
@@ -62,6 +62,7 @@ const baseInput = () => ({
   persona: "phantom",
   conversation: "cli:default",
   agentDir,
+  workingDir: agentDir,
   memory,
   idleTimeoutMs: 1_000,
   hardTimeoutMs: 5_000,
@@ -114,7 +115,13 @@ describe("runTurn — successful path", () => {
     expect(sawPersistedTurns).toBe(2);
   });
 
-  test("workingDir defaults to the running user's home dir (gemini sandbox spans the whole user account)", async () => {
+  // #387: workingDir used to default to homedir() when a caller omitted it.
+  // Every background caller omitted it, so nightly stages woke up in $HOME
+  // with their own memory/ invisible from cwd and went hunting for it —
+  // recursive walks that trip the macOS TCC "access data from other apps"
+  // prompt once per spawned process. There is now NO default: the field is
+  // required, and runTurn hands it to the harness verbatim.
+  test("workingDir is passed to the harness verbatim — no homedir() fallback", async () => {
     let captured: HarnessRequest | undefined;
     const harness = new ScriptedHarness(
       "fake",
@@ -129,10 +136,12 @@ describe("runTurn — successful path", () => {
         ...baseInput(),
         userMessage: "x",
         harnesses: [harness],
+        workingDir: agentDir,
       }),
     );
 
-    expect(captured?.workingDir).toBe(homedir());
+    expect(captured?.workingDir).toBe(agentDir);
+    expect(captured?.workingDir).not.toBe(homedir());
   });
 
   test("workingDir override is respected (callers can scope down)", async () => {
@@ -155,6 +164,30 @@ describe("runTurn — successful path", () => {
     );
 
     expect(captured?.workingDir).toBe(agentDir);
+  });
+
+  test("toolsMode allowlist reaches the harness; omitted stays undefined", async () => {
+    const seen: HarnessRequest[] = [];
+    const mk = () =>
+      new ScriptedHarness("fake", [{ type: "done", finalText: "ok" }], (req) => {
+        seen.push(req);
+      });
+
+    await collect(
+      runTurn({
+        ...baseInput(),
+        userMessage: "x",
+        harnesses: [mk()],
+        toolsMode: { allow: ["Bash", "Read"] },
+      }),
+    );
+    await collect(
+      runTurn({ ...baseInput(), userMessage: "y", harnesses: [mk()] }),
+    );
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]?.toolsMode).toEqual({ allow: ["Bash", "Read"] });
+    expect(seen[1]?.toolsMode).toBeUndefined();
   });
 
   test("passes loaded history to the harness", async () => {


### PR DESCRIPTION
Closes #387.

On macOS, phantombot triggered a relentless **"phantombot would like to access data from other apps"** prompt that cycled continuously during the nightly sweep. Code signing (#361/#363/#364) was already stable, so this was not identity churn, and flipping the box from claude to pi did not help.

## Root cause: the harness working directory

`runTurn`'s `workingDir` was optional and fell back to `homedir()` — and **every caller except the ACP bridge took the default**. A nightly stage therefore woke up in `$HOME` with its own `memory/` and `kb/` invisible from cwd, and went hunting for them.

Confirmed on the affected box:

| Evidence | Finding |
|---|---|
| `lsof` on the live sweep | nightly (pid 3278) and its harness child both had cwd `/Users/andrewhodges` |
| Tool-call audit log, one sweep | **79 `find` invocations, 7 rooted at `/`**, ~12 at `~` |
| Stage output | wrote `cd ~/phantombot/matt \|\| cd .` — compensating by hand for the wrong cwd |
| `fs_usage`, live | ~7 parallel claude Glob workers issuing `openat(..., "Application Support")` in a 10ms burst, with a user `TCC.db` write at the same instant |
| TCC db (as root) | `kTCCServiceSystemPolicyAppData` = `auth_value 5` (undetermined); every other service for this client = `2` (allowed) |

Those walks cross `~/Library/Containers`, which is precisely what `kTCCServiceSystemPolicyAppData` guards. The sweep spawns a fresh process per date, so a 110-date backlog turned one prompt into a barrage. Linux has no TCC, which is why only macOS ever saw it.

## Changes

**1. `workingDir` is now REQUIRED on `TurnInput`, with no default.**

A default nobody passes is a default nobody audits. Every call site now declares which tree the turn may treat as home:

- **Interactive surfaces** (telegram, phantomchat, ask, tick, reactions) pass `homedir()` **explicitly**. This is deliberate and unchanged in behaviour — the owner asks for work on repos all over their home dir, so scoping these down would be a real regression (and for gemini, cwd is a hard sandbox root).
- **Nightly** passes the persona dir.
- The ACP bridge already resolved its own workspace cwd and is untouched.

**2. Nightly stages get a positive tool grant** — `toolsMode: { allow: ["Bash","Read","Write","Edit"] }`, mapping to claude's native `--tools "Bash,Read,Write,Edit"`.

This drops `Glob`/`Grep`, whose parallel workers recursively walk the tree from cwd. The stage still searches — via `phantombot memory search` (FTS + semantic), which queries an index instead of stat-ing the filesystem. `Bash` stays because the memory CLI needs it.

**3. An empty allowlist falls through to the normal surface** rather than emitting `--tools ""`, which would silently run a tool-less nightly that looks like a hang.

## Worth flagging for review

- **Restricting Bash alone would NOT have fixed this.** Part of the walk was inside claude's own search engine, not a shell. Correct cwd is the fix; the allowlist is the belt. I would not want the allowlist mistaken for the mitigation.
- **The allowlist is claude-only.** pi and codex have no positive-grant flag and ignore it. It is documented as defence-in-depth, explicitly **not** a trust boundary — `toolsMode: "none"` remains the real boundary and stays reserved for the threat judge.
- **Blast radius of making `workingDir` required** is compile-time only: every existing caller keeps its exact previous behaviour. The change is that omitting it is now a type error rather than a silent `$HOME`.

## Verification — A/B on the real macOS runtime

Identical scratch persona and stub harness binary on Matt, recording the cwd the OS actually hands the spawned subprocess:

```
main (02e753a):        /Users/andrewhodges
fix/nightly-working-dir: /private/tmp/pb387-test/personas/testp
```

Both nightly stages spawned in the persona dir on the fixed branch. (Verified against a stub harness rather than a real one, so the observation is of the spawn itself and costs no tokens; the stage then "fails" on a missing completion signal, which is expected and irrelevant to what is being measured.)

## Tests

5 new, all green:

- `runTurn` passes `workingDir` verbatim — no `homedir()` fallback
- `toolsMode` allowlist reaches the harness; omitted stays `undefined`
- claude emits `--tools` with exactly the named tools, and **not** `Glob`/`Grep`
- an empty allowlist is ignored rather than silently disabling every tool
- `runNightlyTurn` spawns in the persona dir, never `homedir()`, and grants no tree-walking search tools

The nightly wiring tests sit on `runNightlyTurn` directly because the `runStage` seam the sweep tests use bypasses `runTurn` entirely and can never observe either property.

Full suite: 2811 pass, 3 fail — the same 3 environment-dependent failures present on `main` before this branch (verified by stashing).

## Docs

`README.md` and `AGENTS.md` both updated: the required-`workingDir` rule and what to pass when adding a new `runTurn` caller, plus the nightly's scoping contract and the explicit caveat that the tool grant is claude-only defence-in-depth.

## Unrelated, handled

The wedged `phantombot notify` (pid 2087, 71 min on nostr relay ACKs) was killed on the box. That is the known notify blocking issue, not part of this fix.