### PR TITLE
fix(phantomchat): back up a corrupt phantomchat.json before overwriting it

### DIFF
--- a/src/channels/phantomchat/personaStore.ts
+++ b/src/channels/phantomchat/personaStore.ts
@@ -198,20 +198,32 @@ function parseGroupBots(v: unknown): PhantomchatGroupBot[] {
 }
 
 /**
- * Read the raw on-disk JSON object, or `{}` when the file is absent or
- * unparseable. Deliberately NOT `loadPhantomchatPersonaConfig`: the save path
- * needs the file's literal keys (including ones this build does not know about)
- * and must work even for a file that has no usable nsec, which `load` rejects.
+ * Read the raw on-disk JSON object, or `{}` when the file is ABSENT.
+ * Deliberately NOT `loadPhantomchatPersonaConfig`: the save path needs the
+ * file's literal keys (including ones this build does not know about) and must
+ * work even for a file that has no usable nsec, which `load` rejects.
+ *
+ * A file that EXISTS but will not parse (or is not a JSON object) THROWS: it
+ * is corrupt-but-populated, and the caller must not treat it as an empty
+ * base — otherwise a save would silently discard every existing key
+ * (allowlist, relays, group_bots) that merge semantics were supposed to
+ * preserve (#419 item 4).
  */
 function readRawFileShape(path: string): PhantomchatFileShape {
   if (!existsSync(path)) return {};
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-    return parsed as PhantomchatFileShape;
-  } catch {
-    return {};
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (e) {
+    throw new Error(
+      `phantomchat: ${path} exists but is not parseable JSON`,
+      { cause: e },
+    );
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`phantomchat: ${path} exists but is not a JSON object`);
+  }
+  return parsed as PhantomchatFileShape;
 }
 
 /**
@@ -326,7 +338,21 @@ export async function savePhantomchatPersonaConfig(
   }
   // Start from whatever is on disk so unknown keys survive, then overwrite the
   // fields this caller actually supplied (see MERGE SEMANTICS above).
-  const existing = readRawFileShape(path);
+  // A corrupt-but-populated file is backed up BEFORE the overwrite instead of
+  // being read as `{}` — a warn-and-destroy would still lose the allowlist and
+  // relay tiers, and the backup keeps them recoverable by hand (#419 item 4).
+  let existing: PhantomchatFileShape;
+  try {
+    existing = readRawFileShape(path);
+  } catch (e) {
+    const backup = `${path}.corrupt-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+    await rename(path, backup);
+    log.warn(
+      `phantomchat: ${path} is unparseable — moved to ${backup}; continuing with an empty base`,
+      { error: (e as Error).message },
+    );
+    existing = {};
+  }
   const body: PhantomchatFileShape = { ...existing };
   delete body.nsec; // promoted to identity.json — never written back here
   body.relays = data.relays;

--- a/src/channels/phantomchat/personaStore.ts
+++ b/src/channels/phantomchat/personaStore.ts
@@ -208,12 +208,27 @@ function parseGroupBots(v: unknown): PhantomchatGroupBot[] {
  * base — otherwise a save would silently discard every existing key
  * (allowlist, relays, group_bots) that merge semantics were supposed to
  * preserve (#419 item 4).
+ *
+ * A file that exists but cannot be READ (permissions, I/O) throws
+ * `ConfigReadError` instead: the bytes were never inspected, so the file may
+ * be perfectly valid. Callers must never treat a read failure as corruption.
  */
+class ConfigReadError extends Error {}
+
 function readRawFileShape(path: string): PhantomchatFileShape {
   if (!existsSync(path)) return {};
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (e) {
+    throw new ConfigReadError(
+      `phantomchat: ${path} exists but could not be read`,
+      { cause: e },
+    );
+  }
   let parsed: unknown;
   try {
-    parsed = JSON.parse(readFileSync(path, "utf8"));
+    parsed = JSON.parse(raw);
   } catch (e) {
     throw new Error(
       `phantomchat: ${path} exists but is not parseable JSON`,
@@ -345,6 +360,11 @@ export async function savePhantomchatPersonaConfig(
   try {
     existing = readRawFileShape(path);
   } catch (e) {
+    // A READ failure (EACCES/EIO/…) is not corruption — the file may be valid
+    // and we simply could not inspect it. Renaming it to .corrupt-* would
+    // misdiagnose and discard a good config, so the failure propagates: never
+    // overwrite data you couldn't read.
+    if (e instanceof ConfigReadError) throw e;
     const backup = `${path}.corrupt-${new Date().toISOString().replace(/[:.]/g, "-")}`;
     await rename(path, backup);
     log.warn(

--- a/tests/channels-phantomchat-personaStore.test.ts
+++ b/tests/channels-phantomchat-personaStore.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -601,4 +601,39 @@ describe("corrupt-but-populated phantomchat.json — #419 item 4", () => {
     expect(dir.filter((f) => f.includes("corrupt"))).toEqual([]);
     expect(loadPhantomchatPersonaConfig(agentDir)).toBeDefined();
   });
+
+  // chmod is meaningless on Windows (and on root, which ignores mode bits),
+  // so the read-failure path can't be exercised there — POSIX only.
+  test.skipIf(process.platform === "win32")(
+    "an unreadable file is a read failure, not corruption — save rejects, no backup",
+    async () => {
+      if (process.getuid?.() === 0) return; // root ignores the mode bits
+      const id = generateIdentity();
+      const agentDir = join(workdir, "robbie");
+      await mkdir(agentDir, { recursive: true });
+      const path = phantomchatConfigPath(agentDir);
+      // A perfectly VALID config the process cannot read (EACCES) — the exact
+      // case where a .corrupt-* rename would destroy a good file.
+      const valid = JSON.stringify({
+        relays: ["wss://a.example"],
+        allowed_npubs: ["npub1ok"],
+      });
+      await writeFile(path, valid, "utf8");
+      await chmod(path, 0o000);
+
+      await expect(
+        savePhantomchatPersonaConfig(agentDir, {
+          nsec: id.nsec,
+          relays: ["wss://fresh.example"],
+          allowedNpubs: [],
+        }),
+      ).rejects.toThrow(/could not be read/);
+
+      // No backup was made and the valid file is untouched — bytes preserved.
+      const dir = await readdir(agentDir);
+      expect(dir.filter((f) => f.includes("corrupt"))).toEqual([]);
+      await chmod(path, 0o644); // restore read access, then verify the bytes
+      expect(await readFile(path, "utf8")).toBe(valid);
+    },
+  );
 });

--- a/tests/channels-phantomchat-personaStore.test.ts
+++ b/tests/channels-phantomchat-personaStore.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -535,5 +535,70 @@ describe("relay tier + save merge semantics", () => {
     const loaded = loadPhantomchatPersonaConfig(agentDir)!;
     expect(loaded.relays).toEqual(["wss://new.example"]);
     expect(loaded.relayNpubs).toEqual([relay]);
+  });
+});
+
+describe("corrupt-but-populated phantomchat.json — #419 item 4", () => {
+  test("save backs up an unparseable file instead of silently wiping it", async () => {
+    const id = generateIdentity();
+    const agentDir = join(workdir, "lena");
+    await mkdir(agentDir, { recursive: true });
+    const path = phantomchatConfigPath(agentDir);
+    // A truncated/corrupt file that WAS populated — the exact data-loss case.
+    const corrupt = '{"relays": ["wss://a.example"], "allowed_npubs": ["npub1brok';
+    await writeFile(path, corrupt, "utf8");
+
+    await savePhantomchatPersonaConfig(agentDir, {
+      nsec: id.nsec,
+      relays: ["wss://fresh.example"],
+      allowedNpubs: [],
+    });
+
+    // The corrupt original survived, byte-identical, under .corrupt-*.
+    const dir = await readdir(agentDir);
+    const backups = dir.filter((f) => f.startsWith("phantomchat.json.corrupt-"));
+    expect(backups.length).toBe(1);
+    const backup = await readFile(join(agentDir, backups[0]!), "utf8");
+    expect(backup).toBe(corrupt);
+
+    // The new file is valid and carries what the save supplied.
+    const loaded = loadPhantomchatPersonaConfig(agentDir);
+    expect(loaded).toBeDefined();
+    expect(loaded!.relays).toEqual(["wss://fresh.example"]);
+  });
+
+  test("a file that parses to a non-object is treated as corrupt too", async () => {
+    const id = generateIdentity();
+    const agentDir = join(workdir, "kai");
+    await mkdir(agentDir, { recursive: true });
+    const path = phantomchatConfigPath(agentDir);
+    await writeFile(path, "[1, 2, 3]", "utf8");
+
+    await savePhantomchatPersonaConfig(agentDir, {
+      nsec: id.nsec,
+      relays: ["wss://fresh.example"],
+      allowedNpubs: [],
+    });
+
+    const dir = await readdir(agentDir);
+    const backups = dir.filter((f) => f.startsWith("phantomchat.json.corrupt-"));
+    expect(backups.length).toBe(1);
+    expect(loadPhantomchatPersonaConfig(agentDir)).toBeDefined();
+  });
+
+  test("an absent file still saves clean — no backup, no warn path", async () => {
+    const id = generateIdentity();
+    const agentDir = join(workdir, "salvador");
+    await mkdir(agentDir, { recursive: true });
+
+    await savePhantomchatPersonaConfig(agentDir, {
+      nsec: id.nsec,
+      relays: ["wss://a.example"],
+      allowedNpubs: [],
+    });
+
+    const dir = await readdir(agentDir);
+    expect(dir.filter((f) => f.includes("corrupt"))).toEqual([]);
+    expect(loadPhantomchatPersonaConfig(agentDir)).toBeDefined();
   });
 });


### PR DESCRIPTION
Part of #419 (item 4, split out of the items 1–3 sweep in #422 per review).

## The bug

`readRawFileShape` in `personaStore.ts` returned `{}` for a file that **exists but won\'t parse** — indistinguishable from an absent file. Since #423 made `save` preserve omitted fields *from the existing file*, that preservation silently cannot apply to an unparseable file: a save after a parse failure discards every existing key (`allowed_npubs`, `relays`, `group_bots`, `relay_npubs`) — the exact data #423\'s merge semantics exist to protect. A bare `log.warn` that still overwrites would leave the loss invisible, not prevented.

## The fix

- `readRawFileShape` now separates the two cases: **absent → `{}`** (unchanged), **exists-but-unparseable or non-object → throws** with the path and cause.
- `savePhantomchatPersonaConfig` catches that, **renames the corrupt file to `phantomchat.json.corrupt-<ISO-timestamp>`**, logs a warn with the path + parse error, and continues with an empty base. The corrupt original survives byte-identical for manual recovery; the save is not refused, so the wizard can still (re)configure a persona whose file went bad.

## Tests

Three new cases in the personaStore suite: unparseable JSON is backed up byte-identical and the new file loads; a file parsing to a non-object (array) takes the same path; an absent file still saves clean with no backup. Full suite locally: **3298 pass**, 2 fails are the pre-existing `PHANTOMBOT_PI_API_KEY` ambient-env ones (reproduced identically on clean main). `tsc --noEmit` clean.