### PR TITLE
fix(pi): skip coder-swap without a distinct coder; retry swapped turns, then fall back to primary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,12 +1009,15 @@ Two safety rails keep a swapped turn from ever being *lost*:
   no override store, no scorer, no retry ladder. `/coder` says so instead of
   silently pretending.
 - **Retry, then fall back.** A swapped turn that fails before producing any
-  output (the intermittent provider-hang case: stream never starts, the idle
-  watchdog kills it) is retried up to three times on the coding model, and when
-  those are exhausted the turn is re-run once on the **primary** — a slower but
-  known-good brain beats a lost turn. Failures after visible text is streamed
-  are surfaced as normal harness errors instead, so a reply is never duplicated
-  on screen.
+  output of any kind (the intermittent provider-hang case: stream never
+  starts, the idle watchdog kills it) is retried up to three times on the
+  coding model, and when those are exhausted the turn is re-run once on the
+  **primary** — a slower but known-good brain beats a lost turn. "Output"
+  means anything: streamed text OR a tool run (pi tools surface as progress
+  chunks, not text — and a retry after a bash/notify/vault tool ran would
+  replay its side effects). Failures after the attempt got somewhere are
+  surfaced as normal harness errors instead, and a hard wall-clock cap kill is
+  final — the ladder never multiplies one 60-minute cap into four hours.
 
 Configure all three roles with the `phantombot harness` wizard; the choices are
 mirrored into `config.toml` under `[harnesses.pi.routing]` and visible to

--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,20 @@ then releases it the moment the topic moves off code — stateless and
 self-correcting, no sticky mode. Force it with `/coder`, disable with
 `/coder off`, or clear back to scoring with `/coder default`.
 
+Two safety rails keep a swapped turn from ever being *lost*:
+
+- **No distinct coder → no swap system.** When the coding model is unset — or
+  set to the same model as the primary — the whole swap subsystem is skipped:
+  no override store, no scorer, no retry ladder. `/coder` says so instead of
+  silently pretending.
+- **Retry, then fall back.** A swapped turn that fails before producing any
+  output (the intermittent provider-hang case: stream never starts, the idle
+  watchdog kills it) is retried up to three times on the coding model, and when
+  those are exhausted the turn is re-run once on the **primary** — a slower but
+  known-good brain beats a lost turn. Failures after visible text is streamed
+  are surfaced as normal harness errors instead, so a reply is never duplicated
+  on screen.
+
 Configure all three roles with the `phantombot harness` wizard; the choices are
 mirrored into `config.toml` under `[harnesses.pi.routing]` and visible to
 `phantombot doctor`. They can also be changed live from chat with

--- a/src/channels/commands.ts
+++ b/src/channels/commands.ts
@@ -432,6 +432,18 @@ async function handleCoderSwap(
     };
   }
 
+  // The swap subsystem is skipped entirely when there is no DISTINCT coding
+  // model (unset, or the same as the primary) — an override would be a silent
+  // no-op, so say so instead of pretending it took effect.
+  const routing = ctx.config?.harnesses?.pi?.routing;
+  if (!routing?.codingModel || routing.codingModel === routing.primaryModel) {
+    return {
+      reply:
+        "coding brain: inactive — no coding model configured (or it matches the primary). " +
+        "Set one with /model coding <slug> or the `phantombot harness` wizard.",
+    };
+  }
+
   await applyCoderSwapRequest({
     persona: ctx.persona,
     conversation: ctx.conversation,

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -51,6 +51,7 @@ import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import { reloadVaultForPersona } from "../lib/vault.ts";
 import {
   type HarnessActivity,
+  isHardCapError,
   runHarnessProcess,
 } from "../lib/harnessRunner.ts";
 import { log } from "../lib/logger.ts";
@@ -356,11 +357,23 @@ export class PiHarness implements Harness {
       // turn.
       //
       // Retry discipline (each rule exists for a reason):
-      //   - Only when NOTHING was streamed to the user yet this attempt —
-      //     retrying after visible text would duplicate bubbles on screen
-      //     (the streaming-first trade-off documented in fallback.ts).
+      //   - Only when NOTHING happened yet this attempt — no text streamed AND
+      //     no tool run. Text is not the only non-idempotent thing here: pi's
+      //     tool executions surface as progress chunks, not text, and a retry
+      //     after a bash/notify/vault tool ran would replay those side effects
+      //     wholesale. `producedOutput` flips on any non-heartbeat chunk
+      //     (heartbeat is payload-less by contract), which keeps the genuine
+      //     "provider never started streaming" case — the one this ladder
+      //     exists for — fully retryable while everything that got anywhere
+      //     stays single-shot. Retrying after visible text would ALSO duplicate
+      //     bubbles on screen (the streaming-first trade-off documented in
+      //     fallback.ts).
       //   - Only recoverable, non-terminal errors — a policy violation or
       //     user /stop must not be retried onto another model.
+      //   - NEVER on a hard wall-clock cap kill. The hard cap is the one timer
+      //     that is supposed to be FINAL: a turn that legitimately kept the
+      //     idle timer fed but never converged is exactly what it exists to
+      //     kill. The ladder would multiply one 60-min cap into four hours.
       //   - Errors from the final PRIMARY attempt are yielded as-is so the
       //     orchestrator's normal harness chain still applies afterwards.
       // ─────────────────────────────────────────────────────────────────
@@ -372,7 +385,12 @@ export class PiHarness implements Harness {
         attempt <= CODER_SWAP_MAX_ATTEMPTS && !req.signal?.aborted;
         attempt++
       ) {
-        let streamedText = false;
+        // Tracks whether this attempt produced output of ANY kind (text,
+        // progress from a tool run, done). heartbeat is payload-less by
+        // contract and is excluded, so a provider that never starts streaming
+        // stays retryable — but an attempt that got as far as running a tool
+        // is NOT, because tools have side effects and a re-run is a re-do.
+        let producedOutput = false;
         let failure:
           | (HarnessChunk & { type: "error"; error: string })
           | undefined;
@@ -383,7 +401,7 @@ export class PiHarness implements Harness {
             failure = chunk;
             break;
           }
-          if (chunk.type === "text") streamedText = true;
+          if (chunk.type !== "heartbeat") producedOutput = true;
           yield chunk;
         }
         if (!failure) return; // completed (or the consumer stopped us)
@@ -391,13 +409,15 @@ export class PiHarness implements Harness {
         const retryable =
           failure.recoverable !== false &&
           !failure.terminal &&
-          !streamedText &&
+          !producedOutput &&
+          !isHardCapError(failure.error) &&
           !req.signal?.aborted;
         // Not retryable — surface the error exactly as the single-attempt
-        // path always did: a policy violation, a /stop, or a failure AFTER
-        // visible text must not be re-run on another model (that would
-        // duplicate bubbles on screen, the very trade-off fallback.ts
-        // warns against re-litigating).
+        // path always did: a policy violation, a /stop, a hard-cap kill (the
+        // final timer must stay final), or a failure AFTER the attempt got
+        // somewhere (streamed text OR ran a tool — a re-run would duplicate
+        // bubbles and replay side-effecting tools, the very trade-off
+        // fallback.ts warns against re-litigating).
         if (!retryable) {
           yield failure;
           return;
@@ -413,8 +433,9 @@ export class PiHarness implements Harness {
           });
         }
       }
-      // All swapped attempts failed CLEANLY (nothing ever streamed), so the
-      // primary attempt starts from a blank screen — no duplicated text.
+      // All swapped attempts failed CLEANLY (nothing ever happened — no text,
+      // no tools), so the primary attempt starts from a blank slate: no
+      // duplicated bubbles, no replayed tool side effects.
       // (If the loop exited early because the user aborted, stop here too.)
       if (req.signal?.aborted) return;
       log.warn("pi.invoke coder-swap exhausted — falling back to primary", {

--- a/src/harnesses/pi.ts
+++ b/src/harnesses/pi.ts
@@ -45,7 +45,7 @@ import type {
   HarnessRequest,
 } from "./types.ts";
 import { ENV_PHANTOMBOT_TMP_DIR, ENV_PI_API_KEY, ENV_PI_PROVIDER, type PiRoutingConfig } from "../lib/piRouting.ts";
-import { getCoderSwapOverride, resolveSwapModel } from "../lib/coderSwap.ts";
+import { CODER_SWAP_MAX_ATTEMPTS, getCoderSwapOverride, resolveSwapModel } from "../lib/coderSwap.ts";
 import { buildToolCall, type ToolCallDetail } from "./toolNote.ts";
 import { reloadEnvFiles, withPersonaEnv } from "../lib/envBootstrap.ts";
 import { reloadVaultForPersona } from "../lib/vault.ts";
@@ -124,7 +124,7 @@ export class PiHarness implements Harness {
     const payloadArg = `@${await temp.file("payload.md", payload)}`;
     try {
 
-    const args = [
+    const baseArgs = [
       "--print",
       "--mode", "json",
       "--system-prompt", systemPromptArg,
@@ -156,8 +156,21 @@ export class PiHarness implements Harness {
     // flips back to the primary the moment the work stops being code. We never
     // swap the tool-less threat judge (toolsMode "none") — it must stay on the
     // configured primary and never gain capability.
-    let primaryModel = this.config.routing?.primaryModel;
-    if (req.toolsMode !== "none" && this.config.routing?.codingModel) {
+    //
+    // SKIP the whole swap subsystem — no override read, no scoring, no retry
+    // ladder — when the coding model is unset OR THE SAME as the primary:
+    // there is no distinct brain to swap to, so consulting the override store
+    // and the scorer would be pure I/O and log noise (and a "swapped" turn on
+    // an equal model would activate the retry ladder for nothing).
+    const primaryModel = this.config.routing?.primaryModel;
+    const codingModel = this.config.routing?.codingModel;
+    const coderSwapEligible =
+      req.toolsMode !== "none" &&
+      !!codingModel &&
+      codingModel !== primaryModel;
+    let swapped = false;
+    let swapModel = primaryModel;
+    if (coderSwapEligible) {
       const override =
         req.persona && req.conversation
           ? await getCoderSwapOverride({
@@ -168,15 +181,16 @@ export class PiHarness implements Harness {
       const decision = resolveSwapModel({
         text: req.userMessage,
         override,
-        primaryModel: this.config.routing.primaryModel,
-        codingModel: this.config.routing.codingModel,
+        primaryModel,
+        codingModel,
         // Pass conversation history so the current message is judged IN CONTEXT
         // (recency-decayed ratio over recent USER turns) rather than alone — a
         // natural-language follow-up mid-review no longer drops the coding brain.
         // History is already rebuilt for buildPayload() below, so this is free.
         history: req.history,
       });
-      primaryModel = decision.model;
+      swapped = decision.swapped;
+      swapModel = decision.model;
       if (decision.swapped) {
         log.info("pi.invoke coder-swap active", {
           persona: req.persona,
@@ -195,18 +209,6 @@ export class PiHarness implements Harness {
     // config (like the model), not per-turn env, since the provider is a config
     // choice that pairs with the saved models.
     const provider = this.config.routing?.provider;
-    if (provider) {
-      args.push("--provider", provider);
-    }
-    if (primaryModel) {
-      args.push("--model", primaryModel);
-    }
-    // Tool-less threat-judge mode. Per `pi --help`, `--no-tools` disables all
-    // tools (built-in, extension, and custom) — true zero-tools, native flag,
-    // no deny-list to maintain.
-    if (req.toolsMode === "none") {
-      args.push("--no-tools");
-    }
 
     // Re-source the legacy/runtime env files so file-backed model and routing
     // settings changed on the previous turn are visible without a daemon
@@ -225,14 +227,37 @@ export class PiHarness implements Harness {
     // installs working); neither ⇒ Pi errors as usual. Must precede the
     // positional payload below.
     const piApiKey = process.env[ENV_PI_API_KEY]?.trim();
-    if (piApiKey) {
-      args.push("--api-key", piApiKey);
-    }
 
-    // Payload is the LAST positional arg (pi reads it from argv, not stdin).
-    // This is always `@<tempfile>` so pi loads the payload from disk instead
-    // of the length-limited command line.
-    args.push(payloadArg);
+    /**
+     * Assemble the full argv for ONE attempt. `model` is the brain this
+     * attempt runs on — the swapped coding model or, after the swap's retries
+     * are exhausted, the primary. Everything else (system prompt file, provider,
+     * api-key, payload file) is model-independent and rebuilt identically per
+     * attempt so the ladder only ever varies `--model`.
+     */
+    const buildArgs = (model: string | undefined): string[] => {
+      const argv = [...baseArgs];
+      if (provider) {
+        argv.push("--provider", provider);
+      }
+      if (model) {
+        argv.push("--model", model);
+      }
+      // Tool-less threat-judge mode. Per `pi --help`, `--no-tools` disables all
+      // tools (built-in, extension, and custom) — true zero-tools, native flag,
+      // no deny-list to maintain.
+      if (req.toolsMode === "none") {
+        argv.push("--no-tools");
+      }
+      if (piApiKey) {
+        argv.push("--api-key", piApiKey);
+      }
+      // Payload is the LAST positional arg (pi reads it from argv, not stdin).
+      // This is always `@<tempfile>` so pi loads the payload from disk instead
+      // of the length-limited command line.
+      argv.push(payloadArg);
+      return argv;
+    };
     log.debug("pi.invoke spawning", {
       bin: this.config.bin,
       payloadBytes: totalBytes,
@@ -263,45 +288,144 @@ export class PiHarness implements Harness {
     // processes (Kai's review point). spawnPi.ts falls back to os.tmpdir() when
     // it's unset (degraded/no-persona paths).
     if (req.tmpBaseDir) childEnv[ENV_PHANTOMBOT_TMP_DIR] = req.tmpBaseDir;
-    const proc = spawnInNewSession([this.config.bin, ...args], {
-      cwd: req.workingDir,
-      env: childEnv,
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
 
-    // Shared engine. Pi delivers its payload via argv (stdin ignored, so no
-    // stdinPayload), and the terminal `done` meta records the argv byte count.
-    yield* runHarnessProcess({
-      proc,
-      req,
-      harnessId: this.id,
-      parseEvent: parsePiEvent,
-      activity: piActivity,
-      buildDoneMeta: () => ({ harnessId: this.id, payloadBytes: totalBytes }),
-      // pi is the only harness with no native terminal `done` in its stream —
-      // it derives completion from turn_end (mapped to a `done` marker in
-      // parsePiEvent). Require that marker before accepting an exit-0 run as a
-      // finished answer, so a narration-only mid-task exit falls through to the
-      // next harness rather than being stored as the reply (issue #352).
-      requireCompletion: true,
-      // Bound how long a single contiguous tool-run may keep the idle watchdog
-      // alive via tool_execution_* activity alone, with no user-facing text. pi
-      // only emits tool_execution_update on genuine new output (bash streams
-      // stdout, the coder delegate forwards its child's progress) so a healthy
-      // turn is rarely affected — but a tool that trickles output forever (a
-      // stalled auto-router, a hung network retry that keeps logging) could
-      // otherwise reset the idle timer up to the 60-min hard cap with no
-      // fallback (issue #351). This is a GENEROUS last-resort net: comfortably
-      // above any realistic tool-run yet well under the hard cap, so a
-      // wedged-but-chattery turn fails over in minutes, not an hour. Derived
-      // from the idle window, floored at 20 min, and never above the hard cap.
-      toolTimeoutMs: Math.min(
-        req.hardTimeoutMs ?? Number.POSITIVE_INFINITY,
-        Math.max(req.idleTimeoutMs * 4, 1_200_000),
-      ),
-    });
+    /**
+     * Spawn ONE pi attempt on the given model and stream its chunks. Fresh
+     * subprocess per attempt (the shared engine arms its own kill coordinator
+     * per spawn), same temp payload files (model-independent) and child env.
+     */
+    const runAttempt = async function* (
+      this: PiHarness,
+      model: string | undefined,
+    ): AsyncGenerator<HarnessChunk> {
+      const proc = spawnInNewSession([this.config.bin, ...buildArgs(model)], {
+        cwd: req.workingDir,
+        env: childEnv,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      // Shared engine. Pi delivers its payload via argv (stdin ignored, so no
+      // stdinPayload), and the terminal `done` meta records the argv byte count.
+      yield* runHarnessProcess({
+        proc,
+        req,
+        harnessId: this.id,
+        parseEvent: parsePiEvent,
+        activity: piActivity,
+        buildDoneMeta: () => ({ harnessId: this.id, payloadBytes: totalBytes }),
+        // pi is the only harness with no native terminal `done` in its stream —
+        // it derives completion from turn_end (mapped to a `done` marker in
+        // parsePiEvent). Require that marker before accepting an exit-0 run as a
+        // finished answer, so a narration-only mid-task exit falls through to the
+        // next harness rather than being stored as the reply (issue #352).
+        requireCompletion: true,
+        // Bound how long a single contiguous tool-run may keep the idle watchdog
+        // alive via tool_execution_* activity alone, with no user-facing text. pi
+        // only emits tool_execution_update on genuine new output (bash streams
+        // stdout, the coder delegate forwards its child's progress) so a healthy
+        // turn is rarely affected — but a tool that trickles output forever (a
+        // stalled auto-router, a hung network retry that keeps logging) could
+        // otherwise reset the idle timer up to the 60-min hard cap with no
+        // fallback (issue #351). This is a GENEROUS last-resort net: comfortably
+        // above any realistic tool-run yet well under the hard cap, so a
+        // wedged-but-chattery turn fails over in minutes, not an hour. Derived
+        // from the idle window, floored at 20 min, and never above the hard cap.
+        toolTimeoutMs: Math.min(
+          req.hardTimeoutMs ?? Number.POSITIVE_INFINITY,
+          Math.max(req.idleTimeoutMs * 4, 1_200_000),
+        ),
+      });
+    }.bind(this);
+
+    if (!swapped) {
+      yield* runAttempt(swapModel);
+    } else {
+      // ─────────────────────────────────────────────────────────────────
+      // Coder-swap retry ladder (the "brain swap" fix).
+      //
+      // A swapped turn rides a DIFFERENT provider model than the primary —
+      // and an intermittent provider hang (stream never starts, zero output
+      // for the whole idle window) used to cost the turn outright: pi is
+      // usually the LAST harness in the chain, so an idle kill had no
+      // fallback and the user's message was silently lost. Now a swapped
+      // turn gets up to CODER_SWAP_MAX_ATTEMPTS attempts on the coding
+      // model, and when they're all exhausted the turn is re-run once on
+      // the PRIMARY — a possibly-slower but known-good brain beats a lost
+      // turn.
+      //
+      // Retry discipline (each rule exists for a reason):
+      //   - Only when NOTHING was streamed to the user yet this attempt —
+      //     retrying after visible text would duplicate bubbles on screen
+      //     (the streaming-first trade-off documented in fallback.ts).
+      //   - Only recoverable, non-terminal errors — a policy violation or
+      //     user /stop must not be retried onto another model.
+      //   - Errors from the final PRIMARY attempt are yielded as-is so the
+      //     orchestrator's normal harness chain still applies afterwards.
+      // ─────────────────────────────────────────────────────────────────
+      let lastFailure:
+        | { error: string; recoverable?: boolean; httpStatus?: number }
+        | undefined;
+      for (
+        let attempt = 1;
+        attempt <= CODER_SWAP_MAX_ATTEMPTS && !req.signal?.aborted;
+        attempt++
+      ) {
+        let streamedText = false;
+        let failure:
+          | (HarnessChunk & { type: "error"; error: string })
+          | undefined;
+        for await (const chunk of runAttempt(swapModel)) {
+          if (chunk.type === "error") {
+            // Terminal in the shared engine: yielded last, generator returns
+            // right after. Hold it back while a retry is still possible.
+            failure = chunk;
+            break;
+          }
+          if (chunk.type === "text") streamedText = true;
+          yield chunk;
+        }
+        if (!failure) return; // completed (or the consumer stopped us)
+        lastFailure = failure;
+        const retryable =
+          failure.recoverable !== false &&
+          !failure.terminal &&
+          !streamedText &&
+          !req.signal?.aborted;
+        // Not retryable — surface the error exactly as the single-attempt
+        // path always did: a policy violation, a /stop, or a failure AFTER
+        // visible text must not be re-run on another model (that would
+        // duplicate bubbles on screen, the very trade-off fallback.ts
+        // warns against re-litigating).
+        if (!retryable) {
+          yield failure;
+          return;
+        }
+        if (attempt < CODER_SWAP_MAX_ATTEMPTS) {
+          log.warn("pi.invoke coder-swap attempt failed — retrying", {
+            persona: req.persona,
+            conversation: req.conversation,
+            model: swapModel,
+            attempt,
+            of: CODER_SWAP_MAX_ATTEMPTS,
+            error: failure.error,
+          });
+        }
+      }
+      // All swapped attempts failed CLEANLY (nothing ever streamed), so the
+      // primary attempt starts from a blank screen — no duplicated text.
+      // (If the loop exited early because the user aborted, stop here too.)
+      if (req.signal?.aborted) return;
+      log.warn("pi.invoke coder-swap exhausted — falling back to primary", {
+        persona: req.persona,
+        conversation: req.conversation,
+        model: swapModel,
+        fallbackModel: primaryModel ?? "(pi default)",
+        error: lastFailure?.error,
+      });
+      yield* runAttempt(primaryModel);
+    }
 
     } finally {
       // Remove the temp payload/system-prompt files once the child has exited

--- a/src/lib/coderSwap.ts
+++ b/src/lib/coderSwap.ts
@@ -56,6 +56,14 @@ import { writeFileAtomic } from "./io.ts";
 export const CODER_SWAP_THRESHOLD = 3;
 
 /**
+ * How many times the Pi harness will attempt a turn on the SWAPPED coding
+ * model before giving up on the swap and re-running the turn on the primary
+ * (issue: intermittent provider hangs on the swapped model produced a silent
+ * 5-minute idle kill with the turn lost). Three attempts, then primary.
+ */
+export const CODER_SWAP_MAX_ATTEMPTS = 3;
+
+/**
  * Weight that, on its own, meets any reasonable threshold. Used for HARD
  * signals (an unambiguous PR/MR URL or "pull request"/"merge request" phrase)
  * so a single one trips the swap regardless of threshold tuning.
@@ -396,8 +404,12 @@ export interface ConversationTurn {
  * Decide which model the Pi harness should pin for this turn.
  *
  * Precedence: a manual `/coder`/`/nocoder` override always wins; otherwise the
- * scorer decides. With NO coding model configured there is nothing to swap to,
- * so we always return the primary (and never claim a swap).
+ * scorer decides. With NO coding model configured — or a coding model that is
+ * THE SAME as the primary — there is nothing to swap to, so the whole swap
+ * subsystem is skipped and we always return the primary (never claim a swap).
+ * The equal-models case is a deliberate skip, not a no-op swap: callers use
+ * `swapped` to gate the retry ladder and the override store, so a "swap" to the
+ * same model must not activate either.
  *
  * Two scoring paths:
  *   - `history` PROVIDED ⇒ context-window scoring (scoreCodingContext): the
@@ -425,8 +437,13 @@ export function resolveSwapModel(input: {
 }): SwapDecision {
   const { text, override, primaryModel, codingModel, history } = input;
 
-  if (!codingModel) {
-    return { model: primaryModel, swapped: false, reason: "no-coding-model", score: 0 };
+  if (!codingModel || codingModel === primaryModel) {
+    return {
+      model: primaryModel,
+      swapped: false,
+      reason: codingModel ? "coder-equals-primary" : "no-coding-model",
+      score: 0,
+    };
   }
   if (override === "off") {
     return { model: primaryModel, swapped: false, reason: "override:off", score: 0 };

--- a/src/lib/harnessRunner.ts
+++ b/src/lib/harnessRunner.ts
@@ -227,6 +227,18 @@ export function createKillCoordinator(
   };
 }
 
+/*
+ * Suffix marking the hard wall-clock cap error message, and the matcher for
+ * it. Exported so callers that act on error chunks (e.g. the pi coder-swap
+ * retry ladder) can recognise "the FINAL timer killed this run" without
+ * re-hardcoding the string in two places.
+ */
+export const HARD_CAP_ERROR_SUFFIX = "(hard wall-clock cap)";
+
+export function isHardCapError(error: string): boolean {
+  return error.endsWith(HARD_CAP_ERROR_SUFFIX);
+}
+
 /**
  * Render the standard "killed by X" HarnessChunk for a kill cause.
  * Returns undefined if the process exited naturally (no kill).
@@ -252,7 +264,7 @@ export function killCauseToErrorChunk(
   if (cause === "timeout") {
     return {
       type: "error",
-      error: `${harnessId} timed out after ${hardTimeoutMs ?? "unknown"}ms (hard wall-clock cap)`,
+      error: `${harnessId} timed out after ${hardTimeoutMs ?? "unknown"}ms ${HARD_CAP_ERROR_SUFFIX}`,
       recoverable: true,
     };
   }

--- a/tests/fixtures/fake-pi.sh
+++ b/tests/fixtures/fake-pi.sh
@@ -12,6 +12,10 @@
 #   error    — exit 1
 #   notfound — exit 127
 #   hang     — sleep forever (for the timeout test)
+#   toolthenfail — run one tool (tool_execution_start → progress chunk), then
+#              exit 1 like a provider death: an attempt that DID real,
+#              side-effecting work before dying. Drives the producedOutput
+#              ladder test (tools aren't idempotent → no retry).
 #   argv     — echo argv (joined) as a text_delta, exit 0 (arg-shape test)
 #   env      — echo the PHANTOMBOT_*_MODEL env vars + the PI provider/api-key
 #              as a text_delta, exit 0 (routing env-projection test)
@@ -84,6 +88,16 @@ case "$mode" in
     printf '%s\n' '{"type":"tool_execution_start","toolName":"bash","args":{}}'
     # Process exits 0 mid-task with no turn_end completion signal.
     exit 0
+    ;;
+  toolthenfail)
+    printf '%s\n' '{"type":"session","version":3,"id":"abc"}'
+    printf '%s\n' '{"type":"agent_start"}'
+    printf '%s\n' '{"type":"turn_start"}'
+    # One real tool run — surfaces as a PROGRESS chunk (not text) in the
+    # harness stream, exactly like a bash/notify/vault side effect.
+    printf '%s\n' '{"type":"tool_execution_start","toolName":"bash","args":{"command":"echo side-effect"}}'
+    printf '%s\n' '{"type":"tool_execution_end","toolName":"bash","result":{}}'
+    exit 1
     ;;
   error)
     echo "simulated pi error" >&2

--- a/tests/fixtures/fake-pi.sh
+++ b/tests/fixtures/fake-pi.sh
@@ -15,23 +15,21 @@
 #   argv     — echo argv (joined) as a text_delta, exit 0 (arg-shape test)
 #   env      — echo the PHANTOMBOT_*_MODEL env vars + the PI provider/api-key
 #              as a text_delta, exit 0 (routing env-projection test)
+#   modelgate — append each invocation's argv (one line) to $FAKE_PI_ARGV_LOG,
+#              then exit 1 when argv contains `--model $FAKE_PI_FAIL_MODEL`,
+#              else behave like `normal`. Lets a test make ONE configured
+#              model fail while the other succeeds — the coder-swap retry
+#              ladder / primary-fallback tests.
 
 mode="${FAKE_PI_MODE:-normal}"
 
-case "$mode" in
-  argv)
-    joined="$*"
-    printf '%s\n' "{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"argv: ${joined}\",\"partial\":{}},\"message\":{}}"
-    printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
-    exit 0
-    ;;
-  env)
-    joined="primary=${PHANTOMBOT_PRIMARY_MODEL-} image=${PHANTOMBOT_IMAGE_MODEL-} coding=${PHANTOMBOT_CODING_MODEL-} provider=${PHANTOMBOT_PI_PROVIDER-} apikey=${PHANTOMBOT_PI_API_KEY-}"
-    printf '%s\n' "{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"env: ${joined}\",\"partial\":{}},\"message\":{}}"
-    printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
-    exit 0
-    ;;
-  normal)
+# Record this invocation's argv (one line) when a test asks for it — used by
+# the coder-swap retry-ladder tests to COUNT attempts across modes.
+if [ -n "${FAKE_PI_ARGV_LOG-}" ]; then
+  printf '%s\n' "$*" >>"$FAKE_PI_ARGV_LOG"
+fi
+
+emit_normal() {
     printf '%s\n' '{"type":"session","version":3,"id":"abc"}'
     printf '%s\n' '{"type":"agent_start"}'
     printf '%s\n' '{"type":"turn_start"}'
@@ -48,6 +46,34 @@ case "$mode" in
     printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
     printf '%s\n' '{"type":"agent_end","messages":[]}'
     exit 0
+}
+
+
+case "$mode" in
+  argv)
+    joined="$*"
+    printf '%s\n' "{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"argv: ${joined}\",\"partial\":{}},\"message\":{}}"
+    printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
+    exit 0
+    ;;
+  env)
+    joined="primary=${PHANTOMBOT_PRIMARY_MODEL-} image=${PHANTOMBOT_IMAGE_MODEL-} coding=${PHANTOMBOT_CODING_MODEL-} provider=${PHANTOMBOT_PI_PROVIDER-} apikey=${PHANTOMBOT_PI_API_KEY-}"
+    printf '%s\n' "{\"type\":\"message_update\",\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"env: ${joined}\",\"partial\":{}},\"message\":{}}"
+    printf '%s\n' '{"type":"turn_end","message":{},"toolResults":[]}'
+    exit 0
+    ;;
+  normal)
+    emit_normal
+    ;;
+  modelgate)
+    for arg in "$@"; do
+      if [ "${FAKE_PI_FAIL_MODEL-}" = "*" ] ||
+         { [ -n "${FAKE_PI_FAIL_MODEL-}" ] && [ "$arg" = "$FAKE_PI_FAIL_MODEL" ]; }; then
+        echo "simulated failure for model $arg" >&2
+        exit 1
+      fi
+    done
+    emit_normal
     ;;
   nofinish)
     printf '%s\n' '{"type":"session","version":3,"id":"abc"}'

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -831,6 +831,71 @@ describe("PiHarness coder-swap retry ladder", () => {
     expect(error?.recoverable).toBe(true);
   });
 
+  test("no retry after a TOOL ran, even with zero text (tools aren't idempotent)", async () => {
+    // `toolthenfail` runs one tool (progress chunk, NOT text) and then dies
+    // exit-1 (recoverable). The old gate keyed on streamed TEXT only, so this
+    // read as "nothing happened yet" and re-ran the attempt — replaying
+    // side-effecting tools (bash, notify, vault) up to four times.
+    process.env.FAKE_PI_MODE = "toolthenfail";
+    const chunks = await collect(
+      new PiHarness({
+        bin: FAKE_PI,
+        routing: { primaryModel: "mimo-v2.5", codingModel: "z-ai/glm-5.2" },
+      }).invoke(newRequest({ userMessage: PR_MSG })),
+    );
+    // The tool run surfaced as a progress chunk before the error.
+    expect(chunks.some((c) => c.type === "progress")).toBe(true);
+    const error = chunks.find((c) => c.type === "error") as
+      | { type: "error"; error: string; recoverable?: boolean }
+      | undefined;
+    expect(error?.recoverable).toBe(true);
+    // Exactly ONE invocation — no retry on the coder model, no primary
+    // fallback. The tool's side effects must never be replayed.
+    expect(await loggedArgv()).toHaveLength(1);
+  });
+
+  test("terminal error (exit 127) → exactly one attempt, no ladder (locks the non-retryable rule)", async () => {
+    // notfound exits 127 → recoverable: false. A /stop, a missing binary, or
+    // a policy tripwire must never be re-run on a second brain — this test
+    // locks in the discipline the whole ladder rests on.
+    process.env.FAKE_PI_MODE = "notfound";
+    const chunks = await collect(
+      new PiHarness({
+        bin: FAKE_PI,
+        routing: { primaryModel: "mimo-v2.5", codingModel: "z-ai/glm-5.2" },
+      }).invoke(newRequest({ userMessage: PR_MSG })),
+    );
+    const error = chunks.find((c) => c.type === "error") as
+      | { type: "error"; error: string; recoverable?: boolean }
+      | undefined;
+    expect(error?.recoverable).toBe(false);
+    expect(await loggedArgv()).toHaveLength(1);
+  });
+
+  test("hard wall-clock cap kill is FINAL — no ladder, no primary fallback", async () => {
+    // `hang` with a hard cap far SHORTER than the idle window kills via the
+    // hard timer: "timed out after Nms (hard wall-clock cap)". The cap is the
+    // one timer that is supposed to be final — retrying it 3x would turn one
+    // 60-min cap into four hours. The error is still recoverable (the
+    // orchestrator's harness chain applies) but the ladder must not touch it.
+    process.env.FAKE_PI_MODE = "hang";
+    const chunks = await collect(
+      new PiHarness({
+        bin: FAKE_PI,
+        routing: { primaryModel: "mimo-v2.5", codingModel: "z-ai/glm-5.2" },
+      }).invoke(
+        newRequest({ userMessage: PR_MSG, idleTimeoutMs: 10_000, hardTimeoutMs: 300 }),
+      ),
+    );
+    const error = chunks.find((c) => c.type === "error") as
+      | { type: "error"; error: string; recoverable?: boolean }
+      | undefined;
+    expect(error?.error).toContain("hard wall-clock cap");
+    expect(error?.recoverable).toBe(true);
+    // Exactly ONE invocation — no retries, no primary fallback.
+    expect(await loggedArgv()).toHaveLength(1);
+  });
+
   test("successful swapped turn → single attempt, no ladder", async () => {
     process.env.FAKE_PI_MODE = "modelgate";
     const chunks = await collect(

--- a/tests/harnesses-pi.test.ts
+++ b/tests/harnesses-pi.test.ts
@@ -8,7 +8,9 @@
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve, join } from "node:path";
 import {
   PiHarness,
   parsePiEvent,
@@ -719,5 +721,130 @@ describe("PiHarness.available", () => {
 
   test("returns false for a non-existent absolute path", async () => {
     expect(await new PiHarness({ bin: "/no/such/pi" }).available()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coder-swap retry ladder. A swapped turn rides a different provider model
+// than the primary; when that model hangs or errors the turn used to be lost
+// (pi is usually the last harness in the chain — no fallback). Now: up to
+// CODER_SWAP_MAX_ATTEMPTS attempts on the coding model, then one attempt on
+// the primary. Uses fake-pi.sh's `modelgate` mode, which fails on
+// `--model $FAKE_PI_FAIL_MODEL` and behaves normally otherwise, logging every
+// invocation's argv to $FAKE_PI_ARGV_LOG so tests can count attempts.
+// ---------------------------------------------------------------------------
+
+describe("PiHarness coder-swap retry ladder", () => {
+  const PR_MSG = "review this pull request https://github.com/x/y/pull/1";
+  let logDir: string;
+  let argvLog: string;
+
+  beforeEach(async () => {
+    logDir = await mkdtemp(join(tmpdir(), "fake-pi-argv-"));
+    argvLog = join(logDir, "argv.log");
+    process.env.FAKE_PI_ARGV_LOG = argvLog;
+  });
+
+  afterEach(async () => {
+    delete process.env.FAKE_PI_ARGV_LOG;
+    delete process.env.FAKE_PI_FAIL_MODEL;
+    await rm(logDir, { recursive: true, force: true });
+  });
+
+  const loggedArgv = async (): Promise<string[]> => {
+    try {
+      return (await readFile(argvLog, "utf8")).trim().split("\n").filter(Boolean);
+    } catch {
+      return [];
+    }
+  };
+
+  test("swapped model fails 3x → falls back to the primary and answers", async () => {
+    process.env.FAKE_PI_MODE = "modelgate";
+    process.env.FAKE_PI_FAIL_MODEL = "z-ai/glm-5.2";
+    const chunks = await collect(
+      new PiHarness({
+        bin: FAKE_PI,
+        routing: { primaryModel: "mimo-v2.5", codingModel: "z-ai/glm-5.2" },
+      }).invoke(newRequest({ userMessage: PR_MSG })),
+    );
+    // The turn is ANSWERED — by the primary, after 3 coder attempts.
+    const done = chunks.find((c) => c.type === "done") as
+      | { type: "done"; finalText: string }
+      | undefined;
+    expect(done?.finalText).toBe("hello world");
+    expect(chunks.some((c) => c.type === "error")).toBe(false);
+    const argvs = await loggedArgv();
+    expect(argvs).toHaveLength(4);
+    expect(argvs.slice(0, 3).every((a) => a.includes("--model z-ai/glm-5.2"))).toBe(true);
+    expect(argvs[3]).toContain("--model mimo-v2.5");
+  });
+
+  test("primary fallback failing too → error surfaces (orchestrator chain applies)", async () => {
+    process.env.FAKE_PI_MODE = "modelgate";
+    process.env.FAKE_PI_FAIL_MODEL = "*"; // every model fails
+    const chunks = await collect(
+      new PiHarness({
+        bin: FAKE_PI,
+        routing: { primaryModel: "mimo-v2.5", codingModel: "z-ai/glm-5.2" },
+      }).invoke(newRequest({ userMessage: PR_MSG })),
+    );
+    const error = chunks.find((c) => c.type === "error") as
+      | { type: "error"; error: string; recoverable?: boolean }
+      | undefined;
+    expect(error?.recoverable).toBe(true);
+    // 3 coder attempts + 1 primary attempt, then the error is yielded.
+    expect(await loggedArgv()).toHaveLength(4);
+  });
+
+  test("coding model EQUAL to primary → swap subsystem skipped: single attempt, no ladder", async () => {
+    process.env.FAKE_PI_MODE = "modelgate";
+    process.env.FAKE_PI_FAIL_MODEL = "z-ai/glm-5.2"; // == primary → the only attempt fails
+    const chunks = await collect(
+      new PiHarness({
+        bin: FAKE_PI,
+        routing: { primaryModel: "z-ai/glm-5.2", codingModel: "z-ai/glm-5.2" },
+      }).invoke(newRequest({ userMessage: PR_MSG })),
+    );
+    // No retries, no primary re-run: exactly one invocation, error yielded.
+    expect(await loggedArgv()).toHaveLength(1);
+    expect(chunks.some((c) => c.type === "error")).toBe(true);
+  });
+
+  test("no retry after user-visible text streamed (no doubled reply)", async () => {
+    // `nofinish` streams narration text, then exits 0 WITHOUT turn_end — a
+    // recoverable error AFTER text. Retrying would duplicate the bubbles.
+    process.env.FAKE_PI_MODE = "nofinish";
+    const chunks = await collect(
+      new PiHarness({
+        bin: FAKE_PI,
+        routing: { primaryModel: "mimo-v2.5", codingModel: "z-ai/glm-5.2" },
+      }).invoke(newRequest({ userMessage: PR_MSG })),
+    );
+    expect(chunks.some((c) => c.type === "text")).toBe(true);
+    expect(chunks.some((c) => c.type === "error")).toBe(true);
+    // The swapped model was attempted exactly once — no retry, no fallback.
+    expect(await loggedArgv()).toHaveLength(1);
+    const error = chunks.find((c) => c.type === "error") as
+      | { type: "error"; recoverable?: boolean }
+      | undefined;
+    expect(error?.recoverable).toBe(true);
+  });
+
+  test("successful swapped turn → single attempt, no ladder", async () => {
+    process.env.FAKE_PI_MODE = "modelgate";
+    const chunks = await collect(
+      new PiHarness({
+        bin: FAKE_PI,
+        routing: { primaryModel: "mimo-v2.5", codingModel: "z-ai/glm-5.2" },
+      }).invoke(newRequest({ userMessage: PR_MSG })),
+    );
+    const done = chunks.find((c) => c.type === "done") as
+      | { type: "done"; finalText: string }
+      | undefined;
+    expect(done?.finalText).toBe("hello world");
+    const argvs = await loggedArgv();
+    expect(argvs).toHaveLength(1);
+    expect(argvs[0]).toContain("--model z-ai/glm-5.2");
   });
 });

--- a/tests/lib-coderSwap.test.ts
+++ b/tests/lib-coderSwap.test.ts
@@ -223,6 +223,33 @@ describe("resolveSwapModel", () => {
     });
     expect(d.swapped).toBe(false);
     expect(d.model).toBe(PRIMARY);
+    expect(d.reason).toBe("no-coding-model");
+  });
+
+  test("coding model EQUAL to primary → swap subsystem skipped entirely", () => {
+    // Swapping to the same model is not a swap: no scorer, no override, no
+    // retry ladder. Even a forced /coder override must not claim a swap.
+    const d = resolveSwapModel({
+      text: "refactor the whole codebase in src",
+      primaryModel: PRIMARY,
+      codingModel: PRIMARY,
+    });
+    expect(d.swapped).toBe(false);
+    expect(d.model).toBe(PRIMARY);
+    expect(d.reason).toBe("coder-equals-primary");
+    expect(d.score).toBe(0);
+  });
+
+  test("coding model EQUAL to primary → override:on is also a no-swap", () => {
+    const d = resolveSwapModel({
+      text: "hi there",
+      override: "on",
+      primaryModel: PRIMARY,
+      codingModel: PRIMARY,
+    });
+    expect(d.swapped).toBe(false);
+    expect(d.model).toBe(PRIMARY);
+    expect(d.reason).toBe("coder-equals-primary");
   });
 
   test("score trips → coding model", () => {


### PR DESCRIPTION
## Problem

A coder-swapped turn rides a **different provider model** than the primary — and an intermittent provider hang (the stream never starts, zero output for the whole idle window) used to cost the turn outright. pi is usually the **last** harness in the chain, so the idle kill had no fallback: the notification `🚨 pi timed out · no usable fallback configured [pi], turn undelivered` fired and the user's message was silently lost. Observed twice on kw-phantombot (2026-08-20 06:14 on kimi-k3, 2026-08-21 15:53 + 16:08 on the swapped coder model).

## Changes

### 1. No distinct coder → the swap subsystem is skipped completely

When `routing.codingModel` is unset **or the same model as `primaryModel`**, pi.invoke now skips the whole subsystem: no override-store read, no scorer, no `coder-swap active` log, no retry ladder. There is no distinct brain to swap to — the machinery was pure I/O and log noise, and a "swapped" turn on an equal model would have activated the retry ladder for nothing.

- `resolveSwapModel` gains the same guard (`reason: "coder-equals-primary"`, never claims a swap), so every caller — including a forced `/coder on` override — agrees.
- `/coder` now replies that the swap is inactive and how to configure it, instead of storing an override that can never take effect.

### 2. Retry ladder for brain swaps, then primary fallback

A swapped turn now gets up to **`CODER_SWAP_MAX_ATTEMPTS` (3) attempts on the coding model**; when those are exhausted, the turn is **re-run once on the primary**. A possibly-slower but known-good brain beats a lost turn.

Retry discipline — each rule exists for a reason:

- **Only when the failed attempt streamed nothing to the user.** Retrying after visible text would duplicate bubbles on screen — the streaming-first trade-off `fallback.ts` explicitly warns against re-litigating.
- **Only recoverable, non-terminal errors.** A policy violation or a user `/stop` is surfaced exactly as the single-attempt path always did — never re-run on another model.
- **The final primary attempt's errors flow on as normal harness errors**, so the orchestrator's chain/cooldown machinery still applies afterwards.

Note on interpretation: "three retries" is implemented as **three total attempts** on the swapped brain (then primary). If you'd rather have initial + 3, it's a one-constant change (`CODER_SWAP_MAX_ATTEMPTS`). Worst case with the defaults is ~3 × the idle window (~15 min) before the primary attempt starts.

## Implementation notes

- `pi.invoke` restructured: argv is assembled per attempt (`buildArgs(model)`) around the model-independent temp payload files; each attempt spawns a fresh subprocess with its own kill coordinator. No behavior change on the non-swapped path (single attempt, identical argv).
- `fake-pi.sh` gains a `modelgate` mode: fails when argv contains `--model $FAKE_PI_FAIL_MODEL` (or `*` = fail everything), else behaves like `normal`, and logs every invocation's argv to `$FAKE_PI_ARGV_LOG` so tests can count attempts. The `normal` output was factored into `emit_normal()` to avoid duplication.

## Tests

- 5 new subprocess tests (`PiHarness coder-swap retry ladder`): fail-3×-then-answer-on-primary (asserts 3 coder invocations + 1 primary, answered, no error), all-models-fail (4 attempts, recoverable error surfaces), coder==primary skip (exactly 1 attempt — no ladder), no-retry-after-streamed-text (`nofinish` mode: 1 attempt, error surfaced), happy swapped turn (1 attempt).
- 2 new `resolveSwapModel` unit tests: coder-equals-primary (score path + forced override path) → no swap, `reason: "coder-equals-primary"`.
- Full suite: **3324 pass**; the 2 failures are the documented pre-existing ambient `PHANTOMBOT_PI_API_KEY` isolation class in `tests/harnesses-pi.test.ts` (they reproduce on clean main; CI is green). `tsc --noEmit` clean.

## Out of scope

- Retries for **non-swapped** pi turns — the orchestrator's harness chain already owns that path; this PR only hardens the swap, which has no chain fallback.
- The ambient-env test-isolation bug class (tracked separately; same 2 failures on main).
