### PR TITLE
fix(scaffold): seed memory/norms.md so the judge's briefing drawer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1380,6 +1380,7 @@ Markdown memory lives under each persona directory:
     lessons.md
     people.md
     commitments.md
+    norms.md
   kb/
 ```
 

--- a/src/lib/personaScaffold.ts
+++ b/src/lib/personaScaffold.ts
@@ -10,6 +10,7 @@
  *   │   ├── decisions.md
  *   │   ├── lessons.md
  *   │   ├── commitments.md
+ *   │   ├── norms.md
  *   │   └── archive/
  *   └── kb/
  *       ├── Home.md
@@ -97,6 +98,7 @@ function seedFiles(today: string): Array<[string, string]> {
     ["memory/decisions.md", drawer("Decisions", `Choices with rationale. "We chose X because Y." Promoted from daily files by the nightly cycle.`)],
     ["memory/lessons.md", drawer("Lessons", "Mistakes and learnings. Grows, never shrinks.")],
     ["memory/commitments.md", drawer("Commitments", "Deadlines and obligations. The nightly cycle promotes [commitment]-tagged entries.")],
+    ["memory/norms.md", drawer("Norms", "What is ROUTINE in your owner's world. The threat judge reads this drawer IN FULL before scoring untrusted input, so entries here are what stop it flagging ordinary operations as attacks. Capture with `--tag norm`; the nightly cycle promotes [norm]-tagged entries.")],
 
     ["kb/Home.md", kbHome(today)],
 

--- a/src/orchestrator/screen.ts
+++ b/src/orchestrator/screen.ts
@@ -139,8 +139,13 @@ const PASS_ON_ERROR = (score: number, reason: string): ScreenVerdict => ({
  * threat-relevant and keeps sensitive operational memory (finances, inbox,
  * daily dumps, commitments) out of the judge entirely. Read in FULL now, not
  * as snippets — see DRAWERS_CAP_BYTES. Paths are relative to the persona dir.
+ *
+ * Exported so the scaffold can be tested against it: a drawer the judge briefs
+ * from but `ensurePersonaScaffold` never seeds is invisible on a fresh persona
+ * (missing files are silently skipped below), so the coupling is asserted in
+ * tests rather than left to memory.
  */
-const BRIEFING_DRAWERS: readonly string[] = [
+export const BRIEFING_DRAWERS: readonly string[] = [
   "memory/decisions.md",
   "memory/people.md",
   "memory/norms.md",

--- a/tests/lib-personaScaffold.test.ts
+++ b/tests/lib-personaScaffold.test.ts
@@ -7,8 +7,10 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { TAG_TO_DRAWER } from "../src/lib/heartbeat.ts";
 import { isCanonicalOkfType, parseOkf } from "../src/lib/okf.ts";
 import { ensurePersonaScaffold } from "../src/lib/personaScaffold.ts";
+import { BRIEFING_DRAWERS } from "../src/orchestrator/screen.ts";
 
 let workdir: string;
 
@@ -29,6 +31,7 @@ describe("ensurePersonaScaffold", () => {
       "memory/decisions.md",
       "memory/lessons.md",
       "memory/commitments.md",
+      "memory/norms.md",
     ]) {
       expect(existsSync(join(workdir, f))).toBe(true);
       expect(r.created).toContain(f);
@@ -126,5 +129,39 @@ describe("scaffolded templates carry full OKF frontmatter", () => {
     const raw = await readFile(join(workdir, "kb/templates/concept.md"), "utf8");
     expect(parseOkf(raw).type).toBe("concept");
     expect(existsSync(join(workdir, "kb/templates/atomic-note.md"))).toBe(false);
+  });
+});
+
+describe("the scaffold seeds every drawer the rest of the system writes to", () => {
+  test("every heartbeat promotion target exists after scaffolding", async () => {
+    // Regression: `norms.md` was reachable via `--tag norm` but never seeded,
+    // so the heartbeat's appendFile created it on first capture — a drawer
+    // with no title and no intro, unlike every other one.
+    await ensurePersonaScaffold(workdir);
+    for (const rel of new Set(Object.values(TAG_TO_DRAWER))) {
+      expect(existsSync(join(workdir, rel))).toBe(true);
+      const body = await readFile(join(workdir, rel), "utf8");
+      expect(body.startsWith("# ")).toBe(true);
+    }
+  });
+
+  test("every threat-judge briefing drawer exists after scaffolding", async () => {
+    // A briefing drawer the scaffold skips is silently absent on a fresh
+    // persona: readBriefingDrawers swallows the ENOENT, so the judge briefs
+    // on a partial worldview with nothing logged anywhere.
+    await ensurePersonaScaffold(workdir);
+    for (const rel of BRIEFING_DRAWERS) {
+      expect(existsSync(join(workdir, rel))).toBe(true);
+    }
+  });
+
+  test("the norms drawer explains that the threat judge reads it", async () => {
+    // The drawer's own text is the only place an agent learns this drawer is
+    // security-load-bearing rather than another notes file.
+    await ensurePersonaScaffold(workdir);
+    const norms = await readFile(join(workdir, "memory", "norms.md"), "utf8");
+    expect(norms).toContain("# Norms");
+    expect(norms).toContain("threat judge");
+    expect(norms).toContain("--tag norm");
   });
 });


### PR DESCRIPTION
## The gap

`ensurePersonaScaffold` seeds four structured drawers — people, decisions, lessons, commitments. It does not seed `memory/norms.md`, which is the third of the three drawers the threat judge briefs from:

```ts
// src/orchestrator/screen.ts
const BRIEFING_DRAWERS: readonly string[] = [
  "memory/decisions.md",
  "memory/people.md",
  "memory/norms.md",   // <- never created by the scaffold
];
```

The scaffold's own layout docstring and the README's persona-dir listing both omit it too, so the *documented* shape of a persona directory has been wrong as well.

## Why it stays invisible

Three separate mechanisms each swallow the symptom:

1. **`readBriefingDrawers` skips missing files by design** (`// Missing/unreadable drawer — skip it`). A fresh persona briefs the judge on two drawers instead of three, and nothing is logged.
2. **The heartbeat eventually conjures the file.** `TAG_TO_DRAWER` maps `norm`/`norms` → `memory/norms.md`, and promotion uses `appendFile`, which creates on demand. So the drawer appears on the first `--tag norm` capture — with no `# Norms` title and no intro, unlike every other drawer.
3. **Nothing in a fresh persona mentions the drawer exists.** The other four are self-documenting via their seeded intro text; this one had no text to be self-documenting with.

## What this changes

- Seeds `memory/norms.md` with a title and an intro that states who reads it (the judge, in full) and how to write to it (`--tag norm`).
- Adds it to the scaffold docstring's layout diagram and to the README persona-dir listing.
- Exports `BRIEFING_DRAWERS` from `screen.ts` purely so the coupling is testable.
- Adds three tests, two of which are structural rather than about this one file:
  - every value in `TAG_TO_DRAWER` exists after scaffolding **and starts with an `# ` title**;
  - every entry in `BRIEFING_DRAWERS` exists after scaffolding;
  - the norms drawer's own text names the judge and the capture flag.

The first two are the real point: they make this class of gap fail CI rather than fail silently. Adding a new tag→drawer mapping or a new briefing drawer without seeding it now breaks the build.

## What this does *not* fix

Seeding an empty drawer does not give the judge a baseline. A brand-new persona still knows nothing about what's routine in its principal's world, and will still be jumpier than a seasoned one until norms accumulate. That's inherent — the baseline comes from captures, not from scaffolding. This PR fixes the plumbing (the drawer exists, is documented, is well-formed, and is discoverable to the agent that needs to fill it), not the cold-start.

Behaviour on existing personas is unchanged: the scaffold is idempotent and `write_if_missing`, so a persona that already has a `norms.md` keeps it byte-for-byte.

## Verification

- `bun test` — 2862 pass, 2 skip, 0 fail (170 files)
- `bun tsc --noEmit` — clean
- Manually scaffolded a temp persona and read the generated drawer back.
