### PR TITLE
fix(retrieval): don't sink tier-2 hits behind an oversized tier-1 block

### DIFF
--- a/src/orchestrator/retrieval.ts
+++ b/src/orchestrator/retrieval.ts
@@ -316,8 +316,12 @@ export function formatRetrieved(
         : ` ${h.path}`;
     const block = `\n\n##${label}\n${cleanSnippet(h.snippet)}`;
     // Always include at least one hit (so a single long snippet isn't
-    // silently dropped); after that, respect the budget.
-    if (included > 0 && out.length + block.length > budgetChars) break;
+    // silently dropped); after that, respect the budget. `continue` rather
+    // than `break` (#379 item 4): tier 1 is concatenated ahead of tier 2, so
+    // breaking on the first oversized block always cuts off every
+    // cross-conversation hit behind it, regardless of score. Skipping past
+    // an oversized block lets smaller, lower-positioned hits still fit.
+    if (included > 0 && out.length + block.length > budgetChars) continue;
     out += block;
     included++;
   }

--- a/tests/orchestrator-retrieval.test.ts
+++ b/tests/orchestrator-retrieval.test.ts
@@ -136,6 +136,29 @@ describe("formatRetrieved", () => {
     expect(out).toContain("kb/note-0.md");
     expect(out).not.toContain("kb/note-1.md");
   });
+
+  test("an oversized hit is skipped, not fatal — smaller hits behind it still fit (#379)", () => {
+    // maxTokens tuned so the header + first hit comfortably fit, the second
+    // (oversized) hit alone would blow the remaining budget, but the third —
+    // small, and positioned behind the oversized block — still fits in
+    // what's left once the oversized block is skipped rather than fatal.
+    const settingsTight: RetrievalSettings = { ...settings, maxTokens: 175 }; // ~700 chars
+    const hits = [
+      { path: "kb/first.md", scope: "kb" as const, ftsScore: 3, snippet: "x".repeat(150) },
+      { path: "kb/oversized.md", scope: "kb" as const, ftsScore: 2, snippet: "y".repeat(500) },
+      {
+        path: "turns/phantom/telegram%3ABBB/9",
+        scope: "turns" as const,
+        ftsScore: 1,
+        snippet: "small cross-conversation hit",
+        crossConversation: "telegram:2002",
+      },
+    ];
+    const out = formatRetrieved(hits, settingsTight)!;
+    expect(out).toContain("kb/first.md");
+    expect(out).not.toContain("kb/oversized.md");
+    expect(out).toContain("small cross-conversation hit");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`formatRetrieved` concatenates tier-1 hits ahead of tier-2 cross-conversation
hits (#377/#378), then walks the list applying a char-budget. It `break`s the
loop on the first block that doesn't fit. Because tier 1 is always positioned
first, one oversized tier-1 snippet ended the loop outright and discarded
every tier-2 hit behind it — regardless of score — which is backwards: tier 2
was dropped precisely when tier 1 was rich enough to matter.

Fix: `continue` past the oversized block instead of stopping, so smaller
hits positioned behind it (including tier-2 hits that cleared the deliberately
strict absolute floor) still get a chance to fit in what's left of the budget.
Ordering and scoring are unchanged — this only changes what happens when a
block is skipped.

This was item 4 of #379 (deliberately deferred out of #378 so that PR could
ship on its own). Items 1–3 were resolved there; item 5 shipped in #390.

## Test plan
- [x] Added a regression test: oversized block is skipped, smaller hit
      behind it (a tier-2 cross-conversation hit) still lands.
- [x] `bun test` — full suite, 2852 pass / 2 skip / 0 fail
- [x] `bun tsc --noEmit` — clean

Closes #379