### PR TITLE
Name a wedged harness in the outage alert, and stop implying a fallback existed

### DIFF
--- a/src/lib/harnessAlert.ts
+++ b/src/lib/harnessAlert.ts
@@ -68,9 +68,14 @@ export const ALERT_SEND_TIMEOUT_MS = 20_000;
  *
  * `auth` is the sticky one: unlike a 429 it will never clear on its own,
  * so it is worth waking the owner. `rate_limit` is transient by nature and
- * only escalates when it takes the whole chain down with it.
+ * only escalates when it takes the whole chain down with it. `timeout` is
+ * split out of `other` purely so the outage alert can NAME it: a wedged
+ * harness and a crashed one both rendered as "harness error", which sent
+ * the reader to the journals to find out which (observed on
+ * kw-phantombot 2026-08-20 — a 300s idle kill on a single-harness chain).
+ * It changes no policy: like `other` it never fires the degraded alert.
  */
-export type HarnessFailureCause = "auth" | "rate_limit" | "other";
+export type HarnessFailureCause = "auth" | "rate_limit" | "timeout" | "other";
 
 /**
  * Statuses the claude CLI stamps that mean "this credential/account is not
@@ -89,6 +94,16 @@ const AUTH_MARKERS = [
 const RATE_LIMIT_MARKERS = ["rate_limit", "quota", "resource_exhausted"];
 
 /**
+ * Text `killCauseToErrorChunk` (src/lib/harnessRunner.ts) stamps when it
+ * kills a harness for producing nothing — the hard wall-clock cap, the idle
+ * window, and the startup handshake window respectively. Kept as substrings
+ * of those exact strings so a reworded suffix does not silently
+ * de-classify; if that function's wording changes, this list changes with
+ * it and the tests below say so.
+ */
+const TIMEOUT_MARKERS = ["timed out after", "produced no output within"];
+
+/**
  * Classify a harness error chunk. Matching is on lowercased substrings
  * because the text is harness-authored and varies by CLI ("claude api
  * error: authentication_failed", "pi: 401 unauthorized"). HTTP status
@@ -105,6 +120,7 @@ export function classifyFailure(
   const text = error.toLowerCase();
   if (AUTH_MARKERS.some((m) => text.includes(m))) return "auth";
   if (RATE_LIMIT_MARKERS.some((m) => text.includes(m))) return "rate_limit";
+  if (TIMEOUT_MARKERS.some((m) => text.includes(m))) return "timeout";
   return "other";
 }
 
@@ -239,7 +255,9 @@ export class HarnessAlerter {
         ? "rate limited"
         : cause === "auth"
           ? "auth failure"
-          : "harness error";
+          : cause === "timeout"
+            ? "timed out"
+            : "harness error";
     const detail =
       cause === "rate_limit" && input.httpStatus
         ? ` ${input.httpStatus}`
@@ -250,10 +268,15 @@ export class HarnessAlerter {
     // and the answer is the difference between "add a fallback" and "both of
     // my harnesses are down".
     const chain = input.chain.length > 0 ? ` [${input.chain.join(" \u2192 ")}]` : "";
+    // "no fallback left" implies one was tried and also failed. With a
+    // single-harness chain nothing was ever configured to try, and that is a
+    // different fix (add a fallback, not debug two harnesses), so say so.
+    const exhaustion =
+      input.chain.length <= 1 ? "no fallback configured" : "no fallback left";
     await this.emit(
       input.harnessId,
       "exhausted",
-      `\u{1f6a8} ${input.harnessId} ${label}${detail}${this.hostTag()} \u00b7 no fallback left${chain}, turn undelivered`,
+      `\u{1f6a8} ${input.harnessId} ${label}${detail}${this.hostTag()} \u00b7 ${exhaustion}${chain}, turn undelivered`,
     );
   }
 

--- a/src/lib/harnessAlert.ts
+++ b/src/lib/harnessAlert.ts
@@ -269,10 +269,15 @@ export class HarnessAlerter {
     // my harnesses are down".
     const chain = input.chain.length > 0 ? ` [${input.chain.join(" \u2192 ")}]` : "";
     // "no fallback left" implies one was tried and also failed. With a
-    // single-harness chain nothing was ever configured to try, and that is a
+    // single-entry chain nothing was ever available to try, and that is a
     // different fix (add a fallback, not debug two harnesses), so say so.
+    // "usable", because a chain of one is also what a typo'd or unresolvable
+    // harness id leaves behind — the owner may well have configured a
+    // fallback that never made it into the chain.
     const exhaustion =
-      input.chain.length <= 1 ? "no fallback configured" : "no fallback left";
+      input.chain.length <= 1
+        ? "no usable fallback configured"
+        : "no fallback left";
     await this.emit(
       input.harnessId,
       "exhausted",

--- a/tests/lib-harnessAlert.test.ts
+++ b/tests/lib-harnessAlert.test.ts
@@ -57,10 +57,32 @@ describe("classifyFailure", () => {
     expect(classifyFailure("something vague", 401)).toBe("auth");
   });
 
-  test("anything else is 'other' — a timeout must not page the owner", () => {
+  // The three strings below are copied verbatim from killCauseToErrorChunk()
+  // in src/lib/harnessRunner.ts. If that wording changes, these fail — which
+  // is the point: the classifier matches on its text.
+  test("recognises every wedged-harness kill the runner emits", () => {
     expect(
       classifyFailure("claude timed out after 300000ms (hard wall-clock cap)"),
-    ).toBe("other");
+    ).toBe("timeout");
+    expect(
+      classifyFailure(
+        "pi timed out after 300000ms with no output (likely wedged on a tool call)",
+      ),
+    ).toBe("timeout");
+    expect(
+      classifyFailure(
+        "pi produced no output within 60000ms of startup (likely wedged on the MCP/init handshake)",
+      ),
+    ).toBe("timeout");
+  });
+
+  test("a real auth failure still wins over the word 'timed out'", () => {
+    expect(
+      classifyFailure("claude timed out after 5ms: authentication_failed"),
+    ).toBe("auth");
+  });
+
+  test("anything else is 'other'", () => {
     expect(classifyFailure("claude exited with code 1")).toBe("other");
   });
 });
@@ -201,6 +223,19 @@ describe("send deadline", () => {
     // Settled, and settled by the deadline rather than by the send.
     expect(Date.now() - started).toBeLessThan(2000);
   });
+  test("a wedged harness a fallback absorbed stays silent", async () => {
+    const { alerter, sent } = newAlerter();
+    for (let i = 0; i < DEGRADE_AFTER_FAILURES + 2; i++) {
+      alerter.noteFailure(
+        "claude",
+        "claude timed out after 300000ms with no output (likely wedged on a tool call)",
+      );
+    }
+    await alerter.noteDegraded({ harnessId: "claude", servedBy: "pi" });
+    // Only `auth` pages: a timeout the chain routed around is #284's
+    // deliberate silence, and splitting it out of `other` must not change that.
+    expect(sent).toEqual([]);
+  });
 });
 
 describe("exhausted alert", () => {
@@ -215,9 +250,8 @@ describe("exhausted alert", () => {
     // One line: siren, harness, cause, and that nothing answered.
     expect(sent[0]).not.toContain("\n");
     expect(sent[0]).toContain("\ud83d\udea8 claude rate limited 429");
-    expect(sent[0]).toContain("no fallback left");
-    // The chain answers "out of what?" — one harness means "add a fallback".
-    expect(sent[0]).toContain("[claude]");
+    // One harness: nothing was ever configured to fall back to.
+    expect(sent[0]).toContain("no fallback configured [claude]");
   });
 
   test("fires for a non-rate-limit outage too — no reply was delivered", async () => {
@@ -233,6 +267,33 @@ describe("exhausted alert", () => {
     expect(sent[0]).toContain("harness error");
     expect(sent[0]).not.toContain("rate limited");
     expect(sent[0]).toContain("[claude \u2192 pi]");
+  });
+
+  test("names a wedged harness instead of the generic 'harness error'", async () => {
+    const { alerter, sent } = newAlerter();
+    await alerter.noteExhausted({
+      harnessId: "pi",
+      error:
+        "pi timed out after 300000ms with no output (likely wedged on a tool call)",
+      chain: ["pi"],
+    });
+    expect(sent.length).toBe(1);
+    expect(sent[0]).toContain("\ud83d\udea8 pi timed out");
+    expect(sent[0]).not.toContain("harness error");
+    // A one-harness chain never had a fallback to lose.
+    expect(sent[0]).toContain("no fallback configured [pi]");
+    expect(sent[0]).not.toContain("no fallback left");
+  });
+
+  test("says 'no fallback left' only when the chain actually had one", async () => {
+    const { alerter, sent } = newAlerter();
+    await alerter.noteExhausted({
+      harnessId: "pi",
+      error: "pi exited with code 1",
+      chain: ["claude", "pi"],
+    });
+    expect(sent[0]).toContain("no fallback left [claude \u2192 pi]");
+    expect(sent[0]).not.toContain("no fallback configured");
   });
 
   test("is silent with no sender configured", async () => {

--- a/tests/lib-harnessAlert.test.ts
+++ b/tests/lib-harnessAlert.test.ts
@@ -13,6 +13,19 @@ import {
   HarnessAlerter,
   REALERT_MS,
 } from "../src/lib/harnessAlert.ts";
+import { killCauseToErrorChunk } from "../src/lib/harnessRunner.ts";
+
+/**
+ * The exact text the runner stamps for a kill cause. Derived from
+ * killCauseToErrorChunk() rather than copied, so a reworded kill string
+ * fails these tests instead of silently de-classifying every wedged
+ * harness back to "other".
+ */
+function killText(cause: "timeout" | "idle" | "startup"): string {
+  const chunk = killCauseToErrorChunk(cause, "pi", 300_000, 300_000, 60_000);
+  if (!chunk) throw new Error(`no error chunk for kill cause '${cause}'`);
+  return chunk.error;
+}
 
 function newAlerter(now: () => number = () => 0) {
   const sent: string[] = [];
@@ -57,23 +70,12 @@ describe("classifyFailure", () => {
     expect(classifyFailure("something vague", 401)).toBe("auth");
   });
 
-  // The three strings below are copied verbatim from killCauseToErrorChunk()
-  // in src/lib/harnessRunner.ts. If that wording changes, these fail — which
-  // is the point: the classifier matches on its text.
+  // Inputs come from the runner itself, not from copies of its wording: the
+  // classifier matches on that text, so a rewording there must fail here.
   test("recognises every wedged-harness kill the runner emits", () => {
-    expect(
-      classifyFailure("claude timed out after 300000ms (hard wall-clock cap)"),
-    ).toBe("timeout");
-    expect(
-      classifyFailure(
-        "pi timed out after 300000ms with no output (likely wedged on a tool call)",
-      ),
-    ).toBe("timeout");
-    expect(
-      classifyFailure(
-        "pi produced no output within 60000ms of startup (likely wedged on the MCP/init handshake)",
-      ),
-    ).toBe("timeout");
+    for (const cause of ["timeout", "idle", "startup"] as const) {
+      expect(classifyFailure(killText(cause))).toBe("timeout");
+    }
   });
 
   test("a real auth failure still wins over the word 'timed out'", () => {
@@ -152,6 +154,17 @@ describe("degraded alert", () => {
     await failNTimes(alerter, 1, err);
     expect(sent.length).toBe(2);
   });
+
+  test("a wedged harness a fallback absorbed stays silent", async () => {
+    const { alerter, sent } = newAlerter();
+    for (let i = 0; i < DEGRADE_AFTER_FAILURES + 2; i++) {
+      alerter.noteFailure("claude", killText("idle"));
+    }
+    await alerter.noteDegraded({ harnessId: "claude", servedBy: "pi" });
+    // Only `auth` pages: a timeout the chain routed around is #284's
+    // deliberate silence, and splitting it out of `other` must not change that.
+    expect(sent).toEqual([]);
+  });
 });
 
 describe("mixed causes in one incident", () => {
@@ -223,19 +236,6 @@ describe("send deadline", () => {
     // Settled, and settled by the deadline rather than by the send.
     expect(Date.now() - started).toBeLessThan(2000);
   });
-  test("a wedged harness a fallback absorbed stays silent", async () => {
-    const { alerter, sent } = newAlerter();
-    for (let i = 0; i < DEGRADE_AFTER_FAILURES + 2; i++) {
-      alerter.noteFailure(
-        "claude",
-        "claude timed out after 300000ms with no output (likely wedged on a tool call)",
-      );
-    }
-    await alerter.noteDegraded({ harnessId: "claude", servedBy: "pi" });
-    // Only `auth` pages: a timeout the chain routed around is #284's
-    // deliberate silence, and splitting it out of `other` must not change that.
-    expect(sent).toEqual([]);
-  });
 });
 
 describe("exhausted alert", () => {
@@ -251,7 +251,7 @@ describe("exhausted alert", () => {
     expect(sent[0]).not.toContain("\n");
     expect(sent[0]).toContain("\ud83d\udea8 claude rate limited 429");
     // One harness: nothing was ever configured to fall back to.
-    expect(sent[0]).toContain("no fallback configured [claude]");
+    expect(sent[0]).toContain("no usable fallback configured [claude]");
   });
 
   test("fires for a non-rate-limit outage too — no reply was delivered", async () => {
@@ -274,14 +274,14 @@ describe("exhausted alert", () => {
     await alerter.noteExhausted({
       harnessId: "pi",
       error:
-        "pi timed out after 300000ms with no output (likely wedged on a tool call)",
+        killText("idle"),
       chain: ["pi"],
     });
     expect(sent.length).toBe(1);
     expect(sent[0]).toContain("\ud83d\udea8 pi timed out");
     expect(sent[0]).not.toContain("harness error");
     // A one-harness chain never had a fallback to lose.
-    expect(sent[0]).toContain("no fallback configured [pi]");
+    expect(sent[0]).toContain("no usable fallback configured [pi]");
     expect(sent[0]).not.toContain("no fallback left");
   });
 
@@ -293,7 +293,7 @@ describe("exhausted alert", () => {
       chain: ["claude", "pi"],
     });
     expect(sent[0]).toContain("no fallback left [claude \u2192 pi]");
-    expect(sent[0]).not.toContain("no fallback configured");
+    expect(sent[0]).not.toContain("no usable fallback configured");
   });
 
   test("is silent with no sender configured", async () => {


### PR DESCRIPTION
Follow-up to #407, from a live alert on kw-phantombot:

```
🚨 pi harness error 🖥 kw-phantombot · no fallback left [pi], turn undelivered
```

pi stalled with no output for 5+ minutes, phantombot killed it on the 300s idle timeout, and the chain was length 1 so nothing else could answer. The alert was correct but uninformative — Lena had to read the journals to learn the harness was *wedged* rather than crashed, which is the whole thing the alert was supposed to save.

## Changes

**`timeout` joins the cause enum.** Matched on the text `killCauseToErrorChunk()` already stamps in `src/lib/harnessRunner.ts` — the hard wall-clock cap, the idle window, and the startup handshake window. Renders as `timed out`:

```
🚨 pi timed out 🖥 kw-phantombot · no fallback configured [pi], turn undelivered
```

This changes no policy. Like `other`, it never fires the degraded alert, so a wedge that a fallback absorbed stays silent exactly as #284 intended — there's a test pinning that.

**Single-harness chains say "no fallback configured".** "No fallback left" implies one was tried and also failed, which points the reader at the wrong fix. With a chain of one, the fix is *add a fallback*, not *debug two harnesses*.

## Notes for review

- The three timeout strings in the test are copied verbatim from `killCauseToErrorChunk()`. If that wording is reworded, these tests fail — deliberate, since the classifier matches on its text.
- Auth still wins over timeout in `classifyFailure` (ordering test included): a sticky credential failure that happens to mention a timeout must not be downgraded to a transient-looking label.
- Mutation-verified both guards: removing the `TIMEOUT_MARKERS` branch fails 2 tests, hardcoding `"no fallback left"` fails 2 tests.
- 44 tests pass across `lib-harnessAlert` + `orchestrator-fallback`, typecheck clean.