### PR TITLE
fix: survive an unanswered relay AUTH, and stop the nightly deferring to a dead sweep

### DIFF
--- a/src/channels/phantomchat/authGuardedPool.ts
+++ b/src/channels/phantomchat/authGuardedPool.ts
@@ -1,0 +1,103 @@
+/**
+ * A SimplePool that cannot be killed by an unanswered NIP-42 AUTH (issue #401).
+ *
+ * Kept in its own module, and imported dynamically by both call sites, so the
+ * nostr-tools websocket machinery stays out of the module graph for the paths
+ * that never touch a relay (a Telegram-only notify, most of the test suite).
+ */
+
+import type { AbstractRelay } from "nostr-tools/abstract-relay";
+import { SimplePool } from "nostr-tools/pool";
+
+import { log } from "../../lib/logger.ts";
+import { automaticallyAuthWith, type RelayAuthSigner } from "./relayAuth.ts";
+
+/**
+ * THE BUG: setting `automaticallyAuth` (see relayAuth.ts) is what makes
+ * nostr-tools call `relay.auth()` from its `["AUTH", <challenge>]` frame
+ * handler — and it makes that call fire-and-forget:
+ *
+ *   case 'AUTH': {
+ *     this.challenge = data[1]
+ *     if (this.onauth) {
+ *       this.auth(this.onauth)   // not awaited, not caught
+ *     }
+ *     return
+ *   }
+ *
+ * That promise rejects whenever the relay doesn't answer our kind-22242 event
+ * within `publishTimeout` (`Error("auth timed out")`) or answers `OK:false`
+ * with a reason of its choosing. Nobody is holding it, so it lands as an
+ * `unhandledRejection` — and the process-level guard from #274 re-throws
+ * anything that isn't a benign ICE socket error, which is fatal. A relay that
+ * rate-limits our AUTH therefore kills the daemon, systemd restarts it, and it
+ * reconnects into the same rate limit: a crash loop driven entirely by a
+ * remote box's traffic policy, taking every channel and any in-flight nightly
+ * sweep down with it.
+ *
+ * THE FIX: attach a rejection handler to that promise. `auth()` memoises its
+ * work in `relay.authPromise` and hands the SAME promise to every caller, so
+ * attaching a handler here only marks it as observed — the two call sites that
+ * genuinely await the result (the publish retry and the subscription
+ * `auth-required:` retry, both of which already catch) still see the rejection
+ * and still retry. Nothing is swallowed except the crash.
+ *
+ * Wrapping the INSTANCE rather than `AbstractRelay.prototype` is deliberate:
+ * nostr-tools ships a separate bundled copy of the class in each entry point
+ * (`relay.js`, `pool.js`, `abstract-relay.js`), so the prototype our import
+ * resolves to is not necessarily the one `SimplePool` instantiates.
+ */
+const AUTH_GUARDED = Symbol.for("phantombot.relayAuthGuarded");
+
+type AuthGuardable = AbstractRelay & { [AUTH_GUARDED]?: true };
+
+/**
+ * Make one relay's `auth()` safe to call without awaiting. Idempotent: pools
+ * re-run the `automaticallyAuth` hook on every `ensureRelay`, including for
+ * relays they already hold.
+ */
+export function guardRelayAuthRejection(relay: AbstractRelay): void {
+  const target = relay as AuthGuardable;
+  if (target[AUTH_GUARDED]) return;
+  target[AUTH_GUARDED] = true;
+
+  const original = relay.auth.bind(relay);
+  target.auth = (signAuthEvent) => {
+    const pending = original(signAuthEvent);
+    pending.catch((e: unknown) => {
+      // Expected and survivable: a rate limit, a slow relay, a relay that
+      // simply never OKs auth events. Log it so a persistently failing relay
+      // is visible, and let the retrying call sites decide what to do.
+      log.warn("phantomchat: relay AUTH failed", {
+        relay: relay.url,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    });
+    return pending;
+  };
+}
+
+/**
+ * A `SimplePool` that answers NIP-42 challenges for a persona AND cannot be
+ * killed by one going unanswered.
+ *
+ * The guard is installed from inside the `automaticallyAuth` hook, which the
+ * pool calls after registering the relay in `this.relays` and BEFORE
+ * `relay.connect()` — the only window that closes before a relay can send its
+ * first AUTH frame. Subclassing is what gives us legitimate access to the
+ * protected `relays` map; no casts, no reaching into private state.
+ */
+export class AuthGuardedSimplePool extends SimplePool {
+  constructor(
+    secretKey: Uint8Array,
+    options?: ConstructorParameters<typeof SimplePool>[0],
+  ) {
+    super(options);
+    const signerFor = automaticallyAuthWith(secretKey);
+    this.automaticallyAuth = (relayURL: string): RelayAuthSigner => {
+      const relay = this.relays.get(relayURL);
+      if (relay) guardRelayAuthRejection(relay);
+      return signerFor(relayURL);
+    };
+  }
+}

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -48,6 +48,7 @@ import {
   type ProcessAliveProbe,
   saveNightlyState,
   sweepDailyFiles,
+  selfStartToken,
   sweepLiveness,
 } from "../lib/nightly.ts";
 import { openMemoryStore } from "../memory/store.ts";
@@ -248,8 +249,8 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
     }
     out.write(
       liveness === "dead"
-        ? `nightly: taking over a dead sweep (owner pid ${state.current.pid} is gone, ` +
-          `last beat ${state.current.updated_at})\n`
+        ? `nightly: taking over a dead sweep (owner pid ${state.current.pid} is gone ` +
+          `or has been reused, last beat ${state.current.updated_at})\n`
         : `nightly: taking over a stalled sweep (last beat ${state.current.updated_at})\n`,
     );
   }
@@ -323,6 +324,7 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
           started_at: startedAt,
           updated_at: new Date().toISOString(),
           pid: process.pid,
+          pid_start: selfStartToken() ?? undefined,
         },
       });
 

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -45,9 +45,10 @@ import {
   nightlyConversationKey,
   type PendingDate,
   pendingForDate,
-  STALE_RUN_MS,
+  type ProcessAliveProbe,
   saveNightlyState,
   sweepDailyFiles,
+  sweepLiveness,
 } from "../lib/nightly.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
@@ -108,6 +109,8 @@ export interface RunNightlyInput {
   }) => Promise<TurnResult>;
   /** Test seam — skip the real index refresh. */
   refreshIndex?: (personaDir: string) => Promise<void>;
+  /** Test seam — override the process-liveness probe. */
+  isProcessAlive?: ProcessAliveProbe;
 }
 
 export interface TurnResult {
@@ -228,14 +231,15 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
 
   const state = await loadNightlyState(dir);
 
-  // Single-sweep lock. A long backlog can outlive the gap to the next timer
-  // fire; two sweeps on the same dates would double-file drawers. A marker
-  // older than STALE_RUN_MS is a crashed run, not a live one, so it's taken
-  // over rather than obeyed.
+  // Single-sweep lock. A long backlog can outlive the gap to the next trigger;
+  // two sweeps on the same dates would double-file drawers. Only a marker whose
+  // owner is BOTH still running and still beating is obeyed — a dead owner is
+  // taken over on the spot however fresh its last beat looks (#402), because
+  // the sweep dies with the daemon that spawned it and the restart is exactly
+  // when the marker is freshest.
   if (state.current && !input.force) {
-    const beat = Date.parse(state.current.updated_at ?? state.current.started_at);
-    const alive = !Number.isNaN(beat) && now.getTime() - beat <= STALE_RUN_MS;
-    if (alive) {
+    const liveness = sweepLiveness(state.current, now, input.isProcessAlive);
+    if (liveness === "running") {
       out.write(
         `nightly: a sweep is already in flight (on ${state.current.date}, ` +
           `started ${state.current.started_at}) — skipping. Use --force to override.\n`,
@@ -243,7 +247,10 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
       return 0;
     }
     out.write(
-      `nightly: taking over a stalled sweep (last beat ${state.current.updated_at}) \n`,
+      liveness === "dead"
+        ? `nightly: taking over a dead sweep (owner pid ${state.current.pid} is gone, ` +
+          `last beat ${state.current.updated_at})\n`
+        : `nightly: taking over a stalled sweep (last beat ${state.current.updated_at})\n`,
     );
   }
 

--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -44,7 +44,6 @@ import {
   loadConfig,
 } from "../config.ts";
 import { loadPhantomchatPersonaConfig } from "../channels/phantomchat/personaStore.ts";
-import { automaticallyAuthWith } from "../channels/phantomchat/relayAuth.ts";
 import { synthesize, ttsSupport } from "../lib/audio.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
@@ -73,17 +72,16 @@ const defaultPhantomchatSend: PhantomchatNotifySend = async ({
 }) => {
   // Lazy import keeps the nostr-tools websocket machinery out of the import
   // graph for Telegram-only notifies.
-  const { SimplePool } = await import("nostr-tools/pool");
+  const { AuthGuardedSimplePool } = await import(
+    "../channels/phantomchat/authGuardedPool.ts"
+  );
   const { SimplePoolPhantomchatTransport } = await import(
     "../channels/phantomchat/transport.ts"
   );
-  const pool = new SimplePool();
   // NIP-42 (issue #368): answer AUTH challenges so a notify to an
-  // auth-requiring relay isn't silently dropped. `automaticallyAuth` is a
-  // public AbstractSimplePool field read at relay-connect time — assigning it
-  // before the first publish is the supported path (the SimplePool constructor
-  // type only exposes enablePing/enableReconnect).
-  pool.automaticallyAuth = automaticallyAuthWith(secretKey);
+  // auth-requiring relay isn't silently dropped — and don't die if a relay
+  // never answers the challenge we send back (issue #401).
+  const pool = new AuthGuardedSimplePool(secretKey);
   const transport = new SimplePoolPhantomchatTransport(
     secretKey,
     relays,

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -17,7 +17,6 @@ import { TELEGRAM_BOT_COMMANDS } from "../channels/commands.ts";
 import { createPhantomchatChannel } from "../channels/phantomchat/channel.ts";
 import { runPhantomchatServer } from "../channels/phantomchat/server.ts";
 import { SimplePoolPhantomchatTransport } from "../channels/phantomchat/transport.ts";
-import { automaticallyAuthWith } from "../channels/phantomchat/relayAuth.ts";
 import {
   listPhantomchatPersonas,
   cacheRelaysForPersona,
@@ -618,7 +617,9 @@ export async function runRun(input: RunInput = {}): Promise<number> {
       // SimplePool that gets built here is never actually driven by a test.
       const startPhantomchat =
         input.runPhantomchatServer ?? runPhantomchatServer;
-      const { SimplePool } = await import("nostr-tools/pool");
+      const { AuthGuardedSimplePool } = await import(
+        "../channels/phantomchat/authGuardedPool.ts"
+      );
 
       // Fetch the canonical relay list ONCE (single source of truth, served by
       // the PWA at /relays.json). Shared across every persona. null = fetch
@@ -702,16 +703,14 @@ export async function runRun(input: RunInput = {}): Promise<number> {
         // handled instead by the channel-layer self-heal watchdog, which re-arms
         // the subscription with our own correct wide `since`.
         //
-        // automaticallyAuth: NIP-42 (issue #368). A relay that sends an AUTH
-        // challenge — on connect or mid-subscription — gets a signed kind-22242
-        // response from the persona's key. Without it, a `nip42_auth = true`
-        // relay silently drops every event we publish. (SimplePool's
-        // constructor type only exposes enablePing/enableReconnect, but
-        // `automaticallyAuth` is a public AbstractSimplePool field read at
-        // relay-connect time — assigning it here, before any ensureRelay call,
-        // is the supported path.)
-        const pool = new SimplePool({ enablePing: true });
-        pool.automaticallyAuth = automaticallyAuthWith(identity.secretKey);
+        // NIP-42 (issue #368). A relay that sends an AUTH challenge — on
+        // connect or mid-subscription — gets a signed kind-22242 response from
+        // the persona's key. Without it, a `nip42_auth = true` relay silently
+        // drops every event we publish. The guarded subclass also keeps an
+        // unanswered challenge from crashing the daemon (issue #401).
+        const pool = new AuthGuardedSimplePool(identity.secretKey, {
+          enablePing: true,
+        });
         const transport = new SimplePoolPhantomchatTransport(
           identity.secretKey,
           relays,

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -30,7 +30,8 @@
  * bleed into Telegram chats, and both stages for a date share context.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -107,6 +108,12 @@ export interface NightlyCurrent {
   /** Refreshed as each date starts — drives stale-run detection. */
   updated_at: string;
   pid?: number;
+  /**
+   * OS-supplied start time of `pid`, used to spot pid REUSE (issue #402
+   * follow-up). Absent on markers written by an older build, and on
+   * platforms with no cheap probe — liveness degrades to the pid check.
+   */
+  pid_start?: string;
 }
 
 export interface NightlyState {
@@ -151,6 +158,55 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
+/** Probe seam for the start-time half of the identity check. */
+export type ProcessStartProbe = (pid: number) => string | null;
+
+/**
+ * An opaque token that identifies WHICH process currently holds `pid`.
+ *
+ * `kill(pid, 0)` alone can be fooled: pids wrap, so between the sweep dying
+ * and the next start an unrelated process can inherit the number and be
+ * reported alive. The kernel's own start time for the pid disambiguates —
+ * the reused pid is necessarily a different process with a different start.
+ *
+ * Returns `null` when the platform has no cheap probe or the read fails; the
+ * caller then falls back to the pid check alone, which is what shipped in
+ * #403 and is still strictly better than the time-only rule it replaced.
+ * Only ever compared for equality with a token produced the same way, so the
+ * format is deliberately unspecified.
+ */
+export function processStartToken(pid: number): string | null {
+  try {
+    if (process.platform === "linux") {
+      // /proc/<pid>/stat field 22 (starttime, in clock ticks since boot).
+      // comm (field 2) is parenthesised and may itself contain spaces and
+      // parens, so split AFTER the last ')' — field 3 lands at index 0.
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const tail = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+      return tail[19] ?? null;
+    }
+    if (process.platform === "darwin") {
+      const out = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+        encoding: "utf8",
+        timeout: 5_000,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      return out.trim() || null;
+    }
+  } catch {
+    // Process gone, permission denied, no procfs, ps missing — all mean
+    // "can't tell", and "can't tell" must never masquerade as a match.
+  }
+  return null;
+}
+
+/** Our own token never changes, and on darwin it costs a fork. Compute once. */
+let ownStartToken: string | null | undefined;
+export function selfStartToken(): string | null {
+  if (ownStartToken === undefined) ownStartToken = processStartToken(process.pid);
+  return ownStartToken;
+}
+
 /**
  * Classify an in-flight marker (issue #402).
  *
@@ -172,8 +228,18 @@ export function sweepLiveness(
   current: NightlyCurrent,
   now: Date,
   isAlive: ProcessAliveProbe = isProcessAlive,
+  startToken: ProcessStartProbe = processStartToken,
 ): SweepLiveness {
-  if (typeof current.pid === "number" && !isAlive(current.pid)) return "dead";
+  if (typeof current.pid === "number") {
+    if (!isAlive(current.pid)) return "dead";
+    // Alive, but is it the SAME process? A pid that has wrapped around to an
+    // unrelated process would otherwise hold the lock until the 45-minute
+    // stall timer expires. A null token means "can't tell" — trust the pid.
+    if (current.pid_start) {
+      const seen = startToken(current.pid);
+      if (seen !== null && seen !== current.pid_start) return "dead";
+    }
+  }
   const beat = Date.parse(current.updated_at ?? current.started_at);
   const fresh = !Number.isNaN(beat) && now.getTime() - beat <= STALE_RUN_MS;
   return fresh ? "running" : "stalled";

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -122,6 +122,63 @@ export interface NightlyState {
   current?: NightlyCurrent | null;
 }
 
+/**
+ * What a sweep marker actually means right now.
+ *
+ * - `running` — the owner is alive and beating; a new sweep must stand down.
+ * - `dead`    — the owner process is GONE; the marker is a corpse, take over.
+ * - `stalled` — the owner may still exist but hasn't beaten in STALE_RUN_MS;
+ *               take over (the pre-existing, time-only rule).
+ */
+export type SweepLiveness = "running" | "dead" | "stalled";
+
+/** Probe seam so tests don't have to conjure real pids. */
+export type ProcessAliveProbe = (pid: number) => boolean;
+
+/**
+ * Does this pid name a process that exists on this box?
+ *
+ * `kill(pid, 0)` sends no signal — it only runs the kernel's permission and
+ * existence checks. ESRCH means gone; EPERM means it exists but belongs to
+ * another user, which still counts as alive.
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Classify an in-flight marker (issue #402).
+ *
+ * THE BUG: liveness used to be time-only — a marker younger than
+ * STALE_RUN_MS was assumed to be a running sweep. When the daemon is killed
+ * mid-sweep (a crash, a restart, systemd taking down the cgroup) the child
+ * dies with it and leaves a marker seconds old. The very next start spawns a
+ * sweep, sees that fresh-looking marker, and stands down — DEFERRING TO A
+ * CORPSE. Nothing else fires until the next UTC day rollover, so the backlog
+ * sits untouched for up to a day, reported as `sweep stalled` only after the
+ * 45 minutes have elapsed. Observed on three separate boxes.
+ *
+ * THE FIX: the marker already records `pid`. A dead owner is dead the instant
+ * we look, whatever the clock says, so check the process first and fall back
+ * to the clock only for markers written by an older build (no `pid`) or an
+ * owner that is alive but wedged.
+ */
+export function sweepLiveness(
+  current: NightlyCurrent,
+  now: Date,
+  isAlive: ProcessAliveProbe = isProcessAlive,
+): SweepLiveness {
+  if (typeof current.pid === "number" && !isAlive(current.pid)) return "dead";
+  const beat = Date.parse(current.updated_at ?? current.started_at);
+  const fresh = !Number.isNaN(beat) && now.getTime() - beat <= STALE_RUN_MS;
+  return fresh ? "running" : "stalled";
+}
+
 export function nightlyConversationKey(date: string): string {
   return `system:nightly:${date}`;
 }
@@ -360,7 +417,12 @@ export interface NightlyHealth {
  */
 export async function nightlyHealth(
   personaDir: string,
-  opts: { now?: Date; state?: NightlyState } = {},
+  opts: {
+    now?: Date;
+    state?: NightlyState;
+    /** Test seam — override the process-liveness probe. */
+    isAlive?: ProcessAliveProbe;
+  } = {},
 ): Promise<NightlyHealth> {
   const now = opts.now ?? new Date();
   const state = opts.state ?? (await loadNightlyState(personaDir));
@@ -379,19 +441,22 @@ export async function nightlyHealth(
 
   const cur = state.current;
   if (cur) {
-    const beat = Date.parse(cur.updated_at ?? cur.started_at);
-    const stalled = Number.isNaN(beat) || now.getTime() - beat > STALE_RUN_MS;
-    if (!stalled) {
+    const liveness = sweepLiveness(cur, now, opts.isAlive);
+    if (liveness === "running") {
       return {
         ...base,
         status: "running",
         detail: `${cur.index}/${cur.total} dates, on ${cur.date}`,
       };
     }
+    const since = cur.updated_at ?? cur.started_at;
     return {
       ...base,
       status: "error",
-      detail: `sweep stalled on ${cur.date} since ${cur.updated_at ?? cur.started_at}`,
+      detail:
+        liveness === "dead"
+          ? `sweep died on ${cur.date} — owner pid ${cur.pid} is gone (last beat ${since})`
+          : `sweep stalled on ${cur.date} since ${since}`,
     };
   }
 

--- a/tests/channels-phantomchat-authGuardedPool.test.ts
+++ b/tests/channels-phantomchat-authGuardedPool.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the NIP-42 AUTH crash guard (issue #401).
+ *
+ * THE BUG: nostr-tools answers a relay's `["AUTH", <challenge>]` frame by
+ * calling `relay.auth(this.onauth)` and throwing the promise away — no await,
+ * no catch. When the relay then rate-limits us and never OKs the kind-22242
+ * event we sent back, that promise rejects with nobody holding it, the
+ * rejection reaches `unhandledRejection`, and the #274 guard re-throws
+ * anything that isn't a benign ICE socket error. A remote box's traffic policy
+ * crash-loops the daemon.
+ *
+ * Two properties pin the fix: the fire-and-forget call must not produce an
+ * unhandled rejection, and the callers that DO await `auth()` (the publish
+ * retry and the `auth-required:` subscription retry) must still see it, or
+ * NIP-42 silently stops retrying and #368 regresses.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import type { AbstractRelay } from "nostr-tools/abstract-relay";
+import type { EventTemplate } from "nostr-tools/core";
+import { generateSecretKey, getPublicKey, verifyEvent } from "nostr-tools/pure";
+
+import {
+  AuthGuardedSimplePool,
+  guardRelayAuthRejection,
+} from "../src/channels/phantomchat/authGuardedPool.ts";
+
+const AUTH_TEMPLATE: EventTemplate = {
+  kind: 22242,
+  created_at: Math.floor(Date.now() / 1000),
+  tags: [
+    ["relay", "wss://ratelimited.example"],
+    ["challenge", "abc123"],
+  ],
+  content: "",
+};
+
+/**
+ * The slice of AbstractRelay the guard touches: a url and an `auth()` that
+ * rejects the way a rate-limiting relay makes it reject.
+ */
+function fakeRelay(): {
+  relay: AbstractRelay;
+  authCalls: () => number;
+} {
+  let authCalls = 0;
+  const relay = {
+    url: "wss://ratelimited.example",
+    auth(): Promise<string> {
+      authCalls += 1;
+      return Promise.reject(new Error("auth timed out"));
+    },
+  };
+  return {
+    relay: relay as unknown as AbstractRelay,
+    authCalls: () => authCalls,
+  };
+}
+
+/**
+ * The crash is a whole-process event, and `bun:test` intercepts unhandled
+ * rejections rather than letting them reach a `process.on` listener — so the
+ * only honest way to assert "the daemon stays up" is to run the scenario in a
+ * real subprocess and look at its exit code. That also reproduces the
+ * production failure exactly: `error: auth timed out`, exit 1, systemd
+ * restarts, repeat.
+ *
+ * The two runs differ by ONE line: whether the relay is guarded.
+ */
+const MODULE = join(
+  import.meta.dir,
+  "..",
+  "src/channels/phantomchat/authGuardedPool.ts",
+);
+
+async function runFireAndForgetAuth(
+  guarded: boolean,
+): Promise<{ code: number; stdout: string }> {
+  const script = [
+    `const { guardRelayAuthRejection } = await import(${JSON.stringify(MODULE)});`,
+    `const relay = {`,
+    `  url: "wss://ratelimited.example",`,
+    `  auth: () => Promise.reject(new Error("auth timed out")),`,
+    `};`,
+    guarded ? `guardRelayAuthRejection(relay);` : ``,
+    `// Exactly what nostr-tools does on an ["AUTH", challenge] frame:`,
+    `// call auth() and drop the promise on the floor.`,
+    `relay.auth(async () => {});`,
+    `setTimeout(() => { console.log("SURVIVED"); process.exit(0); }, 150);`,
+  ].join("\n");
+  const proc = Bun.spawn([process.execPath, "-e", script], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  return { code: await proc.exited, stdout };
+}
+
+describe("guardRelayAuthRejection", () => {
+  // The control. This is today's behaviour and it is what kills the daemon —
+  // assert the crash is real, or the test below is a false green. The fixture
+  // imports the guard module in BOTH runs, so this also proves the fix is
+  // per-relay and not some blanket process-level handler.
+  test("an unguarded fire-and-forget auth() kills the process", async () => {
+    const { code, stdout } = await runFireAndForgetAuth(false);
+    expect(code).toBe(1);
+    expect(stdout).not.toContain("SURVIVED");
+  });
+
+  test("a guarded relay survives the same rejection", async () => {
+    const { code, stdout } = await runFireAndForgetAuth(true);
+    expect(code).toBe(0);
+    expect(stdout).toContain("SURVIVED");
+  });
+
+  // Swallowing the rejection outright would break NIP-42 retries: the publish
+  // path calls `await r.auth(...)` and republishes on success.
+  test("callers that await auth() still see the rejection", async () => {
+    const { relay } = fakeRelay();
+    guardRelayAuthRejection(relay);
+    await expect(
+      relay.auth(async () => {
+        throw new Error("unused");
+      }),
+    ).rejects.toThrow("auth timed out");
+  });
+
+  // Pools re-run the automaticallyAuth hook on every ensureRelay, including
+  // for relays they already hold — double-wrapping would call auth() twice per
+  // challenge and publish a second kind-22242 event into the same rate limit.
+  test("guarding twice wraps once", async () => {
+    const { relay, authCalls } = fakeRelay();
+    guardRelayAuthRejection(relay);
+    const wrapped = relay.auth;
+    guardRelayAuthRejection(relay);
+    expect(relay.auth).toBe(wrapped);
+    await expect(
+      relay.auth(async () => {
+        throw new Error("unused");
+      }),
+    ).rejects.toThrow("auth timed out");
+    expect(authCalls()).toBe(1);
+  });
+});
+
+describe("AuthGuardedSimplePool", () => {
+  /** The pool's `relays` map is protected; tests plant a relay in it. */
+  function plant(pool: AuthGuardedSimplePool, relay: AbstractRelay): void {
+    (
+      pool as unknown as { relays: Map<string, AbstractRelay> }
+    ).relays.set(relay.url, relay);
+  }
+
+  test("guards the relay before it can answer an AUTH challenge", async () => {
+    const pool = new AuthGuardedSimplePool(generateSecretKey());
+    const { relay } = fakeRelay();
+    plant(pool, relay);
+    const unguarded = relay.auth;
+    // What ensureRelay does after registering the relay and before connecting.
+    pool.automaticallyAuth?.(relay.url);
+    expect(relay.auth).not.toBe(unguarded);
+    // And the wrapper it installed is the real one: it observes the rejection
+    // while still handing it to the caller.
+    await expect(
+      relay.auth(async () => {
+        throw new Error("unused");
+      }),
+    ).rejects.toThrow("auth timed out");
+  });
+
+  test("still hands back a signer that signs with the persona key", async () => {
+    const sk = generateSecretKey();
+    const pool = new AuthGuardedSimplePool(sk);
+    const { relay } = fakeRelay();
+    plant(pool, relay);
+    const signer = pool.automaticallyAuth?.(relay.url);
+    expect(typeof signer).toBe("function");
+    const signed = await signer!(AUTH_TEMPLATE);
+    expect(signed.kind).toBe(22242);
+    expect(signed.pubkey).toBe(getPublicKey(sk));
+    expect(verifyEvent(signed)).toBe(true);
+  });
+
+  // Defensive: the hook must never throw for a url the pool hasn't registered,
+  // or one unexpected lookup miss takes out every publish.
+  test("an unknown relay url still yields a signer", async () => {
+    const sk = generateSecretKey();
+    const pool = new AuthGuardedSimplePool(sk);
+    const signer = pool.automaticallyAuth?.("wss://never.seen");
+    const signed = await signer!(AUTH_TEMPLATE);
+    expect(signed.pubkey).toBe(getPublicKey(sk));
+  });
+});

--- a/tests/channels-phantomchat-authGuardedPool.test.ts
+++ b/tests/channels-phantomchat-authGuardedPool.test.ts
@@ -17,6 +17,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import type { AbstractRelay } from "nostr-tools/abstract-relay";
 import type { EventTemplate } from "nostr-tools/core";
 import { generateSecretKey, getPublicKey, verifyEvent } from "nostr-tools/pure";
@@ -68,11 +69,11 @@ function fakeRelay(): {
  *
  * The two runs differ by ONE line: whether the relay is guarded.
  */
-const MODULE = join(
-  import.meta.dir,
-  "..",
-  "src/channels/phantomchat/authGuardedPool.ts",
-);
+// A file:// URL, not a bare path: a Windows path in a dynamic import()
+// is not a valid specifier.
+const MODULE = pathToFileURL(
+  join(import.meta.dir, "..", "src/channels/phantomchat/authGuardedPool.ts"),
+).href;
 
 async function runFireAndForgetAuth(
   guarded: boolean,

--- a/tests/channels-phantomchat-authGuardedPool.test.ts
+++ b/tests/channels-phantomchat-authGuardedPool.test.ts
@@ -88,7 +88,10 @@ async function runFireAndForgetAuth(
     `// Exactly what nostr-tools does on an ["AUTH", challenge] frame:`,
     `// call auth() and drop the promise on the floor.`,
     `relay.auth(async () => {});`,
-    `setTimeout(() => { console.log("SURVIVED"); process.exit(0); }, 150);`,
+    // Generous on purpose. The unhandled-rejection crash fires on the very
+    // next microtask drain, so this window only has to outlast scheduling
+    // jitter on a loaded CI runner — a tight one buys nothing but flakes.
+    `setTimeout(() => { console.log("SURVIVED"); process.exit(0); }, 500);`,
   ].join("\n");
   const proc = Bun.spawn([process.execPath, "-e", script], {
     stdout: "pipe",

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -360,6 +360,89 @@ describe("runNightly — bounds and locking", () => {
     expect(h.calls.length).toBe(2);
     expect(out.text).toContain("stalled sweep");
   });
+
+  // Issue #402. The killer case: the daemon dies mid-sweep, so the marker it
+  // leaves behind is SECONDS old — the freshest it will ever be — and the
+  // restart that follows is exactly when a new sweep tries to start. Judging
+  // that marker by its timestamp makes the new sweep defer to a corpse, and
+  // nothing retries until the next UTC day rollover.
+  test("a fresh marker whose owner process is gone is taken over", async () => {
+    await daily("2026-05-01");
+    const { saveNightlyState } = await import("../src/lib/nightly.ts");
+    await saveNightlyState(personaDir, {
+      current: {
+        date: "2026-05-01",
+        index: 1,
+        total: 1,
+        started_at: new Date(now.getTime() - 5_000).toISOString(),
+        updated_at: new Date(now.getTime() - 5_000).toISOString(),
+        pid: 424242,
+      },
+    });
+    const h = harness();
+    const out = new CaptureStream();
+    await runNightly({
+      config, now, out,
+      isProcessAlive: (pid) => pid !== 424242,
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(h.calls.length).toBe(2);
+    expect(out.text).toContain("dead sweep");
+    expect(out.text).toContain("424242");
+  });
+
+  // The other half of the same rule: a live owner still holds the lock, so a
+  // pid check can never turn into a licence to double-file drawers.
+  test("a fresh marker whose owner process is alive still blocks", async () => {
+    await daily("2026-05-01");
+    const { saveNightlyState } = await import("../src/lib/nightly.ts");
+    await saveNightlyState(personaDir, {
+      current: {
+        date: "2026-05-01",
+        index: 1,
+        total: 1,
+        started_at: now.toISOString(),
+        updated_at: now.toISOString(),
+        pid: 424242,
+      },
+    });
+    const h = harness();
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config, now, out,
+      isProcessAlive: () => true,
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(code).toBe(0);
+    expect(h.calls).toEqual([]);
+    expect(out.text).toContain("already in flight");
+  });
+
+  // A live owner that has stopped beating is a wedged turn, not a crash — the
+  // 45-minute rule still applies to it.
+  test("a live owner that stopped beating is still taken over", async () => {
+    await daily("2026-05-01");
+    const { saveNightlyState } = await import("../src/lib/nightly.ts");
+    await saveNightlyState(personaDir, {
+      current: {
+        date: "2026-05-01",
+        index: 1,
+        total: 1,
+        started_at: "2026-05-09T02:00:00Z",
+        updated_at: "2026-05-09T02:00:00Z",
+        pid: 424242,
+      },
+    });
+    const h = harness();
+    const out = new CaptureStream();
+    await runNightly({
+      config, now, out,
+      isProcessAlive: () => true,
+      runStage: h.runStage, refreshIndex: async () => {},
+    });
+    expect(h.calls.length).toBe(2);
+    expect(out.text).toContain("stalled sweep");
+  });
 });
 
 describe("runNightly — --date override", () => {

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -16,8 +16,11 @@ import {
   nightlyHealth,
   nightlyStatePath,
   pendingForDate,
+  isProcessAlive,
+  type NightlyCurrent,
   saveNightlyState,
   STALE_RUN_MS,
+  sweepLiveness,
   sweepDailyFiles,
 } from "../src/lib/nightly.ts";
 import { OKF_TYPES } from "../src/lib/okf.ts";
@@ -264,6 +267,83 @@ describe("dateRecord", () => {
   });
 });
 
+/**
+ * Issue #402. The in-flight marker used to be judged purely on its timestamp,
+ * which is precisely wrong for the way sweeps actually die: the sweep runs
+ * inside the daemon's process, so a crash or a restart kills it while its last
+ * beat is seconds old, and the sweep the restart spawns then stands down out
+ * of deference to a process that no longer exists.
+ */
+describe("sweepLiveness", () => {
+  const now = new Date("2026-05-18T09:00:00Z");
+  function marker(beatAgoMs: number, pid?: number): NightlyCurrent {
+    const at = new Date(now.getTime() - beatAgoMs).toISOString();
+    return {
+      date: "2026-05-01",
+      index: 1,
+      total: 3,
+      started_at: at,
+      updated_at: at,
+      ...(pid === undefined ? {} : { pid }),
+    };
+  }
+
+  test("a dead owner is dead however fresh its last beat looks", () => {
+    expect(sweepLiveness(marker(1_000, 4242), now, () => false)).toBe("dead");
+  });
+
+  test("a live owner with a fresh beat is running", () => {
+    expect(sweepLiveness(marker(1_000, 4242), now, () => true)).toBe("running");
+  });
+
+  // A process that exists but has stopped beating is a wedged turn, not a
+  // crash — the pre-existing 45-minute rule still retires it.
+  test("a live owner past STALE_RUN_MS is stalled", () => {
+    expect(
+      sweepLiveness(marker(STALE_RUN_MS + 1_000, 4242), now, () => true),
+    ).toBe("stalled");
+  });
+
+  // Markers written before this change carry no pid; they must keep behaving
+  // exactly as they did, or an upgrade would start stealing live sweeps.
+  test("a marker with no pid falls back to the clock", () => {
+    expect(sweepLiveness(marker(1_000), now, () => false)).toBe("running");
+    expect(sweepLiveness(marker(STALE_RUN_MS + 1_000), now, () => false)).toBe(
+      "stalled",
+    );
+  });
+
+  test("an unparseable beat is stalled, not running", () => {
+    const bad: NightlyCurrent = {
+      date: "2026-05-01",
+      index: 1,
+      total: 1,
+      started_at: "not-a-date",
+      updated_at: "not-a-date",
+    };
+    expect(sweepLiveness(bad, now, () => true)).toBe("stalled");
+  });
+});
+
+describe("isProcessAlive", () => {
+  test("true for this very process", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  test("false for a pid that has exited", async () => {
+    const child = Bun.spawn(["sh", "-c", "exit 0"]);
+    const pid = child.pid;
+    await child.exited;
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+
+  // pid 1 always exists and (outside a root container) is not ours: kill(2)
+  // answers EPERM, which means "there, but not yours" — still alive.
+  test("a pid we may not signal still counts as alive", () => {
+    expect(isProcessAlive(1)).toBe(true);
+  });
+});
+
 describe("nightlyHealth", () => {
   const now = new Date("2026-05-10T09:00:00Z");
 
@@ -330,6 +410,27 @@ describe("nightlyHealth", () => {
     }
     const h = await nightlyHealth(workdir, { now });
     expect(h.status).toBe("warning");
+  });
+
+  // /status must separate the two failure modes: a dead owner is a crash to
+  // investigate, a stalled one is a hung turn. A dead owner is also reportable
+  // at once, instead of reading "running" for the first 45 minutes.
+  test("a fresh marker whose owner is gone reports died, not running", async () => {
+    await daily("2026-05-01");
+    await saveNightlyState(workdir, {
+      current: {
+        date: "2026-05-01",
+        index: 2,
+        total: 9,
+        started_at: new Date(now.getTime() - 10_000).toISOString(),
+        updated_at: new Date(now.getTime() - 10_000).toISOString(),
+        pid: 4242,
+      },
+    });
+    const h = await nightlyHealth(workdir, { now, isAlive: () => false });
+    expect(h.status).toBe("error");
+    expect(h.detail).toContain("sweep died on 2026-05-01");
+    expect(h.detail).toContain("4242");
   });
 
   test("an in-flight sweep with a fresh beat → running with progress", async () => {

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -20,6 +20,8 @@ import {
   type NightlyCurrent,
   saveNightlyState,
   STALE_RUN_MS,
+  processStartToken,
+  selfStartToken,
   sweepLiveness,
   sweepDailyFiles,
 } from "../src/lib/nightly.ts";
@@ -276,7 +278,11 @@ describe("dateRecord", () => {
  */
 describe("sweepLiveness", () => {
   const now = new Date("2026-05-18T09:00:00Z");
-  function marker(beatAgoMs: number, pid?: number): NightlyCurrent {
+  function marker(
+    beatAgoMs: number,
+    pid?: number,
+    pidStart?: string,
+  ): NightlyCurrent {
     const at = new Date(now.getTime() - beatAgoMs).toISOString();
     return {
       date: "2026-05-01",
@@ -285,6 +291,7 @@ describe("sweepLiveness", () => {
       started_at: at,
       updated_at: at,
       ...(pid === undefined ? {} : { pid }),
+      ...(pidStart === undefined ? {} : { pid_start: pidStart }),
     };
   }
 
@@ -322,6 +329,63 @@ describe("sweepLiveness", () => {
       updated_at: "not-a-date",
     };
     expect(sweepLiveness(bad, now, () => true)).toBe("stalled");
+  });
+
+  // Pids wrap. Between the sweep dying and the next start an unrelated
+  // process can inherit the number, and the pid check alone would then hold
+  // the lock until the 45-minute stall timer expired — the very delay #402
+  // set out to remove.
+  test("a reused pid is dead, not running", () => {
+    const m = marker(1_000, 4242, "8899001");
+    expect(sweepLiveness(m, now, () => true, () => "9911002")).toBe("dead");
+  });
+
+  test("the same pid with the same start time is still running", () => {
+    const m = marker(1_000, 4242, "8899001");
+    expect(sweepLiveness(m, now, () => true, () => "8899001")).toBe("running");
+  });
+
+  // "Can't tell" must never read as "different". An unsupported platform, a
+  // permission error or a racing exit all yield null, and stealing a live
+  // sweep on that basis would double-file the drawers.
+  test("an unavailable start token leaves the pid check in charge", () => {
+    const m = marker(1_000, 4242, "8899001");
+    expect(sweepLiveness(m, now, () => true, () => null)).toBe("running");
+    expect(sweepLiveness(m, now, () => false, () => null)).toBe("dead");
+  });
+
+  // Markers from the first #403 build carry a pid but no pid_start. They
+  // must not gain a start-time opinion retroactively.
+  test("a marker with no pid_start never consults the probe", () => {
+    let probed = false;
+    const m = marker(1_000, 4242);
+    const seen = sweepLiveness(m, now, () => true, () => {
+      probed = true;
+      return "whatever";
+    });
+    expect(seen).toBe("running");
+    expect(probed).toBe(false);
+  });
+});
+
+describe("processStartToken", () => {
+  // Only meaningful where a probe exists; elsewhere null is the contract.
+  const supported =
+    process.platform === "linux" || process.platform === "darwin";
+
+  test("is stable across calls for this process", () => {
+    const a = processStartToken(process.pid);
+    const b = processStartToken(process.pid);
+    expect(a).toBe(b);
+    if (supported) expect(a).not.toBeNull();
+  });
+
+  test("returns null rather than throwing for a pid that cannot exist", () => {
+    expect(processStartToken(-1)).toBeNull();
+  });
+
+  test("selfStartToken agrees with a direct probe of our own pid", () => {
+    expect(selfStartToken()).toBe(processStartToken(process.pid));
   });
 });
 

--- a/tests/lib-nightly.test.ts
+++ b/tests/lib-nightly.test.ts
@@ -331,17 +331,22 @@ describe("isProcessAlive", () => {
   });
 
   test("false for a pid that has exited", async () => {
-    const child = Bun.spawn(["sh", "-c", "exit 0"]);
+    // Spawn bun itself rather than a shell: this suite also runs on Windows.
+    const child = Bun.spawn([process.execPath, "-e", "process.exit(0)"]);
     const pid = child.pid;
     await child.exited;
     expect(isProcessAlive(pid)).toBe(false);
   });
 
-  // pid 1 always exists and (outside a root container) is not ours: kill(2)
-  // answers EPERM, which means "there, but not yours" — still alive.
-  test("a pid we may not signal still counts as alive", () => {
-    expect(isProcessAlive(1)).toBe(true);
-  });
+  // On POSIX pid 1 always exists and is not ours, so kill(2) answers EPERM —
+  // "there, but not yours", which must still count as alive or we would take
+  // over a sweep owned by another user. Windows has no equivalent pid.
+  test.skipIf(process.platform === "win32")(
+    "a pid we may not signal still counts as alive",
+    () => {
+      expect(isProcessAlive(1)).toBe(true);
+    },
+  );
 });
 
 describe("nightlyHealth", () => {


### PR DESCRIPTION
Two independent faults, in one PR because the first one is what exposed the second: the relay crash killed the daemon mid-sweep on Lena's and Kai's boxes, and the nightly guard then refused to restart the sweep it had just lost.

Fixes #401. Fixes #402.

---

## 1. The daemon dies when a relay rate-limits our NIP-42 AUTH (#401)

**Evidence.** Both boxes, same journal, same two storms:

```
NOTICE from wss://<relay>/: rate limited
error: auth timed out
phantombot.service: Main process exited, code=exited, status=7/NOTRUNNING
```

**22 crashes on one box, 23 on the other**, over five days, clustered at 2026-08-18 16:05–16:08 (~15 restarts) and 2026-08-19 06:15–06:16 (~7). They share a relay set, so one relay's traffic policy takes down every daemon simultaneously.

**Root cause.** nostr-tools handles the AUTH frame like this (`lib/esm/abstract-relay.js`):

```js
case 'AUTH': {
  this.challenge = data[1]
  if (this.onauth) {
    this.auth(this.onauth)   // not awaited, not caught
  }
  return
}
```

`auth()` rejects when the relay never OKs our kind-22242 event within `publishTimeout` (`Error("auth timed out")`), or answers `OK:false` with a reason of its choosing. On this path nothing ever holds the promise, so it surfaces as an `unhandledRejection`, and the #274 guard re-throws anything that isn't a benign ICE socket error — correct for a real bug, fatal for a relay having a bad afternoon. Restart, reconnect, same rate limit, repeat.

This path exists only because we set `pool.automaticallyAuth` (#368): without `onauth`, nostr-tools never calls `auth()` from the frame handler. The other two `auth()` call sites — the publish retry and the `auth-required:` subscription retry — are both awaited and already caught.

**Fix.** `AuthGuardedSimplePool` attaches a rejection handler to each relay's `auth()`, installed from inside the `automaticallyAuth` hook. The pool calls that hook after registering the relay in `this.relays` and before `relay.connect()` — the only window that closes before a relay can send its first AUTH frame.

Because `auth()` memoises its work in `relay.authPromise` and hands the same promise to every caller, attaching a handler only marks it observed: the retry paths still see the rejection and still retry, so #368 doesn't regress. Nothing is swallowed except the crash. A failing relay is logged at `warn` with its URL, so a persistently broken one is visible rather than silent.

Three things I considered and rejected:

- **Broadening the #274 process guard to swallow relay errors.** The rejection carries an arbitrary relay-supplied message (`"rate-limited: ..."`, `"blocked: ..."`), so there is nothing to match narrowly, and widening the fatal-rethrow policy would mask genuine bugs. Out of scope, and the wrong lever.
- **Patching `AbstractRelay.prototype`.** nostr-tools ships a separate bundled copy of the class in each entry point (`relay.js`, `pool.js`, `abstract-relay.js`), so the prototype our import resolves to is not necessarily the one `SimplePool` instantiates. Wrapping the instance is identity-independent.
- **A module-level static import of the pool.** Both call sites import nostr-tools lazily on purpose, to keep the websocket machinery out of the graph for Telegram-only notifies — hence a separate module rather than adding the import to `relayAuth.ts`.

## 2. The nightly in-flight guard defers to a dead sweep (#402)

**Evidence.** After the crashes stopped, both boxes sat healthy for 4h15m with 2026-08-18 unprocessed and a marker naming an owner that no longer existed:

| box | marker date | owner pid | started | alive? |
|---|---|---|---|---|
| Lena | 2026-08-18 | 800904 | 06:15:41 | no |
| Kai | 2026-08-18 | 799983 | 06:15:37 | no |

**Root cause.** The guard was time-only: a marker younger than `STALE_RUN_MS` (45 min) was assumed to be a live sweep. That is right when a sweep dies of old age and wrong when it dies suddenly. The sweep runs inside the daemon's own process, so a crash or restart kills it while its last beat is *seconds* old — the freshest it will ever be — and the sweep spawned by the restart stands down out of deference to a process that no longer exists.

The trigger is startup plus the heartbeat's UTC day rollover, so nothing else fires: the backlog waits up to a day. `/status` compounds it by reporting `running` for the first 45 minutes of a dead sweep.

**Fix.** `NightlyCurrent` already records `pid`. `sweepLiveness()` checks the owner process with `kill(pid, 0)` before consulting the clock and returns one of three verdicts:

- `dead` — owner gone, take over now regardless of the timestamp
- `running` — owner alive and beating, stand down (unchanged)
- `stalled` — owner alive but past `STALE_RUN_MS`, take over (unchanged)

Markers with no `pid`, written by older builds, fall back to the clock exactly as before — an upgrade must never start stealing live sweeps. `/status` now says `sweep died on <date> — owner pid N is gone` versus `sweep stalled on <date>`, because a crash to investigate and a hung turn call for different responses.

`EPERM` counts as alive: the pid exists but belongs to another user.

---

## Tests

25 new assertions across 3 files; the full suite is 2883 pass / 0 fail, typecheck clean.

**The #401 crash is asserted as a real subprocess exit,** not a mocked event. `bun:test` intercepts unhandled rejections rather than letting them reach a `process.on` listener, so the honest test spawns a real process and reads its exit code — which also reproduces the production failure exactly (`error: auth timed out`, exit 1). The two runs differ by one line, whether the relay is guarded, and the fixture imports the guard module in *both*, so it also proves the fix is per-relay rather than some blanket process-level handler:

- unguarded fire-and-forget `auth()` → exit 1, no `SURVIVED`
- guarded → exit 0, `SURVIVED`
- awaiting callers still see the rejection (the retry paths)
- guarding twice wraps once (the hook re-runs on every `ensureRelay`)
- the pool guards the relay before connect, and still returns a signer that signs with the persona key

**The #402 tests were verified red before green** — reverting the pid check fails exactly three:

```
(fail) sweepLiveness > a dead owner is dead however fresh its last beat looks
(fail) nightlyHealth > a fresh marker whose owner is gone reports died, not running
(fail) runNightly — bounds and locking > a fresh marker whose owner process is gone is taken over
```

Plus coverage for the branches that must not move: a live owner with a fresh beat still blocks, a live owner past the deadline is still taken over, and a pid-less marker still falls back to the clock.

## Deploy note

Every currently-running box is holding a marker written by the old build, so the first sweep after the upgrade takes the pid-less clock path. From the sweep after that, markers carry a pid and the new rule applies. Lena and Kai still need 2026-08-18 cleared by hand (`phantombot nightly --force`) — this PR stops it recurring, it doesn't drain the existing backlog.
