### PR TITLE
Cap the service logs on macOS and Windows (#428)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,36 @@ Leading `-` makes both optional (no error if either file is absent). The merged 
 
 Service units also set a deterministic `PATH` that includes `~/.local/bin` plus stable user harness shim locations such as `~/.local/share/pi-node/bin` and `~/.local/share/pi-node/current/bin`. Do not rely on interactive shell startup files for service harness discovery. When Phantombot finds a harness in PATH or common npm/pi-node versioned locations, it saves the absolute path in `state.json` and executes that path directly on later starts. `phantombot run` must never fail startup just because a harness binary is missing; log loudly, keep the headless service alive, and let `phantombot doctor` report/repair the configured chain. Windows keep-alive tasks invoke `phantombot run --if-not-running`, which treats an existing run lock as a silent success; foreground invocations retain the diagnostic error.
 
+**Service log retention (`src/lib/logRotate.ts`, #428).** Only macOS and Windows
+need it: on Linux the units log to journald, which owns retention, so
+`serviceLogDir()` returns `null` there and rotation is a no-op. Everywhere else
+phantombot writes plain files (`~/Library/Logs/phantombot/`,
+`<data>/phantombot/logs/`) that nothing ever capped — one macOS box reached
+~700 MB. The **heartbeat** rotates them (every 30 min), because it is already
+the host maintenance pass that heals units and scheduled tasks, so this needs no
+new timer and inherits the same platform dispatch. Defaults are 16 MiB per file
+and 3 retained generations (~64 MB per log worst case), overridable with
+`PHANTOMBOT_LOG_MAX_BYTES` and `PHANTOMBOT_LOG_KEEP`; a junk or negative value
+falls back to the default rather than disabling rotation, and `keep=0` discards
+existing generations instead of stranding them. Three invariants that look like
+tidy-up candidates and are not. **Rotation is COPY-TRUNCATE, never rename** —
+the live file is held open by a process we do not control (launchd, the Windows
+`cmd >>` wrapper) with an O_APPEND descriptor, and a descriptor follows the
+INODE, so renaming the live file leaves the writer appending to the renamed
+inode forever while the new log stays empty. **The live copy is staged to a
+temporary file in the same directory BEFORE any generation is pruned or
+shifted**, and published with a rename: the copy is the step that fails
+(Windows EBUSY/EACCES on a log held by its writer), and pruning first means a
+permanently unrotatable file ages its generations away on every heartbeat
+without ever writing a new snapshot — retained history destroyed by the thing
+meant to retain it. **The directory lock is ownership-aware**: takeover of a
+stale lock is serialised by a second exclusive `wx` create and re-validated
+under it, because every contender reads the same stale timestamp and a plain
+overwrite lets all of them decide they won; release is gated on the token the
+holder wrote, so a pass whose lock was stolen cannot delete its successor's.
+The whole thing is guarded on `isPhantombotBinary`, so a dev run or a stray test
+cannot truncate a developer's real logs.
+
 If you change a unit body (any `generate*` function in `src/lib/systemd.ts`), `ensureUnitCurrent` will detect the on-disk unit as stale on the next `phantombot voice` / `phantombot harness` / etc. run and rewrite it automatically. The previous body is preserved as `${unitPath}.bak` for rollback.
 
 ## Credentials

--- a/README.md
+++ b/README.md
@@ -420,6 +420,14 @@ phantombot logs       # tail its logs (Ctrl-C to stop)
 phantombot logs --no-follow --lines 200   # dump the last 200 lines and exit
 ```
 
+**Log rotation.** On Linux the units log to journald, which applies its own
+retention. On macOS and Windows phantombot writes plain files
+(`~/Library/Logs/phantombot/`, `<data>/phantombot/logs/`), so the heartbeat
+caps them every 30 minutes: any log over 16 MB is copied to `<name>.log.1` and
+truncated in place, keeping 3 generations (~64 MB per log, worst case).
+Override with `PHANTOMBOT_LOG_MAX_BYTES` and `PHANTOMBOT_LOG_KEEP`;
+`phantombot doctor` prints the directory's current size.
+
 | Verb | Linux (systemd) | macOS (launchd) | Windows (Task Scheduler) |
 |---|---|---|---|
 | `start` | `systemctl --user start` | `bootstrap` (or `kickstart`) | enable task + hidden detached launch |

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -41,7 +41,13 @@ import {
   routingExtensionStatus,
 } from "../lib/piExtensionProvision.ts";
 import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
-import { currentPlatform } from "../lib/platform.ts";
+import {
+  configuredKeep,
+  configuredMaxBytes,
+  inspectLogDir,
+  type LogDirStats,
+} from "../lib/logRotate.ts";
+import { currentPlatform, serviceLogDir } from "../lib/platform.ts";
 import {
   editorConnectorBroken,
   reconcileEditorConnectors,
@@ -126,6 +132,20 @@ export interface DoctorReport {
     newest_good?: string;
     /** Drawer files still on disk because retirement held them back. */
     unretired_drawers: string[];
+  };
+  /**
+   * File-based service logs (#428). Absent on Linux, where the units log to
+   * journald and phantombot owns no files to cap.
+   */
+  service_logs?: {
+    dir: string;
+    bytes: number;
+    /** Per-file cap rotation applies, in bytes. */
+    max_bytes: number;
+    /** Retained generations per log file. */
+    keep: number;
+    /** Live logs currently over the cap (rotated on the next heartbeat). */
+    over_cap: string[];
   };
   capture: {
     window_hours: number;
@@ -254,6 +274,12 @@ export interface RunDoctorInput {
   checkSystemd?:
     | false
     | ((staleTimers: string[]) => Promise<DoctorReport["systemd"] | undefined>);
+  /**
+   * Test seam for the service-log section (#428). `null` models a platform
+   * with no file logs (Linux/journald); a path models macOS/Windows. In
+   * production this is undefined and doctor resolves the real directory.
+   */
+  serviceLogDir?: string | null;
   /**
    * Test seam for the timer-fired marker check. Pass `false` to skip
    * (used by tests that don't care about staleness). Pass a function
@@ -477,6 +503,20 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     });
   }
 
+  // File-based service logs (#428). Null on Linux: journald owns retention
+  // there, so there is nothing for phantombot to measure or cap.
+  const logDir =
+    input.serviceLogDir !== undefined ? input.serviceLogDir : serviceLogDir();
+  let logStats: LogDirStats | undefined;
+  if (logDir) {
+    try {
+      logStats = await inspectLogDir(logDir);
+    } catch {
+      // An unreadable log directory is not a reason to fail `doctor`; the
+      // section is simply omitted.
+    }
+  }
+
   // Restore points for the database checked above (#417).
   const restorePoints = await listRestorePoints(config.memoryDbPath);
   // Only the newest point is integrity-checked in the common case: each check
@@ -510,6 +550,17 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
         ? { oldest_pending: health.oldest_pending }
         : {}),
     },
+    ...(logDir && logStats
+      ? {
+          service_logs: {
+            dir: logDir,
+            bytes: logStats.bytes,
+            max_bytes: configuredMaxBytes(),
+            keep: configuredKeep(),
+            over_cap: logStats.overCap,
+          },
+        }
+      : {}),
     memory_db: {
       path: config.memoryDbPath,
       healthy: dbHealth.ok,
@@ -658,6 +709,19 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     out.write(
       "  → no restore points yet; the next nightly sweep takes one " +
         "(or run `phantombot memory backup`)\n",
+    );
+  }
+  if (report.service_logs) {
+    const sl = report.service_logs;
+    out.write(
+      `  service logs: ${tick(sl.over_cap.length === 0)} — ` +
+        `${Math.round((sl.bytes / 1024 / 1024) * 10) / 10} MB in ${sl.dir} ` +
+        `(cap ${Math.round(sl.max_bytes / 1024 / 1024)} MB/file, ` +
+        `keep ${sl.keep})` +
+        (sl.over_cap.length > 0
+          ? ` — over cap: ${sl.over_cap.join(", ")}`
+          : "") +
+        "\n",
     );
   }
   if (unretiredDrawers.length > 0) {

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -25,6 +25,10 @@ import {
   type NightlyTriggerReason,
   spawnNightlySweep,
 } from "../lib/nightlyTrigger.ts";
+import {
+  rotateServiceLogs,
+  type RotateLogDirResult,
+} from "../lib/logRotate.ts";
 import { currentPlatform } from "../lib/platform.ts";
 import { openMemoryStore } from "../memory/store.ts";
 import { flushDueConversationTurns } from "../orchestrator/turnIndexer.ts";
@@ -83,6 +87,12 @@ export interface RunHeartbeatCliInput {
   triggerNightly?:
     | false
     | ((persona: string, reason: NightlyTriggerReason) => void);
+  /**
+   * Test seam for the service-log rotation pass. Pass `false` to skip it, or
+   * a function to substitute a fake. Production passes undefined → rotate the
+   * host's service log directory (null on Linux, where journald owns it).
+   */
+  rotateLogs?: false | (() => Promise<RotateLogDirResult | null>);
 }
 
 /** Outcome of the heartbeat's incremental note-embed pass. */
@@ -197,6 +207,39 @@ export async function runHeartbeatCli(
       }
     } catch (e) {
       log.warn("heartbeat: service self-heal threw unexpectedly", {
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Cap the service logs on the same cadence. launchd and the Windows task
+  // wrapper append to plain files forever — one macOS box reached ~700 MB
+  // before anyone noticed (#428). The heartbeat is already the host
+  // maintenance pass (it heals systemd units and scheduled tasks above), so
+  // rotation needs no new timer and inherits the same platform dispatch.
+  // Wrapped in try/catch: a rotation hiccup must never break the primary
+  // heartbeat work.
+  if (input.rotateLogs !== false) {
+    try {
+      const r = input.rotateLogs
+        ? await input.rotateLogs()
+        : await rotateServiceLogs();
+      if (r && r.rotated.length > 0) {
+        log.info("heartbeat: rotated service logs", {
+          dir: r.dir,
+          rotated: r.rotated.map((f) => `${f.file}: ${f.bytes}`),
+        });
+      }
+      // A log that is over the cap and could NOT be rotated is the case this
+      // whole pass exists to prevent, so it warns rather than staying silent.
+      if (r && r.skipped.length > 0) {
+        log.warn("heartbeat: service logs could not be rotated", {
+          dir: r.dir,
+          skipped: r.skipped.map((f) => `${f.file}: ${f.reason}`),
+        });
+      }
+    } catch (e) {
+      log.warn("heartbeat: log rotation threw unexpectedly", {
         error: (e as Error).message,
       });
     }

--- a/src/lib/launchd.ts
+++ b/src/lib/launchd.ts
@@ -14,7 +14,9 @@
  *   ~/Library/LaunchAgents/dev.phantombot.tick.plist
  *
  * Logs go to ~/Library/Logs/phantombot/<unit>.{out,err}.log (no journald
- * on Mac, and `log show` is a poor fit for free-form bot output).
+ * on Mac, and `log show` is a poor fit for free-form bot output). launchd
+ * appends to them forever with no size cap, so the heartbeat rotates them
+ * itself — see src/lib/logRotate.ts.
  *
  * Note on env files: launchd's `EnvironmentVariables` plist key only
  * accepts inline static values — it has no equivalent of systemd's
@@ -46,8 +48,16 @@ function launchAgentsDir(): string {
   return join(homedir(), "Library", "LaunchAgents");
 }
 
-function logsDir(): string {
+/**
+ * Directory launchd writes every unit's stdout/stderr into. Exported so the
+ * log-rotation pass (#428) can cap the files launchd itself never rotates.
+ */
+export function launchdLogsDir(): string {
   return join(homedir(), "Library", "Logs", "phantombot");
+}
+
+function logsDir(): string {
+  return launchdLogsDir();
 }
 
 export function defaultPlistPath(): string {

--- a/src/lib/logRotate.ts
+++ b/src/lib/logRotate.ts
@@ -1,0 +1,313 @@
+/**
+ * Size-capped rotation for phantombot's file-based service logs (#428).
+ *
+ * Only two platforms need this. On Linux the systemd --user units log to
+ * journald, which rotates on its own; on macOS launchd appends forever to the
+ * `StandardOutPath`/`StandardErrorPath` files baked into the plist, and on
+ * Windows each scheduled task appends with `cmd >>`. Neither caps anything, so
+ * a long-lived box grows a single log file without limit — one macOS host
+ * reached ~700 MB before it was truncated by hand.
+ *
+ * COPY-TRUNCATE, NEVER RENAME — this is the whole design, and getting it
+ * wrong is worse than shipping nothing. The live file is held open by a
+ * process we do not control (launchd, or the always-on `cmd` wrapper) with an
+ * O_APPEND descriptor. A descriptor follows the INODE, not the path: rename
+ * the live file to `.1` and the writer keeps appending to the renamed inode
+ * forever, so the freshly-created `<name>.log` stays empty and every log line
+ * after the first rotation silently lands in a file nobody tails. Copying the
+ * bytes out and then truncating the original in place keeps the writer's
+ * descriptor pointed at the same inode, and O_APPEND recomputes the offset per
+ * write, so the file refills from 0 rather than leaving a sparse hole.
+ *
+ * The known cost of copy-truncate (logrotate's `copytruncate` has the same
+ * one): lines written between the copy and the truncate are lost. That window
+ * is a few milliseconds against a 30-minute cadence, and the alternative is
+ * losing every line indefinitely — see above.
+ *
+ * Rotated generations (`<name>.log.1` … `.log.N`) are NOT held open by
+ * anyone, so those are shifted with plain renames.
+ */
+
+import { existsSync } from "node:fs";
+import {
+  copyFile,
+  readdir,
+  readFile,
+  rename,
+  stat,
+  truncate,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { isPhantombotBinary } from "./binaryIdentity.ts";
+import { serviceLogDir } from "./platform.ts";
+
+/** Per-file size above which a log is rotated. */
+export const DEFAULT_MAX_BYTES = 16 * 1024 * 1024;
+/** How many rotated generations to retain per log file. */
+export const DEFAULT_KEEP = 3;
+/** A lock older than this is treated as abandoned by a crashed rotation. */
+export const LOCK_STALE_MS = 5 * 60_000;
+
+const LOCK_FILE = ".rotate.lock";
+
+export interface RotateLogDirInput {
+  /** Directory of `*.log` files to rotate. */
+  dir: string;
+  /** Rotate a file once it exceeds this many bytes. Default 16 MiB. */
+  maxBytes?: number;
+  /** Retained generations per file; 0 discards instead of keeping. Default 3. */
+  keep?: number;
+  /** Injectable clock, for lock staleness. Default `new Date()`. */
+  now?: Date;
+}
+
+export interface RotatedLog {
+  /** Base name of the rotated log. */
+  file: string;
+  /** Size in bytes at the moment it was rotated. */
+  bytes: number;
+}
+
+export interface SkippedLog {
+  file: string;
+  /** Error code (`EBUSY`, `EACCES`, …) or message. */
+  reason: string;
+}
+
+export interface RotateLogDirResult {
+  dir: string;
+  rotated: RotatedLog[];
+  /** Files that were over the cap but could not be rotated. */
+  skipped: SkippedLog[];
+  /** True when another rotation holds the directory lock; nothing was done. */
+  lockedOut: boolean;
+}
+
+/**
+ * Read the numeric override from `name`, ignoring anything that isn't a
+ * finite, non-negative number. A typo'd env var must never disable rotation
+ * or set a nonsense cap — it falls back to the default instead.
+ */
+function numericEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return Math.floor(n);
+}
+
+/** Configured per-file cap (`PHANTOMBOT_LOG_MAX_BYTES`, else 16 MiB). */
+export function configuredMaxBytes(): number {
+  const n = numericEnv("PHANTOMBOT_LOG_MAX_BYTES", DEFAULT_MAX_BYTES);
+  // 0 would mean "rotate on every pass", which is a footgun, not a setting.
+  return n > 0 ? n : DEFAULT_MAX_BYTES;
+}
+
+/** Configured retained generations (`PHANTOMBOT_LOG_KEEP`, else 3). */
+export function configuredKeep(): number {
+  return numericEnv("PHANTOMBOT_LOG_KEEP", DEFAULT_KEEP);
+}
+
+/**
+ * Take the directory lock. Two personas' heartbeats can fire at the same
+ * second and both target the same shared log directory; without this they can
+ * interleave the generation shift and lose (or duplicate) a generation.
+ * Returns false when a FRESH lock is already held — a stale one is stolen, so
+ * a crashed rotation cannot wedge rotation forever.
+ */
+async function acquireLock(dir: string, now: Date): Promise<boolean> {
+  const path = join(dir, LOCK_FILE);
+  try {
+    await writeFile(path, `${process.pid} ${now.toISOString()}\n`, {
+      flag: "wx",
+    });
+    return true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+  }
+  let heldAt: number | undefined;
+  try {
+    const body = await readFile(path, "utf8");
+    const iso = body.trim().split(/\s+/)[1];
+    const t = iso ? Date.parse(iso) : Number.NaN;
+    if (Number.isFinite(t)) heldAt = t;
+  } catch {
+    // Unreadable lock — fall through and treat it as stale.
+  }
+  if (heldAt !== undefined && now.getTime() - heldAt < LOCK_STALE_MS) {
+    return false;
+  }
+  await writeFile(path, `${process.pid} ${now.toISOString()}\n`);
+  return true;
+}
+
+async function releaseLock(dir: string): Promise<void> {
+  try {
+    await unlink(join(dir, LOCK_FILE));
+  } catch {
+    // Already gone (stolen as stale by another pass) — nothing to release.
+  }
+}
+
+/**
+ * Absolute paths of `<path>.<n>` generations with `n >= min`, newest first.
+ */
+async function generationsAtLeast(
+  path: string,
+  min: number,
+): Promise<string[]> {
+  const dir = dirname(path);
+  const prefix = `${basename(path)}.`;
+  const hits: string[] = [];
+  for (const name of await readdir(dir)) {
+    if (!name.startsWith(prefix)) continue;
+    const n = Number(name.slice(prefix.length));
+    if (Number.isInteger(n) && n >= min) hits.push(join(dir, name));
+  }
+  return hits;
+}
+
+/**
+ * Shift `<path>.1 … .N` up by one, dropping the oldest, then copy the live
+ * file into `.1` and truncate it in place.
+ */
+async function rotateOne(path: string, keep: number): Promise<void> {
+  if (keep > 0) {
+    // Prune every generation at or beyond `keep` before shifting. `.${keep}`
+    // alone would be handled by the rename below overwriting it, but a keep
+    // that was LOWERED (or a leftover from an older install) strands `.4`,
+    // `.5`, … on disk forever — files nothing rotates and nothing ever
+    // deletes, which is the same unbounded growth one directory deeper. Scan
+    // rather than counting up from `keep`, so a GAP in the sequence cannot
+    // hide everything above it.
+    for (const dead of await generationsAtLeast(path, keep)) {
+      await unlink(dead);
+    }
+    for (let i = keep - 1; i >= 1; i--) {
+      const from = `${path}.${i}`;
+      if (existsSync(from)) await rename(from, `${path}.${i + 1}`);
+    }
+    // Copy BEFORE truncating: if the copy fails we throw with the live file
+    // still intact, which is the direction we want to fail in.
+    await copyFile(path, `${path}.1`);
+  }
+  await truncate(path, 0);
+}
+
+/**
+ * Rotate every `*.log` in `dir` that exceeds the size cap. Already-rotated
+ * generations (`*.log.1`) are not candidates — the `.log` suffix test excludes
+ * them, so a generation is never rotated twice.
+ *
+ * Never throws for a single unrotatable file: on Windows the live log can be
+ * locked by the writing `cmd`, which surfaces as EBUSY/EPERM. That file is
+ * reported in `skipped` and the pass continues.
+ */
+export async function rotateLogDir(
+  input: RotateLogDirInput,
+): Promise<RotateLogDirResult> {
+  const { dir } = input;
+  const maxBytes = input.maxBytes ?? configuredMaxBytes();
+  const keep = input.keep ?? configuredKeep();
+  const now = input.now ?? new Date();
+  const result: RotateLogDirResult = {
+    dir,
+    rotated: [],
+    skipped: [],
+    lockedOut: false,
+  };
+  if (!existsSync(dir)) return result;
+
+  if (!(await acquireLock(dir, now))) {
+    result.lockedOut = true;
+    return result;
+  }
+  try {
+    const names = (await readdir(dir)).filter((n) => n.endsWith(".log"));
+    for (const name of names.sort()) {
+      const path = join(dir, name);
+      try {
+        const s = await stat(path);
+        if (!s.isFile() || s.size <= maxBytes) continue;
+        await rotateOne(path, keep);
+        result.rotated.push({ file: name, bytes: s.size });
+      } catch (e) {
+        const err = e as NodeJS.ErrnoException;
+        result.skipped.push({ file: name, reason: err.code ?? err.message });
+      }
+    }
+  } finally {
+    await releaseLock(dir);
+  }
+  return result;
+}
+
+/** Read-only view of a log directory, for `doctor`. */
+export interface LogDirStats {
+  /** Total bytes of every `*.log*` file (live and rotated) under `dir`. */
+  bytes: number;
+  /** Live logs already over the cap; the next pass rotates these. */
+  overCap: string[];
+}
+
+/**
+ * Size up a log directory without touching it. Takes no lock and renames
+ * nothing, so it is safe to call while a rotation is in flight — a file that
+ * vanishes mid-scan simply contributes nothing.
+ */
+export async function inspectLogDir(
+  dir: string,
+  maxBytes = configuredMaxBytes(),
+): Promise<LogDirStats> {
+  const stats: LogDirStats = { bytes: 0, overCap: [] };
+  if (!existsSync(dir)) return stats;
+  for (const name of (await readdir(dir)).sort()) {
+    if (!name.includes(".log")) continue;
+    try {
+      const s = await stat(join(dir, name));
+      if (!s.isFile()) continue;
+      stats.bytes += s.size;
+      // Only LIVE logs are rotation candidates; a `.log.1` generation is
+      // already rotated and is never a candidate again.
+      if (name.endsWith(".log") && s.size > maxBytes) stats.overCap.push(name);
+    } catch {
+      // Raced with a rotation — a missing file contributes nothing.
+    }
+  }
+  return stats;
+}
+
+/** Input for {@link rotateServiceLogs}; both fields exist to be injected. */
+export interface RotateServiceLogsInput {
+  /**
+   * Log directory to cap. Defaults to the host's service log directory, and
+   * `null` means "this platform has none" (Linux → journald).
+   */
+  dir?: string | null;
+  /**
+   * Whether we are the INSTALLED binary. Defaults to a real check of
+   * `process.execPath`.
+   */
+  installed?: boolean;
+}
+
+/**
+ * Rotate the host's service logs, or return null when there is nothing to do.
+ *
+ * Guarded on binary identity for the same reason the service self-heal is: a
+ * dev `bun src/index.ts` run (or a test that reaches production code by
+ * accident) shares the developer's real `~/Library/Logs/phantombot`, and
+ * truncating a developer's logs from a unit test is not an acceptable
+ * side effect of running the suite.
+ */
+export async function rotateServiceLogs(
+  input: RotateServiceLogsInput = {},
+): Promise<RotateLogDirResult | null> {
+  const installed = input.installed ?? isPhantombotBinary(process.execPath);
+  if (!installed) return null;
+  const dir = input.dir !== undefined ? input.dir : serviceLogDir();
+  if (!dir) return null;
+  return rotateLogDir({ dir });
+}

--- a/src/lib/logRotate.ts
+++ b/src/lib/logRotate.ts
@@ -233,10 +233,15 @@ export interface ReleaseLockOptions {
  * alike — happens while holding it, which makes the check and the unlink
  * atomic with respect to each other.
  *
- * If the steal lock cannot be taken, a takeover is in flight right now. It
- * will replace our lock itself, so we simply return: not deleting is always
- * safe (a leftover lock is stale within {@link LOCK_STALE_MS} and stealable),
- * whereas deleting under a racing takeover is the bug this guards.
+ * If the steal lock cannot be taken, a takeover is in flight right now (or a
+ * pass crashed mid-steal). Either way we return WITHOUT deleting: not deleting
+ * is always safe (a leftover lock is stale within {@link LOCK_STALE_MS} and
+ * stealable by the next pass), whereas deleting under a racing takeover is the
+ * bug this guards. A steal lock that is itself stale is cleared on the way out
+ * so it cannot wedge later passes — but, exactly as in {@link acquireLock},
+ * clearing and then taking it in the same pass would reintroduce the race: the
+ * original steal holder may be paused just before its own mutation of the real
+ * lock, and would install its successor into the window we just opened.
  *
  * Exported (with {@link acquireLock}) so the lock protocol itself can be
  * driven directly from tests; nothing outside this module calls it.
@@ -250,17 +255,17 @@ export async function releaseLock(
   const path = join(dir, LOCK_FILE);
   const stealPath = join(dir, STEAL_FILE);
 
-  let held = await createLock(stealPath, now);
+  const held = await createLock(stealPath, now);
   if (!held) {
-    // A steal lock left behind by a crashed pass must not wedge releases
-    // forever; clear it once it is itself stale, then try again.
+    // A steal lock left behind by a crashed pass must not wedge later passes,
+    // so clear it once it is itself stale — but do NOT take it here. Leaving
+    // our own lock in place is safe; it goes stale and the next pass steals it.
     const stealHolder = await readLock(stealPath);
     if (stealHolder && isStale(stealHolder, now)) {
       await rm(stealPath, { force: true });
-      held = await createLock(stealPath, now);
     }
+    return;
   }
-  if (!held) return;
 
   try {
     const holder = await readLock(path);

--- a/src/lib/logRotate.ts
+++ b/src/lib/logRotate.ts
@@ -34,11 +34,13 @@ import {
   readdir,
   readFile,
   rename,
+  rm,
   stat,
   truncate,
   unlink,
   writeFile,
 } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { basename, dirname, join } from "node:path";
 import { isPhantombotBinary } from "./binaryIdentity.ts";
 import { serviceLogDir } from "./platform.ts";
@@ -51,6 +53,12 @@ export const DEFAULT_KEEP = 3;
 export const LOCK_STALE_MS = 5 * 60_000;
 
 const LOCK_FILE = ".rotate.lock";
+/**
+ * Second lock, taken ONLY to serialise the takeover of a stale {@link
+ * LOCK_FILE}. Every mutation of the real lock happens while holding this, so
+ * "is it still stale?" can be re-checked without a race.
+ */
+const STEAL_FILE = ".rotate.lock.steal";
 
 export interface RotateLogDirInput {
   /** Directory of `*.log` files to rotate. */
@@ -110,44 +118,110 @@ export function configuredKeep(): number {
   return numericEnv("PHANTOMBOT_LOG_KEEP", DEFAULT_KEEP);
 }
 
+/** Contents of a held lock: owner pid, when it was taken, and its token. */
+interface LockHolder {
+  heldAt?: number;
+  token?: string;
+}
+
+async function readLock(path: string): Promise<LockHolder | null> {
+  let body: string;
+  try {
+    body = await readFile(path, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return null;
+    // Unreadable but present — treat it as a holder with no timestamp, which
+    // makes it stale (and therefore stealable) rather than permanent.
+    return {};
+  }
+  const [, iso, token] = body.trim().split(/\s+/);
+  const t = iso ? Date.parse(iso) : Number.NaN;
+  return { heldAt: Number.isFinite(t) ? t : undefined, token };
+}
+
+function isStale(holder: LockHolder, now: Date): boolean {
+  if (holder.heldAt === undefined) return true;
+  return now.getTime() - holder.heldAt >= LOCK_STALE_MS;
+}
+
+/** Create the lock exclusively. Returns our token, or null if it exists. */
+async function createLock(path: string, now: Date): Promise<string | null> {
+  const token = randomUUID();
+  try {
+    await writeFile(path, `${process.pid} ${now.toISOString()} ${token}\n`, {
+      flag: "wx",
+    });
+    return token;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+    return null;
+  }
+}
+
 /**
  * Take the directory lock. Two personas' heartbeats can fire at the same
  * second and both target the same shared log directory; without this they can
  * interleave the generation shift and lose (or duplicate) a generation.
- * Returns false when a FRESH lock is already held — a stale one is stolen, so
- * a crashed rotation cannot wedge rotation forever.
+ * Returns the owner token, or null when a FRESH lock is already held.
+ *
+ * Takeover of a STALE lock (left by a crashed pass, so rotation cannot wedge
+ * forever) is the delicate part: a plain overwrite lets every contender that
+ * read the same stale timestamp decide it won. So the steal is serialised by a
+ * SECOND exclusive create — `wx` is atomic on every supported platform — and
+ * the winner re-reads the lock while holding it. A contender that was looking
+ * at a now-superseded stale lock therefore sees the successor's FRESH lock and
+ * backs out instead of clobbering it. Exactly one contender enters.
  */
-async function acquireLock(dir: string, now: Date): Promise<boolean> {
+export async function acquireLock(dir: string, now: Date): Promise<string | null> {
   const path = join(dir, LOCK_FILE);
+  const stealPath = join(dir, STEAL_FILE);
+
+  const direct = await createLock(path, now);
+  if (direct) return direct;
+
+  const holder = await readLock(path);
+  // Vanished between the create and the read — one more uncontended attempt.
+  if (!holder) return await createLock(path, now);
+  if (!isStale(holder, now)) return null;
+
+  // Serialise the steal. Only the winner of this create may touch the lock.
+  if (!(await createLock(stealPath, now))) {
+    // Someone else is stealing right now, or crashed mid-steal. A steal lock
+    // that is itself stale is cleared here so the NEXT pass can proceed;
+    // clearing and stealing in one pass would reintroduce the race.
+    const stealHolder = await readLock(stealPath);
+    if (stealHolder && isStale(stealHolder, now)) {
+      await rm(stealPath, { force: true });
+    }
+    return null;
+  }
   try {
-    await writeFile(path, `${process.pid} ${now.toISOString()}\n`, {
-      flag: "wx",
-    });
-    return true;
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+    // Re-check under the steal lock: this is the read that cannot be raced.
+    const current = await readLock(path);
+    if (current && !isStale(current, now)) return null;
+    await rm(path, { force: true });
+    return await createLock(path, now);
+  } finally {
+    await rm(stealPath, { force: true });
   }
-  let heldAt: number | undefined;
-  try {
-    const body = await readFile(path, "utf8");
-    const iso = body.trim().split(/\s+/)[1];
-    const t = iso ? Date.parse(iso) : Number.NaN;
-    if (Number.isFinite(t)) heldAt = t;
-  } catch {
-    // Unreadable lock — fall through and treat it as stale.
-  }
-  if (heldAt !== undefined && now.getTime() - heldAt < LOCK_STALE_MS) {
-    return false;
-  }
-  await writeFile(path, `${process.pid} ${now.toISOString()}\n`);
-  return true;
 }
 
-async function releaseLock(dir: string): Promise<void> {
+/**
+ * Release a lock we own. Ownership is checked against the token we wrote: a
+ * pass whose lock was stolen as stale must not delete the successor's lock and
+ * hand a third pass the directory mid-rotation.
+ *
+ * Exported (with {@link acquireLock}) so the lock protocol itself can be
+ * driven directly from tests; nothing outside this module calls it.
+ */
+export async function releaseLock(dir: string, token: string): Promise<void> {
+  const path = join(dir, LOCK_FILE);
+  const holder = await readLock(path);
+  if (!holder || holder.token !== token) return;
   try {
-    await unlink(join(dir, LOCK_FILE));
+    await unlink(path);
   } catch {
-    // Already gone (stolen as stale by another pass) — nothing to release.
+    // Already gone — nothing to release.
   }
 }
 
@@ -170,28 +244,52 @@ async function generationsAtLeast(
 }
 
 /**
- * Shift `<path>.1 … .N` up by one, dropping the oldest, then copy the live
- * file into `.1` and truncate it in place.
+ * Snapshot the live file into `.1` and truncate it in place, shifting the
+ * existing generations up by one and dropping anything beyond `keep`.
+ *
+ * ORDER MATTERS. The copy is the step most likely to fail (on Windows the live
+ * log can be held by the writing `cmd`, which surfaces as EBUSY/EACCES), and
+ * pruning/shifting first would mean a file that never manages to copy loses a
+ * generation on every heartbeat until all retained history is gone — without
+ * ever producing a new snapshot. So the copy goes to a temporary file in the
+ * same directory FIRST; only once those bytes are safely on disk are the
+ * existing generations touched, and the snapshot is published with a rename.
+ * Every failure path removes the temporary and leaves the live file and all
+ * generations exactly as they were.
+ *
+ * `keep === 0` means "discard", not "keep what is already there": every
+ * numbered generation is pruned and no new snapshot is taken.
  */
 async function rotateOne(path: string, keep: number): Promise<void> {
   if (keep > 0) {
-    // Prune every generation at or beyond `keep` before shifting. `.${keep}`
-    // alone would be handled by the rename below overwriting it, but a keep
-    // that was LOWERED (or a leftover from an older install) strands `.4`,
-    // `.5`, … on disk forever — files nothing rotates and nothing ever
-    // deletes, which is the same unbounded growth one directory deeper. Scan
-    // rather than counting up from `keep`, so a GAP in the sequence cannot
-    // hide everything above it.
-    for (const dead of await generationsAtLeast(path, keep)) {
+    // Not `*.log`, and not a numeric generation, so neither the rotation scan
+    // nor the prune scan can ever mistake it for a log.
+    const tmp = `${path}.rotating-${randomUUID()}`;
+    try {
+      await copyFile(path, tmp);
+      // Prune every generation at or beyond `keep` before shifting. `.${keep}`
+      // alone would be handled by the rename below overwriting it, but a keep
+      // that was LOWERED (or a leftover from an older install) strands `.4`,
+      // `.5`, … on disk forever — files nothing rotates and nothing ever
+      // deletes, which is the same unbounded growth one directory deeper. Scan
+      // rather than counting up from `keep`, so a GAP in the sequence cannot
+      // hide everything above it.
+      for (const dead of await generationsAtLeast(path, keep)) {
+        await unlink(dead);
+      }
+      for (let i = keep - 1; i >= 1; i--) {
+        const from = `${path}.${i}`;
+        if (existsSync(from)) await rename(from, `${path}.${i + 1}`);
+      }
+      await rename(tmp, `${path}.1`);
+    } catch (e) {
+      await rm(tmp, { force: true });
+      throw e;
+    }
+  } else {
+    for (const dead of await generationsAtLeast(path, 1)) {
       await unlink(dead);
     }
-    for (let i = keep - 1; i >= 1; i--) {
-      const from = `${path}.${i}`;
-      if (existsSync(from)) await rename(from, `${path}.${i + 1}`);
-    }
-    // Copy BEFORE truncating: if the copy fails we throw with the live file
-    // still intact, which is the direction we want to fail in.
-    await copyFile(path, `${path}.1`);
   }
   await truncate(path, 0);
 }
@@ -220,7 +318,8 @@ export async function rotateLogDir(
   };
   if (!existsSync(dir)) return result;
 
-  if (!(await acquireLock(dir, now))) {
+  const token = await acquireLock(dir, now);
+  if (!token) {
     result.lockedOut = true;
     return result;
   }
@@ -239,7 +338,7 @@ export async function rotateLogDir(
       }
     }
   } finally {
-    await releaseLock(dir);
+    await releaseLock(dir, token);
   }
   return result;
 }

--- a/src/lib/logRotate.ts
+++ b/src/lib/logRotate.ts
@@ -206,22 +206,73 @@ export async function acquireLock(dir: string, now: Date): Promise<string | null
   }
 }
 
+/** Options for {@link releaseLock}. */
+export interface ReleaseLockOptions {
+  /** Injectable clock, for staleness of the steal lock. Default `new Date()`. */
+  now?: Date;
+  /**
+   * Test hook, awaited between the ownership read and the unlink, i.e. exactly
+   * at the interleave a check-then-unlink release would lose. Not used in
+   * production.
+   */
+  afterOwnershipRead?: () => Promise<void>;
+}
+
 /**
  * Release a lock we own. Ownership is checked against the token we wrote: a
  * pass whose lock was stolen as stale must not delete the successor's lock and
  * hand a third pass the directory mid-rotation.
  *
+ * The token check alone is not enough, because reading the token and deleting
+ * the file are two syscalls. A pass that overran {@link LOCK_STALE_MS} still
+ * holds a lock any contender may steal, so the steal can land BETWEEN our read
+ * (which still returns our own token) and our unlink (which would then remove
+ * the successor's fresh lock, letting a third pass in mid-rotation). So the
+ * release runs under the same {@link STEAL_FILE} lock that serialises takeover
+ * in {@link acquireLock}: every mutation of the real lock — steal and release
+ * alike — happens while holding it, which makes the check and the unlink
+ * atomic with respect to each other.
+ *
+ * If the steal lock cannot be taken, a takeover is in flight right now. It
+ * will replace our lock itself, so we simply return: not deleting is always
+ * safe (a leftover lock is stale within {@link LOCK_STALE_MS} and stealable),
+ * whereas deleting under a racing takeover is the bug this guards.
+ *
  * Exported (with {@link acquireLock}) so the lock protocol itself can be
  * driven directly from tests; nothing outside this module calls it.
  */
-export async function releaseLock(dir: string, token: string): Promise<void> {
+export async function releaseLock(
+  dir: string,
+  token: string,
+  options: ReleaseLockOptions = {},
+): Promise<void> {
+  const now = options.now ?? new Date();
   const path = join(dir, LOCK_FILE);
-  const holder = await readLock(path);
-  if (!holder || holder.token !== token) return;
+  const stealPath = join(dir, STEAL_FILE);
+
+  let held = await createLock(stealPath, now);
+  if (!held) {
+    // A steal lock left behind by a crashed pass must not wedge releases
+    // forever; clear it once it is itself stale, then try again.
+    const stealHolder = await readLock(stealPath);
+    if (stealHolder && isStale(stealHolder, now)) {
+      await rm(stealPath, { force: true });
+      held = await createLock(stealPath, now);
+    }
+  }
+  if (!held) return;
+
   try {
-    await unlink(path);
-  } catch {
-    // Already gone — nothing to release.
+    const holder = await readLock(path);
+    if (options.afterOwnershipRead) await options.afterOwnershipRead();
+    if (!holder || holder.token !== token) return;
+    try {
+      await unlink(path);
+    } catch {
+      // Already gone — nothing to release.
+    }
+  } finally {
+    await rm(stealPath, { force: true });
   }
 }
 

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -29,6 +29,7 @@
 import {
   defaultLaunchdServiceControl,
   launchdLogPaths,
+  launchdLogsDir,
 } from "./launchd.ts";
 import {
   defaultSystemdServiceControl,
@@ -39,6 +40,7 @@ import {
   defaultTaskSchedulerServiceControl,
   scheduleWindowsRelaunch,
   taskLogPaths,
+  taskLogsDir,
   taskNames,
 } from "./taskScheduler.ts";
 
@@ -265,6 +267,26 @@ export function logsCommand(): string {
     case "linux":
     default:
       return "journalctl --user -u phantombot -f";
+  }
+}
+
+/**
+ * Directory of file-based service logs phantombot itself must keep bounded,
+ * or null when the platform's service manager already does it.
+ *
+ * Linux returns null ON PURPOSE: the systemd --user units log to journald,
+ * which applies its own retention. Rotating there would mean rotating files
+ * nothing writes to. macOS and Windows both append to plain files with no cap
+ * (#428), so those are the two that need the pass.
+ */
+export function serviceLogDir(over?: HintOverrides): string | null {
+  switch (over?.platform ?? currentPlatform()) {
+    case "darwin":
+      return launchdLogsDir();
+    case "windows":
+      return taskLogsDir();
+    default:
+      return null;
   }
 }
 

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -43,8 +43,9 @@
  * process's stdout/stderr, so the action is run through `cmd /c` with the
  * streams redirected (append) to per-task .out.log / .err.log under the
  * phantombot data dir's logs\ folder - the same out/err split launchd writes
- * to ~/Library/Logs. Log ROTATION is not yet handled here (documented
- * limitation; WinSW is the upgrade path for rotation + richer supervision).
+ * to ~/Library/Logs. Task Scheduler does not rotate them either, so the
+ * heartbeat caps these files itself every 30 min (see src/lib/logRotate.ts);
+ * WinSW remains the upgrade path for richer supervision.
  *
  * No console flash: a task whose Command is cmd.exe pops a visible console
  * window every time it fires - intolerable for the tick task that runs every
@@ -277,8 +278,17 @@ export function bootSchemaNeedsMigration(installedVersion: number): boolean {
 /** Short label used for the per-task log filenames. */
 type TaskLabel = "phantombot" | "heartbeat" | "tick" | "login";
 
-function logsDir(): string {
+/**
+ * Directory the scheduled tasks redirect their stdout/stderr into. Exported
+ * so the log-rotation pass (#428) can cap files that `cmd >>` appends to
+ * forever.
+ */
+export function taskLogsDir(): string {
   return join(xdgDataHome(), "phantombot", "logs");
+}
+
+function logsDir(): string {
+  return taskLogsDir();
 }
 
 /** Absolute path of a task's stdout / stderr log files. */

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -1032,4 +1032,62 @@ describe("runDoctor — memory database (#417)", () => {
     expect(out.text).toContain("memory/norms.md");
     expect(out.text).toContain("--retire");
   });
+  describe("service logs (#428)", () => {
+    async function logDir(): Promise<string> {
+      const d = join(workdir, "logs");
+      await mkdir(d, { recursive: true });
+      return d;
+    }
+
+    test("reports size and flags a log over the cap", async () => {
+      const d = await logDir();
+      await writeFile(join(d, "tick.out.log"), "x".repeat(2048));
+      await writeFile(join(d, "tick.out.log.1"), "x".repeat(1024));
+      process.env.PHANTOMBOT_LOG_MAX_BYTES = "1000";
+      const out = new CaptureStream();
+
+      const code = await runDoctor({ config, out, serviceLogDir: d });
+
+      delete process.env.PHANTOMBOT_LOG_MAX_BYTES;
+      expect(code).toBe(0);
+      expect(out.text).toContain("service logs:");
+      // Rotated generations count toward the footprint …
+      expect(out.text).toContain("0 MB in ");
+      // … but only the live log is named as a rotation candidate.
+      expect(out.text).toContain("over cap: tick.out.log");
+      expect(out.text).not.toContain("tick.out.log.1");
+    });
+
+    test("no over-cap log → no over-cap list", async () => {
+      const d = await logDir();
+      await writeFile(join(d, "tick.out.log"), "x".repeat(10));
+      const out = new CaptureStream();
+
+      expect(await runDoctor({ config, out, serviceLogDir: d })).toBe(0);
+      expect(out.text).toContain("service logs:");
+      expect(out.text).not.toContain("over cap");
+    });
+
+    test("a platform with no file logs omits the section entirely", async () => {
+      const out = new CaptureStream();
+      expect(await runDoctor({ config, out, serviceLogDir: null })).toBe(0);
+      expect(out.text).not.toContain("service logs:");
+    });
+
+    test("json report carries the same numbers", async () => {
+      const d = await logDir();
+      await writeFile(join(d, "tick.out.log"), "x".repeat(2048));
+      process.env.PHANTOMBOT_LOG_MAX_BYTES = "1000";
+      const out = new CaptureStream();
+
+      await runDoctor({ config, out, json: true, serviceLogDir: d });
+
+      delete process.env.PHANTOMBOT_LOG_MAX_BYTES;
+      const report = JSON.parse(out.text);
+      expect(report.service_logs.dir).toBe(d);
+      expect(report.service_logs.bytes).toBe(2048);
+      expect(report.service_logs.max_bytes).toBe(1000);
+      expect(report.service_logs.over_cap).toEqual(["tick.out.log"]);
+    });
+  });
 });

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { rmrf } from "./fixtures/rmrf.ts";
@@ -301,5 +301,62 @@ describe("runHeartbeatCli", () => {
     expect(code).toBe(0);
     expect(out.text).toContain("heartbeat ok");
     expect(out.text).not.toContain("embedded");
+  });
+  test("rotateLogs seam runs and its result is swallowed on failure", async () => {
+    let called = 0;
+    const out = new CaptureStream();
+    const code = await runHeartbeatCli({
+      config,
+      out,
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+      rotateLogs: async () => {
+        called++;
+        throw new Error("disk on fire");
+      },
+    });
+    // A rotation failure is logged, never fatal: the heartbeat's primary work
+    // must complete on a box whose log directory is unwritable.
+    expect(called).toBe(1);
+    expect(code).toBe(0);
+    expect(out.text).toContain("heartbeat ok");
+  });
+
+  test("rotateLogs: false skips the pass", async () => {
+    const code = await runHeartbeatCli({
+      config,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+      // `false` short-circuits the pass entirely.
+      rotateLogs: false,
+    });
+    expect(code).toBe(0);
+  });
+
+  test("the production pass never touches logs from a dev (non-binary) run", async () => {
+    // Windows resolves the service log dir under XDG_DATA_HOME, which this
+    // suite redirects into the workdir — so without the isPhantombotBinary
+    // guard this test's file would be truncated by a plain `bun test` run.
+    const logs = join(workdir, "phantombot", "logs");
+    await mkdir(logs, { recursive: true });
+    const live = join(logs, "phantombot.out.log");
+    await writeFile(live, "x".repeat(64));
+    process.env.PHANTOMBOT_LOG_MAX_BYTES = "8";
+
+    const code = await runHeartbeatCli({
+      config,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+    });
+
+    delete process.env.PHANTOMBOT_LOG_MAX_BYTES;
+    expect(code).toBe(0);
+    expect((await readFile(live, "utf8")).length).toBe(64);
+    expect(existsSync(`${live}.1`)).toBe(false);
   });
 });

--- a/tests/lib-logRotate.test.ts
+++ b/tests/lib-logRotate.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { chmod, mkdtemp, open, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rmrf } from "./fixtures/rmrf.ts";
+import {
+  configuredKeep,
+  configuredMaxBytes,
+  DEFAULT_KEEP,
+  DEFAULT_MAX_BYTES,
+  inspectLogDir,
+  LOCK_STALE_MS,
+  rotateLogDir,
+  rotateServiceLogs,
+} from "../src/lib/logRotate.ts";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "phantombot-logrot-"));
+});
+
+afterEach(async () => {
+  delete process.env.PHANTOMBOT_LOG_MAX_BYTES;
+  delete process.env.PHANTOMBOT_LOG_KEEP;
+  await rmrf(dir);
+});
+
+async function writeLog(name: string, bytes: number): Promise<string> {
+  const path = join(dir, name);
+  await writeFile(path, "x".repeat(bytes));
+  return path;
+}
+
+describe("rotateLogDir", () => {
+  test("rotates a log over the cap and leaves one under it alone", async () => {
+    await writeLog("big.log", 200);
+    await writeLog("small.log", 10);
+
+    const r = await rotateLogDir({ dir, maxBytes: 100 });
+
+    expect(r.rotated.map((f) => f.file)).toEqual(["big.log"]);
+    expect(r.rotated[0]?.bytes).toBe(200);
+    expect(r.skipped).toEqual([]);
+    expect(r.lockedOut).toBe(false);
+    expect((await stat(join(dir, "big.log"))).size).toBe(0);
+    expect((await readFile(join(dir, "big.log.1"), "utf8")).length).toBe(200);
+    expect((await stat(join(dir, "small.log"))).size).toBe(10);
+    expect(existsSync(join(dir, "small.log.1"))).toBe(false);
+  });
+
+  /**
+   * The regression test for the whole design. launchd holds an O_APPEND
+   * descriptor on the live file, and a descriptor follows the INODE: a
+   * rename-based rotation leaves the writer appending to the renamed file, so
+   * everything logged after the first rotation disappears from the live log.
+   * Model that writer with a real appending file handle held ACROSS the
+   * rotation.
+   */
+  test("a writer holding the live file keeps writing to the live path", async () => {
+    const path = await writeLog("held.log", 200);
+    const fh = await open(path, "a");
+    try {
+      await rotateLogDir({ dir, maxBytes: 100 });
+      await fh.write("after-rotation\n");
+    } finally {
+      await fh.close();
+    }
+
+    // The post-rotation line must be in the LIVE file, and the file must not
+    // have been left with a 200-byte sparse hole in front of it.
+    expect(await readFile(path, "utf8")).toBe("after-rotation\n");
+    expect((await readFile(join(dir, "held.log.1"), "utf8")).length).toBe(200);
+  });
+
+  test("shifts generations and drops the oldest beyond keep", async () => {
+    await writeFile(join(dir, "a.log.1"), "gen1");
+    await writeFile(join(dir, "a.log.2"), "gen2");
+    await writeFile(join(dir, "a.log.3"), "gen3");
+    await writeLog("a.log", 200);
+
+    await rotateLogDir({ dir, maxBytes: 100, keep: 3 });
+
+    expect((await readFile(join(dir, "a.log.1"), "utf8")).length).toBe(200);
+    expect(await readFile(join(dir, "a.log.2"), "utf8")).toBe("gen1");
+    expect(await readFile(join(dir, "a.log.3"), "utf8")).toBe("gen2");
+    // gen3 fell off the end rather than becoming a fourth generation.
+    expect(existsSync(join(dir, "a.log.4"))).toBe(false);
+  });
+
+  test("prunes generations stranded beyond a lowered keep", async () => {
+    await writeFile(join(dir, "a.log.4"), "old4");
+    await writeFile(join(dir, "a.log.5"), "old5");
+    await writeLog("a.log", 200);
+
+    await rotateLogDir({ dir, maxBytes: 100, keep: 3 });
+
+    // Nothing rotates `.4`/`.5` any more, so leaving them would be exactly the
+    // unbounded-growth bug, one directory deeper.
+    expect(existsSync(join(dir, "a.log.4"))).toBe(false);
+    expect(existsSync(join(dir, "a.log.5"))).toBe(false);
+    expect((await readFile(join(dir, "a.log.1"), "utf8")).length).toBe(200);
+  });
+
+  test("keep 0 truncates without keeping a copy", async () => {
+    await writeLog("a.log", 200);
+
+    await rotateLogDir({ dir, maxBytes: 100, keep: 0 });
+
+    expect((await stat(join(dir, "a.log"))).size).toBe(0);
+    expect(existsSync(join(dir, "a.log.1"))).toBe(false);
+  });
+
+  test("an already-rotated generation is never itself a candidate", async () => {
+    await writeFile(join(dir, "a.log.1"), "y".repeat(500));
+    await writeLog("a.log", 10);
+
+    const r = await rotateLogDir({ dir, maxBytes: 100 });
+
+    expect(r.rotated).toEqual([]);
+    expect(existsSync(join(dir, "a.log.1.1"))).toBe(false);
+    expect((await readFile(join(dir, "a.log.1"), "utf8")).length).toBe(500);
+  });
+
+  test("a fresh lock held by another pass rotates nothing", async () => {
+    await writeLog("a.log", 200);
+    await writeFile(
+      join(dir, ".rotate.lock"),
+      `999999 ${new Date().toISOString()}\n`,
+    );
+
+    const r = await rotateLogDir({ dir, maxBytes: 100 });
+
+    expect(r.lockedOut).toBe(true);
+    expect(r.rotated).toEqual([]);
+    expect((await stat(join(dir, "a.log"))).size).toBe(200);
+  });
+
+  test("a stale lock is stolen so a crash cannot wedge rotation", async () => {
+    await writeLog("a.log", 200);
+    const stale = new Date(Date.now() - LOCK_STALE_MS - 1_000).toISOString();
+    await writeFile(join(dir, ".rotate.lock"), `999999 ${stale}\n`);
+
+    const r = await rotateLogDir({ dir, maxBytes: 100 });
+
+    expect(r.lockedOut).toBe(false);
+    expect(r.rotated.map((f) => f.file)).toEqual(["a.log"]);
+    // Released on the way out, not left behind for the next pass to trip on.
+    expect(existsSync(join(dir, ".rotate.lock"))).toBe(false);
+  });
+
+  test("the lock file itself is never rotated", async () => {
+    await writeFile(join(dir, ".rotate.lock"), "x".repeat(500));
+    const r = await rotateLogDir({ dir, maxBytes: 100 });
+    expect(r.rotated).toEqual([]);
+  });
+
+  test("a missing directory is a no-op, not a throw", async () => {
+    const r = await rotateLogDir({ dir: join(dir, "nope"), maxBytes: 100 });
+    expect(r.rotated).toEqual([]);
+    expect(r.lockedOut).toBe(false);
+  });
+
+  test.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    "an unrotatable file is reported and the pass continues",
+    async () => {
+      await writeLog("a-locked.log", 200);
+      await writeLog("b-ok.log", 200);
+      // Deny writes to the directory AFTER the lock is taken is impossible
+      // from outside, so instead make the live file unreadable: copyFile then
+      // fails and the live bytes must survive.
+      await chmod(join(dir, "a-locked.log"), 0o000);
+
+      const r = await rotateLogDir({ dir, maxBytes: 100 });
+
+      expect(r.skipped.map((f) => f.file)).toEqual(["a-locked.log"]);
+      expect(r.rotated.map((f) => f.file)).toEqual(["b-ok.log"]);
+      // Failed rotation must not have destroyed the original.
+      await chmod(join(dir, "a-locked.log"), 0o600);
+      expect((await stat(join(dir, "a-locked.log"))).size).toBe(200);
+    },
+  );
+});
+
+describe("configured limits", () => {
+  test("defaults apply when the env vars are unset", () => {
+    expect(configuredMaxBytes()).toBe(DEFAULT_MAX_BYTES);
+    expect(configuredKeep()).toBe(DEFAULT_KEEP);
+  });
+
+  test("valid overrides are honoured", () => {
+    process.env.PHANTOMBOT_LOG_MAX_BYTES = "4096";
+    process.env.PHANTOMBOT_LOG_KEEP = "1";
+    expect(configuredMaxBytes()).toBe(4096);
+    expect(configuredKeep()).toBe(1);
+  });
+
+  test("junk and negative overrides fall back to the defaults", () => {
+    process.env.PHANTOMBOT_LOG_MAX_BYTES = "sixteen megs";
+    process.env.PHANTOMBOT_LOG_KEEP = "-3";
+    expect(configuredMaxBytes()).toBe(DEFAULT_MAX_BYTES);
+    expect(configuredKeep()).toBe(DEFAULT_KEEP);
+  });
+
+  test("a zero cap falls back rather than rotating on every pass", () => {
+    process.env.PHANTOMBOT_LOG_MAX_BYTES = "0";
+    expect(configuredMaxBytes()).toBe(DEFAULT_MAX_BYTES);
+  });
+});
+
+describe("inspectLogDir", () => {
+  test("counts every generation but flags only live logs over the cap", async () => {
+    await writeLog("a.log", 200);
+    await writeFile(join(dir, "a.log.1"), "y".repeat(300));
+    await writeLog("b.log", 10);
+
+    const s = await inspectLogDir(dir, 100);
+
+    expect(s.bytes).toBe(510);
+    expect(s.overCap).toEqual(["a.log"]);
+  });
+
+  test("a missing directory reports zero", async () => {
+    expect(await inspectLogDir(join(dir, "nope"), 100)).toEqual({
+      bytes: 0,
+      overCap: [],
+    });
+  });
+});
+
+describe("rotateServiceLogs", () => {
+  test("a non-installed (dev) run never touches the logs", async () => {
+    await writeLog("a.log", 200);
+    process.env.PHANTOMBOT_LOG_MAX_BYTES = "8";
+
+    expect(await rotateServiceLogs({ dir, installed: false })).toBeNull();
+
+    expect((await stat(join(dir, "a.log"))).size).toBe(200);
+    expect(existsSync(join(dir, "a.log.1"))).toBe(false);
+  });
+
+  test("a platform with no file logs (Linux/journald) is a no-op", async () => {
+    expect(await rotateServiceLogs({ dir: null, installed: true })).toBeNull();
+  });
+
+  test("an installed run rotates the directory", async () => {
+    await writeLog("a.log", 200);
+    process.env.PHANTOMBOT_LOG_MAX_BYTES = "100";
+
+    const r = await rotateServiceLogs({ dir, installed: true });
+
+    expect(r?.rotated.map((f) => f.file)).toEqual(["a.log"]);
+    expect((await stat(join(dir, "a.log"))).size).toBe(0);
+  });
+});

--- a/tests/lib-logRotate.test.ts
+++ b/tests/lib-logRotate.test.ts
@@ -208,6 +208,55 @@ describe("rotateLogDir", () => {
     expect(existsSync(join(dir, ".rotate.lock"))).toBe(false);
   });
 
+  /**
+   * The release race Kai flagged: the token check and the unlink are two
+   * syscalls, so a pass that overran LOCK_STALE_MS can have its lock stolen
+   * BETWEEN them and then delete the successor's fresh lock. The hook fires at
+   * exactly that point; a contender must not be able to install a successor
+   * there, and the resumed release must leave whatever lock is present alone
+   * unless it is still ours.
+   */
+  test("release cannot delete a successor installed mid-release", async () => {
+    // Our own lock, taken long enough ago that any contender sees it as stale.
+    const staleNow = new Date(Date.now() - LOCK_STALE_MS - 1_000);
+    const token = await acquireLock(dir, staleNow);
+    expect(token).toBeString();
+
+    let takeover: string | null = "not-attempted";
+    await releaseLock(dir, token as string, {
+      afterOwnershipRead: async () => {
+        // A contender tries to steal our (now stale) lock at the worst moment.
+        takeover = await acquireLock(dir, new Date());
+      },
+    });
+
+    // Takeover is serialised against release, so it cannot land in the window.
+    expect(takeover).toBeNull();
+    // Our own lock is gone, so the contender's next pass gets in cleanly.
+    expect(existsSync(join(dir, ".rotate.lock"))).toBe(false);
+    const next = await acquireLock(dir, new Date());
+    expect(next).toBeString();
+    await releaseLock(dir, next as string);
+    expect(existsSync(join(dir, ".rotate.lock"))).toBe(false);
+  });
+
+  test("release leaves no steal lock behind", async () => {
+    const token = await acquireLock(dir, new Date());
+    await releaseLock(dir, token as string);
+    expect(existsSync(join(dir, ".rotate.lock.steal"))).toBe(false);
+  });
+
+  test("release is not wedged by a stale steal lock", async () => {
+    const token = await acquireLock(dir, new Date());
+    const stale = new Date(Date.now() - LOCK_STALE_MS - 1_000).toISOString();
+    await writeFile(join(dir, ".rotate.lock.steal"), `999999 ${stale}\n`);
+
+    await releaseLock(dir, token as string);
+
+    expect(existsSync(join(dir, ".rotate.lock"))).toBe(false);
+    expect(existsSync(join(dir, ".rotate.lock.steal"))).toBe(false);
+  });
+
   test("the lock file itself is never rotated", async () => {
     await writeFile(join(dir, ".rotate.lock"), "x".repeat(500));
     const r = await rotateLogDir({ dir, maxBytes: 100 });

--- a/tests/lib-logRotate.test.ts
+++ b/tests/lib-logRotate.test.ts
@@ -1,16 +1,26 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { chmod, mkdtemp, open, readFile, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  open,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { rmrf } from "./fixtures/rmrf.ts";
 import {
+  acquireLock,
   configuredKeep,
   configuredMaxBytes,
   DEFAULT_KEEP,
   DEFAULT_MAX_BYTES,
   inspectLogDir,
   LOCK_STALE_MS,
+  releaseLock,
   rotateLogDir,
   rotateServiceLogs,
 } from "../src/lib/logRotate.ts";
@@ -103,13 +113,20 @@ describe("rotateLogDir", () => {
     expect((await readFile(join(dir, "a.log.1"), "utf8")).length).toBe(200);
   });
 
-  test("keep 0 truncates without keeping a copy", async () => {
+  test("keep 0 truncates and discards every existing generation", async () => {
     await writeLog("a.log", 200);
+    // Lowering keep to 0 must DISCARD retained history, not freeze it on disk
+    // forever: nothing would ever rotate or delete these again.
+    await writeFile(join(dir, "a.log.1"), "gen1");
+    await writeFile(join(dir, "a.log.2"), "gen2");
+    await writeFile(join(dir, "a.log.3"), "gen3");
 
     await rotateLogDir({ dir, maxBytes: 100, keep: 0 });
 
     expect((await stat(join(dir, "a.log"))).size).toBe(0);
     expect(existsSync(join(dir, "a.log.1"))).toBe(false);
+    expect(existsSync(join(dir, "a.log.2"))).toBe(false);
+    expect(existsSync(join(dir, "a.log.3"))).toBe(false);
   });
 
   test("an already-rotated generation is never itself a candidate", async () => {
@@ -150,6 +167,47 @@ describe("rotateLogDir", () => {
     expect(existsSync(join(dir, ".rotate.lock"))).toBe(false);
   });
 
+  /**
+   * The stale-takeover race. Every contender reads the SAME stale timestamp,
+   * so a plain overwrite lets all of them conclude they own the directory and
+   * rotate at once — the exact interleaved generation shift the lock exists to
+   * prevent. Exactly one may enter; the rest must report `lockedOut`.
+   */
+  test("only one of many concurrent passes steals a stale lock", async () => {
+    await writeLog("a.log", 200);
+    const stale = new Date(Date.now() - LOCK_STALE_MS - 1_000).toISOString();
+    await writeFile(join(dir, ".rotate.lock"), `999999 ${stale}\n`);
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => rotateLogDir({ dir, maxBytes: 100 })),
+    );
+
+    expect(results.filter((r) => !r.lockedOut).length).toBe(1);
+    // …and the one that entered did the rotation, exactly once.
+    expect(results.flatMap((r) => r.rotated).map((f) => f.file)).toEqual([
+      "a.log",
+    ]);
+    expect(existsSync(join(dir, "a.log.2"))).toBe(false);
+  });
+
+  test("a pass whose lock was stolen cannot release its successor's", async () => {
+    const stale = new Date(Date.now() - LOCK_STALE_MS - 1_000).toISOString();
+    await writeFile(join(dir, ".rotate.lock"), `999999 ${stale}\n`);
+
+    const successor = await acquireLock(dir, new Date());
+    expect(successor).toBeString();
+
+    // The crashed/stale owner finally reaches its own release.
+    await releaseLock(dir, "the-stale-owners-token");
+    expect(existsSync(join(dir, ".rotate.lock"))).toBe(true);
+    const held = await readFile(join(dir, ".rotate.lock"), "utf8");
+    expect(held).toContain(successor as string);
+
+    // The real owner still can.
+    await releaseLock(dir, successor as string);
+    expect(existsSync(join(dir, ".rotate.lock"))).toBe(false);
+  });
+
   test("the lock file itself is never rotated", async () => {
     await writeFile(join(dir, ".rotate.lock"), "x".repeat(500));
     const r = await rotateLogDir({ dir, maxBytes: 100 });
@@ -179,6 +237,38 @@ describe("rotateLogDir", () => {
       // Failed rotation must not have destroyed the original.
       await chmod(join(dir, "a-locked.log"), 0o600);
       expect((await stat(join(dir, "a-locked.log"))).size).toBe(200);
+    },
+  );
+
+  /**
+   * The copy is the step most likely to fail (Windows EBUSY/EACCES on a live
+   * log held by the writing `cmd`). If generations were pruned and shifted
+   * first, every heartbeat would age them one more step without ever writing a
+   * new snapshot, so a permanently unrotatable file quietly erases ALL of its
+   * retained history. Nothing may move until the bytes are safely copied.
+   */
+  test.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    "a failed live copy leaves every retained generation untouched",
+    async () => {
+      await writeLog("a.log", 200);
+      await writeFile(join(dir, "a.log.1"), "gen1");
+      await writeFile(join(dir, "a.log.2"), "gen2");
+      await writeFile(join(dir, "a.log.3"), "gen3");
+      await chmod(join(dir, "a.log"), 0o000);
+
+      const r = await rotateLogDir({ dir, maxBytes: 100, keep: 3 });
+
+      expect(r.rotated).toEqual([]);
+      expect(r.skipped.map((f) => f.file)).toEqual(["a.log"]);
+      expect(await readFile(join(dir, "a.log.1"), "utf8")).toBe("gen1");
+      expect(await readFile(join(dir, "a.log.2"), "utf8")).toBe("gen2");
+      expect(await readFile(join(dir, "a.log.3"), "utf8")).toBe("gen3");
+      await chmod(join(dir, "a.log"), 0o600);
+      expect((await stat(join(dir, "a.log"))).size).toBe(200);
+      // No half-written snapshot left behind for the next pass to trip on.
+      expect(
+        (await readdir(dir)).filter((n) => n.includes(".rotating-")),
+      ).toEqual([]);
     },
   );
 });

--- a/tests/lib-logRotate.test.ts
+++ b/tests/lib-logRotate.test.ts
@@ -246,15 +246,45 @@ describe("rotateLogDir", () => {
     expect(existsSync(join(dir, ".rotate.lock.steal"))).toBe(false);
   });
 
-  test("release is not wedged by a stale steal lock", async () => {
+  /**
+   * A steal lock we cannot take means a takeover may be in flight, and its
+   * holder can be paused just before it mutates the real lock. Release must
+   * therefore return WITHOUT deleting — deleting would open exactly the window
+   * the steal holder is about to install its successor into. Stale or fresh,
+   * the real lock is left alone; only a STALE steal lock is cleared, so later
+   * passes are not wedged.
+   */
+  test("release never deletes the real lock while a steal lock is held", async () => {
     const token = await acquireLock(dir, new Date());
-    const stale = new Date(Date.now() - LOCK_STALE_MS - 1_000).toISOString();
-    await writeFile(join(dir, ".rotate.lock.steal"), `999999 ${stale}\n`);
+    // A contender that is mid-steal (its steal lock is fresh).
+    await writeFile(
+      join(dir, ".rotate.lock.steal"),
+      `999999 ${new Date().toISOString()} contender\n`,
+    );
 
     await releaseLock(dir, token as string);
 
-    expect(existsSync(join(dir, ".rotate.lock"))).toBe(false);
+    // Ours survives: the paused steal holder is still entitled to replace it.
+    expect(existsSync(join(dir, ".rotate.lock"))).toBe(true);
+    // A fresh steal lock belongs to the contender — we must not clear it.
+    expect(existsSync(join(dir, ".rotate.lock.steal"))).toBe(true);
+  });
+
+  test("release clears a stale steal lock but still leaves the real lock", async () => {
+    const token = await acquireLock(dir, new Date());
+    const stale = new Date(Date.now() - LOCK_STALE_MS - 1_000).toISOString();
+    await writeFile(join(dir, ".rotate.lock.steal"), `999999 ${stale} old\n`);
+
+    await releaseLock(dir, token as string);
+
+    // Not deleted: clearing the steal lock and taking it in the same pass is
+    // the race — the old steal holder may resume and install a successor.
+    expect(existsSync(join(dir, ".rotate.lock"))).toBe(true);
+    // But the stale steal lock is gone, so nothing is wedged...
     expect(existsSync(join(dir, ".rotate.lock.steal"))).toBe(false);
+    // ...and the leftover real lock is recoverable by the next pass once stale.
+    const later = new Date(Date.now() + LOCK_STALE_MS + 1_000);
+    expect(await acquireLock(dir, later)).toBeString();
   });
 
   test("the lock file itself is never rotated", async () => {


### PR DESCRIPTION
Closes #428.

## What was wrong

`launchd` (macOS) and the `cmd >>` task wrapper (Windows) append to plain log files with no size limit, and phantombot never rotated them. One macOS box reached **~700 MB** and was cleared by a manual `truncate`; every log file on that host still carried its **original May 6 birth time**, so nothing had ever rotated them. Linux is unaffected — the systemd `--user` units log to journald, which applies its own retention.

## The fix

`src/lib/logRotate.ts`, run from the **heartbeat** — already the host maintenance pass that heals systemd units and scheduled tasks on the same 30-minute cadence, so this needs no new timer and inherits the same platform dispatch. `serviceLogDir()` returns `null` on Linux, and the pass is a no-op there.

**Copy-truncate, never rename.** This is the whole design. The live file is held open by a process we do not control with an `O_APPEND` descriptor, and a descriptor follows the **inode**: renaming the live file leaves the writer appending to the renamed inode forever, so the freshly-created `<name>.log` stays empty and every line after the first rotation lands in a file nobody tails. Copying the bytes out and truncating in place keeps the writer on the same inode, and `O_APPEND` recomputes the offset per write, so the file refills from 0 with no sparse hole.

Verified against a real external writer holding an appending fd across a rotation:

```
{"rotated":[{"file":"svc.out.log","bytes":1655}],"skipped":[],"lockedOut":false}
live size: 4805   gen1: 1687
tail of live:   line 199 …   line 200 …
head of live:   line 54 …          <- refilled from 0, not a NUL hole
```

Also in here:

- **Generations beyond `keep` are pruned by scanning**, not by counting up from `keep`, so a lowered `keep` (or a leftover from an older install) cannot strand `.4`, `.5`, … — files nothing rotates and nothing ever deletes, i.e. the same bug one directory deeper.
- **A directory lock**, stolen when stale, so two personas' heartbeats cannot interleave the generation shift and a crashed pass cannot wedge rotation forever.
- **An unrotatable file is reported, not fatal** — EBUSY from a Windows writer, EACCES, etc. It lands in `skipped`, the heartbeat `warn`s (that case is exactly what this pass exists to prevent), the pass continues, and the live bytes survive because the copy happens *before* the truncate.
- **Guarded on binary identity**, like the existing service self-heal: a dev `bun src/index.ts` run must not truncate the developer's real `~/Library/Logs/phantombot`.
- **`doctor`** prints the directory footprint and names any live log over the cap, so growth is visible before it is a problem.

Defaults: **16 MB per file, 3 generations** (~64 MB per log worst case), overridable with `PHANTOMBOT_LOG_MAX_BYTES` / `PHANTOMBOT_LOG_KEEP`, both of which fall back to the default on junk, negative or zero input rather than disabling rotation or rotating on every pass.

## Deliberately not changed

`heartbeat.err.log` is ~100 % `info`/`warn` lines. That is **by design** (`logger.ts`): all levels go to stderr because stdout is a protocol channel for the ACP stdio server and the MCP proxy, and a stray write there corrupts the JSON-RPC wire. Splitting by level would break that contract; rotation is the correct fix.

## Verification

- `bun tsc --noEmit` clean; full suite **3381 pass / 0 fail / 2 skip**.
- Mutation-checked — each of these reddens tests, none is decorative:

| mutation | result |
|---|---|
| rename instead of copy-truncate | 2 fail |
| drop the prune-beyond-keep scan | 1 fail |
| ignore a fresh lock | 1 fail |
| widen candidates to `*.log*` (rotate a generation twice) | 2 fail |
| ignore the size cap | 2 fail |
| drop the dev/binary guard | 1 fail |
| accept negative env overrides | 1 fail |
| `inspect` flags generations as over-cap | 1 fail |
| drop doctor's over-cap list / human line / JSON field | 1 / 2 / 3 fail |

The rename mutation is the one that matters most: it is the plausible naive implementation, and it fails the test that models launchd's held descriptor.
