### PR TITLE
fix(retrieval): widen tier-2 candidate pool so provenance re-ranking has room

### DIFF
--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -298,6 +298,18 @@ export interface SearchHit {
    * confidentiality boundary. Only set for conversation-turn hits.
    */
   audience?: TurnAudience;
+  /**
+   * Multiplicative time-decay factor applied to this hit's ordering inside
+   * hybridSearch (see turnDecayFactor), when decay was requested. Carried
+   * on the hit — separately from the RAW `ftsScore`/`rrfScore`, which stay
+   * undecayed for callers that threshold on relevance — so a downstream
+   * re-rank (e.g. tier-2 provenance weighting in retrieval.ts) can factor
+   * decay back in instead of silently dropping it once the hit has left
+   * hybridSearch's own decay-ordered slice. Always populated by
+   * hybridSearch (1 = no decay, when decay wasn't requested or the turn's
+   * age was unavailable). Only meaningful for conversation-turn hits.
+   */
+  decayFactor?: number;
   snippet: string;
 }
 
@@ -1381,7 +1393,8 @@ export class MemoryIndex {
             (b.ftsScore ?? 0) * (factors.get(b.path) ?? 1) -
             (a.ftsScore ?? 0) * (factors.get(a.path) ?? 1),
         )
-        .slice(0, limit);
+        .slice(0, limit)
+        .map((h) => ({ ...h, decayFactor: factors.get(h.path) ?? 1 }));
     }
 
     // Vector search. Brute-force cosine over all embeddings.
@@ -1489,6 +1502,7 @@ export class MemoryIndex {
           ftsScore: ftsHit?.ftsScore,
           vecScore: vecScores.get(path),
           rrfScore,
+          decayFactor: decayFactors?.get(path) ?? 1,
           ...turnMeta,
           snippet: ftsHit?.snippet ?? this.snippetForPath(path),
         };

--- a/src/orchestrator/retrieval.ts
+++ b/src/orchestrator/retrieval.ts
@@ -219,9 +219,15 @@ export async function retrieveContext(
       // defaults, a genuine ≈4 BM25 match stops clearing the 2.0 floor
       // past ~30 days and tier 2 goes permanently silent for exactly the
       // aged cross-chat memory #377 exists to surface.
+      // Pool width is deliberately wider than crossLimit: crossProvenanceWeight
+      // (below, via selectCrossConversationHits) re-ranks survivors by trust,
+      // and a pool truncated to crossLimit BEFORE that re-rank runs leaves
+      // nothing for it to rerank — it would just rubber-stamp RRF's raw top-N
+      // (#382). hybridSearch's own limit clamp (≤50) is the real ceiling; this
+      // just asks for enough candidates that provenance has room to work.
       const candidates = ix.hybridSearch(query, queryVec, {
         scope: "turns",
-        limit: crossLimit,
+        limit: Math.max(crossLimit * 10, CROSS_CANDIDATE_POOL_MIN),
         decay,
         turnFilter,
       });
@@ -396,6 +402,15 @@ export function crossAttribution(
  * hit's position among survivors and never decides admission: the floor
  * (`minScore` / `minVecScore`) still runs on RAW relevance, untouched.
  */
+/**
+ * Floor on the tier-2 candidate pool passed into hybridSearch, independent
+ * of crossLimit (the OUTPUT cap applied after provenance re-ranking, in
+ * selectCrossConversationHits). Matches hybridSearch's internal FTS/vector
+ * pool width (25 each side, see memoryIndex.ts) — no point asking for a
+ * shallower pool than hybridSearch already builds internally.
+ */
+export const CROSS_CANDIDATE_POOL_MIN = 25;
+
 export const CROSS_SOURCE_WEIGHT: Record<FactSource, number> = {
   principal: 1,
   self: 0.9,

--- a/src/orchestrator/retrieval.ts
+++ b/src/orchestrator/retrieval.ts
@@ -394,15 +394,6 @@ export function crossAttribution(
 }
 
 /**
- * Tier-2 TRUST weights, by `source` (who asserted the content).
- *
- * Weight, do not filter — the principal's call on #377. A low-provenance
- * memory is still a memory; the failure we are guarding is a weak claim
- * OUTRANKING a strong one, not a weak claim existing. So provenance moves a
- * hit's position among survivors and never decides admission: the floor
- * (`minScore` / `minVecScore`) still runs on RAW relevance, untouched.
- */
-/**
  * Floor on the tier-2 candidate pool passed into hybridSearch, independent
  * of crossLimit (the OUTPUT cap applied after provenance re-ranking, in
  * selectCrossConversationHits). Matches hybridSearch's internal FTS/vector
@@ -411,6 +402,15 @@ export function crossAttribution(
  */
 export const CROSS_CANDIDATE_POOL_MIN = 25;
 
+/**
+ * Tier-2 TRUST weights, by `source` (who asserted the content).
+ *
+ * Weight, do not filter — the principal's call on #377. A low-provenance
+ * memory is still a memory; the failure we are guarding is a weak claim
+ * OUTRANKING a strong one, not a weak claim existing. So provenance moves a
+ * hit's position among survivors and never decides admission: the floor
+ * (`minScore` / `minVecScore`) still runs on RAW relevance, untouched.
+ */
 export const CROSS_SOURCE_WEIGHT: Record<FactSource, number> = {
   principal: 1,
   self: 0.9,
@@ -544,11 +544,19 @@ export function selectCrossConversationHits(
   // floor than we have slots for, the slots go to the better-attested ones
   // rather than to whoever happened to rank higher lexically.
   //
+  // decayFactor is folded back in here deliberately: hybridSearch's own
+  // ordering is decay-adjusted, but with the pool now wider than `limit`
+  // (#382) that ordering only decides who ENTERS the pool, not who wins the
+  // final slots — this multiply is what makes decay matter again for a pool
+  // this wide. Without it, a 400-day-old hit at the decay floor can
+  // outrank a same-day hit purely on raw score × provenance (#390 review).
+  // 1 when decay wasn't requested, so this is a no-op in that case.
+  //
   // Ordering only: the weighted value is never written back onto the hit,
   // so nothing downstream can mistake it for a relevance score. Array.sort
   // is stable, so equal weights preserve the incoming best-first order.
   const ranked = out
-    .map((h, i) => ({ h, i, w: crossProvenanceWeight(h) }))
+    .map((h, i) => ({ h, i, w: crossProvenanceWeight(h) * (h.decayFactor ?? 1) }))
     .sort((a, b) => scoreOf(b.h) * b.w - scoreOf(a.h) * a.w || a.i - b.i)
     .map((r) => r.h);
   return ranked.slice(0, opts.limit);

--- a/src/orchestrator/retrieval.ts
+++ b/src/orchestrator/retrieval.ts
@@ -223,11 +223,12 @@ export async function retrieveContext(
       // (below, via selectCrossConversationHits) re-ranks survivors by trust,
       // and a pool truncated to crossLimit BEFORE that re-rank runs leaves
       // nothing for it to rerank — it would just rubber-stamp RRF's raw top-N
-      // (#382). hybridSearch's own limit clamp (≤50) is the real ceiling; this
-      // just asks for enough candidates that provenance has room to work.
+      // (#382). Taking the whole fused pool also means hybridSearch's own
+      // decay-ordered slice no longer selects anything, which is why the
+      // re-rank multiplies decayFactor back in — see selectCrossConversationHits.
       const candidates = ix.hybridSearch(query, queryVec, {
         scope: "turns",
-        limit: Math.max(crossLimit * 10, CROSS_CANDIDATE_POOL_MIN),
+        limit: CROSS_CANDIDATE_POOL,
         decay,
         turnFilter,
       });
@@ -394,13 +395,18 @@ export function crossAttribution(
 }
 
 /**
- * Floor on the tier-2 candidate pool passed into hybridSearch, independent
- * of crossLimit (the OUTPUT cap applied after provenance re-ranking, in
- * selectCrossConversationHits). Matches hybridSearch's internal FTS/vector
- * pool width (25 each side, see memoryIndex.ts) — no point asking for a
- * shallower pool than hybridSearch already builds internally.
+ * Width of the tier-2 candidate pool passed into hybridSearch, independent of
+ * crossLimit (the OUTPUT cap applied after provenance and decay re-ranking, in
+ * selectCrossConversationHits).
+ *
+ * 50 is hybridSearch's own ceiling, not an arbitrary number: it clamps `limit`
+ * to 50 and its RRF merge fuses at most 25 FTS + 25 vector paths, so asking
+ * for 50 means "hand me the whole fused pool and let the re-rank decide the
+ * output" — which is the entire point of #382. Cost is bounded by that same
+ * ceiling: the per-hit `lookupScope`/`turnMetaForPath`/`snippetForPath`
+ * round-trips only run on paths that survived the merge, ≤50 of them.
  */
-export const CROSS_CANDIDATE_POOL_MIN = 25;
+export const CROSS_CANDIDATE_POOL = 50;
 
 /**
  * Tier-2 TRUST weights, by `source` (who asserted the content).

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -1047,6 +1047,16 @@ describe("per-path BM25 lookup for vector-only hits (#378)", () => {
   const vec = new Float32Array([1, 0, 0]);
   const pad = Array.from({ length: 120 }, (_, k) => `padding${k}`).join(" ");
 
+  // Note: this fixture's raw BM25 for BBB is ~5.4e-7 — effectively zero,
+  // because all 31 seeded docs contain every query term so IDF collapses.
+  // That's far below the production tier-2 floor (minScore: 2.0), and that's
+  // fine: the invariant under test is score CONVENTION (per-path must equal
+  // undecayed), not a realistic score value. Don't "fix" this fixture to
+  // produce a plausible-looking score — doing so would break the length
+  // inversion (padding vs. short fillers) that pushes BBB out of the FTS
+  // top-25 pool, which is the vector-only condition the test depends on.
+  // (#379/5)
+
   // Shared seeding helper so both tests use the same fixture.
   function seed(): void {
     // 30 short filler turns in AAA — all lexically competitive.

--- a/tests/orchestrator-retrieval.test.ts
+++ b/tests/orchestrator-retrieval.test.ts
@@ -515,6 +515,62 @@ describe("retrieveContext", () => {
     expect(out!).not.toContain("DDD");
   });
 
+  test("time-decay still wins a cross-conversation tie-break with the widened pool (#390)", async () => {
+    // Same shape as the #382 test above, but the axis under test is AGE, not
+    // provenance — both candidates share provenance (unverified/internal) so
+    // decay is the only thing that can separate them. FRESH is 1 day old;
+    // ANCIENT is 400 days old (well past the 30-day half-life, pinned at the
+    // 0.02 floor) and states the query terms more times, so it wins on raw
+    // BM25 alone.
+    //
+    // Before the #390 fix, hybridSearch's OWN decay-adjusted ordering decided
+    // who survived truncation to `limit` — but #382 widened that pool well
+    // past crossLimit, so decay only gated pool ENTRY, and the final
+    // selectCrossConversationHits re-rank (raw score × provenance) had no
+    // decay term at all: ANCIENT's stronger raw BM25 let it win outright.
+    const ix = await MemoryIndex.open(indexPath);
+    await ix.refreshStale(personaDir);
+    seedFillerTurns(ix);
+    ix.upsertTurn({
+      id: 1,
+      persona: "phantom",
+      conversation: "phantomchat:group:FRESH",
+      role: "user",
+      text: "Yeti spelunking checksum noted once for the record.",
+      createdAt: new Date(Date.now() - 86_400_000), // 1 day old
+      embeddable: true,
+      source: "unverified",
+      origin: "internal",
+    });
+    ix.upsertTurn({
+      id: 2,
+      persona: "phantom",
+      conversation: "phantomchat:group:ANCIENT",
+      role: "user",
+      text: "Yeti spelunking yeti spelunking yeti spelunking checksum retry backoff.",
+      createdAt: new Date(Date.now() - 400 * 86_400_000), // 400 days old
+      embeddable: true,
+      source: "unverified",
+      origin: "internal",
+    });
+    ix.close();
+
+    const out = await retrieveContext({
+      query: "yeti spelunking checksum",
+      personaDir,
+      indexPath,
+      embeddings: noEmbeddings,
+      settings: {
+        ...DEFAULT_RETRIEVAL,
+        crossConversation: { ...DEFAULT_CROSS_CONVERSATION, limit: 1 },
+      },
+      conversation: "phantomchat:group:AAA", // no in-conversation match
+    });
+    expect(out).toBeDefined();
+    expect(out!).toContain("FRESH");
+    expect(out!).not.toContain("ANCIENT");
+  });
+
   test("excluded sources never surface cross-conversation", async () => {
     const ix = await MemoryIndex.open(indexPath);
     await ix.refreshStale(personaDir);

--- a/tests/orchestrator-retrieval.test.ts
+++ b/tests/orchestrator-retrieval.test.ts
@@ -459,6 +459,62 @@ describe("retrieveContext", () => {
     expect(crossLabels.length).toBe(2);
   });
 
+  test("candidate pool is wider than crossLimit, so provenance re-ranking has something to work with (#382)", async () => {
+    // Two candidates, one per conversation, both clearing the raw-relevance
+    // floor. DDD has the stronger raw BM25 (repeats the query terms) but
+    // weak provenance (unverified/internal, weight 0.42). EEE has weaker raw
+    // BM25 (states the terms once) but full-trust provenance
+    // (principal/channel, weight 1.0) — so weighted, EEE should outrank DDD.
+    //
+    // Before the fix, hybridSearch's own `limit` was crossLimit (1 here), so
+    // only DDD (the raw-BM25 winner) ever reached selectCrossConversationHits
+    // — EEE was truncated out of the pool before provenance got a vote, and
+    // the hard-capped output was always DDD. The fix widens the pool so both
+    // candidates survive into the re-rank.
+    const ix = await MemoryIndex.open(indexPath);
+    await ix.refreshStale(personaDir);
+    seedFillerTurns(ix);
+    const when = new Date(Date.now() - 86_400_000); // same day: decay a wash
+    ix.upsertTurn({
+      id: 1,
+      persona: "phantom",
+      conversation: "phantomchat:group:DDD",
+      role: "user",
+      text: "Narwhal telemetry narwhal telemetry narwhal telemetry checksum retry backoff.",
+      createdAt: when,
+      embeddable: true,
+      source: "unverified",
+      origin: "internal",
+    });
+    ix.upsertTurn({
+      id: 2,
+      persona: "phantom",
+      conversation: "phantomchat:group:EEE",
+      role: "user",
+      text: "Narwhal telemetry checksum noted once for the record.",
+      createdAt: when,
+      embeddable: true,
+      source: "principal",
+      origin: "channel",
+    });
+    ix.close();
+
+    const out = await retrieveContext({
+      query: "narwhal telemetry checksum",
+      personaDir,
+      indexPath,
+      embeddings: noEmbeddings,
+      settings: {
+        ...DEFAULT_RETRIEVAL,
+        crossConversation: { ...DEFAULT_CROSS_CONVERSATION, limit: 1 },
+      },
+      conversation: "phantomchat:group:AAA", // no in-conversation match
+    });
+    expect(out).toBeDefined();
+    expect(out!).toContain("EEE");
+    expect(out!).not.toContain("DDD");
+  });
+
   test("excluded sources never surface cross-conversation", async () => {
     const ix = await MemoryIndex.open(indexPath);
     await ix.refreshStale(personaDir);


### PR DESCRIPTION
## Summary
- `hybridSearch`'s own `limit` was `crossLimit` (default 3), so only that many candidates ever reached `selectCrossConversationHits` — the provenance re-ranking added in #380 had nothing left to reorder and just rubber-stamped RRF's raw top-N. Widens the pool passed into `hybridSearch` to a flat `CROSS_CANDIDATE_POOL = 50`; the output cap (`crossLimit`) is unchanged.
- Carries `decayFactor` out of `hybridSearch` on `SearchHit` and folds it into the tier-2 re-rank key (`scoreOf(h) * (decayFactor ?? 1) * crossProvenanceWeight(h)`), so widening the pool doesn't drop time-decay out of the ordering. `rrfScore`/`ftsScore` stay raw, because the `minScore: 2.0` floor is calibrated on undecayed scores.
- One-line comment on the `#378` BM25 fixture (`tests/lib-memoryIndex.test.ts`) explaining why its near-zero raw score is intentional, so a future edit doesn't "fix" it into breaking the vector-only condition the test depends on.

Re-verified against current `main` (69e9d10) before writing this — #379 items 1-3 were already delivered by #380 and closed separately; this covers the two survivors (item 4 held back deliberately, see below).

Closes #382. Closes #379 (item 5; item 4 — tier-2 dropped first on token budget — is a separate, more invasive change and stays open as its own follow-up).

### Correction to the `635e792` commit body
That commit message says *"No behaviour change at the default crossLimit (5 → 50 either way)"*. That is wrong on both counts and is corrected here rather than by a force-push (the branch is already approved):

- The default `crossLimit` is **3**, not 5 (`DEFAULT_CROSS_CONVERSATION.limit = 3`, `src/config.ts:339`).
- So the old expression yielded `max(3 * 10, 25) = 30`, and the flat constant makes it **50**. That *is* a behaviour change on the default path: 20 more candidates enter the tier-2 re-rank per turn.

Why that's safe:
- Output is still capped at `crossLimit`, and the admission gates (`minScore` / `minVecScore`) are untouched — nothing new slips past the floor.
- Candidates ranked 31–50 carry low `rrfScore`, and the re-rank key is `rrfScore × decay × provenance`, so they only take a slot when genuinely better-attested or fresher — which is #382's intent.
- Cost is bounded: ≤20 extra `lookupScope` / `turnMetaForPath` / `snippetForPath` round-trips plus a slightly wider vec-only BM25 backfill, all in-process SQLite. The 50 ceiling is real — `hybridSearch` clamps `limit` to ≤50 and its RRF merge fuses at most 25 FTS + 25 vector.

## Test plan
- [x] Provenance regression test (`orchestrator-retrieval.test.ts`): two cross-conversation candidates, one with stronger raw BM25 but low-trust provenance, one weaker raw BM25 but full-trust provenance. Confirmed it **fails** without the fix and **passes** with it.
- [x] Age-gap regression test: 1-day-old vs 400-day-old (pinned at the 0.02 decay floor), same provenance, the ancient hit carrying stronger raw BM25, `limit: 1` — asserts the fresh hit wins. Mutation-checked: removing the `decayFactor` multiply fails it.
- [x] `bun test tests/orchestrator-retrieval.test.ts` — 47 pass
- [x] `bun test tests/lib-memoryIndex.test.ts` — 59 pass
- [x] `bun test` (full suite) — 2850 pass, 0 fail, 2 skip
- [x] `bun tsc --noEmit` — clean
