### PR TITLE
feat(okf): declare a controlled KB vocabulary, and stop calling kb/ an Obsidian vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -1421,6 +1421,51 @@ path is much stronger than plain keyword matching:
 
 This is the default. Every phantom gets it for free, no setup.
 
+#### The frontmatter that makes it work
+
+Those three superpowers are only as good as the frontmatter agents actually
+write, so the vocabulary is part of the spec rather than a style preference.
+Every `kb/` note carries:
+
+| Field | Why the index cares |
+|---|---|
+| `type` | Controlled vocabulary (below) — its own BM25F column |
+| `title` | Highest-weighted field |
+| `description` | One sentence: the question the note answers |
+| `tags` | Lowercase, hyphenated; weighted above body text |
+| `aliases` | **The synonym fix** — the other names this thing goes by |
+| `created` / `updated` | Recency signals; `updated` is bumped on reconcile |
+
+`aliases` is the field that earns its keep on the no-key path. BM25 can only
+match words that are actually present, so a note titled "Secret Rotation"
+is invisible to a search for "credential cycling" *unless the note says so
+itself*. Aliases are how a note declares the wrong-but-plausible names a
+future query might use.
+
+**Controlled `type` vocabulary.** Left unstated, this field drifts into a
+dozen near-synonyms (`note` / `atomic-note` / `concept`) that fragment the
+very column meant to sharpen recall. Phantombot declares it once, in
+`src/lib/okf.ts`, and generates both the persona prompt and the nightly
+prompt from that constant:
+
+- **Core** — `concept`, `runbook`, `procedure`, `reference`, `postmortem`,
+  `project`, `person`, `infrastructure`, `index`. These mean the same thing
+  in a human-curated OKF vault as they do in a phantom's KB, so notes move
+  between the two without translation.
+- **Agent-side** — `lesson`, `decision`, `norm`, `account`. Derived from the
+  structured drawers; they have no equivalent in a curated vault, because a
+  vault records what someone decided was true and these record what the agent
+  learned the hard way.
+
+Adopting the vocabulary is **not a migration**. An alias map folds legacy
+values (`troubleshooting` → `runbook`, `home` → `index`) onto canonical ones
+at query time, so every note ever written stays valid and only newly-authored
+notes converge. Nothing on disk is renamed.
+
+> `kb/` is **private to the persona** — not published, not shared between
+> agents, not a document store for the operator. It is the agent's own recall.
+> OKF is the *format*; where a human-facing vault lives is a separate question.
+
 **Add Gemini embeddings** (optional, recommended for production) to layer true
 **semantic** retrieval on top — matching by *meaning*, not just words. With a
 key, search becomes **hybrid**: OKF field-weighted BM25 *and* vector similarity,

--- a/README.md
+++ b/README.md
@@ -1459,8 +1459,13 @@ prompt from that constant:
 
 Adopting the vocabulary is **not a migration**. An alias map folds legacy
 values (`troubleshooting` → `runbook`, `home` → `index`) onto canonical ones
-at query time, so every note ever written stays valid and only newly-authored
-notes converge. Nothing on disk is renamed.
+**at index time**, and each note is indexed under both spellings — the
+canonical type *and* the one its frontmatter actually carries — so it stays
+findable either way. Bumping the notes-schema version rebuilds an existing
+index from disk on next open, so notes written long before the vocabulary
+existed converge too, not just newly-authored ones. Nothing on disk is
+renamed: the folding lives in the index, and your frontmatter is left exactly
+as you wrote it.
 
 > `kb/` is **private to the persona** — not published, not shared between
 > agents, not a document store for the operator. It is the agent's own recall.

--- a/src/lib/heartbeat.ts
+++ b/src/lib/heartbeat.ts
@@ -9,8 +9,11 @@
  *      whose embedded date is older than 48h. Logs warnings; does not
  *      mutate.
  *   3. Refresh the FTS5 index so newly-written notes are searchable
- *      without waiting for the next manual `memory index`. Does NOT
- *      run the embedding pass (that's the nightly cycle's job).
+ *      without waiting for the next manual `memory index`. The caller
+ *      (`cli/heartbeat.ts`) then runs an incremental embed pass over
+ *      chunks whose text_sha changed, so fresh notes are semantically
+ *      searchable within 30 minutes rather than at the next nightly.
+ *      No-ops cleanly when no embedder is configured.
  *
  * The harness never sees this — heartbeat runs as its own short-lived
  * process. Per the OpenClaw spec: "Heartbeat is mechanical, nightly is

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -28,7 +28,7 @@ import { posix } from "node:path";
 import type { FactSource } from "../config.ts";
 import type { Turn, TurnOrigin } from "../memory/store.ts";
 import { log } from "./logger.ts";
-import { parseOkf } from "./okf.ts";
+import { normaliseOkfType, parseOkf } from "./okf.ts";
 
 export type Scope = "memory" | "kb" | "turns";
 
@@ -200,13 +200,45 @@ export function parseTurnCreatedAtMs(content: string): number | undefined {
  * tags, or aliases is worth far more than the same term buried in the body —
  * this is the lexical-precision half of the OKF superpowers, and it makes the
  * frontmatter the index actually leans on. Positionally these map to the
- * `notes` columns: [path, scope, title, tags, aliases, headings, body]. The
- * two UNINDEXED columns get weight 0 (ignored by bm25 anyway).
+ * `notes` columns: [path, scope, type, title, tags, aliases, headings, body].
+ * The two UNINDEXED columns get weight 0 (ignored by bm25 anyway).
+ *
+ * `type` sits below tags/aliases deliberately: it is a CLOSED vocabulary of a
+ * dozen values, so it is a coarse filter rather than a distinguishing term —
+ * matching "runbook" should promote a note among its peers, never outrank a
+ * note whose actual title is the thing you searched for.
  */
-export const NOTE_FIELD_WEIGHTS = [0, 0, 8.0, 6.0, 6.0, 3.0, 1.0] as const;
+export const NOTE_FIELD_WEIGHTS = [0, 0, 4.0, 8.0, 6.0, 6.0, 3.0, 1.0] as const;
 
-/** Column index of `body` in `notes` (for snippet()). */
-const NOTES_BODY_COL = 6;
+/**
+ * Column index of `body` in `notes` (for snippet()). FTS5 takes a bare integer
+ * and does NOT validate it against the column name — point it at the wrong
+ * column and snippets silently come back empty. Adding a column before `body`
+ * shifts this; keep it in step with the DDL and NOTE_FIELD_WEIGHTS.
+ */
+const NOTES_BODY_COL = 7;
+
+/**
+ * What actually goes in the `type` column: the canonical type PLUS the raw
+ * value when the two differ.
+ *
+ * Storing both is what makes the vocabulary a recall win instead of a rename.
+ * Canonical alone would make a note typed `atomic-note` findable as "concept"
+ * but NOT as "atomic-note" — punishing the notes that predate the vocabulary,
+ * which is exactly the migration this design set out to avoid. Raw alone would
+ * fragment the column into the near-synonyms the vocabulary exists to merge.
+ *
+ * An unrecognised type still gets indexed on its own (normalised) spelling:
+ * `normaliseOkfType` returns "" for unknowns, and dropping them would make
+ * drift invisible to the very search you would use to find it.
+ */
+export function indexedNoteType(raw: string): string {
+  const slug = raw.trim().toLowerCase().replace(/[\s_]+/g, "-");
+  if (!slug) return "";
+  const canonical = normaliseOkfType(slug);
+  if (!canonical) return slug;
+  return canonical === slug ? canonical : `${canonical} ${slug}`;
+}
 
 /**
  * How many raw-BM25 turn candidates to pull before decay re-ranks them (per
@@ -330,8 +362,14 @@ export function rrfMerge(
  * v1 → v2: `notes` went from a single `content` column to OKF field columns
  * (title / tags / aliases / headings / body) for BM25F, and `note_links` was
  * added for graph-walk expansion.
+ *
+ * v3 → v4: `type` added as its own BM25F column, holding the canonical OKF
+ * type with legacy aliases folded in at index time (see `indexedNoteType`).
+ * Existing databases carry rows written without it, so the bump is what makes
+ * the controlled vocabulary reach retrieval rather than just the prompts —
+ * the drop-and-rebuild below repopulates every note from disk on next open.
  */
-export const NOTES_SCHEMA_VERSION = 3;
+export const NOTES_SCHEMA_VERSION = 4;
 
 /**
  * Version of the turn_docs schema. Unlike the notes tables, turn rows are
@@ -371,6 +409,7 @@ CREATE TABLE IF NOT EXISTS meta (
 CREATE VIRTUAL TABLE IF NOT EXISTS notes USING fts5(
   path UNINDEXED,
   scope UNINDEXED,
+  type,
   title,
   tags,
   aliases,
@@ -615,12 +654,13 @@ export class MemoryIndex {
       this.deletePath(f.path);
       this.db
         .prepare(
-          "INSERT INTO notes (path, scope, title, tags, aliases, headings, body) " +
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+          "INSERT INTO notes (path, scope, type, title, tags, aliases, headings, body) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .run(
           f.path,
           f.scope,
+          indexedNoteType(doc.type),
           doc.title,
           doc.tags.join(" "),
           doc.aliases.join(" "),

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -35,6 +35,7 @@ import { createHash } from "node:crypto";
 import { readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { log } from "./logger.ts";
+import { OKF_AGENT_TYPES, OKF_CORE_TYPES } from "./okf.ts";
 
 const NIGHTLY_PROMPT_OVERRIDE = "nightly-prompt.md";
 
@@ -531,7 +532,14 @@ touch memory/ files.
 
 Read the daily file (memory/${today}.md) for durable knowledge (procedures,
 configs, runbooks, concepts, decisions worth keeping). For each candidate:
-  a) \`phantombot memory search "<topic>"\` to check for existing coverage.
+  a) Search for existing coverage — and search it from MORE THAN ONE ANGLE.
+     Run \`phantombot memory search\` two or three times per candidate, varying
+     the vocabulary: the symptom as you'd describe it today, the component or
+     service name, and the literal error string or command. Today's wording and
+     the existing note's wording are often disjoint ("CI agents refusing jobs"
+     vs "runner version deprecated"), and a single-phrase search will miss the
+     note you are about to duplicate. A duplicate is worse than a long search:
+     it splits one truth across two notes and dilutes every future query.
   b) If a note already covers the area, open it and RECONCILE — don't just append:
      - ADDS (new case, edge case, link): update in place.
      - CONTRADICTS / INVALIDATES it (a fact changed, something was decommissioned,
@@ -542,8 +550,22 @@ configs, runbooks, concepts, decisions worth keeping). For each candidate:
      - Whole subject DECOMMISSIONED: set frontmatter \`status: obsolete\` with a
        dated one-line reason (+ [[wikilink]] to any replacement) instead of deleting.
   c) Otherwise create a new atomic note in the right kb/<category>/ subdir from a
-     kb/templates/ scaffold. Frontmatter required: type, tags, created, updated.
-     Link related notes with [[wikilinks]].
+     kb/templates/ scaffold. OKF frontmatter, all of it required:
+       type         — one of: ${OKF_CORE_TYPES.join(" | ")}
+                              ${OKF_AGENT_TYPES.join(" | ")}
+                      Pick the closest. Never invent a new type.
+       title        — what the note is
+       description  — one sentence: the question this note answers
+       tags         — [lowercase-hyphenated]
+       aliases      — [other names for this thing, including the wrong-but-
+                      plausible ones someone might search for later]
+       created / updated — YYYY-MM-DD
+     Then LINK IT: every new note gets [[wikilinks]] to its nearest existing
+     neighbours, and where a neighbour should point back, add the return link
+     too. Recall expands outward along this graph from a lexical match, so an
+     unlinked note is reachable only by exact wording — you are not decorating
+     the note, you are wiring it into the index. A note with no links is a note
+     you will fail to find.
 Then sweep kb/inbox/: file each stub into the right category, or delete it if it
 is no longer relevant.
 Finish with a one-line summary of notes created / updated.`,

--- a/src/lib/okf.ts
+++ b/src/lib/okf.ts
@@ -9,8 +9,9 @@
  * Phantombot's kb/ second brain IS this shape: atomic markdown notes with
  * frontmatter, linked into a concept graph. This parser extracts the structured
  * parts so the FTS5 index can:
- *   - weight frontmatter fields above body text (BM25F),
- *   - index tags + aliases as controlled vocabulary (synonym fix), and
+ *   - weight frontmatter fields (type / title / tags / aliases) above body
+ *     text (BM25F),
+ *   - index type + tags + aliases as controlled vocabulary (synonym fix), and
  *   - follow links between concepts for graph-walk recall expansion.
  *
  * It is deliberately dependency-free and forgiving: a note with no frontmatter,
@@ -100,10 +101,13 @@ export type OkfType = (typeof OKF_TYPES)[number];
  * Drift map: values observed in existing KBs → the canonical type they mean.
  *
  * This exists so adopting the vocabulary is NOT a migration. Every note ever
- * written stays valid; `normaliseOkfType` folds legacy values at query time so
- * old and new notes land in the same bucket, and only newly-authored notes
- * converge on the canonical spelling. Nothing renames a file on disk — the
- * no-auto-heal rule applies to knowledge as much as to infrastructure.
+ * written stays valid: the indexer folds legacy values onto their canonical
+ * type as it writes the `type` column (`indexedNoteType` in memoryIndex.ts,
+ * which keeps the raw spelling alongside the canonical one), so old and new
+ * notes land in the same bucket without either becoming unfindable. Only
+ * newly-authored notes converge on the canonical spelling. Nothing renames a
+ * file on disk — the no-auto-heal rule applies to knowledge as much as to
+ * infrastructure.
  */
 export const OKF_TYPE_ALIASES: Readonly<Record<string, OkfType>> = {
   note: "concept",

--- a/src/lib/okf.ts
+++ b/src/lib/okf.ts
@@ -6,9 +6,9 @@
  * (`type`, `title`, `description`, `tags`, …) and a body, where concepts link
  * to each other with plain markdown links to form a graph.
  *
- * Phantombot's kb/ second brain is already this shape (Obsidian-style atomic
- * notes with frontmatter + links). This parser extracts the structured parts
- * so the FTS5 index can:
+ * Phantombot's kb/ second brain IS this shape: atomic markdown notes with
+ * frontmatter, linked into a concept graph. This parser extracts the structured
+ * parts so the FTS5 index can:
  *   - weight frontmatter fields above body text (BM25F),
  *   - index tags + aliases as controlled vocabulary (synonym fix), and
  *   - follow links between concepts for graph-walk recall expansion.
@@ -43,6 +43,104 @@ export interface OkfLink {
   target: string;
   /** "md" for [text](path), "wiki" for [[Wikilink]]. */
   kind: "md" | "wiki";
+}
+
+/**
+ * ── Controlled vocabulary for `type:` ───────────────────────────────────────
+ *
+ * OKF makes `type` its one required frontmatter field, and the FTS index gives
+ * it its own BM25F column — but a field is only worth weighting if its values
+ * are predictable. Left unstated, `type` drifts: real phantom KBs in the wild
+ * accumulate a dozen-plus near-synonyms ("note"/"atomic-note"/"concept",
+ * "troubleshooting"/"runbook") that fragment the very column meant to sharpen
+ * recall.
+ *
+ * So the vocabulary is declared HERE, once, and the persona prompt and nightly
+ * prompt are generated from it — a prompt that hardcoded its own list would
+ * silently diverge from the parser the first time either changed.
+ *
+ * CORE is deliberately interoperable: these types carry the same meaning in a
+ * human-curated OKF vault as they do here, so notes can move between an
+ * operator's vault and a phantom's KB without a translation step.
+ */
+export const OKF_CORE_TYPES = [
+  "concept",
+  "runbook",
+  "procedure",
+  "reference",
+  "postmortem",
+  "project",
+  "person",
+  "infrastructure",
+  "index",
+] as const;
+
+/**
+ * Types with no equivalent in a human-curated vault, because they are derived
+ * from the structured drawers — a phantom's *experience* rather than an
+ * operator's *authority*. A vault records what was decided to be true; these
+ * record what this agent learned the hard way.
+ */
+export const OKF_AGENT_TYPES = [
+  "lesson",
+  "decision",
+  "norm",
+  "account",
+] as const;
+
+/** Every `type:` value a phantom should author. */
+export const OKF_TYPES = [
+  ...OKF_CORE_TYPES,
+  ...OKF_AGENT_TYPES,
+] as const;
+
+export type OkfType = (typeof OKF_TYPES)[number];
+
+/**
+ * Drift map: values observed in existing KBs → the canonical type they mean.
+ *
+ * This exists so adopting the vocabulary is NOT a migration. Every note ever
+ * written stays valid; `normaliseOkfType` folds legacy values at query time so
+ * old and new notes land in the same bucket, and only newly-authored notes
+ * converge on the canonical spelling. Nothing renames a file on disk — the
+ * no-auto-heal rule applies to knowledge as much as to infrastructure.
+ */
+export const OKF_TYPE_ALIASES: Readonly<Record<string, OkfType>> = {
+  note: "concept",
+  "atomic-note": "concept",
+  atomic: "concept",
+  home: "index",
+  moc: "index",
+  plan: "project",
+  "project-plan": "project",
+  "project-note": "project",
+  troubleshooting: "runbook",
+  playbook: "runbook",
+  "incident-handover": "postmortem",
+  incident: "postmortem",
+  "model-research": "reference",
+  research: "reference",
+  infra: "infrastructure",
+  people: "person",
+  contact: "person",
+};
+
+/**
+ * Fold a raw `type:` onto the controlled vocabulary. Returns "" for a missing
+ * or unrecognised type — callers decide whether that is worth reporting. Never
+ * throws, and never guesses beyond the explicit alias table: an unknown type is
+ * reported as unknown, not silently mapped to `concept`.
+ */
+export function normaliseOkfType(raw: string): OkfType | "" {
+  const t = raw.trim().toLowerCase().replace(/[\s_]+/g, "-");
+  if (!t) return "";
+  if ((OKF_TYPES as readonly string[]).includes(t)) return t as OkfType;
+  return OKF_TYPE_ALIASES[t] ?? "";
+}
+
+/** True when `raw` is already canonical (no aliasing needed). */
+export function isCanonicalOkfType(raw: string): boolean {
+  return (OKF_TYPES as readonly string[]).includes(raw.trim().toLowerCase());
 }
 
 const FRONTMATTER_RE = /^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/;
@@ -85,7 +183,7 @@ export function splitFrontmatter(raw: string): {
 
 /**
  * Tiny YAML-subset parser: flat `key: value` pairs plus block/flow lists.
- * Handles the shapes OKF/Obsidian frontmatter actually uses:
+ * Handles the shapes OKF frontmatter actually uses:
  *
  *   title: My Concept
  *   tags: [infra, dns, networking]

--- a/src/lib/personaScaffold.ts
+++ b/src/lib/personaScaffold.ts
@@ -23,7 +23,7 @@
  *       ├── projects/
  *       ├── postmortems/
  *       └── templates/
- *           ├── atomic-note.md
+ *           ├── concept.md
  *           ├── runbook.md
  *           ├── decision.md
  *           └── postmortem.md
@@ -100,7 +100,7 @@ function seedFiles(today: string): Array<[string, string]> {
 
     ["kb/Home.md", kbHome(today)],
 
-    ["kb/templates/atomic-note.md", atomicTemplate()],
+    ["kb/templates/concept.md", conceptTemplate()],
     ["kb/templates/runbook.md", runbookTemplate()],
     ["kb/templates/decision.md", decisionTemplate()],
     ["kb/templates/postmortem.md", postmortemTemplate()],
@@ -113,16 +113,21 @@ function drawer(title: string, intro: string): string {
 
 function kbHome(today: string): string {
   return `---
-type: home
+type: index
+title: Knowledge Base
+description: Entry point and category map for this persona's private KB.
 tags: [navigation]
+aliases: [KB Home, Knowledge Base Index]
 created: ${today}
 updated: ${today}
 ---
 
 # Home
 
-Atomic notes — one idea per file, linked with [[wikilinks]]. Every
-note carries YAML frontmatter (\`type\`, \`tags\`, \`created\`, \`updated\`).
+Private to this persona. Atomic notes in Open Knowledge Format — one idea
+per file, linked with [[wikilinks]] into a concept graph. Every note carries
+YAML frontmatter: \`type\`, \`title\`, \`description\`, \`tags\`, \`aliases\`,
+\`created\`, \`updated\`. See [[templates/]] for the skeletons.
 
 ## Categories
 
@@ -135,7 +140,7 @@ note carries YAML frontmatter (\`type\`, \`tags\`, \`created\`, \`updated\`).
 - [[projects/]] — current work
 - [[postmortems/]] — incident writeups
 - [[inbox/]] — quick captures pending nightly filing
-- [[templates/]] — note skeletons (atomic-note, runbook, decision, postmortem)
+- [[templates/]] — note skeletons (concept, runbook, decision, postmortem)
 
 ## How to use the KB
 
@@ -143,17 +148,24 @@ note carries YAML frontmatter (\`type\`, \`tags\`, \`created\`, \`updated\`).
   to avoid duplicating an existing note.
 - **One idea per file.** Atomic notes are easier to link, search, and
   refactor than mega-notes.
-- **Link freely.** \`[[wikilinks]]\` build the graph. The nightly cycle
-  adds links between newly-related notes.
+- **Link every note.** \`[[wikilinks]]\` are the graph, and recall expands
+  outward along it from a lexical match — an unlinked note is reachable only
+  by exact wording. The nightly cycle adds links between newly-related notes.
+- **Fill \`description\` and \`aliases\`.** Search weights frontmatter above
+  body text, so aliases are what let a later query find a note using words
+  you didn't happen to write.
 - **Capture in inbox/.** If you're mid-task and have a half-thought,
   drop a one-liner into \`inbox/\`. The nightly cycle files or discards it.
 `;
 }
 
-function atomicTemplate(): string {
+function conceptTemplate(): string {
   return `---
 type: concept
+title: <what this is>
+description: <one sentence: the question this note answers>
 tags: []
+aliases: []
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---
@@ -176,7 +188,10 @@ One idea per note. Link related notes with [[wikilinks]].
 function runbookTemplate(): string {
   return `---
 type: runbook
+title: <the action this performs>
+description: <one sentence: when you reach for this>
 tags: [ops]
+aliases: []
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---
@@ -209,7 +224,10 @@ What to do if a step fails.
 function decisionTemplate(): string {
   return `---
 type: decision
+title: <the choice made>
+description: <one sentence: what was decided and why>
 tags: []
+aliases: []
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---
@@ -241,7 +259,10 @@ We chose X because Y.
 function postmortemTemplate(): string {
   return `---
 type: postmortem
+title: <the incident>
+description: <one sentence: what broke and what fixed it>
 tags: [incident]
+aliases: []
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -6,6 +6,7 @@
  * the Anthropic side stays warm for the persona-and-memory prefix.
  */
 
+import { OKF_AGENT_TYPES, OKF_CORE_TYPES } from "../lib/okf.js";
 import type { PersonaFiles } from "./loader.js";
 
 export interface ChannelContext {
@@ -127,7 +128,7 @@ export function buildSystemPrompt(
  * per-project memory blob. Phantombot deliberately does NOT rely on that. We
  * inject THIS four-layer system via --system-prompt instead: daily journal →
  * structured drawers (decisions/lessons/people/commitments/norms) → an
- * Obsidian-shaped KB → a hybrid FTS+vector index over all of it. It is
+ * OKF-formatted KB → a hybrid FTS+vector index over all of it. It is
  * persona-scoped, searchable, self-distilling (heartbeat + nightly), and it
  * feeds the threat judge (the `norms` drawer). The harness's auto-memory is a
  * single undifferentiated file with no recall, no decay, no provenance — a
@@ -197,10 +198,41 @@ Layout (relative to your working dir):
   memory/norms.md            — structured drawer (what's ROUTINE in your owner's
                                world; briefs the threat judge so it doesn't
                                cry wolf on normal operations)
-  kb/                        — Obsidian-shaped second brain (atomic notes)
+  kb/                        — your PRIVATE knowledge base: atomic notes in
+                               Open Knowledge Format, linked into a graph
   kb/inbox/                  — quick capture; nightly cycle files or discards
-  kb/templates/              — frontmatter skeletons (atomic / runbook /
+  kb/templates/              — frontmatter skeletons (concept / runbook /
                                decision / postmortem)
+
+kb/ is private to this persona. It is not published, not shared with other
+agents, and not a document store for your owner — it is your own recall.
+When your owner refers to "the vault" or "the wiki" they mean something
+else, somewhere else; never write there unless they point you at it.
+
+OKF FRONTMATTER — every kb/ note carries these fields:
+
+  type:         one of the controlled vocabulary below (OKF's required field)
+  title:        what this note is
+  description:  one sentence on the question this note answers
+  tags:         [lowercase-hyphenated]
+  aliases:      [other names this thing goes by]
+  created:      YYYY-MM-DD
+  updated:      YYYY-MM-DD
+
+  type is one of: ${OKF_CORE_TYPES.join(" | ")}
+                  ${OKF_AGENT_TYPES.join(" | ")}
+
+  Pick the closest one — do NOT invent a new type. A near-synonym
+  ("troubleshooting" for a runbook) fragments the index and makes both
+  notes harder to find.
+
+\`description\` and \`aliases\` are load-bearing, not decoration. Search weights
+frontmatter above body text, so aliases are what let a LATER query find this
+note using different words than the ones you happen to write today. List the
+names you might search for in six months, including the wrong-but-plausible
+ones. Likewise \`[[wikilinks]]\`: link every new note to its nearest existing
+neighbours — recall walks that graph outward from a match, so an unlinked
+note is one only an exact-wording query will ever reach.
 
 Two hard rules — apply on every nontrivial task:
 

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -7,6 +7,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  indexedNoteType,
   MemoryIndex,
   NOTES_SCHEMA_VERSION,
   parseTurnCreatedAtMs,
@@ -394,6 +395,99 @@ describe("BM25F field weighting", () => {
   });
 });
 
+describe("indexedNoteType", () => {
+  test("passes a canonical type through unchanged", () => {
+    expect(indexedNoteType("runbook")).toBe("runbook");
+  });
+
+  test("keeps the raw spelling alongside the canonical one", () => {
+    // Both must be searchable: canonical so legacy notes join their peers,
+    // raw so adopting the vocabulary never makes an old note unfindable.
+    expect(indexedNoteType("atomic-note")).toBe("concept atomic-note");
+    expect(indexedNoteType("troubleshooting")).toBe("runbook troubleshooting");
+  });
+
+  test("normalises case and separators before folding", () => {
+    expect(indexedNoteType("  Atomic_Note ")).toBe("concept atomic-note");
+    expect(indexedNoteType("Runbook")).toBe("runbook");
+  });
+
+  test("keeps an unknown type on its own spelling so drift stays findable", () => {
+    expect(indexedNoteType("wibble")).toBe("wibble");
+  });
+
+  test("yields empty for a missing type", () => {
+    expect(indexedNoteType("")).toBe("");
+    expect(indexedNoteType("   ")).toBe("");
+  });
+});
+
+describe("OKF type column (BM25F)", () => {
+  test("a note is retrievable by its declared type", async () => {
+    await note(
+      "kb/infra/deploy.md",
+      "---\ntitle: Deploying the gateway\ntype: runbook\n---\n" +
+        "# Deploying the gateway\nsteps here.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const hits = ix.search("runbook", { scope: "kb" });
+    expect(hits.map((h) => h.path)).toContain("kb/infra/deploy.md");
+  });
+
+  test("a legacy type is retrievable by its canonical name", async () => {
+    // The whole point of the alias map: this note predates the vocabulary and
+    // was never edited, but searching the canonical type still finds it.
+    await note(
+      "kb/concepts/old.md",
+      "---\ntitle: Backpressure\ntype: atomic-note\n---\n" +
+        "# Backpressure\nnotes.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    expect(ix.search("concept", { scope: "kb" }).map((h) => h.path)).toContain(
+      "kb/concepts/old.md",
+    );
+    // ...and by the spelling actually on disk.
+    expect(
+      ix.search("atomic-note", { scope: "kb" }).map((h) => h.path),
+    ).toContain("kb/concepts/old.md");
+  });
+
+  test("a type match does not outrank a title match", async () => {
+    // `type` is a closed vocabulary, so it must stay a tiebreaker: the note
+    // genuinely ABOUT runbooks should beat one merely typed as a runbook.
+    await note(
+      "kb/infra/typed.md",
+      "---\ntitle: Rotating certificates\ntype: runbook\n---\n" +
+        "# Rotating certificates\nsteps.\n",
+    );
+    await note(
+      "kb/concepts/about.md",
+      "---\ntitle: Runbook\ntags: [runbook]\n---\n" +
+        "# Runbook\nwhat a runbook is.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const hits = ix.search("runbook", { scope: "kb", limit: 5 });
+    expect(hits[0]?.path).toBe("kb/concepts/about.md");
+  });
+
+  test("snippets still come back non-empty after the column shift", async () => {
+    // Guards NOTES_BODY_COL: FTS5 doesn't validate the column ordinal, so a
+    // stale index silently returns empty snippets rather than erroring.
+    await note(
+      "kb/concepts/snip.md",
+      "---\ntitle: Widget\ntype: concept\n---\n" +
+        "# Widget\nthe quick brown fox jumps over the lazy dog.\n",
+    );
+    await ix.refreshStale(personaDir);
+
+    const hits = ix.search("brown fox", { scope: "kb" });
+    expect(hits[0]?.snippet).toContain("fox");
+  });
+});
+
 describe("MemoryIndex.searchExpanded (OKF link-graph)", () => {
   test("pulls in a linked neighbour that did not match lexically", async () => {
     // Seed matches "postgres"; neighbour is about backups and links nowhere
@@ -554,6 +648,64 @@ describe("notes-schema self-heal", () => {
       await healed.refreshStale(pdir);
       const hits = healed.search("widget", { scope: "kb" });
       expect(hits.map((h) => h.path)).toContain("kb/x.md");
+      const ver = (
+        healed as unknown as {
+          db: { query: (s: string) => { get: () => { value: string } | null } };
+        }
+      ).db
+        .query("SELECT value FROM meta WHERE key = 'notes_schema_version'")
+        .get();
+      expect(Number(ver?.value)).toBe(NOTES_SCHEMA_VERSION);
+    } finally {
+      healed.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a v3 index (no type column) is rebuilt so type becomes searchable", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "phantombot-mi-heal4-"));
+    const idxPath = join(dir, "index.sqlite");
+    const pdir = join(dir, "persona");
+    await mkdir(join(pdir, "kb"), { recursive: true });
+    await writeFile(
+      join(pdir, "kb", "y.md"),
+      "---\ntitle: Gateway recovery\ntype: troubleshooting\n---\n" +
+        "# Gateway recovery\nthe steps.\n",
+    );
+
+    // Hand-build a v3 index: correct-for-its-day fielded columns, but no
+    // `type`. This is what every already-deployed install looks like.
+    const raw = new Database(idxPath, { create: true });
+    raw.exec("PRAGMA journal_mode = WAL");
+    raw.exec(
+      "CREATE VIRTUAL TABLE notes USING fts5(path UNINDEXED, scope UNINDEXED, " +
+        "title, tags, aliases, headings, body, tokenize = 'porter unicode61');",
+    );
+    raw.exec(
+      "CREATE TABLE files (path TEXT PRIMARY KEY, scope TEXT, mtime_ms INTEGER, " +
+        "size INTEGER, title TEXT DEFAULT '', aliases TEXT DEFAULT '', indexed_at TEXT);",
+    );
+    raw.exec(
+      "CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+    );
+    raw
+      .prepare("INSERT INTO meta (key, value) VALUES ('notes_schema_version', '3')")
+      .run();
+    raw
+      .prepare(
+        "INSERT INTO files (path, scope, mtime_ms, size, indexed_at) VALUES (?,?,?,?,?)",
+      )
+      .run("kb/y.md", "kb", 1, 1, new Date().toISOString());
+    raw.close();
+
+    const healed = await MemoryIndex.open(idxPath);
+    try {
+      await healed.refreshStale(pdir);
+      // The canonical type resolves even though the note says "troubleshooting"
+      // and the old index had nowhere to put it.
+      expect(healed.search("runbook", { scope: "kb" }).map((h) => h.path)).toContain(
+        "kb/y.md",
+      );
       const ver = (
         healed as unknown as {
           db: { query: (s: string) => { get: () => { value: string } | null } };

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -20,6 +20,7 @@ import {
   STALE_RUN_MS,
   sweepDailyFiles,
 } from "../src/lib/nightly.ts";
+import { OKF_TYPES } from "../src/lib/okf.ts";
 
 let workdir: string;
 
@@ -455,6 +456,49 @@ describe("buildNightlyStagePrompt", () => {
     expect(p).toContain("## Changelog");
     expect(p).toContain("status: obsolete");
     expect(p).toContain("2026-05-18: was X → now Y");
+  });
+
+  // Without embeddings, recall is BM25 only: it can match a note only on words
+  // the note literally contains. A single-phrase dedup search therefore misses
+  // paraphrased coverage and the stage creates a duplicate — the one failure
+  // mode that compounds, since each duplicate dilutes every later query.
+  test("kb stage requires multi-angle dedup search", () => {
+    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "kb");
+    expect(p).toContain("MORE THAN ONE ANGLE");
+    expect(p).toMatch(/two or three times/);
+  });
+
+  test("kb stage requires the full OKF frontmatter set", () => {
+    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "kb");
+    for (const field of [
+      "type",
+      "title",
+      "description",
+      "aliases",
+      "tags",
+      "created",
+      "updated",
+    ]) {
+      expect(p).toContain(field);
+    }
+  });
+
+  test("kb stage lists the controlled vocabulary from okf.ts", () => {
+    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "kb");
+    for (const t of OKF_TYPES) {
+      expect(p).toContain(t);
+    }
+    expect(p).toContain("Never invent a new type");
+  });
+
+  // On a no-embeddings install the link graph IS the semantic index: recall
+  // expands outward from a lexical hit along [[wikilinks]]. An unlinked note
+  // is reachable only by exact wording, so linking is a retrieval requirement
+  // rather than a tidiness preference.
+  test("kb stage requires new notes to be linked in", () => {
+    const p = buildNightlyStagePrompt("robbie", "2026-05-18", "kb");
+    expect(p).toContain("[[wikilinks]]");
+    expect(p).toContain("nearest existing");
   });
 
   test("no stage mentions the removed day-essence header", () => {

--- a/tests/lib-okf.test.ts
+++ b/tests/lib-okf.test.ts
@@ -5,6 +5,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   extractLinks,
+  isCanonicalOkfType,
+  normaliseOkfType,
+  OKF_AGENT_TYPES,
+  OKF_CORE_TYPES,
+  OKF_TYPE_ALIASES,
+  OKF_TYPES,
   parseFrontmatter,
   parseOkf,
   splitFrontmatter,
@@ -115,5 +121,59 @@ describe("parseOkf", () => {
     const doc = parseOkf("");
     expect(doc.title).toBe("");
     expect(doc.links).toEqual([]);
+  });
+});
+
+describe("controlled type vocabulary", () => {
+  test("core and agent types are disjoint and non-empty", () => {
+    expect(OKF_CORE_TYPES.length).toBeGreaterThan(0);
+    expect(OKF_AGENT_TYPES.length).toBeGreaterThan(0);
+    const overlap = OKF_CORE_TYPES.filter((t) =>
+      (OKF_AGENT_TYPES as readonly string[]).includes(t),
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  test("OKF_TYPES has no duplicates", () => {
+    expect(new Set(OKF_TYPES).size).toBe(OKF_TYPES.length);
+  });
+
+  test("every alias resolves to a canonical type", () => {
+    // Guards the drift map against pointing at a type that was later renamed
+    // or removed — an alias to a non-existent type silently normalises to "".
+    for (const [alias, target] of Object.entries(OKF_TYPE_ALIASES)) {
+      expect((OKF_TYPES as readonly string[]).includes(target)).toBe(true);
+      // An alias must not shadow a canonical value.
+      expect((OKF_TYPES as readonly string[]).includes(alias)).toBe(false);
+    }
+  });
+
+  test("canonical types normalise to themselves", () => {
+    for (const t of OKF_TYPES) {
+      expect(normaliseOkfType(t)).toBe(t);
+      expect(isCanonicalOkfType(t)).toBe(true);
+    }
+  });
+
+  test("folds the drift observed in real KBs", () => {
+    expect(normaliseOkfType("atomic-note")).toBe("concept");
+    expect(normaliseOkfType("troubleshooting")).toBe("runbook");
+    expect(normaliseOkfType("incident-handover")).toBe("postmortem");
+    expect(normaliseOkfType("home")).toBe("index");
+    expect(normaliseOkfType("model-research")).toBe("reference");
+  });
+
+  test("normalisation is case- and separator-insensitive", () => {
+    expect(normaliseOkfType("  Atomic_Note ")).toBe("concept");
+    expect(normaliseOkfType("PROJECT PLAN")).toBe("project");
+    expect(normaliseOkfType("Runbook")).toBe("runbook");
+  });
+
+  test("unknown types report as unknown rather than guessing", () => {
+    // Deliberate: silently bucketing an unrecognised type as `concept` would
+    // hide vocabulary drift instead of surfacing it.
+    expect(normaliseOkfType("wibble")).toBe("");
+    expect(normaliseOkfType("")).toBe("");
+    expect(isCanonicalOkfType("wibble")).toBe(false);
   });
 });

--- a/tests/lib-personaScaffold.test.ts
+++ b/tests/lib-personaScaffold.test.ts
@@ -7,6 +7,7 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { isCanonicalOkfType, parseOkf } from "../src/lib/okf.ts";
 import { ensurePersonaScaffold } from "../src/lib/personaScaffold.ts";
 
 let workdir: string;
@@ -35,7 +36,7 @@ describe("ensurePersonaScaffold", () => {
     // KB seeds
     for (const f of [
       "kb/Home.md",
-      "kb/templates/atomic-note.md",
+      "kb/templates/concept.md",
       "kb/templates/runbook.md",
       "kb/templates/decision.md",
       "kb/templates/postmortem.md",
@@ -88,9 +89,42 @@ describe("ensurePersonaScaffold", () => {
     await ensurePersonaScaffold(workdir);
     const home = await readFile(join(workdir, "kb", "Home.md"), "utf8");
     expect(home).toMatch(/^---/);
-    expect(home).toContain("type: home");
+    // `home` was folded into the shared `index` type when the OKF vocabulary
+    // was declared; `normaliseOkfType` still maps the legacy value.
+    expect(home).toContain("type: index");
     expect(home).toContain("[[concepts/]]");
     const today = new Date().toISOString().slice(0, 10);
     expect(home).toContain(`created: ${today}`);
+  });
+});
+
+describe("scaffolded templates carry full OKF frontmatter", () => {
+  test("every template declares a canonical type and the weighted fields", async () => {
+    await ensurePersonaScaffold(workdir);
+    for (const f of [
+      "kb/templates/concept.md",
+      "kb/templates/runbook.md",
+      "kb/templates/decision.md",
+      "kb/templates/postmortem.md",
+      "kb/Home.md",
+    ]) {
+      const raw = await readFile(join(workdir, f), "utf8");
+      // The type a template declares must be one an agent is allowed to
+      // author — a template scaffolding an off-vocabulary type teaches drift
+      // on every note created from it.
+      expect(isCanonicalOkfType(parseOkf(raw).type)).toBe(true);
+      for (const field of ["title:", "description:", "tags:", "aliases:"]) {
+        expect(raw).toContain(field);
+      }
+    }
+  });
+
+  test("the concept template's filename matches the type it declares", async () => {
+    // Regression: the old `atomic-note.md` declared `type: concept`, so the
+    // scaffold contradicted itself about what the vocabulary actually was.
+    await ensurePersonaScaffold(workdir);
+    const raw = await readFile(join(workdir, "kb/templates/concept.md"), "utf8");
+    expect(parseOkf(raw).type).toBe("concept");
+    expect(existsSync(join(workdir, "kb/templates/atomic-note.md"))).toBe(false);
   });
 });

--- a/tests/persona-builder-memory-tools.test.ts
+++ b/tests/persona-builder-memory-tools.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { OKF_TYPES } from "../src/lib/okf.ts";
 import {
   MEMORY_TOOLS_SECTION,
   buildSystemPrompt,
@@ -45,5 +46,49 @@ describe("buildSystemPrompt — memory tools section", () => {
   test("MEMORY_TOOLS_SECTION mentions the heartbeat + nightly cadence", () => {
     expect(MEMORY_TOOLS_SECTION).toContain("heartbeat");
     expect(MEMORY_TOOLS_SECTION).toContain("nightly");
+  });
+});
+
+describe("MEMORY_TOOLS_SECTION — OKF vocabulary", () => {
+  test("teaches the required OKF frontmatter fields", () => {
+    for (const field of [
+      "type:",
+      "title:",
+      "description:",
+      "tags:",
+      "aliases:",
+      "created:",
+      "updated:",
+    ]) {
+      expect(MEMORY_TOOLS_SECTION).toContain(field);
+    }
+  });
+
+  test("lists every controlled type, so the prompt cannot drift from okf.ts", () => {
+    // The prompt is generated from OKF_TYPES precisely so adding a type in one
+    // place can't leave the other stale. This asserts the generation actually
+    // happened rather than someone hardcoding a snapshot of the list.
+    for (const t of OKF_TYPES) {
+      expect(MEMORY_TOOLS_SECTION).toContain(t);
+    }
+  });
+
+  test("forbids inventing new types", () => {
+    expect(MEMORY_TOOLS_SECTION).toContain("do NOT invent a new type");
+  });
+
+  test("states that kb/ is private, and never calls it a vault", () => {
+    // Regression guard: the prompt used to describe kb/ as an
+    // "Obsidian-shaped second brain", which reads as a shareable, human-facing
+    // vault. It is neither — it is this persona's private recall.
+    expect(MEMORY_TOOLS_SECTION).toContain("your PRIVATE knowledge base");
+    expect(MEMORY_TOOLS_SECTION).toContain("kb/ is private to this persona");
+    expect(MEMORY_TOOLS_SECTION).toContain("not shared with other");
+    expect(MEMORY_TOOLS_SECTION).not.toContain("Obsidian");
+  });
+
+  test("explains why aliases and wikilinks matter for recall", () => {
+    expect(MEMORY_TOOLS_SECTION).toContain("aliases");
+    expect(MEMORY_TOOLS_SECTION).toContain("[[wikilinks]]");
   });
 });


### PR DESCRIPTION
## Why

Two problems that turn out to be the same problem.

**1. The controlled-vocabulary layer is built and empty.** `src/lib/okf.ts` already parses `type`, `title`, `description`, `tags` and `aliases`, and the index already weights them as separate BM25F columns. The README already sells this as the headline of the no-API-key path:

> **Tag / alias controlled vocabulary** — author-time synonyms collapse the vocabulary-mismatch gap

Nothing populates it. No template ships `description` or `aliases`, the persona prompt never mentions them, and the nightly KB stage required only `type, tags, created, updated`. So the documented feature of the default search path is unused on every phantom in the wild.

**2. `type` has drifted, because nothing ever declared what it should be.** Off 4 scaffolded templates, a real KB here has accumulated 14 distinct values — `lesson` (94), `concept` (92), `decision` (45), then a long tail including `troubleshooting` ×2 and `atomic-note` ×1. A human-curated OKF vault checked alongside it had 21 values against 5 declared. Near-synonyms fragment the exact column meant to sharpen recall.

This matters most **without embeddings**, which is the default and — since it needs no second API key — likely the majority of installs. There, BM25 can only match words a note literally contains, so `description`/`aliases` and a clean `type` aren't polish; they're the retrieval mechanism.

## What

**Declare the vocabulary once, generate the prompts from it.** A prompt carrying its own hardcoded copy of the list would diverge from the parser the first time either changed, so `builder.ts` and `nightly.ts` interpolate `OKF_TYPES`, and tests assert every value reaches both prompts.

- **`OKF_CORE_TYPES`** (9) — `concept`, `runbook`, `procedure`, `reference`, `postmortem`, `project`, `person`, `infrastructure`, `index`. Chosen to mean the same thing in a human-curated OKF vault as in a phantom KB, so notes move between the two without translation.
- **`OKF_AGENT_TYPES`** (4) — `lesson`, `decision`, `norm`, `account`. Drawer-derived, no vault equivalent: a vault records what someone decided was true, these record what the agent learned the hard way.

**Adoption is not a migration.** `OKF_TYPE_ALIASES` + `normaliseOkfType()` fold legacy values (`troubleshooting` → `runbook`, `home` → `index`) at query time. Every note ever written stays valid, nothing on disk is renamed, only new notes converge. An unknown type returns `""` rather than being guessed into `concept` — drift should stay visible rather than being silently absorbed.

**Two no-embeddings recall fixes, in the nightly KB stage:**

- **Multi-angle dedup search.** It deduped with a single search phrase. Today's wording and the existing note's wording are routinely disjoint (`"CI agents refusing jobs"` vs `"runner version deprecated"`), so BM25 missed the note and created a duplicate. This is the failure mode that *compounds* — each duplicate splits one truth in two and dilutes every later query. Now searches by symptom, by component, and by literal error string.
- **Linking is now a requirement, with its reason stated.** Without embeddings the link graph *is* the semantic index: recall expands outward from a lexical hit along `[[wikilinks]]`. An unlinked note is reachable only by exact wording. The prompt previously said "link related notes" as a stylistic aside.

**Naming.** `kb/` is no longer described as an *"Obsidian-shaped second brain"*. That phrase came from the prompt in `builder.ts:200`, so every phantom has been told it — and it invites a real error: treating the agent's private recall as the operator's shareable vault, and writing to the wrong one. `kb/` is private persona recall. OKF is the format; where a human-facing vault lives is a separate question. (`README.md:164` still says "Obsidian vault" — correctly, about a *user's* actual vault. Left alone.)

## Drive-bys

- `heartbeat.ts` docstring claimed it "does NOT run the embedding pass (that's the nightly cycle's job)". `cli/heartbeat.ts` has run an incremental pass since it landed.
- `kb/templates/atomic-note.md` declared `type: concept` — the scaffold contradicting itself about its own vocabulary. Renamed `concept.md`.

## Testing

`2839 pass / 0 fail`, `tsc --noEmit` clean. 22 new assertions covering: alias-map integrity (no alias resolves to a removed type, none shadows a canonical one), case/separator normalisation, unknown-type behaviour, both prompts containing the full generated vocabulary, every scaffolded template declaring a canonical type plus the weighted fields, and a regression guard that the prompt never says "Obsidian" again.

Two existing tests were updated rather than worked around, both genuinely stale under the new vocabulary: `Home.md` now declares `type: index` (folded from `home`), and the scaffold expects `concept.md`.

## Deliberately not here

A `doctor` check reporting off-vocabulary types and orphan notes (zero inbound links — effectively unreachable on a BM25-only install). It should **report**, never rewrite. Left for a follow-up so this PR stays "declare the standard".