### PR TITLE
fix(nightly): launch the rollover sweep as a transient systemd unit

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ Run a chat agent ("Phantom") as a **CLI tool** on the operator's own machine. Al
 | `src/memory/store.ts` | bun:sqlite wrapper. `turns` table (`appendTurn`, `recentTurns`, …) + `capture_log` table (`appendCapture`, `lastCaptureAt`, `countCapturesSince`, turn counters for the nudge/doctor). | `bun:sqlite` |
 | `src/lib/nightly.ts` | Stage model + prompt bodies, the `.nightly-state.json` ledger (`sweepDailyFiles`, `dateRecord`), and `nightlyHealth` for `/status` + doctor. | filesystem |
 | `src/lib/nightlyCompact.ts` | Compaction budgets, candidate selection, the pre-pass archive under `memory/archive/<date>/`, and the shrink-guard verdict that reverts an over-eager pass. | filesystem, `lib/nightly` |
-| `src/lib/nightlyTrigger.ts` | When the sweep runs: `dayRolledOver` (heartbeat trigger) + `spawnNightlySweep` (detached fire, also used by `run` at startup). | `node:child_process` |
+| `src/lib/nightlyTrigger.ts` | When the sweep runs: `dayRolledOver` (heartbeat trigger) + `spawnNightlySweep` (transient systemd unit on Linux, detached child elsewhere; also used by `run` at startup). | `node:child_process` |
 | `src/lib/indexRefresh.ts` | `refreshPersonaIndex`: incremental FTS + embedding refresh, called in code by the nightly after both stages join. | `lib/memoryIndex`, `lib/embedJob` |
 | `src/cli/doctor.ts` | `phantombot doctor`: reports the nightly ledger (read-only) + `capture_log`, repairs units/timers/connectors. | `memory/store`, `lib/nightly` |
 | `src/importer/openclaw.ts` | Walks an OpenClaw agent dir; copies recognized markdown into the personas dir. | filesystem |
@@ -136,7 +136,12 @@ Three properties worth knowing when touching this code:
    run diffs the daily files against a ledger in `.nightly-state.json`
    (mtime + size, then content hash) and processes whatever is new, grew, or
    half-finished. It is triggered by startup and by the heartbeat detecting a
-   calendar-day rollover — there is no nightly timer. Per date it runs exactly
+   calendar-day rollover — there is no nightly timer. On systemd the sweep is
+   launched as its own transient `--user` unit rather than as a detached child:
+   the rollover trigger runs inside `phantombot-heartbeat.service`, which is
+   `Type=oneshot`, so its cgroup (and everything left in it) is torn down the
+   moment the heartbeat exits. `detached`/`unref` leaves Node's event loop, not
+   the cgroup. Per date it runs exactly
    two harness turns — `distill`
    (drawers + MEMORY.md) and `kb` — **concurrently**, because their write
    targets are disjoint; neither may write back to the daily file, or the hash

--- a/src/lib/nightlyTrigger.ts
+++ b/src/lib/nightlyTrigger.ts
@@ -21,9 +21,16 @@
  * Both triggers are safe to fire redundantly: the sweep is ledger-driven and
  * idempotent, no-ops in milliseconds when nothing is pending, and holds an
  * in-flight marker so two sweeps can't double-file the same drawers.
+ *
+ * HOW the sweep is launched matters as much as when: on systemd the rollover
+ * trigger runs inside a `Type=oneshot` unit whose cgroup is torn down the
+ * instant the heartbeat exits, which killed the detached child seconds after
+ * it started. See {@link buildNightlyLaunch}.
  */
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 
 import { log } from "./logger.ts";
 
@@ -66,29 +73,217 @@ export function dayRolledOver(
 }
 
 /**
- * Fire a detached `phantombot nightly` for the given persona.
+ * Resolved facts about the host that decide HOW the sweep is launched.
+ * Injectable so the decision is testable without a systemd box.
+ */
+export interface NightlyHostEnv {
+  /** `process.platform`. */
+  platform: string;
+  /** Absolute path to `systemd-run`, or undefined when it is not installed. */
+  systemdRunPath?: string;
+  /** Is this host booted under systemd (`/run/systemd/system` exists)? */
+  systemdBooted: boolean;
+  /** Is there a systemd --user session to own a transient unit? */
+  userSessionRuntimeDir?: string;
+  /** Home directory, used to resolve the env files the unit sources. */
+  home: string;
+}
+
+const SYSTEMD_RUN_PATHS = ["/usr/bin/systemd-run", "/bin/systemd-run"];
+
+/** Probe the real host. */
+export function detectNightlyHostEnv(): NightlyHostEnv {
+  return {
+    platform: process.platform,
+    systemdRunPath: SYSTEMD_RUN_PATHS.find((p) => existsSync(p)),
+    systemdBooted: existsSync("/run/systemd/system"),
+    userSessionRuntimeDir: process.env.XDG_RUNTIME_DIR,
+    home: homedir(),
+  };
+}
+
+/**
+ * A transient unit name for one sweep. systemd unit names accept only
+ * `[A-Za-z0-9:_.\-]`, and a persona name is user-supplied, so everything else
+ * is folded to `-`. The timestamp+pid suffix keeps two concurrent launches
+ * from colliding on a name (`--collect` reaps each one once it finishes).
+ */
+export function nightlyUnitName(
+  persona: string,
+  at: Date = new Date(),
+  pid: number = process.pid,
+): string {
+  const safe = persona.replace(/[^A-Za-z0-9:_.-]/g, "-").slice(0, 48);
+  const stamp = at.toISOString().replace(/[-:]/g, "").slice(0, 15);
+  return `phantombot-nightly-${safe}-${stamp}-${pid}`;
+}
+
+/** What to actually execute, and whether it is the transient-unit path. */
+export interface NightlyLaunch {
+  command: string;
+  args: string[];
+  /** True when this launches a transient systemd unit rather than a bare child. */
+  transient: boolean;
+}
+
+/**
+ * Wrap the bare `phantombot nightly` invocation in `systemd-run --user` when
+ * the host is systemd, and leave it bare otherwise.
  *
- * Detached + unref'd on purpose: a first sweep over a long backlog can run for
- * many minutes, and it must not hold its parent's event loop (the daemon's
- * channel loop, or a heartbeat process that is supposed to exit in seconds) or
- * die when that parent does.
+ * WHY (this is the bug this module exists to avoid): the rollover trigger runs
+ * inside `phantombot-heartbeat.service`, which is `Type=oneshot`. The moment
+ * `phantombot heartbeat` exits, systemd considers the unit finished and tears
+ * down its cgroup — SIGKILLing every process still in it. `detached: true` +
+ * `unref()` only detaches from Node's event loop and the controlling terminal;
+ * it does NOT leave the cgroup, so the sweep was being killed about a second
+ * after it started. Evidence: on the Linux boxes the sweep ledger has never
+ * once recorded a completion in the 00:xx hour, while the launchd (macOS) and
+ * Windows hosts have them routinely — the Linux nightly only ever completed
+ * off the daemon-STARTUP trigger, i.e. it silently depended on restarts.
+ *
+ * A transient unit is its own cgroup with its own lifecycle, so the parent
+ * exiting is no longer fatal. It also gets the sweep its own journal entry,
+ * which is how the failure would have been visible in the first place.
+ *
+ * `KillMode=process` on the heartbeat unit was the smaller alternative and was
+ * rejected: it leaves the sweep in the heartbeat's cgroup, so the NEXT
+ * heartbeat 30 minutes later would kill a long backlog sweep mid-run.
+ *
+ * Env fidelity: a transient `--user` unit inherits the user manager's
+ * environment, not the caller's, so the unit re-sources exactly the two env
+ * files every other phantombot unit sources and pins the same PATH. Secrets
+ * are never passed as `--setenv`, which would expose them in `systemctl show`
+ * and the journal; the sweep decrypts its own vault at startup as any other
+ * `phantombot` invocation does.
+ */
+export function buildNightlyLaunch(
+  bare: { command: string; args: string[] },
+  persona: string,
+  env: NightlyHostEnv,
+  unitName: string = nightlyUnitName(persona),
+): NightlyLaunch {
+  const usable =
+    env.platform === "linux" &&
+    env.systemdBooted &&
+    !!env.systemdRunPath &&
+    !!env.userSessionRuntimeDir;
+  if (!usable) return { ...bare, transient: false };
+  return {
+    command: env.systemdRunPath as string,
+    args: [
+      "--user",
+      "--quiet",
+      // Reap the unit as soon as it finishes (or fails) so a box that has
+      // swept for a year does not accumulate a year of failed unit stubs.
+      "--collect",
+      `--unit=${unitName}`,
+      `--description=Phantombot nightly sweep (${persona})`,
+      `--property=Environment=PATH=${nightlyUnitPath(env.home)}`,
+      `--property=EnvironmentFile=-${env.home}/.config/phantombot/.env`,
+      `--property=EnvironmentFile=-${env.home}/.env`,
+      "--",
+      bare.command,
+      ...bare.args,
+    ],
+    transient: true,
+  };
+}
+
+/**
+ * The same PATH the installed units pin, with `%h` resolved here: unit-file
+ * specifiers are expanded by the unit-file parser, and transient properties
+ * go over D-Bus where they are not.
+ */
+function nightlyUnitPath(home: string): string {
+  return [
+    `${home}/.local/share/pi-node/bin`,
+    `${home}/.local/share/pi-node/current/bin`,
+    `${home}/.pi/agent/bin`,
+    `${home}/.local/bin`,
+    "/usr/local/sbin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/usr/bin",
+    "/sbin",
+    "/bin",
+  ].join(":");
+}
+
+/** The bare `phantombot nightly` argv for this build (dev script vs binary). */
+export function bareNightlyCommand(persona: string): {
+  command: string;
+  args: string[];
+} {
+  const entry = process.argv[1] ?? "";
+  const dev = entry.endsWith(".ts") || entry.endsWith(".js");
+  return {
+    command: process.execPath,
+    args: dev
+      ? [entry, "nightly", "--persona", persona]
+      : ["nightly", "--persona", persona],
+  };
+}
+
+/**
+ * Fire a `phantombot nightly` for the given persona so that it OUTLIVES its
+ * caller.
+ *
+ * On systemd hosts the sweep is launched as a transient `--user` unit (see
+ * {@link buildNightlyLaunch}); everywhere else it is a detached, unref'd child
+ * as before — launchd and Windows do not kill it when the parent exits.
+ *
+ * The systemd path is launched SYNCHRONOUSLY on purpose. `systemd-run` returns
+ * as soon as the start job is enqueued (tens of ms), but the caller here is a
+ * heartbeat that exits immediately afterwards — spawning `systemd-run` itself
+ * asynchronously would re-open the same race one level up, with the helper
+ * killed before it had registered the unit.
+ *
+ * A failing `systemd-run` (old systemd without transient EnvironmentFile, no
+ * user bus, a name collision) falls back to the bare detached child, which is
+ * strictly what this function did before. The sweep is ledger-driven and
+ * idempotent, so a duplicate launch is harmless.
  */
 export function spawnNightlySweep(
   persona: string,
   reason: NightlyTriggerReason,
+  env: NightlyHostEnv = detectNightlyHostEnv(),
 ): void {
-  const entry = process.argv[1] ?? "";
-  const dev = entry.endsWith(".ts") || entry.endsWith(".js");
-  const args = dev
-    ? [entry, "nightly", "--persona", persona]
-    : ["nightly", "--persona", persona];
+  const bare = bareNightlyCommand(persona);
+  const launch = buildNightlyLaunch(bare, persona, env);
+
+  if (launch.transient) {
+    try {
+      const res = spawnSync(launch.command, launch.args, { stdio: "ignore" });
+      if (!res.error && res.status === 0) {
+        log.info("nightly: spawned sweep", {
+          persona,
+          reason,
+          via: "systemd-run",
+        });
+        return;
+      }
+      log.warn("nightly: systemd-run failed, falling back to detached child", {
+        persona,
+        reason,
+        status: res.status,
+        error: res.error?.message,
+      });
+    } catch (e) {
+      log.warn("nightly: systemd-run threw, falling back to detached child", {
+        persona,
+        reason,
+        error: (e as Error).message,
+      });
+    }
+  }
+
   try {
-    const child = spawn(process.execPath, args, {
+    const child = spawn(bare.command, bare.args, {
       detached: true,
       stdio: "ignore",
     });
     child.unref();
-    log.info("nightly: spawned sweep", { persona, reason });
+    log.info("nightly: spawned sweep", { persona, reason, via: "detached" });
   } catch (e) {
     log.warn("nightly: could not spawn sweep", {
       persona,

--- a/src/lib/nightlyTrigger.ts
+++ b/src/lib/nightlyTrigger.ts
@@ -33,6 +33,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 
 import { log } from "./logger.ts";
+import { PHANTOMBOT_SERVICE_PATH } from "./systemd.ts";
 
 /** Why a sweep was fired. Logged, and useful in tests. */
 export type NightlyTriggerReason = "startup" | "rollover" | "manual";
@@ -193,20 +194,14 @@ export function buildNightlyLaunch(
  * The same PATH the installed units pin, with `%h` resolved here: unit-file
  * specifiers are expanded by the unit-file parser, and transient properties
  * go over D-Bus where they are not.
+ *
+ * Derived from {@link PHANTOMBOT_SERVICE_PATH} rather than restated, so a
+ * future entry added to the service PATH cannot silently skip the transient
+ * nightly unit and leave the sweep resolving binaries against a different
+ * lookup path than every other phantombot unit.
  */
 function nightlyUnitPath(home: string): string {
-  return [
-    `${home}/.local/share/pi-node/bin`,
-    `${home}/.local/share/pi-node/current/bin`,
-    `${home}/.pi/agent/bin`,
-    `${home}/.local/bin`,
-    "/usr/local/sbin",
-    "/usr/local/bin",
-    "/usr/sbin",
-    "/usr/bin",
-    "/sbin",
-    "/bin",
-  ].join(":");
+  return PHANTOMBOT_SERVICE_PATH.replaceAll("%h", home);
 }
 
 /** The bare `phantombot nightly` argv for this build (dev script vs binary). */

--- a/tests/lib-nightlyTrigger.test.ts
+++ b/tests/lib-nightlyTrigger.test.ts
@@ -11,6 +11,7 @@ import {
   type NightlyHostEnv,
   nightlyUnitName,
 } from "../src/lib/nightlyTrigger.ts";
+import { PHANTOMBOT_SERVICE_PATH } from "../src/lib/systemd.ts";
 
 describe("dailyFileDate", () => {
   test("uses the same basis the daily-file writer uses (UTC)", () => {
@@ -104,6 +105,17 @@ describe("buildNightlyLaunch", () => {
     expect(path).toBeDefined();
     expect(path).not.toContain("%h");
     expect(path).toContain("/home/robbie/.local/bin");
+  });
+
+  test("the pinned PATH stays in lockstep with the installed units", () => {
+    // Derived, not restated: if the service PATH gains an entry, the transient
+    // nightly unit has to gain it too, or the sweep resolves binaries against
+    // a different lookup path than every other phantombot unit.
+    const l = buildNightlyLaunch(bare, "robbie", systemd);
+    const path = l.args.find((a) => a.startsWith("--property=Environment=PATH="));
+    expect(path).toBe(
+      `--property=Environment=PATH=${PHANTOMBOT_SERVICE_PATH.replaceAll("%h", "/home/robbie")}`,
+    );
   });
 
   test("no secrets are passed on the command line", () => {

--- a/tests/lib-nightlyTrigger.test.ts
+++ b/tests/lib-nightlyTrigger.test.ts
@@ -4,7 +4,13 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { dailyFileDate, dayRolledOver } from "../src/lib/nightlyTrigger.ts";
+import {
+  buildNightlyLaunch,
+  dailyFileDate,
+  dayRolledOver,
+  type NightlyHostEnv,
+  nightlyUnitName,
+} from "../src/lib/nightlyTrigger.ts";
 
 describe("dailyFileDate", () => {
   test("uses the same basis the daily-file writer uses (UTC)", () => {
@@ -54,5 +60,112 @@ describe("dayRolledOver", () => {
     expect(
       dayRolledOver("2026-05-26T09:00:00Z", new Date("2026-06-02T09:00:00Z")),
     ).toBe(true);
+  });
+});
+
+describe("buildNightlyLaunch", () => {
+  const bare = { command: "/usr/local/bin/phantombot", args: ["nightly", "--persona", "robbie"] };
+  const systemd: NightlyHostEnv = {
+    platform: "linux",
+    systemdRunPath: "/usr/bin/systemd-run",
+    systemdBooted: true,
+    userSessionRuntimeDir: "/run/user/1000",
+    home: "/home/robbie",
+  };
+
+  test("systemd hosts launch a TRANSIENT unit, not a bare child", () => {
+    // The whole bug: a detached child stays in the heartbeat's Type=oneshot
+    // cgroup and is SIGKILLed when `phantombot heartbeat` exits ~1s later.
+    // Only a separate unit has a lifecycle of its own.
+    const l = buildNightlyLaunch(bare, "robbie", systemd, "phantombot-nightly-robbie-x");
+    expect(l.transient).toBe(true);
+    expect(l.command).toBe("/usr/bin/systemd-run");
+    expect(l.args).toContain("--user");
+    expect(l.args).toContain("--collect");
+    expect(l.args).toContain("--unit=phantombot-nightly-robbie-x");
+    // The real command still runs, after the `--` separator.
+    const sep = l.args.indexOf("--");
+    expect(sep).toBeGreaterThan(0);
+    expect(l.args.slice(sep + 1)).toEqual([bare.command, ...bare.args]);
+  });
+
+  test("the transient unit re-sources the env files and pins PATH", () => {
+    // A --user transient unit inherits the user MANAGER's environment, not the
+    // caller's, so without this the sweep would run with neither phantombot's
+    // own .env nor the agent's ~/.env, and with whatever PATH the manager has.
+    const l = buildNightlyLaunch(bare, "robbie", systemd);
+    expect(l.args).toContain("--property=EnvironmentFile=-/home/robbie/.env");
+    expect(l.args).toContain(
+      "--property=EnvironmentFile=-/home/robbie/.config/phantombot/.env",
+    );
+    const path = l.args.find((a) => a.startsWith("--property=Environment=PATH="));
+    // `%h` is a unit-FILE specifier; transient properties travel over D-Bus
+    // where nothing expands it, so home must already be resolved here.
+    expect(path).toBeDefined();
+    expect(path).not.toContain("%h");
+    expect(path).toContain("/home/robbie/.local/bin");
+  });
+
+  test("no secrets are passed on the command line", () => {
+    // --setenv would put the value in `systemctl show` and the journal.
+    const l = buildNightlyLaunch(bare, "robbie", systemd);
+    expect(l.args.some((a) => a.startsWith("--setenv"))).toBe(false);
+  });
+
+  test("macOS stays a bare detached child — launchd does not kill it", () => {
+    const l = buildNightlyLaunch(bare, "robbie", {
+      platform: "darwin",
+      systemdBooted: false,
+      home: "/Users/matt",
+    });
+    expect(l.transient).toBe(false);
+    expect(l.command).toBe(bare.command);
+    expect(l.args).toEqual(bare.args);
+  });
+
+  test("Windows stays a bare detached child", () => {
+    const l = buildNightlyLaunch(bare, "megan", {
+      platform: "win32",
+      systemdBooted: false,
+      home: "C:\\Users\\megan",
+    });
+    expect(l.transient).toBe(false);
+  });
+
+  test("linux WITHOUT systemd-run installed falls back to the bare child", () => {
+    const l = buildNightlyLaunch(bare, "robbie", { ...systemd, systemdRunPath: undefined });
+    expect(l.transient).toBe(false);
+  });
+
+  test("linux with no user session (no XDG_RUNTIME_DIR) falls back", () => {
+    // `systemd-run --user` has no bus to talk to here; a bare child at least
+    // runs, and on a non-unit caller nothing tears its cgroup down.
+    const l = buildNightlyLaunch(bare, "robbie", { ...systemd, userSessionRuntimeDir: undefined });
+    expect(l.transient).toBe(false);
+  });
+
+  test("a container that has systemd-run but is not systemd-booted falls back", () => {
+    const l = buildNightlyLaunch(bare, "robbie", { ...systemd, systemdBooted: false });
+    expect(l.transient).toBe(false);
+  });
+});
+
+describe("nightlyUnitName", () => {
+  test("folds characters systemd rejects in a unit name", () => {
+    // Persona names are user-supplied; `/` or a space would make systemd-run
+    // fail and silently drop us onto the fallback path forever.
+    const name = nightlyUnitName("dev/persona name!", new Date("2026-08-21T00:00:40Z"), 42);
+    expect(name).toMatch(/^[A-Za-z0-9:_.-]+$/);
+    expect(name).toContain("dev-persona-name-");
+  });
+
+  test("two launches in the same second do not collide on a name", () => {
+    const at = new Date("2026-08-21T00:00:40Z");
+    expect(nightlyUnitName("robbie", at, 10)).not.toBe(nightlyUnitName("robbie", at, 11));
+  });
+
+  test("a very long persona name stays inside systemd's name limit", () => {
+    const name = nightlyUnitName("x".repeat(300));
+    expect(name.length).toBeLessThan(120);
   });
 });


### PR DESCRIPTION
## The bug

On systemd the **day-rollover nightly sweep has never completed**. The trigger fires correctly — the heartbeat logs `heartbeat: day rolled over, spawned nightly sweep` at 00:00:40Z — but the sweep dies about a second later.

`phantombot-heartbeat.service` is `Type=oneshot`. When `phantombot heartbeat` exits, systemd considers the unit finished and tears down its cgroup, SIGKILLing everything still in it. `detached: true` + `unref()` detaches the child from Node's event loop and the controlling terminal; it does **not** leave the cgroup.

Evidence, not inference:

- Reproduced directly: `systemd-run --user -p Type=oneshot` spawning a `setsid sleep` → **child killed**.
- Sweep ledgers on the Linux hosts: **188 processed dates, zero** ever completed in the 00:xx UTC hour. The launchd (macOS) and Windows hosts have 00:xx completions routinely.
- On three Linux personas the last sweep timestamp equals the daemon **start** timestamp to the second. A fourth that happened to restart *after* midnight is clean — the control case.

So on Linux the nightly has only ever run off the **startup** trigger: it silently depended on restarts. It surfaces as a persistent `doctor` WARN with yesterday still pending, which is honest — the sweep genuinely didn't run.

This is pre-existing and **not** caused by the 1.1.279 update.

## The fix

Launch the sweep as its own **transient `--user` unit**, which has a cgroup and a lifecycle of its own — and its own journal entries, which is how this would have been visible in the first place.

`KillMode=process` on the heartbeat unit was the smaller alternative and is rejected in the code comment: it leaves the sweep inside the heartbeat's cgroup, so the **next** heartbeat 30 minutes later would kill a long backlog sweep mid-run.

Details worth reviewing:

- **`systemd-run` is invoked synchronously.** It returns as soon as the start job is enqueued (tens of ms), but the caller exits immediately afterwards — spawning the helper asynchronously would re-open the same race one level up, with `systemd-run` itself killed before it registered the unit.
- **Env fidelity.** A `--user` transient unit inherits the user *manager's* environment, not the caller's. The unit therefore re-sources the same two env files every other phantombot unit sources and pins the same PATH, with `%h` resolved in code — transient properties travel over D-Bus, which does not expand unit specifiers. **No secret is passed via `--setenv`**, which would expose it in `systemctl show` and the journal; the sweep decrypts its own vault at startup like any other `phantombot` invocation.
- **Unit naming.** Persona names are user-supplied, so they're folded to systemd's legal charset (an unfolded `/` or space would make `systemd-run` fail and drop us onto the fallback forever). Timestamp+pid suffix so two launches can't collide; `--collect` so finished units are reaped.
- **Fallback.** Any `systemd-run` failure — old systemd, no user bus, name collision — falls back to exactly the previous detached-child behaviour, and logs the reason. The sweep is ledger-driven and idempotent, so a duplicate launch is harmless.
- **macOS and Windows are untouched.** launchd and Task Scheduler don't kill the child; those hosts stay on the bare detached path, asserted by tests.

## Verification

- **12 new tests**, all mutation-verified — four separate mutations (always-transient, dropped `EnvironmentFile` props, unexpanded `%h`, unsanitised unit name) each redden exactly the tests that cover them (5/1/1/1 failures respectively), 18/18 green otherwise.
- **Live end-to-end on a real box:** ran the built argv from inside a genuine `Type=oneshot` transient unit. Parent exited; sweep unit still `active` with a live MainPID. Under the old code path the identical child is dead in ~1s.
- Full suite **3220 pass / 0 fail**, `tsc --noEmit` clean.
