### PR TITLE
feat(nightly): add a compaction stage that can only shrink what is over budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1812,11 +1812,39 @@ processed, or whose last pass didn't finish:
 
 ```text
 sweep (code) -> per date: distill ‖ kb -> index refresh (code) -> ledger (code)
+                                                            \-> compact (once)
 ```
 
 * `distill` files the day's captures into the drawers (people / decisions /
   lessons / commitments / norms) and maintains MEMORY.md's `## Recent`.
 * `kb` extracts durable knowledge into `kb/` — reconcile, create, sweep inbox.
+* `compact` runs **once per sweep**, after every date is distilled, and is the
+  only stage that removes anything. See below.
+
+#### Compaction
+
+`distill` and `kb` only ever append, so the always-in-context files grow without
+bound — a 663KB drawer set costs tokens on every turn and buries live facts
+under dead ones. The compaction stage is the other half of the loop, and it is
+built to be safe rather than thorough:
+
+* Only files **over budget** are touched (MEMORY.md 16KB, drawers 128KB, a
+  fully-distilled daily file 8KB). A healthy persona pays one `stat` per file.
+* Every candidate is copied verbatim into `memory/archive/<YYYY-MM-DD>/`
+  **before** the stage runs. Nothing is ever deleted, and the nightly is the
+  only code path that moves a memory file.
+* Afterwards each file is re-stat-ed and judged. A pass that removes more than
+  its allowance (40%, or 90% for a closed daily file), empties a file or loses
+  one is **rolled back from that copy** and recorded as `reverted`.
+* Byte accounting per file lands in the ledger under `compaction`, so "is memory
+  still growing?" is answerable without grepping the log.
+* A daily file is only trimmed once the ledger shows both stages `ok` for it and
+  it is at least 30 days old.
+
+Drawers are measured and reported but **not rewritten**: their dedupe and
+lifecycle work moves to the database, where it is a uniqueness constraint rather
+than an LLM pass over prose. `--no-compact` skips the stage; a `--date`
+backfill never runs it.
 
 The two stages run **concurrently**: they read the same daily file and write
 disjoint targets. Neither writes back to the daily file, which is what keeps
@@ -1834,7 +1862,8 @@ fire redundantly: re-running with nothing pending costs nothing, and a machine
 that was off for a week sweeps the backlog when it comes back. There is no
 `--resume` and no catch-up mode. Useful flags:
 `--date <YYYY-MM-DD>` to reprocess one day, `--max-dates N` to bound a manual
-run, `--force` to take over a stuck in-flight marker.
+run, `--force` to take over a stuck in-flight marker, `--no-compact` to leave
+over-budget files untouched.
 
 A stage runs **scoped to the persona directory**. Its working directory is the
 persona dir (not your home dir), it runs with no MCP servers, and it is granted

--- a/README.md
+++ b/README.md
@@ -1828,8 +1828,8 @@ bound — a 663KB drawer set costs tokens on every turn and buries live facts
 under dead ones. The compaction stage is the other half of the loop, and it is
 built to be safe rather than thorough:
 
-* Only files **over budget** are touched (MEMORY.md 16KB, drawers 128KB, a
-  fully-distilled daily file 8KB). A healthy persona pays one `stat` per file.
+* Only files **over budget** are touched (MEMORY.md 16KB, a fully-distilled
+  daily file 8KB). A healthy persona pays one `stat` per file.
 * Every candidate is copied verbatim into `memory/archive/<YYYY-MM-DD>/`
   **before** the stage runs. Nothing is ever deleted, and the nightly is the
   only code path that moves a memory file.
@@ -1839,12 +1839,21 @@ built to be safe rather than thorough:
 * Byte accounting per file lands in the ledger under `compaction`, so "is memory
   still growing?" is answerable without grepping the log.
 * A daily file is only trimmed once the ledger shows both stages `ok` for it and
-  it is at least 30 days old.
+  it is at least 30 days old. Because compaction rewrites that file, its ledger
+  entry is re-fingerprinted afterwards — otherwise the next sweep would see the
+  date as *changed* and pay for both LLM stages again, every night.
+* `memory/archive/` is **never indexed**. A rollback copy is a recovery artefact
+  for a human with `cp`; indexing it would feed the stale text compaction just
+  removed straight back into search as a live document.
+* The stage runs even when **no date is pending** — its inputs are whole-file
+  sizes, not a day's events, so the steady-state night with a drained backlog is
+  exactly the night it matters.
 
-Drawers are measured and reported but **not rewritten**: their dedupe and
+Drawers are measured and reported but **never candidates**: their dedupe and
 lifecycle work moves to the database, where it is a uniqueness constraint rather
-than an LLM pass over prose. `--no-compact` skips the stage; a `--date`
-backfill never runs it.
+than an LLM pass over prose. Selecting them would buy a turn whose own prompt
+tells it to change nothing. `--no-compact` skips the stage; a `--date` backfill
+never runs it.
 
 The two stages run **concurrently**: they read the same daily file and write
 disjoint targets. Neither writes back to the daily file, which is what keeps

--- a/README.md
+++ b/README.md
@@ -1853,7 +1853,10 @@ Drawers are measured and reported but **never candidates**: their dedupe and
 lifecycle work moves to the database, where it is a uniqueness constraint rather
 than an LLM pass over prose. Selecting them would buy a turn whose own prompt
 tells it to change nothing. `--no-compact` skips the stage; a `--date` backfill
-never runs it.
+never runs it; and a sweep in which **any date stage failed** skips it too — a
+failed distill can leave MEMORY.md half-rewritten, so the archive would preserve
+the damage instead of the clean pre-sweep file. Over-budget files simply wait
+for the next clean sweep.
 
 The two stages run **concurrently**: they read the same daily file and write
 disjoint targets. Neither writes back to the daily file, which is what keeps

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,8 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 | `src/persona/loader.ts` | Reads BOOT.md / SOUL.md / IDENTITY.md (required) + MEMORY.md / tools.md / AGENTS.md (optional). | filesystem |
 | `src/persona/builder.ts` | Concatenates persona pieces + (deferred) retrieved memory + invocation context into a system prompt string. | `loader.ts` |
 | `src/memory/store.ts` | bun:sqlite wrapper. `turns` table (`appendTurn`, `recentTurns`, …) + `capture_log` table (`appendCapture`, `lastCaptureAt`, `countCapturesSince`, turn counters for the nudge/doctor). | `bun:sqlite` |
-| `src/lib/nightly.ts` | Two-stage model + prompt bodies, the `.nightly-state.json` ledger (`sweepDailyFiles`, `dateRecord`), and `nightlyHealth` for `/status` + doctor. | filesystem |
+| `src/lib/nightly.ts` | Stage model + prompt bodies, the `.nightly-state.json` ledger (`sweepDailyFiles`, `dateRecord`), and `nightlyHealth` for `/status` + doctor. | filesystem |
+| `src/lib/nightlyCompact.ts` | Compaction budgets, candidate selection, the pre-pass archive under `memory/archive/<date>/`, and the shrink-guard verdict that reverts an over-eager pass. | filesystem, `lib/nightly` |
 | `src/lib/nightlyTrigger.ts` | When the sweep runs: `dayRolledOver` (heartbeat trigger) + `spawnNightlySweep` (detached fire, also used by `run` at startup). | `node:child_process` |
 | `src/lib/indexRefresh.ts` | `refreshPersonaIndex`: incremental FTS + embedding refresh, called in code by the nightly after both stages join. | `lib/memoryIndex`, `lib/embedJob` |
 | `src/cli/doctor.ts` | `phantombot doctor`: reports the nightly ledger (read-only) + `capture_log`, repairs units/timers/connectors. | `memory/store`, `lib/nightly` |
@@ -139,7 +140,11 @@ Three properties worth knowing when touching this code:
    (`refreshPersonaIndex`), which both guarantees it and orders it after the
    writes. There is no `--resume` and no catch-up mode: a half-done date is just
    a date the ledger doesn't call done. `doctor` reports this state; it no longer
-   repairs it, so the job has one owner.
+   repairs it, so the job has one owner. A third stage, `compact`, runs ONCE per
+   sweep (its inputs are whole-file sizes, not one day's events) and is the only
+   stage that removes anything: it archives every over-budget file verbatim
+   first, then reverts any rewrite that overshoots its shrink allowance. Drawer
+   dedupe is deliberately NOT part of it — that lifecycle moves to the database.
 
 ## Open design questions
 

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -36,11 +36,13 @@ import { refreshPersonaIndex } from "../lib/indexRefresh.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { log } from "../lib/logger.ts";
 import {
+  buildCompactionPrompt,
   buildNightlyPromptForPersona,
   buildNightlyStagePrompt,
   dateRecord,
   loadNightlyState,
   NIGHTLY_STAGES,
+  type NightlyState,
   type NightlyStage,
   nightlyConversationKey,
   type PendingDate,
@@ -51,6 +53,15 @@ import {
   selfStartToken,
   sweepLiveness,
 } from "../lib/nightly.ts";
+import {
+  archiveDirPath,
+  archiveForCompaction,
+  type CompactionCandidate,
+  type CompactionOutcome,
+  compactionCandidates,
+  formatCompactionSummary,
+  settleCompaction,
+} from "../lib/nightlyCompact.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { runTurn } from "../orchestrator/turn.ts";
 
@@ -97,6 +108,14 @@ export interface RunNightlyInput {
   maxDates?: number;
   /** Run even if another sweep holds the in-flight marker. */
   force?: boolean;
+  /**
+   * Skip the compaction stage (issue #410). Set by `--no-compact`, and always
+   * true for a `--date` backfill: reprocessing one old day should not also
+   * rewrite MEMORY.md.
+   */
+  skipCompaction?: boolean;
+  /** Test seam — override the daily-file age gate. */
+  compactMinAgeDays?: number;
   out?: WriteSink;
   err?: WriteSink;
   /** Test seam — override the clock. */
@@ -105,7 +124,7 @@ export interface RunNightlyInput {
   runStage?: (args: {
     persona: string;
     date: string;
-    stage: NightlyStage | "override";
+    stage: NightlyStage | "override" | "compact";
     prompt: string;
   }) => Promise<TurnResult>;
   /** Test seam — skip the real index refresh. */
@@ -201,6 +220,63 @@ export async function runNightlyTurn(opts: {
     errored = (e as Error).message;
   }
   return { finalReply, errored, durationMs: Date.now() - startedAt };
+}
+
+
+/**
+ * Run the compaction pass over whatever is currently over budget.
+ *
+ * The safety property lives here, not in the prompt: every candidate is
+ * copied into `memory/archive/<today>/` BEFORE the stage runs, and each file
+ * is re-stat-ed and judged afterwards. A pass that overshoots its shrink
+ * allowance, empties a file or loses one is rolled back from that copy. The
+ * stage itself is never trusted to have done the right thing.
+ *
+ * Returns null when nothing is over budget — the common case, and free.
+ */
+export async function runCompaction(opts: {
+  personaDir: string;
+  persona: string;
+  today: string;
+  state: NightlyState;
+  minAgeDays?: number;
+  runOne: (prompt: string) => Promise<TurnResult>;
+  out: WriteSink;
+}): Promise<{ outcomes: CompactionOutcome[]; error?: string } | null> {
+  const candidates = await compactionCandidates(opts.personaDir, opts.state, {
+    today: opts.today,
+    ...(opts.minAgeDays !== undefined ? { minAgeDays: opts.minAgeDays } : {}),
+  });
+  if (candidates.length === 0) return null;
+
+  const archiveDir = archiveDirPath(opts.personaDir, opts.today);
+  const archived = new Map<CompactionCandidate, string>();
+  for (const c of candidates) {
+    archived.set(c, await archiveForCompaction(opts.personaDir, c, opts.today));
+  }
+
+  const r = await opts.runOne(
+    buildCompactionPrompt(opts.persona, opts.today, candidates, archiveDir),
+  );
+
+  // Settle regardless of how the turn ended: a stage that timed out may still
+  // have half-rewritten a file, and that is exactly what the guard is for.
+  const outcomes: CompactionOutcome[] = [];
+  for (const c of candidates) {
+    outcomes.push(await settleCompaction(c, archived.get(c)!));
+  }
+  opts.out.write(formatCompactionSummary(outcomes));
+
+  await saveNightlyState(opts.personaDir, {
+    compaction: {
+      ran_at: new Date().toISOString(),
+      archive_dir: archiveDir,
+      files: outcomes,
+      bytes_before: outcomes.reduce((n, o) => n + o.bytesBefore, 0),
+      bytes_after: outcomes.reduce((n, o) => n + o.bytesAfter, 0),
+    },
+  });
+  return { outcomes, ...(r.errored ? { error: r.errored } : {}) };
 }
 
 export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
@@ -329,7 +405,7 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
       });
 
       const runOne = async (
-        stage: NightlyStage | "override",
+        stage: NightlyStage | "override" | "compact",
         prompt: string,
       ): Promise<TurnResult> =>
         input.runStage
@@ -415,6 +491,49 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
         out.write(`nightly: ${pending.date} ok (${Date.now() - t0}ms)\n`);
       }
     }
+
+    // ---------------------------------------------------------------------
+    // Stage three: compaction (issue #410).
+    //
+    // Runs ONCE per sweep, after every date has been distilled, because its
+    // inputs are whole-file sizes rather than one day's events — and because
+    // running it per date would rewrite MEMORY.md N times in a backlog drain.
+    // Skipped for `--date` backfills and for personas with a monolithic
+    // prompt override, which owns its own contract.
+    // ---------------------------------------------------------------------
+    if (!input.skipCompaction && !input.today && !monolithic) {
+      const compaction = await runCompaction({
+        personaDir: dir,
+        persona,
+        today: now.toISOString().slice(0, 10),
+        state: await loadNightlyState(dir),
+        minAgeDays: input.compactMinAgeDays,
+        runOne: async (prompt) =>
+          input.runStage
+            ? await input.runStage({
+                persona,
+                date: now.toISOString().slice(0, 10),
+                stage: "compact",
+                prompt,
+              })
+            : await runNightlyTurn({
+                persona,
+                conversation: `${nightlyConversationKey(now.toISOString().slice(0, 10))}:compact`,
+                userMessage: prompt,
+                agentDir: dir,
+                harnesses,
+                memory: memory!,
+              }),
+        out,
+      });
+      if (compaction?.error) {
+        errors.push(`compaction: ${compaction.error}`);
+        log.error("nightly: compaction stage failed", {
+          persona,
+          error: compaction.error,
+        });
+      }
+    }
   } finally {
     await memory?.close();
   }
@@ -466,6 +585,12 @@ export default defineCommand({
       description: "Run even if another sweep holds the in-flight marker.",
       default: false,
     },
+    "no-compact": {
+      type: "boolean",
+      description:
+        "Skip the compaction stage (leave over-budget files untouched).",
+      default: false,
+    },
   },
   async run({ args }) {
     const max = args["max-dates"] ? Number(args["max-dates"]) : undefined;
@@ -474,6 +599,7 @@ export default defineCommand({
       today: args.date ? String(args.date) : undefined,
       maxDates: Number.isFinite(max) ? max : undefined,
       force: Boolean(args.force),
+      skipCompaction: Boolean(args["no-compact"]),
     });
   },
 });

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -562,8 +562,26 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
     // running it per date would rewrite MEMORY.md N times in a backlog drain.
     // Skipped for `--date` backfills and for personas with a monolithic
     // prompt override, which owns its own contract.
+    //
+    // Also skipped whenever any date stage failed this sweep. A failed distill
+    // turn can still have partially rewritten MEMORY.md before erroring, so the
+    // archive compaction takes would capture that damaged state rather than the
+    // clean pre-sweep one — and a second model rewrite on top of it would bury
+    // the damage. Leave over-budget files alone and compact on the next clean
+    // sweep instead.
     // ---------------------------------------------------------------------
-    if (!input.skipCompaction && !input.today && !monolithic) {
+    const compactionEligible =
+      !input.skipCompaction && !input.today && !monolithic;
+    if (compactionEligible && errors.length > 0) {
+      out.write(
+        `nightly: compaction skipped — ${errors.length} stage error(s) this sweep; ` +
+          `over-budget files are left untouched until a clean sweep\n`,
+      );
+      log.warn("nightly: compaction skipped after stage failure", {
+        persona,
+        errors: errors.length,
+      });
+    } else if (compactionEligible) {
       // Keep the beat fresh across a stage that can outlive the stall timer.
       await holdSweep(todayStamp, queue.length);
       const compaction = await runCompaction({
@@ -647,7 +665,7 @@ export default defineCommand({
   meta: {
     name: "nightly",
     description:
-      "Run the cognitive distillation sweep — every unprocessed or changed daily file is distilled into the drawers, MEMORY.md and the KB. Idempotent: re-running with nothing pending does nothing.",
+      "Run the cognitive distillation sweep — every unprocessed or changed daily file is distilled into the drawers, MEMORY.md and the KB. The date sweep is idempotent: re-running with nothing pending distills nothing. The once-per-sweep compaction check still runs, and rewrites a file only if it is over budget (skip it with --no-compact).",
   },
   args: {
     persona: {

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -243,7 +243,7 @@ export async function runCompaction(opts: {
   state: NightlyState;
   minAgeDays?: number;
   runOne: (prompt: string) => Promise<TurnResult>;
-  /** Re-index after files were rewritten. Skipped when nothing changed. */
+  /** Re-index after the stage ran. Always called: see the call site. */
   reconcileIndex?: () => Promise<void>;
   out: WriteSink;
 }): Promise<{ outcomes: CompactionOutcome[]; error?: string } | null> {
@@ -283,7 +283,14 @@ export async function runCompaction(opts: {
   const touched = outcomes.filter(
     (o) => o.kind === "daily" && o.bytesAfter !== o.bytesBefore,
   ).length;
-  const rewritten = outcomes.some((o) => o.status !== "unchanged");
+  // NOT `status !== "unchanged"`: `unchanged` is a SIZE verdict, and the stage
+  // can rewrite a file to different content of exactly the same byte length —
+  // in which case the index kept serving the pre-compaction text for a file
+  // that had in fact changed, which is the one outcome this stage exists to
+  // prevent. The stage only runs when there were candidates at all (the
+  // no-candidate case returned above), so reconcile unconditionally: a refresh
+  // over genuinely untouched files is a stat-cheap no-op, a missed one is
+  // stale memory that stays searchable.
   const ledgerPatch: Record<string, NightlyDateRecord> = {};
   for (const c of candidates) {
     if (c.kind !== "daily" || c.date === undefined) continue;
@@ -312,7 +319,7 @@ export async function runCompaction(opts: {
 
   // The sweep's index refresh ran BEFORE this stage, so any file compaction
   // rewrote is still indexed at its old contents until this runs.
-  if (rewritten && opts.reconcileIndex) await opts.reconcileIndex();
+  if (opts.reconcileIndex) await opts.reconcileIndex();
   log.info("nightly: compaction settled", {
     persona: opts.persona,
     files: outcomes.length,
@@ -429,21 +436,35 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
   const memory = input.runStage ? null : await openMemoryStore(config.memoryDbPath);
   const startedAt = new Date().toISOString();
   const errors: string[] = [];
+  const todayStamp = now.toISOString().slice(0, 10);
+
+  // The in-flight marker covers the WHOLE sweep, not just the date loop.
+  // Compaction runs even when the queue is empty — which, once the backlog is
+  // drained, is every night — so a marker written only per date left exactly
+  // that path unlocked: two sweeps would both pass the liveness check, archive
+  // the same pre-image and point concurrent LLM writers at the same files.
+  // Acquired before any work, refreshed as each date starts and again before
+  // compaction so a long stage never reads as stalled, cleared in the finally.
+  const holdSweep = async (date: string, index: number): Promise<void> => {
+    await saveNightlyState(dir, {
+      current: {
+        date,
+        index,
+        total: queue.length,
+        started_at: startedAt,
+        updated_at: new Date().toISOString(),
+        pid: process.pid,
+        pid_start: selfStartToken() ?? undefined,
+      },
+    });
+  };
 
   try {
+    await holdSweep(queue[0]?.date ?? todayStamp, 0);
+
     for (const [i, pending] of queue.entries()) {
       const conversation = nightlyConversationKey(pending.date);
-      await saveNightlyState(dir, {
-        current: {
-          date: pending.date,
-          index: i + 1,
-          total: queue.length,
-          started_at: startedAt,
-          updated_at: new Date().toISOString(),
-          pid: process.pid,
-          pid_start: selfStartToken() ?? undefined,
-        },
-      });
+      await holdSweep(pending.date, i + 1);
 
       const runOne = async (
         stage: NightlyStage | "override" | "compact",
@@ -543,6 +564,8 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
     // prompt override, which owns its own contract.
     // ---------------------------------------------------------------------
     if (!input.skipCompaction && !input.today && !monolithic) {
+      // Keep the beat fresh across a stage that can outlive the stall timer.
+      await holdSweep(todayStamp, queue.length);
       const compaction = await runCompaction({
         personaDir: dir,
         persona,

--- a/src/cli/nightly.ts
+++ b/src/cli/nightly.ts
@@ -42,6 +42,7 @@ import {
   dateRecord,
   loadNightlyState,
   NIGHTLY_STAGES,
+  type NightlyDateRecord,
   type NightlyState,
   type NightlyStage,
   nightlyConversationKey,
@@ -60,6 +61,7 @@ import {
   type CompactionOutcome,
   compactionCandidates,
   formatCompactionSummary,
+  measureDrawers,
   settleCompaction,
 } from "../lib/nightlyCompact.ts";
 import { openMemoryStore } from "../memory/store.ts";
@@ -241,6 +243,8 @@ export async function runCompaction(opts: {
   state: NightlyState;
   minAgeDays?: number;
   runOne: (prompt: string) => Promise<TurnResult>;
+  /** Re-index after files were rewritten. Skipped when nothing changed. */
+  reconcileIndex?: () => Promise<void>;
   out: WriteSink;
 }): Promise<{ outcomes: CompactionOutcome[]; error?: string } | null> {
   const candidates = await compactionCandidates(opts.personaDir, opts.state, {
@@ -267,6 +271,34 @@ export async function runCompaction(opts: {
   }
   opts.out.write(formatCompactionSummary(outcomes));
 
+  // Reconcile the ledger for every daily file this pass touched.
+  //
+  // The ledger keys "has this date been distilled?" on mtime + size + hash of
+  // the daily file. Compaction rewrites that file — and so does a rollback —
+  // so leaving the pre-compaction record in place makes the NEXT sweep see the
+  // date as `changed`, re-queue it, and pay for both LLM stages again on a day
+  // whose content was only ever removed. Left alone it re-bills every single
+  // night, forever. The distillation verdict (stages_done/status) is carried
+  // over untouched: what changed is the file's fingerprint, not its history.
+  const touched = outcomes.filter(
+    (o) => o.kind === "daily" && o.bytesAfter !== o.bytesBefore,
+  ).length;
+  const rewritten = outcomes.some((o) => o.status !== "unchanged");
+  const ledgerPatch: Record<string, NightlyDateRecord> = {};
+  for (const c of candidates) {
+    if (c.kind !== "daily" || c.date === undefined) continue;
+    const prev = opts.state.processed?.[c.date];
+    if (!prev) continue;
+    const fresh = await pendingForDate(opts.personaDir, c.date);
+    if (!fresh) continue;
+    ledgerPatch[c.date] = {
+      ...prev,
+      mtime_ms: fresh.mtime_ms,
+      size: fresh.size,
+      hash: fresh.hash,
+    };
+  }
+
   await saveNightlyState(opts.personaDir, {
     compaction: {
       ran_at: new Date().toISOString(),
@@ -275,6 +307,16 @@ export async function runCompaction(opts: {
       bytes_before: outcomes.reduce((n, o) => n + o.bytesBefore, 0),
       bytes_after: outcomes.reduce((n, o) => n + o.bytesAfter, 0),
     },
+    ...(Object.keys(ledgerPatch).length > 0 ? { processed: ledgerPatch } : {}),
+  });
+
+  // The sweep's index refresh ran BEFORE this stage, so any file compaction
+  // rewrote is still indexed at its old contents until this runs.
+  if (rewritten && opts.reconcileIndex) await opts.reconcileIndex();
+  log.info("nightly: compaction settled", {
+    persona: opts.persona,
+    files: outcomes.length,
+    dailies_reledgered: touched,
   });
   return { outcomes, ...(r.errored ? { error: r.errored } : {}) };
 }
@@ -367,22 +409,21 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
     cap !== undefined && cap > 0 ? Math.max(0, queue.length - cap) : 0;
   if (deferred > 0) queue = queue.slice(0, cap);
 
+  // An empty queue is NOT an early return. Compaction's inputs are whole-file
+  // sizes, not a day's events, so the night it most needs to run is exactly
+  // the steady-state night where nothing new is pending — which is every night
+  // once the backlog is drained. Returning here made the stage permanently
+  // inert outside a backfill. The date loop below simply does nothing instead.
   if (queue.length === 0) {
     out.write(`nightly: persona='${persona}' — nothing pending\n`);
-    await saveNightlyState(dir, {
-      last_run: now.toISOString(),
-      last_status: "ok",
-      current: null,
-    });
-    return 0;
+  } else {
+    out.write(
+      `nightly: persona='${persona}' — ${queue.length} date(s) to process ` +
+        `[${queue.map((q) => `${q.date}:${q.reason}`).join(", ")}]` +
+        (deferred > 0 ? ` (+${deferred} deferred to the next run)` : "") +
+        `\n`,
+    );
   }
-
-  out.write(
-    `nightly: persona='${persona}' — ${queue.length} date(s) to process ` +
-      `[${queue.map((q) => `${q.date}:${q.reason}`).join(", ")}]` +
-      (deferred > 0 ? ` (+${deferred} deferred to the next run)` : "") +
-      `\n`,
-  );
 
   const monolithic = existsSync(join(dir, "nightly-prompt.md"));
   const memory = input.runStage ? null : await openMemoryStore(config.memoryDbPath);
@@ -524,8 +565,28 @@ export async function runNightly(input: RunNightlyInput = {}): Promise<number> {
                 harnesses,
                 memory: memory!,
               }),
+        reconcileIndex: async () => {
+          if (input.refreshIndex) {
+            await input.refreshIndex(dir);
+            return;
+          }
+          const ix = await refreshPersonaIndex({
+            config,
+            personaDir: dir,
+            indexPath: memoryIndexPath(persona),
+          });
+          if (ix.error) {
+            err.write(`nightly: post-compaction index refresh failed — ${ix.error}\n`);
+          }
+        },
         out,
       });
+      for (const d of await measureDrawers(dir)) {
+        out.write(
+          `nightly: drawer over budget — ${d.path}: ${d.sizeBytes} bytes ` +
+            `(budget ${d.budgetBytes}); compaction does not rewrite drawers\n`,
+        );
+      }
       if (compaction?.error) {
         errors.push(`compaction: ${compaction.error}`);
         log.error("nightly: compaction stage failed", {

--- a/src/lib/memoryIndex.ts
+++ b/src/lib/memoryIndex.ts
@@ -1658,6 +1658,19 @@ export function resolveMdLink(srcPath: string, target: string): string | null {
   return rel;
 }
 
+/**
+ * Directories under a scope root that are never indexed.
+ *
+ * `memory/archive/` holds pre-image copies the nightly compaction stage takes
+ * before it rewrites a file. Indexing them would put the PRE-compaction text
+ * back into FTS and vector search as a live document — so the stale, dead or
+ * superseded facts compaction just removed would be retrieved again, ranked
+ * alongside the current ones, and with a rollback copy for every pass the
+ * duplicates would compound nightly. The archive is a recovery artefact for a
+ * human with `cp`, not memory.
+ */
+const UNINDEXED_DIRS = new Set(["archive"]);
+
 /** Walk personaDir/memory/ and personaDir/kb/ for .md files. Synchronous. */
 export function walkMarkdown(personaDir: string): IndexedFile[] {
   const out: IndexedFile[] = [];
@@ -1691,6 +1704,9 @@ function walk(
     if (entry.name.startsWith(".")) continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
+      // Only at the scope root: a KB note filed under `kb/foo/archive/` is a
+      // note the persona chose to write, not a rollback copy.
+      if (dir === root && UNINDEXED_DIRS.has(entry.name)) continue;
       walk(root, full, scope, out);
       continue;
     }

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -42,6 +42,10 @@ import {
   type ProcessStartProbe,
 } from "./processLiveness.ts";
 import { OKF_AGENT_TYPES, OKF_CORE_TYPES } from "./okf.ts";
+import type {
+  CompactionCandidate,
+  CompactionOutcome,
+} from "./nightlyCompact.ts";
 
 const NIGHTLY_PROMPT_OVERRIDE = "nightly-prompt.md";
 
@@ -132,6 +136,23 @@ export interface NightlyState {
   processed?: Record<string, NightlyDateRecord>;
   /** Set while a sweep is in flight; cleared when it finishes. */
   current?: NightlyCurrent | null;
+  /**
+   * What the last compaction pass did, per file (issue #410). Byte accounting
+   * lives in the ledger rather than only in the log so `doctor` and a human
+   * can both answer "is memory still growing?" without grepping journald.
+   */
+  compaction?: NightlyCompactionRecord;
+}
+
+/** Outcome of one whole compaction pass. */
+export interface NightlyCompactionRecord {
+  ran_at: string;
+  /** Where the pre-compaction copies of these files live. */
+  archive_dir: string;
+  files: CompactionOutcome[];
+  /** Total bytes before/after across every file the pass touched. */
+  bytes_before: number;
+  bytes_after: number;
 }
 
 /**
@@ -680,4 +701,79 @@ Run BOTH stages below, in order, in this single turn.
 ${NIGHTLY_STAGE_BODY.distill(today)}
 
 ${NIGHTLY_STAGE_BODY.kb(today)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Compaction prompt (issue #410)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-kind instructions for the compaction pass. Written as REMOVAL rules
+ * with an explicit "when in doubt, keep it" default, because the failure mode
+ * that matters is losing a fact, not leaving a file 5% too big.
+ *
+ * Drawers get a measure-and-report instruction rather than a rewrite: their
+ * dedupe/merge lifecycle moves to the database in the follow-up work, and an
+ * LLM pass over them now would be built twice.
+ */
+const COMPACTION_KIND_BODY: Record<CompactionCandidate["kind"], string> = {
+  memory: `MEMORY.md is loaded into context on EVERY turn, so every byte is
+    rent. Prune it: drop "## Recent" bullets that are stale, superseded, or now
+    have a permanent home in a drawer or KB note; collapse anything that has
+    bloated into prose down to one line plus a [[pointer]]. Do NOT remove
+    standing facts about your owner, trust rules, or infrastructure state that
+    has no home elsewhere — move those, don't delete them.`,
+  drawer: `Do NOT rewrite this file. Its dedupe and lifecycle work is moving to
+    the database, so an edit here would be undone. Report its size and the
+    three largest sources of duplication you can see, and move on.`,
+  daily: `This day is CLOSED and fully distilled — every stage completed and its
+    contents are already filed in the drawers and the KB. Reduce it to: the
+    date heading, the items that were promoted (one line each), and any
+    capture lines. Drop transcript-shaped narration, tool output and
+    working-notes. If you cannot tell whether something was promoted, keep it.`,
+};
+
+/**
+ * Build the compaction stage prompt. Runs ONCE per sweep (not once per date)
+ * because its inputs are whole-file sizes, not a day's events.
+ */
+export function buildCompactionPrompt(
+  personaName: string,
+  today: string,
+  candidates: CompactionCandidate[],
+  archiveDir: string,
+): string {
+  const list = candidates
+    .map(
+      (c) =>
+        `  - ${c.path} — ${c.sizeBytes} bytes (budget ${c.budgetBytes})\n` +
+        `    ${COMPACTION_KIND_BODY[c.kind].replace(/\s+/g, " ").trim()}`,
+    )
+    .join("\n");
+  return `${nightlyPreamble(personaName, today)}
+
+STAGE: COMPACT (shrink what has grown past its budget)
+
+The distill and kb stages only append. This stage is the other half: it removes
+what is dead, duplicated, or has a permanent home elsewhere. It runs alone —
+no sibling stage is writing right now.
+
+Every file below has ALREADY been copied verbatim to ${archiveDir}, so a
+mistake is recoverable. Do not read, write or clean up that directory.
+
+Files over budget:
+${list}
+
+Rules that apply to all of them:
+  - Rewrite a file IN PLACE. Never delete a file, never move one, never create
+    a new file to replace one.
+  - Keep the file's existing shape: same headings, same ordering, same style.
+    A reader should see the same document with less in it.
+  - A pass that removes more than its allowance is automatically reverted by
+    phantombot, so aim to prune, not to rebuild from scratch.
+  - When you are unsure whether something is still live, KEEP IT. Another
+    night will get it.
+
+Finish with one line per file: path, roughly what you removed, and what you
+deliberately kept.`;
 }

--- a/src/lib/nightly.ts
+++ b/src/lib/nightly.ts
@@ -712,9 +712,11 @@ ${NIGHTLY_STAGE_BODY.kb(today)}`;
  * with an explicit "when in doubt, keep it" default, because the failure mode
  * that matters is losing a fact, not leaving a file 5% too big.
  *
- * Drawers get a measure-and-report instruction rather than a rewrite: their
- * dedupe/merge lifecycle moves to the database in the follow-up work, and an
- * LLM pass over them now would be built twice.
+ * The `drawer` entry is defensive only — drawers are not selected as
+ * candidates (see measureDrawers), because their dedupe/merge lifecycle moves
+ * to the database in the follow-up work and an LLM pass over them now would be
+ * built twice. It survives so a hand-built candidate can never reach the
+ * prompt without an instruction.
  */
 const COMPACTION_KIND_BODY: Record<CompactionCandidate["kind"], string> = {
   memory: `MEMORY.md is loaded into context on EVERY turn, so every byte is
@@ -723,9 +725,9 @@ const COMPACTION_KIND_BODY: Record<CompactionCandidate["kind"], string> = {
     bloated into prose down to one line plus a [[pointer]]. Do NOT remove
     standing facts about your owner, trust rules, or infrastructure state that
     has no home elsewhere — move those, don't delete them.`,
-  drawer: `Do NOT rewrite this file. Its dedupe and lifecycle work is moving to
-    the database, so an edit here would be undone. Report its size and the
-    three largest sources of duplication you can see, and move on.`,
+  drawer: `Do NOT rewrite this file, and do not read it. Its dedupe and
+    lifecycle work is moving to the database, so any edit here would be undone.
+    Leave it exactly as it is.`,
   daily: `This day is CLOSED and fully distilled — every stage completed and its
     contents are already filed in the drawers and the KB. Reduce it to: the
     date heading, the items that were promoted (one line each), and any

--- a/src/lib/nightlyCompact.ts
+++ b/src/lib/nightlyCompact.ts
@@ -1,0 +1,355 @@
+/**
+ * Nightly compaction — stage three (issue #410).
+ *
+ * The distill and kb stages only ever APPEND. Nothing in the system has ever
+ * removed a byte, so the always-in-context files grow without bound: on this
+ * box the drawers reached 663KB and MEMORY.md drifted past its useful size,
+ * which costs tokens on every single turn and buries live facts under dead
+ * ones. Compaction is the missing half of the loop.
+ *
+ * Three rules shape the whole design:
+ *
+ *   1. NOTHING IS EVER DELETED. Before a file is rewritten its exact bytes are
+ *      copied to `memory/archive/<YYYY-MM-DD>/`. A bad pass is recovered with
+ *      `cp`, not a restore from backup. The nightly is the only writer here —
+ *      no other code path moves or removes a memory file.
+ *   2. A PASS THAT EATS TOO MUCH IS REVERTED, not surfaced-and-kept. Each
+ *      target carries a `maxShrinkPct`; a rewrite that overshoots it (or that
+ *      empties or loses the file) is rolled back from the archive copy and
+ *      recorded as `reverted` in the ledger.
+ *   3. ONLY OVER-BUDGET FILES ARE TOUCHED. A file inside its budget costs one
+ *      `stat` and is left alone, so a healthy persona pays nothing.
+ *
+ * Deliberately NOT in scope here: drawer dedupe/merge. `commitments.md`,
+ * `decisions.md` and `lessons.md` are append-only logs with a lifecycle —
+ * they become database rows in the follow-up work, at which point dedupe is a
+ * uniqueness constraint rather than an LLM pass over prose. Building the LLM
+ * version first would be throwaway. What this stage does to the drawers is
+ * measure them and report the overage.
+ */
+
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { log } from "./logger.ts";
+import type { NightlyState } from "./nightly.ts";
+import { NIGHTLY_STAGES } from "./nightly.ts";
+
+/** What kind of file a compaction target is — drives the prompt wording. */
+export type CompactionKind = "memory" | "drawer" | "daily";
+
+export interface CompactionBudget {
+  /** Persona-relative path, e.g. `memory/MEMORY.md`. */
+  path: string;
+  kind: CompactionKind;
+  /** Compaction is considered only once the file exceeds this many bytes. */
+  budgetBytes: number;
+  /**
+   * Largest share of the file a single pass may remove. Exceeding it reverts
+   * the pass. Daily files are allowed to lose most of their bulk because the
+   * whole point is to reduce a closed, fully-distilled day to its promoted
+   * items; MEMORY.md is prose in the prompt and must only be pruned.
+   */
+  maxShrinkPct: number;
+}
+
+/** Drawers, in the order the distill stage writes them. */
+export const DRAWER_FILES = [
+  "people.md",
+  "decisions.md",
+  "lessons.md",
+  "commitments.md",
+  "norms.md",
+] as const;
+
+/** 16KB of orientation text is already ~4k tokens on EVERY turn. */
+export const MEMORY_BUDGET_BYTES = 16 * 1024;
+/** A drawer is read by search, not by the prompt — it can afford more. */
+export const DRAWER_BUDGET_BYTES = 128 * 1024;
+/** A closed day that has been fully distilled should be a summary, not a log. */
+export const DAILY_BUDGET_BYTES = 8 * 1024;
+
+/**
+ * A daily file is only ever trimmed once it is this old AND fully distilled.
+ * The age gate is not about safety — the ledger already proves distillation —
+ * it is so a day is still readable in full while it is recent enough that
+ * someone might go back and check what actually happened.
+ */
+export const DAILY_MIN_AGE_DAYS = 30;
+
+/** Optional per-persona override, e.g. `{"memory/MEMORY.md": 32768}`. */
+export const BUDGET_OVERRIDE_FILE = "memory/.compaction-budgets.json";
+
+export function defaultBudgets(): CompactionBudget[] {
+  return [
+    {
+      path: "MEMORY.md",
+      kind: "memory",
+      budgetBytes: MEMORY_BUDGET_BYTES,
+      maxShrinkPct: 40,
+    },
+    ...DRAWER_FILES.map((f) => ({
+      path: join("memory", f),
+      kind: "drawer" as const,
+      budgetBytes: DRAWER_BUDGET_BYTES,
+      maxShrinkPct: 40,
+    })),
+  ];
+}
+
+/**
+ * Merge the persona's optional budget overrides over the defaults. Only the
+ * byte budget is overridable — `maxShrinkPct` is a safety guard, not a knob,
+ * and a persona that could raise it could talk itself into an empty drawer.
+ */
+export async function resolveBudgets(
+  personaDir: string,
+): Promise<CompactionBudget[]> {
+  const base = defaultBudgets();
+  const p = join(personaDir, BUDGET_OVERRIDE_FILE);
+  if (!existsSync(p)) return base;
+  try {
+    const raw = JSON.parse(await readFile(p, "utf8")) as Record<string, unknown>;
+    return base.map((b) => {
+      const v = raw[b.path];
+      return typeof v === "number" && Number.isFinite(v) && v > 0
+        ? { ...b, budgetBytes: Math.floor(v) }
+        : b;
+    });
+  } catch (e) {
+    log.warn("nightly: budget override unreadable; using defaults", {
+      path: p,
+      error: (e as Error).message,
+    });
+    return base;
+  }
+}
+
+/** One file this sweep intends to compact. */
+export interface CompactionCandidate extends CompactionBudget {
+  /** Absolute path. */
+  absPath: string;
+  sizeBytes: number;
+  /** For `daily` candidates only: the date the file covers. */
+  date?: string;
+}
+
+const DAILY_FILE_RE = /^(\d{4}-\d{2}-\d{2})\.md$/;
+
+function daysBetween(a: string, b: string): number {
+  const ms = Date.parse(`${b}T00:00:00Z`) - Date.parse(`${a}T00:00:00Z`);
+  return Number.isNaN(ms) ? 0 : Math.floor(ms / 86_400_000);
+}
+
+/**
+ * Which files are over budget right now.
+ *
+ * Daily files carry two extra conditions on top of the byte budget: the
+ * ledger must show BOTH stages complete with status `ok` (so everything worth
+ * keeping is already in a drawer or a KB note), and the date must be at least
+ * `minAgeDays` old. Anything else is left alone.
+ */
+export async function compactionCandidates(
+  personaDir: string,
+  state: NightlyState,
+  opts: {
+    today: string;
+    budgets?: CompactionBudget[];
+    minAgeDays?: number;
+    dailyBudgetBytes?: number;
+  },
+): Promise<CompactionCandidate[]> {
+  const budgets = opts.budgets ?? (await resolveBudgets(personaDir));
+  const minAge = opts.minAgeDays ?? DAILY_MIN_AGE_DAYS;
+  const dailyBudget = opts.dailyBudgetBytes ?? DAILY_BUDGET_BYTES;
+  const out: CompactionCandidate[] = [];
+
+  for (const b of budgets) {
+    const absPath = join(personaDir, b.path);
+    let size: number;
+    try {
+      size = (await stat(absPath)).size;
+    } catch {
+      continue; // a drawer that has never been written is not a candidate
+    }
+    if (size > b.budgetBytes) out.push({ ...b, absPath, sizeBytes: size });
+  }
+
+  const memDir = join(personaDir, "memory");
+  if (!existsSync(memDir)) return out;
+  const ledger = state.processed ?? {};
+  for (const file of (await readdir(memDir)).sort()) {
+    const m = DAILY_FILE_RE.exec(file);
+    if (!m) continue;
+    const date = m[1]!;
+    const rec = ledger[date];
+    const distilled =
+      rec !== undefined &&
+      rec.status === "ok" &&
+      NIGHTLY_STAGES.every((s) => rec.stages_done.includes(s));
+    if (!distilled) continue;
+    if (daysBetween(date, opts.today) < minAge) continue;
+    const absPath = join(memDir, file);
+    let size: number;
+    try {
+      size = (await stat(absPath)).size;
+    } catch {
+      continue;
+    }
+    if (size <= dailyBudget) continue;
+    out.push({
+      path: join("memory", file),
+      kind: "daily",
+      budgetBytes: dailyBudget,
+      // A fully-distilled day is expected to collapse to a stub; the guard
+      // here only catches a pass that truncates it to nothing at all.
+      maxShrinkPct: 90,
+      absPath,
+      sizeBytes: size,
+      date,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Archive — the only reason any of this is safe to run unattended
+// ---------------------------------------------------------------------------
+
+export function archiveDirPath(personaDir: string, stamp: string): string {
+  return join(personaDir, "memory", "archive", stamp);
+}
+
+/**
+ * Copy a file's exact bytes into `memory/archive/<stamp>/` and return the
+ * archive path. Copies rather than moves: the live file must stay in place
+ * for the stage to rewrite, and a half-applied pass must never leave a gap
+ * where memory used to be. A second pass on the same day overwrites its own
+ * earlier copy, which is correct — the archive holds the pre-compaction state
+ * for that DATE, not every intermediate.
+ */
+export async function archiveForCompaction(
+  personaDir: string,
+  candidate: CompactionCandidate,
+  stamp: string,
+): Promise<string> {
+  const dir = archiveDirPath(personaDir, stamp);
+  await mkdir(dir, { recursive: true });
+  // Flatten the persona-relative path so `memory/decisions.md` and a future
+  // `kb/decisions.md` can't collide inside one archive dir.
+  const dest = join(dir, candidate.path.replace(/[\\/]/g, "__"));
+  if (!existsSync(dest)) await copyFile(candidate.absPath, dest);
+  return dest;
+}
+
+/** Put the archived bytes back over the live file. */
+export async function restoreFromArchive(
+  archivePath: string,
+  absPath: string,
+): Promise<void> {
+  await copyFile(archivePath, absPath);
+}
+
+// ---------------------------------------------------------------------------
+// Verdict
+// ---------------------------------------------------------------------------
+
+export type CompactionStatus = "compacted" | "unchanged" | "grew" | "reverted";
+
+export interface CompactionOutcome {
+  path: string;
+  kind: CompactionKind;
+  bytesBefore: number;
+  bytesAfter: number;
+  status: CompactionStatus;
+  /** Why a pass was reverted, for the ledger and the operator. */
+  note?: string;
+}
+
+/**
+ * Judge one rewritten file.
+ *
+ * `grew` is not an error — a stage that decides a file was already minimal
+ * and adds a clarifying line has done nothing harmful — but it IS recorded,
+ * because a compaction pass that consistently grows its target is a prompt
+ * bug worth seeing in the ledger.
+ */
+export function compactionVerdict(
+  candidate: CompactionCandidate,
+  bytesAfter: number,
+): { status: CompactionStatus; note?: string } {
+  if (bytesAfter === 0) {
+    return { status: "reverted", note: "pass emptied the file" };
+  }
+  if (bytesAfter > candidate.sizeBytes) return { status: "grew" };
+  if (bytesAfter === candidate.sizeBytes) return { status: "unchanged" };
+  const removedPct =
+    ((candidate.sizeBytes - bytesAfter) / candidate.sizeBytes) * 100;
+  if (removedPct > candidate.maxShrinkPct) {
+    return {
+      status: "reverted",
+      note: `pass removed ${removedPct.toFixed(1)}% (limit ${candidate.maxShrinkPct}%)`,
+    };
+  }
+  return { status: "compacted" };
+}
+
+/**
+ * Stat the rewritten file, judge it, and roll it back if the verdict says so.
+ * A file that has vanished entirely is treated exactly like an emptied one.
+ */
+export async function settleCompaction(
+  candidate: CompactionCandidate,
+  archivePath: string,
+): Promise<CompactionOutcome> {
+  let bytesAfter = 0;
+  try {
+    bytesAfter = (await stat(candidate.absPath)).size;
+  } catch {
+    bytesAfter = 0;
+  }
+  const { status, note } = compactionVerdict(candidate, bytesAfter);
+  if (status === "reverted") {
+    await restoreFromArchive(archivePath, candidate.absPath);
+    log.warn("nightly: compaction reverted", {
+      path: candidate.path,
+      before: candidate.sizeBytes,
+      after: bytesAfter,
+      note,
+    });
+    return {
+      path: candidate.path,
+      kind: candidate.kind,
+      bytesBefore: candidate.sizeBytes,
+      bytesAfter: candidate.sizeBytes,
+      status,
+      ...(note ? { note } : {}),
+    };
+  }
+  return {
+    path: candidate.path,
+    kind: candidate.kind,
+    bytesBefore: candidate.sizeBytes,
+    bytesAfter,
+    status,
+    ...(note ? { note } : {}),
+  };
+}
+
+/** One line per file, for the sweep's stdout. */
+export function formatCompactionSummary(outcomes: CompactionOutcome[]): string {
+  if (outcomes.length === 0) return "nightly: compaction — nothing over budget\n";
+  const before = outcomes.reduce((n, o) => n + o.bytesBefore, 0);
+  const after = outcomes.reduce((n, o) => n + o.bytesAfter, 0);
+  const lines = outcomes.map(
+    (o) =>
+      `  ${o.path}: ${o.bytesBefore} → ${o.bytesAfter} bytes (${o.status}` +
+      `${o.note ? ` — ${o.note}` : ""})`,
+  );
+  return (
+    `nightly: compaction — ${outcomes.length} file(s), ${before} → ${after} bytes\n` +
+    lines.join("\n") +
+    "\n"
+  );
+}

--- a/src/lib/nightlyCompact.ts
+++ b/src/lib/nightlyCompact.ts
@@ -20,18 +20,21 @@
  *   3. ONLY OVER-BUDGET FILES ARE TOUCHED. A file inside its budget costs one
  *      `stat` and is left alone, so a healthy persona pays nothing.
  *
- * Deliberately NOT in scope here: drawer dedupe/merge. `commitments.md`,
+ * Deliberately NOT in scope here: the drawers. `commitments.md`,
  * `decisions.md` and `lessons.md` are append-only logs with a lifecycle —
  * they become database rows in the follow-up work, at which point dedupe is a
  * uniqueness constraint rather than an LLM pass over prose. Building the LLM
- * version first would be throwaway. What this stage does to the drawers is
- * measure them and report the overage.
+ * version first would be throwaway, so they are never CANDIDATES at all:
+ * `measureDrawers()` reports the overage for one `stat` each and no turn is
+ * spent. (Selecting them and telling the prompt "do not change this file" is
+ * worse than not selecting them — it pays for a no-op turn every sweep.)
  */
 
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { readFile } from "node:fs/promises";
+import { writeFileAtomic } from "./io.ts";
 import { log } from "./logger.ts";
 import type { NightlyState } from "./nightly.ts";
 import { NIGHTLY_STAGES } from "./nightly.ts";
@@ -89,13 +92,40 @@ export function defaultBudgets(): CompactionBudget[] {
       budgetBytes: MEMORY_BUDGET_BYTES,
       maxShrinkPct: 40,
     },
-    ...DRAWER_FILES.map((f) => ({
-      path: join("memory", f),
-      kind: "drawer" as const,
-      budgetBytes: DRAWER_BUDGET_BYTES,
-      maxShrinkPct: 40,
-    })),
   ];
+}
+
+/**
+ * Drawer sizes, for reporting only.
+ *
+ * Drawers are deliberately NOT compaction candidates. Their dedupe/merge
+ * lifecycle moves to the database in the follow-up work, so the only thing an
+ * LLM pass could do here today is get thrown away — and a candidate whose
+ * prompt says "do not change this file" is a paid no-op turn every single
+ * sweep, forever. Measuring them costs one `stat` each and still surfaces the
+ * overage in the sweep output.
+ */
+export interface DrawerMeasurement {
+  path: string;
+  sizeBytes: number;
+  budgetBytes: number;
+}
+
+export async function measureDrawers(
+  personaDir: string,
+  budgetBytes: number = DRAWER_BUDGET_BYTES,
+): Promise<DrawerMeasurement[]> {
+  const out: DrawerMeasurement[] = [];
+  for (const f of DRAWER_FILES) {
+    const path = join("memory", f);
+    try {
+      const size = (await stat(join(personaDir, path))).size;
+      if (size > budgetBytes) out.push({ path, sizeBytes: size, budgetBytes });
+    } catch {
+      continue;
+    }
+  }
+  return out;
 }
 
 /**
@@ -223,11 +253,16 @@ export function archiveDirPath(personaDir: string, stamp: string): string {
 
 /**
  * Copy a file's exact bytes into `memory/archive/<stamp>/` and return the
- * archive path. Copies rather than moves: the live file must stay in place
- * for the stage to rewrite, and a half-applied pass must never leave a gap
- * where memory used to be. A second pass on the same day overwrites its own
- * earlier copy, which is correct — the archive holds the pre-compaction state
- * for that DATE, not every intermediate.
+ * archive path. Copies rather than moves: the live file must stay in place for
+ * the stage to rewrite, and a half-applied pass must never leave a gap where
+ * memory used to be.
+ *
+ * Every pass gets its OWN copy, even a second pass on the same day. Reusing
+ * the first pass's copy would be actively wrong: rollback restores the bytes
+ * in the archive, so a second pass that overshoots would be rolled back past
+ * its own starting point and resurrect content the FIRST pass had correctly
+ * removed. The archive holds a pre-image per pass, not per date — and since
+ * nothing here is ever deleted, the earlier pre-image stays alongside it.
  */
 export async function archiveForCompaction(
   personaDir: string,
@@ -238,17 +273,29 @@ export async function archiveForCompaction(
   await mkdir(dir, { recursive: true });
   // Flatten the persona-relative path so `memory/decisions.md` and a future
   // `kb/decisions.md` can't collide inside one archive dir.
-  const dest = join(dir, candidate.path.replace(/[\\/]/g, "__"));
-  if (!existsSync(dest)) await copyFile(candidate.absPath, dest);
+  const base = candidate.path.replace(/[\\/]/g, "__");
+  let dest = join(dir, base);
+  // A same-day repeat pass lands next to its predecessor rather than over it.
+  for (let n = 2; existsSync(dest) && n < 1000; n++) {
+    dest = join(dir, base.replace(/(\.md)?$/, `.${n}$1`));
+  }
+  await copyFile(candidate.absPath, dest);
   return dest;
 }
 
-/** Put the archived bytes back over the live file. */
+/**
+ * Put the archived bytes back over the live file.
+ *
+ * Atomic, via tempfile + fsync + rename. A plain `copyFile` over the live path
+ * truncates the target first, so a crash mid-restore leaves MEMORY.md or a
+ * daily file half-written — turning a recoverable bad pass into real data
+ * loss, in the exact code path whose whole job is to prevent that.
+ */
 export async function restoreFromArchive(
   archivePath: string,
   absPath: string,
 ): Promise<void> {
-  await copyFile(archivePath, absPath);
+  await writeFileAtomic(absPath, await readFile(archivePath, "utf8"));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { NIGHTLY_TOOLS, runNightly, runNightlyTurn } from "../src/cli/nightly.ts";
@@ -686,6 +686,100 @@ describe("runNightly — compaction stage (#410)", () => {
     expect(state.compaction?.bytes_after).toBe(15 * 1024);
     expect(state.compaction?.files[0]!.status).toBe("compacted");
     expect(out.text).toContain("compaction");
+  });
+
+  test("STEADY STATE: runs with an empty queue, the night it matters most", async () => {
+    // Regression: the sweep used to return as soon as no date was pending, so
+    // compaction never reached the one shape that is the norm — a box whose
+    // backlog is drained. It was reachable only during a backfill.
+    await daily("2026-05-01");
+    const first = compactHarness("x".repeat(15 * 1024));
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: first.runStage as never, refreshIndex: async () => {},
+    });
+
+    // Second sweep: the date is in the ledger and unchanged, so nothing pends.
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    const h = compactHarness("x".repeat(15 * 1024));
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config, now, out,
+      runStage: h.runStage as never, refreshIndex: async () => {},
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("nothing pending");
+    expect(h.calls).toEqual(["compact"]);
+    expect((await loadNightlyState(personaDir)).compaction?.files[0]!.status).toBe(
+      "compacted",
+    );
+  });
+
+  test("a rewritten daily is re-ledgered so the next sweep does not re-bill it", async () => {
+    // Compaction rewrites the daily file, which changes the mtime/size/hash the
+    // ledger keys on. Without reconciliation the next sweep sees `changed`,
+    // re-queues the date and pays for both LLM stages again — every night.
+    await daily("2026-05-01", "y".repeat(20 * 1024));
+    const first = {
+      calls: [] as string[],
+      runStage: async (a: { stage: string }) => {
+        first.calls.push(a.stage);
+        if (a.stage === "compact") {
+          await writeFile(
+            join(personaDir, "memory", "2026-05-01.md"),
+            "y".repeat(4 * 1024),
+            "utf8",
+          );
+        }
+        return { finalReply: "done", durationMs: 1 };
+      },
+    };
+    // `now` is well past the daily age gate for 2026-05-01.
+    await runNightly({
+      config, now, out: new CaptureStream(), compactMinAgeDays: 1,
+      runStage: first.runStage as never, refreshIndex: async () => {},
+    });
+    const state = await loadNightlyState(personaDir);
+    expect(state.compaction?.files.some((f) => f.kind === "daily")).toBe(true);
+    const rec = state.processed?.["2026-05-01"]!;
+    const st = await stat(join(personaDir, "memory", "2026-05-01.md"));
+    expect(rec.size).toBe(st.size);
+    expect(rec.status).toBe("ok");
+    expect(rec.stages_done).toEqual([...NIGHTLY_STAGES]);
+
+    // Next sweep: nothing pending, so no distill/kb turn is spent on it again.
+    const second = compactHarness("x");
+    const out = new CaptureStream();
+    await runNightly({
+      config, now, out, compactMinAgeDays: 1,
+      runStage: second.runStage as never, refreshIndex: async () => {},
+    });
+    expect(out.text).toContain("nothing pending");
+    expect(second.calls).not.toContain("distill");
+  });
+
+  test("index is refreshed again after a rewrite, never before it", async () => {
+    await daily("2026-05-01");
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    const events: string[] = [];
+    const h = {
+      runStage: async (a: { stage: string }) => {
+        events.push(`stage:${a.stage}`);
+        if (a.stage === "compact") {
+          await writeFile(join(personaDir, "MEMORY.md"), "x".repeat(15 * 1024), "utf8");
+        }
+        return { finalReply: "done", durationMs: 1 };
+      },
+    };
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage as never,
+      refreshIndex: async () => {
+        events.push("index");
+      },
+    });
+    expect(events[events.length - 1]).toBe("index");
+    expect(events.filter((e) => e === "index")).toHaveLength(2);
   });
 
   test("nothing over budget → no compact turn at all", async () => {

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -715,6 +715,96 @@ describe("runNightly — compaction stage (#410)", () => {
     );
   });
 
+  test("STEADY STATE: the sweep marker is held across an empty-queue compaction", async () => {
+    // Regression: the in-flight marker was written only inside the date loop,
+    // so the steady-state path — no date pending, compaction still running —
+    // held no lock at all. Two sweeps would both reach `compact`, archive the
+    // same pre-image and point concurrent LLM writers at the same files.
+    await daily("2026-05-01");
+    const drain = compactHarness("x".repeat(15 * 1024));
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: drain.runStage as never, refreshIndex: async () => {},
+    });
+
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    let release: () => void = () => {};
+    const blocked = new Promise<void>((r) => {
+      release = r;
+    });
+    let compactEntered: () => void = () => {};
+    const entered = new Promise<void>((r) => {
+      compactEntered = r;
+    });
+    const first = {
+      calls: [] as string[],
+      runStage: async (a: { stage: string }) => {
+        first.calls.push(a.stage);
+        if (a.stage === "compact") {
+          compactEntered();
+          await blocked;
+        }
+        return { finalReply: "done", durationMs: 1 };
+      },
+    };
+    const firstRun = runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: first.runStage as never, refreshIndex: async () => {},
+    });
+
+    // With the first sweep parked inside compaction, a second one must see the
+    // marker and stand down rather than start its own pass.
+    await entered;
+    const second = compactHarness("x".repeat(15 * 1024));
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config, now, out,
+      runStage: second.runStage as never, refreshIndex: async () => {},
+    });
+    expect(code).toBe(0);
+    expect(out.text).toContain("already in flight");
+    expect(second.calls).not.toContain("compact");
+
+    release();
+    await firstRun;
+    // …and the marker is cleared on the way out, so the next sweep is free.
+    expect((await loadNightlyState(personaDir)).current ?? null).toBeNull();
+  });
+
+  test("a same-size rewrite still reconciles the index", async () => {
+    // `unchanged` is a SIZE verdict. The stage can replace a file with
+    // different content of exactly the same byte length; keying the
+    // post-compaction index refresh on the byte count left FTS/vector serving
+    // the pre-compaction text for a file that had in fact changed.
+    await daily("2026-05-01");
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    const rewrite = "y".repeat(20 * 1024);
+    const events: string[] = [];
+    const h = {
+      runStage: async (a: { stage: string }) => {
+        events.push(`stage:${a.stage}`);
+        if (a.stage === "compact") {
+          await writeFile(join(personaDir, "MEMORY.md"), rewrite, "utf8");
+        }
+        return { finalReply: "done", durationMs: 1 };
+      },
+    };
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage as never,
+      refreshIndex: async () => {
+        events.push("index");
+      },
+    });
+    // Same byte count, different bytes: the verdict says `unchanged`…
+    const state = await loadNightlyState(personaDir);
+    expect(state.compaction?.files[0]!.status).toBe("unchanged");
+    expect(await Bun.file(join(personaDir, "MEMORY.md")).text()).toBe(rewrite);
+    // …but the index is still reconciled afterwards.
+    expect(events[events.length - 1]).toBe("index");
+    expect(events.filter((e) => e === "index")).toHaveLength(2);
+  });
+
   test("a rewritten daily is re-ledgered so the next sweep does not re-bill it", async () => {
     // Compaction rewrites the daily file, which changes the mtime/size/hash the
     // ledger keys on. Without reconciliation the next sweep sees `changed`,

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -932,6 +932,40 @@ describe("runNightly — compaction stage (#410)", () => {
     expect(b.calls).not.toContain("compact");
   });
 
+  test("a failed date stage stops compaction from touching the file", async () => {
+    // Regression: compaction ran even when distill had errored. A distill turn
+    // can partially rewrite MEMORY.md before failing, so the archive would have
+    // captured the damaged state, and a second model rewrite would sit on top
+    // of it. No compact turn, and no compaction ledger.
+    await daily("2026-05-01");
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    const calls: string[] = [];
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config, now, out,
+      runStage: (async (a: { stage: string }) => {
+        calls.push(a.stage);
+        if (a.stage === "distill") {
+          // partial rewrite, then failure
+          await writeFile(join(personaDir, "MEMORY.md"), "half-written", "utf8");
+          return { finalReply: "", errored: "timeout", durationMs: 1 };
+        }
+        if (a.stage === "compact") {
+          await writeFile(join(personaDir, "MEMORY.md"), "x", "utf8");
+        }
+        return { finalReply: "done", durationMs: 1 };
+      }) as never,
+      refreshIndex: async () => {},
+    });
+    expect(code).toBe(1);
+    expect(calls).not.toContain("compact");
+    expect((await loadNightlyState(personaDir)).compaction).toBeUndefined();
+    expect(await Bun.file(join(personaDir, "MEMORY.md")).text()).toBe(
+      "half-written",
+    );
+    expect(out.text).toContain("compaction skipped");
+  });
+
   test("a failed compact turn still settles the file and is reported", async () => {
     await daily("2026-05-01");
     await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");

--- a/tests/cli-nightly.test.ts
+++ b/tests/cli-nightly.test.ts
@@ -62,7 +62,7 @@ async function daily(date: string, body = `notes for ${date}`): Promise<void> {
 
 interface StageCall {
   date: string;
-  stage: NightlyStage | "override";
+  stage: NightlyStage | "override" | "compact";
   prompt: string;
   startedAt: number;
   endedAt: number;
@@ -77,7 +77,7 @@ function harness(opts: { fail?: string[]; delayMs?: number } = {}) {
   const calls: StageCall[] = [];
   const runStage = async (a: {
     date: string;
-    stage: NightlyStage | "override";
+    stage: NightlyStage | "override" | "compact";
     prompt: string;
   }) => {
     const startedAt = Date.now();
@@ -641,5 +641,130 @@ describe("runNightlyTurn — trusted prompt, untrusted provenance", () => {
     expect(pairCalls).toHaveLength(1);
     expect(pairCalls[0]!.user.source).toBe("other");
     expect(pairCalls[0]!.assistant.source).toBe("other");
+  });
+});
+
+describe("runNightly — compaction stage (#410)", () => {
+  const over = "x".repeat(20 * 1024);
+
+  /** A stage stub that rewrites MEMORY.md to `after` when compaction runs. */
+  function compactHarness(after: string | null) {
+    const calls: string[] = [];
+    return {
+      calls,
+      runStage: async (a: { stage: string; prompt: string }) => {
+        calls.push(a.stage);
+        if (a.stage === "compact") {
+          const p = join(personaDir, "MEMORY.md");
+          if (after === null) await rm(p);
+          else await writeFile(p, after, "utf8");
+        }
+        return { finalReply: "done", durationMs: 1 };
+      },
+    };
+  }
+
+  test("runs once per sweep, not once per date, and only over budget", async () => {
+    await daily("2026-05-01");
+    await daily("2026-05-02");
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    const h = compactHarness("x".repeat(15 * 1024));
+    const out = new CaptureStream();
+    const code = await runNightly({
+      config, now, out,
+      runStage: h.runStage as never,
+      refreshIndex: async () => {},
+    });
+    expect(code).toBe(0);
+    expect(h.calls.filter((s) => s === "compact")).toHaveLength(1);
+    // and it runs after every date's stages
+    expect(h.calls[h.calls.length - 1]).toBe("compact");
+
+    const state = await loadNightlyState(personaDir);
+    expect(state.compaction?.files).toHaveLength(1);
+    expect(state.compaction?.bytes_before).toBe(20 * 1024);
+    expect(state.compaction?.bytes_after).toBe(15 * 1024);
+    expect(state.compaction?.files[0]!.status).toBe("compacted");
+    expect(out.text).toContain("compaction");
+  });
+
+  test("nothing over budget → no compact turn at all", async () => {
+    await daily("2026-05-01");
+    await writeFile(join(personaDir, "MEMORY.md"), "small", "utf8");
+    const h = compactHarness("x");
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage as never,
+      refreshIndex: async () => {},
+    });
+    expect(h.calls).not.toContain("compact");
+    expect((await loadNightlyState(personaDir)).compaction).toBeUndefined();
+  });
+
+  test("an over-eager pass is reverted and recorded", async () => {
+    await daily("2026-05-01");
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    const h = compactHarness("gone");
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage as never,
+      refreshIndex: async () => {},
+    });
+    const state = await loadNightlyState(personaDir);
+    expect(state.compaction?.files[0]!.status).toBe("reverted");
+    expect(state.compaction?.bytes_after).toBe(20 * 1024);
+    const live = await Bun.file(join(personaDir, "MEMORY.md")).text();
+    expect(live).toBe(over);
+  });
+
+  test("a file deleted by the pass comes back from the archive", async () => {
+    await daily("2026-05-01");
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    const h = compactHarness(null);
+    await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: h.runStage as never,
+      refreshIndex: async () => {},
+    });
+    expect(await Bun.file(join(personaDir, "MEMORY.md")).text()).toBe(over);
+  });
+
+  test("--no-compact and --date backfills skip it", async () => {
+    await daily("2026-05-01");
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+
+    const a = compactHarness("x");
+    await runNightly({
+      config, now, out: new CaptureStream(), skipCompaction: true,
+      runStage: a.runStage as never, refreshIndex: async () => {},
+    });
+    expect(a.calls).not.toContain("compact");
+
+    const b = compactHarness("x");
+    await runNightly({
+      config, now, out: new CaptureStream(), today: "2026-05-01",
+      runStage: b.runStage as never, refreshIndex: async () => {},
+    });
+    expect(b.calls).not.toContain("compact");
+  });
+
+  test("a failed compact turn still settles the file and is reported", async () => {
+    await daily("2026-05-01");
+    await writeFile(join(personaDir, "MEMORY.md"), over, "utf8");
+    const code = await runNightly({
+      config, now, out: new CaptureStream(),
+      runStage: (async (a: { stage: string }) => {
+        if (a.stage === "compact") {
+          await writeFile(join(personaDir, "MEMORY.md"), "wrecked", "utf8");
+          return { finalReply: "", errored: "timeout", durationMs: 1 };
+        }
+        return { finalReply: "done", durationMs: 1 };
+      }) as never,
+      refreshIndex: async () => {},
+    });
+    expect(code).toBe(1);
+    expect(await Bun.file(join(personaDir, "MEMORY.md")).text()).toBe(over);
+    const state = await loadNightlyState(personaDir);
+    expect(state.errors?.some((e) => e.startsWith("compaction:"))).toBe(true);
   });
 });

--- a/tests/lib-memoryIndex.test.ts
+++ b/tests/lib-memoryIndex.test.ts
@@ -100,6 +100,29 @@ describe("walkMarkdown", () => {
     ].sort());
   });
 
+  test("never indexes memory/archive/ — rollback copies are not memory", async () => {
+    // The nightly compaction stage copies a file's PRE-compaction bytes into
+    // memory/archive/<date>/ before rewriting it. Indexing those would put the
+    // stale, superseded facts compaction just removed straight back into
+    // search as live documents, ranked next to the current ones.
+    await note("memory/people.md", "current");
+    await mkdir(join(personaDir, "memory/archive/2026-08-20"), { recursive: true });
+    await note("memory/archive/2026-08-20/memory__people.md", "stale pre-image");
+    await note("memory/archive/2026-08-20/MEMORY.md", "stale pre-image");
+    const paths = walkMarkdown(personaDir).map((f) => f.path);
+    expect(paths).toEqual(["memory/people.md"]);
+  });
+
+  test("a kb note nested under an archive/ folder is still indexed", async () => {
+    // The exclusion is the scope root only — a persona that files notes under
+    // kb/something/archive/ wrote those on purpose.
+    await mkdir(join(personaDir, "kb/projects/archive"), { recursive: true });
+    await note("kb/projects/archive/Old Project.md", "kept");
+    expect(walkMarkdown(personaDir).map((f) => f.path)).toEqual([
+      "kb/projects/archive/Old Project.md",
+    ]);
+  });
+
   test("records nested paths posix-style, never with backslashes", async () => {
     await note("kb/concepts/Foo.md", "foo");
     const paths = walkMarkdown(personaDir).map((f) => f.path);

--- a/tests/lib-nightlyCompact.test.ts
+++ b/tests/lib-nightlyCompact.test.ts
@@ -11,6 +11,7 @@ import {
   DAILY_BUDGET_BYTES,
   defaultBudgets,
   formatCompactionSummary,
+  measureDrawers,
   resolveBudgets,
   settleCompaction,
 } from "../src/lib/nightlyCompact.ts";
@@ -50,6 +51,24 @@ describe("compactionCandidates", () => {
   test("ignores drawers that do not exist", async () => {
     const got = await compactionCandidates(dir, {}, { today: "2026-08-20" });
     expect(got).toEqual([]);
+  });
+
+  test("an over-budget drawer is NEVER a candidate", async () => {
+    // Drawers are measured, not rewritten: their dedupe lifecycle moves to the
+    // database, so selecting one here would buy a paid LLM turn whose prompt
+    // then tells it to change nothing — every sweep, forever.
+    await writeFile(join(dir, "memory", "commitments.md"), big(700 * 1024));
+    await writeFile(join(dir, "memory", "decisions.md"), big(700 * 1024));
+    expect(await compactionCandidates(dir, {}, { today: "2026-08-20" })).toEqual([]);
+    expect(defaultBudgets().map((b) => b.path)).toEqual(["MEMORY.md"]);
+  });
+
+  test("measureDrawers reports the overage without making a candidate", async () => {
+    await writeFile(join(dir, "memory", "commitments.md"), big(700 * 1024));
+    await writeFile(join(dir, "memory", "norms.md"), big(10));
+    const got = await measureDrawers(dir);
+    expect(got.map((d) => d.path)).toEqual(["memory/commitments.md"]);
+    expect(got[0]!.sizeBytes).toBe(700 * 1024);
   });
 
   test("daily file needs BOTH stages ok before it is a candidate", async () => {
@@ -168,6 +187,30 @@ describe("archive + settle", () => {
     expect(outcome.status).toBe("reverted");
     expect(outcome.bytesAfter).toBe(outcome.bytesBefore);
     expect(await readFile(p, "utf8")).toBe("keep me".repeat(20));
+  });
+
+  test("a second same-day pass archives its OWN pre-image, not the first's", async () => {
+    // Regression: reusing the first pass's copy rolls a later pass back PAST
+    // its own starting point, resurrecting content the first pass correctly
+    // removed. Each pass must be recoverable to the state it began from.
+    const p = join(dir, "MEMORY.md");
+    await writeFile(p, "A".repeat(100));
+    const first = await archiveForCompaction(dir, candidate(p, 100), "2026-08-20");
+
+    // pass one prunes down to 70 bytes, legitimately
+    await writeFile(p, "B".repeat(70));
+    const c2 = candidate(p, 70);
+    const second = await archiveForCompaction(dir, c2, "2026-08-20");
+    expect(second).not.toBe(first);
+    expect(await readFile(second, "utf8")).toBe("B".repeat(70));
+    // the first pre-image survives — nothing in the archive is ever deleted
+    expect(await readFile(first, "utf8")).toBe("A".repeat(100));
+
+    // pass two overshoots and is rolled back to 70 bytes, NOT to 100
+    await writeFile(p, "C");
+    const outcome = await settleCompaction(c2, second);
+    expect(outcome.status).toBe("reverted");
+    expect(await readFile(p, "utf8")).toBe("B".repeat(70));
   });
 
   test("a file deleted by the pass is restored", async () => {

--- a/tests/lib-nightlyCompact.test.ts
+++ b/tests/lib-nightlyCompact.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  archiveDirPath,
+  archiveForCompaction,
+  type CompactionCandidate,
+  compactionCandidates,
+  compactionVerdict,
+  DAILY_BUDGET_BYTES,
+  defaultBudgets,
+  formatCompactionSummary,
+  resolveBudgets,
+  settleCompaction,
+} from "../src/lib/nightlyCompact.ts";
+import { NIGHTLY_STAGES, type NightlyState } from "../src/lib/nightly.ts";
+
+let dir: string;
+
+const okRecord = {
+  mtime_ms: 1,
+  size: 1,
+  hash: "h",
+  stages_done: [...NIGHTLY_STAGES],
+  completed_at: "2026-01-01T00:00:00.000Z",
+  status: "ok" as const,
+};
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "phantombot-compact-"));
+  await mkdir(join(dir, "memory"), { recursive: true });
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+const big = (n: number) => "x".repeat(n);
+
+describe("compactionCandidates", () => {
+  test("picks only files over budget", async () => {
+    await writeFile(join(dir, "MEMORY.md"), big(20 * 1024));
+    await writeFile(join(dir, "memory", "decisions.md"), big(1024));
+    const got = await compactionCandidates(dir, {}, { today: "2026-08-20" });
+    expect(got.map((c) => c.path)).toEqual(["MEMORY.md"]);
+    expect(got[0]!.kind).toBe("memory");
+    expect(got[0]!.sizeBytes).toBe(20 * 1024);
+  });
+
+  test("ignores drawers that do not exist", async () => {
+    const got = await compactionCandidates(dir, {}, { today: "2026-08-20" });
+    expect(got).toEqual([]);
+  });
+
+  test("daily file needs BOTH stages ok before it is a candidate", async () => {
+    await writeFile(join(dir, "memory", "2026-01-01.md"), big(DAILY_BUDGET_BYTES + 1));
+    const partial: NightlyState = {
+      processed: { "2026-01-01": { ...okRecord, status: "partial", stages_done: ["distill"] } },
+    };
+    expect(await compactionCandidates(dir, partial, { today: "2026-08-20" })).toEqual([]);
+
+    const done: NightlyState = { processed: { "2026-01-01": okRecord } };
+    const got = await compactionCandidates(dir, done, { today: "2026-08-20" });
+    expect(got.map((c) => c.path)).toEqual([join("memory", "2026-01-01.md")]);
+    expect(got[0]!.date).toBe("2026-01-01");
+  });
+
+  test("daily file inside the age window is left alone", async () => {
+    await writeFile(join(dir, "memory", "2026-08-19.md"), big(DAILY_BUDGET_BYTES + 1));
+    const state: NightlyState = { processed: { "2026-08-19": okRecord } };
+    expect(await compactionCandidates(dir, state, { today: "2026-08-20" })).toEqual([]);
+    const got = await compactionCandidates(dir, state, {
+      today: "2026-08-20",
+      minAgeDays: 0,
+    });
+    expect(got).toHaveLength(1);
+  });
+});
+
+describe("resolveBudgets", () => {
+  test("override raises a byte budget but never the shrink guard", async () => {
+    await writeFile(
+      join(dir, "memory", ".compaction-budgets.json"),
+      JSON.stringify({ "MEMORY.md": 99_999, maxShrinkPct: 100 }),
+    );
+    const b = await resolveBudgets(dir);
+    const mem = b.find((x) => x.path === "MEMORY.md")!;
+    expect(mem.budgetBytes).toBe(99_999);
+    expect(mem.maxShrinkPct).toBe(40);
+  });
+
+  test("unreadable override falls back to defaults", async () => {
+    await writeFile(join(dir, "memory", ".compaction-budgets.json"), "{not json");
+    expect(await resolveBudgets(dir)).toEqual(defaultBudgets());
+  });
+});
+
+describe("compactionVerdict", () => {
+  const c = (size: number, pct = 40): CompactionCandidate => ({
+    path: "MEMORY.md",
+    kind: "memory",
+    budgetBytes: 10,
+    maxShrinkPct: pct,
+    absPath: "/nope",
+    sizeBytes: size,
+  });
+
+  test("classifies each outcome", () => {
+    expect(compactionVerdict(c(100), 80).status).toBe("compacted");
+    expect(compactionVerdict(c(100), 100).status).toBe("unchanged");
+    expect(compactionVerdict(c(100), 120).status).toBe("grew");
+    expect(compactionVerdict(c(100), 0).status).toBe("reverted");
+  });
+
+  test("shrinking past the allowance is reverted, at the boundary it is not", () => {
+    expect(compactionVerdict(c(100), 60).status).toBe("compacted"); // exactly 40%
+    const over = compactionVerdict(c(100), 59);
+    expect(over.status).toBe("reverted");
+    expect(over.note).toContain("limit 40%");
+  });
+
+  test("a daily file may lose most of its bulk", () => {
+    expect(compactionVerdict(c(1000, 90), 100).status).toBe("compacted");
+    expect(compactionVerdict(c(1000, 90), 99).status).toBe("reverted");
+  });
+});
+
+describe("archive + settle", () => {
+  const candidate = (absPath: string, size: number): CompactionCandidate => ({
+    path: "MEMORY.md",
+    kind: "memory",
+    budgetBytes: 10,
+    maxShrinkPct: 40,
+    absPath,
+    sizeBytes: size,
+  });
+
+  test("archives the exact bytes before a pass", async () => {
+    const p = join(dir, "MEMORY.md");
+    await writeFile(p, "original");
+    const archived = await archiveForCompaction(dir, candidate(p, 8), "2026-08-20");
+    expect(archived.startsWith(archiveDirPath(dir, "2026-08-20"))).toBe(true);
+    expect(await readFile(archived, "utf8")).toBe("original");
+    // the live file is copied, never moved
+    expect(await readFile(p, "utf8")).toBe("original");
+  });
+
+  test("a pass within the allowance is kept and accounted", async () => {
+    const p = join(dir, "MEMORY.md");
+    await writeFile(p, big(100));
+    const c = candidate(p, 100);
+    const archived = await archiveForCompaction(dir, c, "2026-08-20");
+    await writeFile(p, big(70));
+    const outcome = await settleCompaction(c, archived);
+    expect(outcome.status).toBe("compacted");
+    expect(outcome.bytesBefore).toBe(100);
+    expect(outcome.bytesAfter).toBe(70);
+    expect((await stat(p)).size).toBe(70);
+  });
+
+  test("an over-eager pass is rolled back from the archive", async () => {
+    const p = join(dir, "MEMORY.md");
+    await writeFile(p, "keep me".repeat(20));
+    const c = candidate(p, (await stat(p)).size);
+    const archived = await archiveForCompaction(dir, c, "2026-08-20");
+    await writeFile(p, "oops");
+    const outcome = await settleCompaction(c, archived);
+    expect(outcome.status).toBe("reverted");
+    expect(outcome.bytesAfter).toBe(outcome.bytesBefore);
+    expect(await readFile(p, "utf8")).toBe("keep me".repeat(20));
+  });
+
+  test("a file deleted by the pass is restored", async () => {
+    const p = join(dir, "MEMORY.md");
+    await writeFile(p, "content");
+    const c = candidate(p, 7);
+    const archived = await archiveForCompaction(dir, c, "2026-08-20");
+    await rm(p);
+    const outcome = await settleCompaction(c, archived);
+    expect(outcome.status).toBe("reverted");
+    expect(await readFile(p, "utf8")).toBe("content");
+  });
+});
+
+test("summary reports totals and per-file bytes", () => {
+  const s = formatCompactionSummary([
+    { path: "MEMORY.md", kind: "memory", bytesBefore: 100, bytesAfter: 60, status: "compacted" },
+  ]);
+  expect(s).toContain("100 → 60 bytes");
+  expect(s).toContain("MEMORY.md");
+  expect(formatCompactionSummary([])).toContain("nothing over budget");
+});


### PR DESCRIPTION
Stage three of the nightly: the first thing in phantombot that can remove a byte.

`distill` and `kb` only ever append. Nothing has ever shrunk, so the always-in-context files grow without bound — the drawers on one box reached 663KB, which is rent paid on every single turn and buries live facts under dead ones.

The design bias here is **safe over thorough**. A night that reclaims nothing is fine; a night that loses a fact is not.

- **Only over-budget files are candidates.** MEMORY.md 16KB, drawers 128KB, a fully-distilled daily file 8KB. Per-persona overrides in `memory/.compaction-budgets.json` — byte budgets only, never the shrink guard. A healthy persona pays one `stat` per file and no turn.
- **Every candidate is copied verbatim to `memory/archive/<YYYY-MM-DD>/` before the stage runs.** Nothing is ever deleted, and the nightly is the only code path that moves a memory file. Recovery is `cp`, not a restore.
- **Every file is re-stat-ed and judged afterwards.** A pass that removes more than its allowance (40%; 90% for a closed daily file), empties a file, or loses one is rolled back from that copy and recorded as `reverted`. This settles even when the turn *errored* — a timed-out stage may have left a half-rewrite on disk, which is precisely what the guard is for.
- **Byte accounting per file goes in the ledger** under `compaction`, so "is memory still growing?" is answerable without grepping journald.
- **Runs once per sweep**, after every date is distilled — its inputs are whole-file sizes, not one day's events, and running it per date would rewrite MEMORY.md N times while draining a backlog. Skipped for `--date` backfills, for personas with a monolithic prompt override, and by `--no-compact`.
- **Daily files are trimmed only** once the ledger shows both stages `ok` for that date and it is at least 30 days old. The age gate isn't about safety — the ledger already proves distillation — it's so a recent day is still readable in full.

### Deliberately not in scope: drawer dedupe

`commitments.md`, `decisions.md` and `lessons.md` are append-only logs with a lifecycle — a table pretending to be prose. They become database rows in the follow-up work, at which point dedupe is a uniqueness constraint and "compaction" is a query. An LLM dedupe pass over them now would be built twice and thrown away once. So this stage measures the drawers and reports the overage, and its prompt explicitly tells the stage not to rewrite them.

### Tests

`tests/lib-nightlyCompact.test.ts` (14) covers candidate selection including both daily gates, budget overrides, every verdict at its boundary, and the archive/restore path. `tests/cli-nightly.test.ts` adds six end-to-end cases: once-per-sweep ordering, no-candidates-no-turn, revert on overshoot, restore after deletion, both skip paths, and settle-after-a-failed-turn.

Full suite green (3133 pass), typecheck clean.

Part of #410.
