### PR TITLE
Split releases into stable and preview rings (#432)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,152 @@
+name: Promote a release to stable
+
+# The manual half of the release rings (#432).
+#
+# release.yml cuts EVERY merge to main as a prerelease, which GitHub keeps out
+# of `/releases/latest`. That endpoint is what a stable host resolves against
+# (src/lib/githubReleases.ts), so a merge reaches only hosts running
+# `update_channel = "preview"`. This workflow is the button that ships a build
+# to everyone else.
+#
+# What it does NOT do: rebuild. Promotion flips the `prerelease` flag on a
+# release that already exists, so the binaries and SHA256SUMS a stable host
+# downloads are bit-identical to the ones that soaked on the preview ring. A
+# promotion that rebuilt would ship an artifact nobody had actually run, which
+# would make the soak meaningless.
+#
+# Rollback needs nothing from this workflow: `phantombot update` gates on
+# `release.version === currentVersion` (string equality, not a `>` compare), so
+# a host stuck on a bad preview build flips `update_channel` back to "stable"
+# and installs the current stable even though its version number is LOWER.
+# If a PROMOTED release turns out bad, promote the previous good tag — GitHub
+# lets `--latest` move backwards, and the same equality gate lets hosts follow.
+#
+# Usage: Actions → "Promote a release to stable" → Run workflow. Leave `tag`
+# empty to promote the newest prerelease (the usual case), or name a tag
+# explicitly to promote an older one.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to promote (e.g. v1.1.291). Empty = newest prerelease.'
+        required: false
+        type: string
+
+permissions:
+  contents: write        # edit the release (flip prerelease -> latest)
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve the tag to promote
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            # Newest prerelease, excluding drafts (a draft has no public
+            # assets and no git tag, so it cannot be promoted). The releases
+            # list is newest-first, same ordering a preview host sees.
+            TAG=$(gh api "repos/${REPO}/releases?per_page=20" \
+              --jq '[.[] | select(.draft == false) | select(.prerelease == true)][0].tag_name // ""')
+            if [ -z "$TAG" ]; then
+              echo "::error::no prerelease found to promote — is everything already stable?"
+              exit 1
+            fi
+            echo "No tag given; newest prerelease is $TAG"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the release is promotable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Fail closed on every precondition. A promotion is the one action
+          # in this repo that changes what the WHOLE fleet installs, so it
+          # refuses on anything it does not fully understand rather than
+          # flipping a half-built release to latest.
+          REL=$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>/dev/null || echo '')
+          if [ -z "$REL" ]; then
+            echo "::error::release ${TAG} does not exist in ${REPO}"
+            exit 1
+          fi
+          if [ "$(echo "$REL" | jq -r '.draft')" = "true" ]; then
+            echo "::error::release ${TAG} is a DRAFT — publish it before promoting"
+            exit 1
+          fi
+
+          # Every asset a client needs must be present. `phantombot update`
+          # refuses to install without SHA256SUMS, and a host whose target is
+          # missing gets a hard error — so a release short of assets must
+          # never become latest.
+          ASSETS=$(echo "$REL" | jq -r '.assets[].name')
+          MISSING=""
+          for NAME in \
+            "phantombot-${TAG}-linux-x64" \
+            "phantombot-${TAG}-linux-arm64" \
+            "phantombot-${TAG}-darwin-x64" \
+            "phantombot-${TAG}-darwin-arm64" \
+            "phantombot-${TAG}-windows-x64.exe" \
+            "phantombot-${TAG}-windows-arm64.exe" \
+            "SHA256SUMS"; do
+            echo "$ASSETS" | grep -qx -- "$NAME" || MISSING="${MISSING} ${NAME}"
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::release ${TAG} is missing assets:${MISSING}"
+            exit 1
+          fi
+
+          if [ "$(echo "$REL" | jq -r '.prerelease')" = "false" ]; then
+            echo "::notice::${TAG} is already stable — re-running to re-assert --latest"
+          fi
+          echo "OK: ${TAG} has all 7 assets and is publishable"
+
+      - name: Promote to stable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # --latest is explicit and load-bearing: GitHub's "latest" pointer
+          # is by publish date among non-prereleases, and we want the pointer
+          # to land on the tag we just promoted even when an older release is
+          # flipped (a rollback promotion).
+          gh release edit "$TAG" --prerelease=false --latest
+          echo "promoted $TAG to stable"
+
+      - name: Confirm and summarize
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+          # Read back from the API rather than trusting the edit's exit code:
+          # this is the line that proves stable hosts will now resolve it.
+          LATEST=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name')
+          if [ "$LATEST" != "$TAG" ]; then
+            echo "::error::promoted ${TAG} but /releases/latest still reports ${LATEST}"
+            exit 1
+          fi
+          {
+            echo "### Promoted \`${TAG}\` to stable"
+            echo ""
+            echo "\`/releases/latest\` now resolves to **${TAG}**, so every host on"
+            echo "the stable ring installs it on its next \`phantombot update\`."
+            echo "No rebuild happened — these are the same binaries that ran on"
+            echo "the preview ring."
+            echo ""
+            echo "[Release notes](${SERVER_URL}/${REPO}/releases/tag/${TAG})"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,26 @@ name: Release on PR merge
 # --restart` from cron and wants always-fresh binaries. If a PR shouldn't
 # release, we'll add a `release:skip` label gate later.
 #
+# RELEASE RINGS (#432) — every release cut here is a PRERELEASE.
+#
+# `gh release create --prerelease` below is the whole mechanism. GitHub's
+# `/releases/latest` endpoint EXCLUDES prereleases by design, and that is the
+# endpoint a stable host resolves against (src/lib/githubReleases.ts), so a
+# merge to main now reaches only hosts that opted in with
+# `update_channel = "preview"` — they resolve the `/releases` LIST instead and
+# take its newest entry.
+#
+# Promotion to stable is a HUMAN act, not a CI outcome: run the
+# "Promote a release to stable" workflow (promote.yml) and press the button.
+# It flips `--prerelease=false --latest` on a release that ALREADY EXISTS —
+# no rebuild, no re-tag. The bytes a stable host installs are byte-for-byte
+# the ones that soaked on the preview ring, which is the entire point; a
+# promotion that rebuilt would ship something nobody had run.
+#
+# Why CI cannot decide this: green tests are the bar for MERGING. If they
+# were also the bar for stable, the two rings would be the same ring and the
+# soak would be decoration. Stable means a human watched a real host run it.
+#
 # Why bun-linux-x64-baseline (and not plain bun-linux-x64): one of the
 # deploy targets (the `kw-openclaw` supervisor box that runs kai) is older
 # silicon without AVX2. The non-baseline target SIGILLs on launch there.
@@ -327,6 +347,13 @@ jobs:
 
           Install with: phantombot update
 
+          Release ring: PREVIEW. This is a prerelease, so it is served only to
+          hosts running \`update_channel = "preview"\`; \`/releases/latest\`
+          does not return it and stable hosts will not see it. To ship it to
+          everyone, run the "Promote a release to stable" workflow against
+          ${TAG} — that flips this exact release (same binaries, same
+          checksums) to latest without rebuilding.
+
           macOS note: the darwin binaries are cross-compiled and unsigned.
           install.sh handles the xattr / ad-hoc codesign dance for you. If
           you download the binary directly, clear the Gatekeeper quarantine
@@ -359,7 +386,13 @@ jobs:
           else
             TITLE="$TAG"
           fi
+          # --prerelease is the release-ring gate (#432): it keeps this build
+          # out of /releases/latest, so only preview hosts resolve it until a
+          # human promotes it via promote.yml. Do NOT drop this flag to "fix"
+          # an update that isn't arriving — that ships an unsoaked build to
+          # the whole fleet. Promote the tag instead.
           gh release create "$TAG" \
+            --prerelease \
             --target "$SHA" \
             --title "$TITLE" \
             --notes-file release-notes.md \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,19 +277,59 @@ section.
 
 ## Release pipeline
 
-Every merged PR auto-releases `v1.0.<PR_NUMBER>`. The workflow at `.github/workflows/release.yml`:
+Every merge to `main` auto-releases `v1.1.<RUN_NUMBER>` as a **prerelease**. The
+workflow at `.github/workflows/release.yml`:
 
-1. Triggers on `pull_request: closed` + `merged == true` + `branches: main`.
-2. Checks out the merge-commit SHA (not main HEAD; pins to exactly the code that merged).
+1. Triggers on `push: main` (branch protection means a push IS a merge), minus a
+   narrow `paths-ignore` denylist of docs/website surfaces. NOT
+   `pull_request: closed` — a fork-merged PR runs that with a read-only token and
+   `gh release create` 403s.
+2. Checks out `github.sha` (the merge commit), so the tag pins to exactly the
+   code that merged.
 3. Runs `bun tsc --noEmit` and `bun test` as gates.
-4. `sed -i "s/0.1.0-dev/1.0.${PR_NUMBER}/" src/version.ts` (replaces only the literal placeholder, preserves the doc comment block).
-5. Cross-compiles `bun-linux-x64-baseline` and `bun-linux-arm64`.
-6. Computes `SHA256SUMS`.
-7. `gh release create v1.0.<PR_NUMBER> --target <merge_commit_sha> …` so the git tag is pinned to the commit, not the moving HEAD.
+4. `sed -i "s/0.1.0-dev/1.1.${RUN_NUMBER}/" src/version.ts` (replaces only the
+   literal placeholder, preserves the doc comment block).
+5. Regenerates + version-stamps the embedded VS Code extension.
+6. Cross-compiles linux x64-baseline/arm64, darwin x64/arm64, windows x64/arm64.
+7. Computes `SHA256SUMS`.
+8. `gh release create v1.1.<RUN_NUMBER> --prerelease --target <sha> …`.
 
-`phantombot update` reads this feed via the GitHub Releases API.
+**Release rings (#432).** `--prerelease` in step 8 is the whole gate. GitHub's
+`/releases/latest` excludes prereleases, and that is what a `stable` host
+resolves (`src/lib/githubReleases.ts`); a host with `update_channel = "preview"`
+resolves the `/releases` LIST instead and takes its newest non-draft entry. So a
+merge reaches only the preview ring until a human runs the
+`.github/workflows/promote.yml` workflow_dispatch, which flips
+`--prerelease=false --latest` on an **existing** release.
 
-**Versioning is intentionally not semver.** `1.0.<PR_NUMBER>` — patch is the PR number, ordered by merge time, not semantic impact. Don't bolt semver-aware logic on (`phantombot update --major-only` etc.); the version string can't carry that information.
+Four things here look like tidy-up candidates and are not:
+
+- **Promotion must never rebuild.** The point of a ring is that the bytes the
+  fleet installs are the bytes that soaked. A promotion that rebuilt would ship
+  an artifact nobody ran, and the soak would be theatre.
+- **CI must not decide stable.** Green tests are the bar for MERGING. If they
+  were also the bar for promotion the two rings would be one ring. Stable means
+  a human watched a real host run it.
+- **The updater compares versions for EQUALITY, not `>`** (`src/cli/update.ts`).
+  This is what makes rollback free: a host stranded on preview `1.1.291` flips
+  `update_channel` back to `stable` and installs `1.1.280`, a LOWER number.
+  Turning that into a "newer than" compare strands every preview host on
+  whatever build broke; `tests/cli-update.test.ts` has a test that goes red if
+  you do.
+- **An unrecognised `update_channel` falls back to `stable`, not preview**
+  (`resolveUpdateChannel` in `src/config.ts`). A typo must never opt a box into
+  a ring its operator did not choose.
+
+`phantombot update`, the `/update` chat command and the heartbeat update-check
+all resolve through the host's configured ring, and `phantombot doctor` reports
+it — a bug report that does not say which ring it came from is uninterpretable
+once `latest` stops meaning "newest build".
+
+**Versioning is intentionally not semver.** `1.1.<RUN_NUMBER>` — patch is the
+release workflow's monotonic run number, not semantic impact and not the PR
+number (PR numbers can regress; the PR is recorded in the release title/notes).
+Don't bolt semver-aware logic on (`phantombot update --major-only` etc.); the
+version string can't carry that information.
 
 ## How to add a new subcommand
 

--- a/README.md
+++ b/README.md
@@ -470,6 +470,10 @@ Minimal config example:
 ```toml
 default_persona = "phantom"
 
+# Release ring this host follows: "stable" (default) or "preview".
+# See "Release rings" under Maintenance.
+update_channel = "stable"
+
 [harnesses]
 chain = ["pi", "claude", "codex"]
 
@@ -2066,6 +2070,43 @@ phantombot update --force --restart
 Updates download to a temporary file, verify SHA256, atomically rename over the
 live binary, and clean up after themselves.
 
+### Release rings: stable and preview
+
+Every merge to `main` is published as a GitHub **prerelease**. GitHub's
+`/releases/latest` endpoint excludes prereleases, and that is the endpoint a
+default host resolves — so a merge does not reach the fleet until a human
+presses the promote button on it.
+
+Pick a ring per host in `config.toml`:
+
+```toml
+# "stable" (default) — install only releases a human promoted.
+# "preview"          — install every merge to main.
+update_channel = "preview"
+```
+
+`PHANTOMBOT_UPDATE_CHANNEL` overrides the file. An unrecognised value falls
+back to `stable` with a warning, so a typo can never move a host onto a ring
+you did not pick. `phantombot doctor` prints the active ring and version, so a
+bug report from a preview host is interpretable without asking which build it
+is on.
+
+The intended shape: put **one** host on `preview`, let it run the new build for
+a few days, then promote. Promotion is the "Promote a release to stable"
+workflow in Actions — it flips the `prerelease` flag on a release that already
+exists, so the binaries stable hosts install are bit-identical to the ones that
+soaked. Nothing is rebuilt.
+
+**Rolling back needs no special command.** The updater compares versions for
+*equality*, not "is newer", so a host on a bad preview build flips
+`update_channel` back to `stable` and the next `phantombot update` installs the
+current stable — even though its version number is lower. Same for a bad
+*promoted* release: promote the last good tag and every stable host follows it
+back down.
+
+A side effect worth naming: stable hosts stop updating on every merge. Fewer,
+deliberate updates instead of one per PR.
+
 On Linux the restart runs `systemctl --user restart` from *inside* the service
 being restarted, so systemd tears down the whole cgroup — including the
 `systemctl` child phantombot just spawned — as soon as it accepts the job. That
@@ -2213,11 +2254,16 @@ block. Pass `--no-telegram` to skip that.
 
 ## Versioning
 
-Versions use `major.minor.patch`, where `patch` is the GitHub PR number.
-Merged PR #142 publishes `v1.0.142`.
+Versions use `major.minor.patch`, where `patch` is the release workflow's run
+number — a per-workflow counter that only ever grows. It is *not* the PR
+number: PR numbers can regress when a later PR merges first. The originating PR
+is recorded in the release title and notes instead.
 
 This is intentionally not semantic versioning. Do not add semver-aware update
-logic.
+logic — in particular, do not turn the updater's version *equality* check into
+a "newer than" comparison. That equality is what lets a host move DOWN a
+version when it switches from the preview ring back to stable; see
+[Release rings](#release-rings-stable-and-preview).
 
 ## Design Principles
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -42,6 +42,11 @@ import {
 } from "../lib/piExtensionProvision.ts";
 import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
 import {
+  DEFAULT_UPDATE_CHANNEL,
+  type UpdateChannel,
+} from "../lib/githubReleases.ts";
+import { VERSION } from "../version.ts";
+import {
   configuredKeep,
   configuredMaxBytes,
   inspectLogDir,
@@ -166,6 +171,17 @@ export interface DoctorReport {
     provider: "gemini" | "none";
     /** gemini provider AND a key present = vector/semantic search is live. */
     semantic_search: boolean;
+  };
+  /**
+   * Release ring this host follows (#432) plus the version it is on now.
+   * Reported so a bug report from a preview box is interpretable without
+   * asking: "which build is this?" is the first question on any report, and
+   * on the preview ring the answer is no longer "whatever is latest".
+   * Informational — never an exit-code input; both rings are valid.
+   */
+  update: {
+    channel: UpdateChannel;
+    version: string;
   };
   /**
    * Linux-only — undefined on macOS and dev hosts without a user-systemd
@@ -377,6 +393,8 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   // Embeddings status — informational only. Vector search is live only when
   // the provider is gemini AND a key is actually present; everything else
   // (provider "none", or "gemini" with an empty key) means keyword-only.
+  const updateChannel = config.updateChannel ?? DEFAULT_UPDATE_CHANNEL;
+
   const embProvider = config.embeddings.provider;
   const semanticSearch =
     embProvider === "gemini" && !!config.embeddings.gemini?.apiKey;
@@ -586,6 +604,10 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       provider: embProvider,
       semantic_search: semanticSearch,
     },
+    update: {
+      channel: updateChannel,
+      version: VERSION,
+    },
     ...(systemdReport ? { systemd: systemdReport } : {}),
     ...(timersReport ? { timers: timersReport } : {}),
     ...(harnessReport ? { harnesses: harnessReport } : {}),
@@ -738,6 +760,14 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       ? `  embeddings: semantic (vector) search ON — provider '${embProvider}'\n`
       : "  embeddings: semantic (vector) search off — OKF field-weighted BM25 " +
         "+ link-graph expansion active. Optional: add Gemini with `phantombot embedding`\n",
+  );
+  // Same neutrality as the embeddings line: a ring is a choice, not a fault.
+  out.write(
+    `  update: on ${VERSION}, ${updateChannel} channel — ` +
+      (updateChannel === "preview"
+        ? "installs every merge to main (`update_channel` in config.toml)"
+        : "installs only promoted releases") +
+      "\n",
   );
   if (health.backlog > 0) {
     out.write(

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -32,10 +32,13 @@ import {
   type ResignAfterUpdateResult,
 } from "../lib/macSigning.ts";
 import {
+  DEFAULT_UPDATE_CHANNEL,
   detectSupportedTarget,
   findLatestRelease,
   type LatestRelease,
+  type UpdateChannel,
 } from "../lib/githubReleases.ts";
+import { loadConfig } from "../config.ts";
 import {
   defaultServiceControl,
   restartCommand,
@@ -70,6 +73,13 @@ export interface RunUpdateInput {
   procPlatform?: string;
   /** Defaults to VERSION constant. Tests override. */
   currentVersion?: string;
+  /**
+   * Release ring to install from (#432). Defaults to the host's configured
+   * channel (`update_channel` in config.toml / PHANTOMBOT_UPDATE_CHANNEL),
+   * falling back to "stable" if the config cannot be read — an update must
+   * never be blocked by an unreadable config, and stable is the safe ring.
+   */
+  channel?: UpdateChannel;
   /** Inject for testing. */
   fetchImpl?: typeof fetch;
   serviceControl?: ServiceControl;
@@ -125,6 +135,7 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
   const procArch = input.procArch ?? process.arch;
   const procPlatform = input.procPlatform ?? process.platform;
   const target = detectSupportedTarget(procPlatform, procArch);
+  const channel = input.channel ?? (await resolveHostChannel());
 
   if (!target) {
     err.write(
@@ -161,23 +172,31 @@ export async function runUpdate(input: RunUpdateInput = {}): Promise<number> {
   // 1. Discover latest release.
   const r = await findLatestRelease({
     target,
+    channel,
     fetchImpl: input.fetchImpl,
   });
   if (!r.ok) {
-    err.write(`update check failed: ${r.error}\n`);
+    err.write(`update check failed (${channel} channel): ${r.error}\n`);
     return 1;
   }
   const release = r.release;
 
-  // 2. Compare versions.
+  // 2. Compare versions. Deliberately EQUALITY, not "is newer": on the
+  //    preview ring a host that wants out flips update_channel back to
+  //    stable, and the stable release it should land on has a LOWER version
+  //    number than the preview build it is running. A `>` compare here would
+  //    strand that host on the bad build. See lib/githubReleases.ts.
   if (release.version === currentVersion) {
-    out.write(`Already on ${release.tag}.\n`);
+    out.write(`Already on ${release.tag}${channelSuffix(channel, release)}.\n`);
     return 0;
   }
 
   // 3. --check just reports.
   if (input.check) {
-    out.write(`Update available: ${currentVersion} → ${release.version}\n`);
+    out.write(
+      `Update available: ${currentVersion} → ${release.version}` +
+        `${channelSuffix(channel, release)}\n`,
+    );
     out.write(`  asset:  ${release.binary.name} (${formatBytes(release.binary.size)})\n`);
     return 2;
   }
@@ -478,6 +497,34 @@ async function defaultConfirmRestart(): Promise<boolean> {
     initialValue: true,
   });
   return !p.isCancel(r) && r === true;
+}
+
+/**
+ * Read the host's release ring from config. An unreadable or absent config
+ * must never block an update, so any failure degrades to the stable ring
+ * (which is also what every pre-#432 host effectively followed).
+ */
+async function resolveHostChannel(): Promise<UpdateChannel> {
+  try {
+    const cfg = await loadConfig();
+    return cfg.updateChannel ?? DEFAULT_UPDATE_CHANNEL;
+  } catch {
+    return DEFAULT_UPDATE_CHANNEL;
+  }
+}
+
+/**
+ * " (preview)" / " (preview — promoted to stable)" annotation for the
+ * version lines, so a preview host's output always says which ring the
+ * number came from. Silent on stable, where it would be noise on every
+ * existing install.
+ */
+function channelSuffix(
+  channel: UpdateChannel,
+  release: LatestRelease,
+): string {
+  if (channel !== "preview") return "";
+  return release.prerelease ? " (preview)" : " (preview — already promoted)";
 }
 
 function formatBytes(n: number): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,11 @@ import { join } from "node:path";
 import { parse as parseToml } from "smol-toml";
 import { log } from "./lib/logger.ts";
 import {
+  asUpdateChannel,
+  DEFAULT_UPDATE_CHANNEL,
+  type UpdateChannel,
+} from "./lib/githubReleases.ts";
+import {
   type PiRoutingConfig,
   resolveRouting,
 } from "./lib/piRouting.ts";
@@ -637,6 +642,19 @@ export interface Config {
    */
   chattiness?: boolean;
 
+  /**
+   * Release ring this HOST follows (#432): "stable" (default) or "preview".
+   *
+   * Host-level, not per-persona, because it selects which BINARY the box
+   * installs — every persona on a host necessarily runs the same one.
+   * "preview" picks up every merge to main; "stable" only moves when a
+   * human presses the promote button on a release. See lib/githubReleases.ts.
+   *
+   * Optional on the type so partial test fixtures need no update; loadConfig
+   * always populates it, and read sites default to DEFAULT_UPDATE_CHANNEL.
+   */
+  updateChannel?: UpdateChannel;
+
   embeddings: {
     /** "gemini" | "none". "none" = FTS5-only search. */
     provider: "gemini" | "none";
@@ -915,6 +933,14 @@ export async function loadConfig(): Promise<Config> {
       asBool(toml.chattiness) ??
       DEFAULT_CHATTINESS,
 
+    // Which release ring this host follows. Env wins over TOML wins over
+    // the default, same precedence as everything else. An UNRECOGNISED
+    // value falls back to "stable" with a warning rather than being treated
+    // as opt-in: a typo (`update_channel = "prevew"`) must never leave a
+    // box quietly following a ring the operator did not choose, and stable
+    // is the fail-closed direction.
+    updateChannel: resolveUpdateChannel(toml.update_channel),
+
     embeddings: buildEmbeddingsConfig(tomlEmbeddings, tomlGemini),
 
     retrieval: buildRetrievalConfig(tomlRetrieval, tomlTurnIndexing),
@@ -927,6 +953,34 @@ export async function loadConfig(): Promise<Config> {
 
     p2p: buildP2PConfig(tomlP2p),
   };
+}
+
+/**
+ * Resolve the host's release ring: `PHANTOMBOT_UPDATE_CHANNEL` env, then
+ * `update_channel` in config.toml, then the stable default. Anything that
+ * is not exactly "stable" or "preview" is rejected with a warning and
+ * treated as stable — see the call site for why we fail closed.
+ */
+function resolveUpdateChannel(tomlValue: unknown): UpdateChannel {
+  const fromEnv = process.env.PHANTOMBOT_UPDATE_CHANNEL;
+  if (fromEnv !== undefined && fromEnv !== "") {
+    const parsed = asUpdateChannel(fromEnv);
+    if (parsed) return parsed;
+    log.warn("config: ignoring unrecognized PHANTOMBOT_UPDATE_CHANNEL", {
+      value: fromEnv,
+      using: DEFAULT_UPDATE_CHANNEL,
+    });
+    return DEFAULT_UPDATE_CHANNEL;
+  }
+  if (tomlValue !== undefined) {
+    const parsed = asUpdateChannel(tomlValue);
+    if (parsed) return parsed;
+    log.warn("config: ignoring unrecognized update_channel in config.toml", {
+      value: String(tomlValue),
+      using: DEFAULT_UPDATE_CHANNEL,
+    });
+  }
+  return DEFAULT_UPDATE_CHANNEL;
 }
 
 /**

--- a/src/lib/githubReleases.ts
+++ b/src/lib/githubReleases.ts
@@ -14,6 +14,45 @@
 
 const DEFAULT_REPO = "phantomyard/phantombot";
 
+/**
+ * Which release ring a host follows (#432).
+ *
+ *   "stable"  — GitHub's `/releases/latest`, which EXCLUDES prereleases by
+ *               design. Every merge to main is cut as a prerelease, so a
+ *               stable host only moves when a human presses the promote
+ *               button (`.github/workflows/promote.yml` flips that same
+ *               release to `--prerelease=false --latest`). No rebuild: the
+ *               bytes a stable host installs are the exact bytes that soaked
+ *               on the preview ring.
+ *   "preview" — the `/releases` LIST, newest first, prereleases included.
+ *               A preview host therefore picks up every merge to main.
+ *
+ * Rollback needs no version arithmetic: the updater gates on
+ * `release.version === currentVersion` (plain string equality, not `>` — see
+ * cli/update.ts), so flipping a bad-preview host back to `stable` installs
+ * the current stable even though its number is LOWER.
+ */
+export type UpdateChannel = "stable" | "preview";
+
+/** Ring a host follows when nothing says otherwise. Fail-closed: stable. */
+export const DEFAULT_UPDATE_CHANNEL: UpdateChannel = "stable";
+
+/**
+ * Narrow an arbitrary value (TOML key, env var) to an UpdateChannel.
+ * Returns undefined for anything else so callers can warn + fall back
+ * rather than silently following a ring the operator did not ask for.
+ */
+export function asUpdateChannel(v: unknown): UpdateChannel | undefined {
+  return v === "stable" || v === "preview" ? v : undefined;
+}
+
+/**
+ * How many releases to pull when resolving the preview ring. The list is
+ * newest-first and we only ever want its first non-draft entry, so this is
+ * just headroom for a run of drafts — not a page we walk.
+ */
+const PREVIEW_PAGE_SIZE = 20;
+
 /** What kind of host arch the running phantombot needs an asset for. */
 export type SupportedArch = "x64" | "arm64";
 
@@ -61,6 +100,13 @@ export interface LatestRelease {
   binary: ReleaseAsset;
   /** The SHA256SUMS file alongside it. */
   checksums: ReleaseAsset;
+  /**
+   * True when GitHub has this release flagged as a prerelease — i.e. it is
+   * on the preview ring and has not been promoted. Always false for a
+   * release resolved via the stable channel, because `/releases/latest`
+   * cannot return one.
+   */
+  prerelease: boolean;
 }
 
 export type FindLatestResult =
@@ -68,20 +114,33 @@ export type FindLatestResult =
   | { ok: false; error: string };
 
 /**
- * Hit GitHub's `/releases/latest` endpoint, find the binary asset that
- * matches the requested target + the SHA256SUMS file beside it, and
+ * Resolve the newest release on the requested ring, find the binary asset
+ * that matches the requested target + the SHA256SUMS file beside it, and
  * return everything `phantombot update` needs to download and verify.
+ *
+ * Stable hits `/releases/latest` (prereleases excluded by GitHub); preview
+ * hits the `/releases` list and takes its first non-draft entry. Both paths
+ * share the auth-retry and asset-resolution logic below, so the two rings
+ * can never disagree about what "has a usable binary" means.
  */
 export async function findLatestRelease(opts: {
   target: SupportedTarget;
+  /** Release ring to resolve against. Default: stable. */
+  channel?: UpdateChannel;
   /** Override the upstream repo. Default: env var or DEFAULT_REPO. */
   repo?: string;
   fetchImpl?: typeof fetch;
 }): Promise<FindLatestResult> {
   const fetchImpl = opts.fetchImpl ?? fetch;
+  const channel = opts.channel ?? DEFAULT_UPDATE_CHANNEL;
   const repo =
     opts.repo ?? process.env.PHANTOMBOT_UPDATE_REPO ?? DEFAULT_REPO;
-  const url = `https://api.github.com/repos/${repo}/releases/latest`;
+  // Preview asks for the LIST (newest first, prereleases included); stable
+  // asks for the single endpoint that filters prereleases out for us.
+  const url =
+    channel === "preview"
+      ? `https://api.github.com/repos/${repo}/releases?per_page=${PREVIEW_PAGE_SIZE}`
+      : `https://api.github.com/repos/${repo}/releases/latest`;
 
   const hadToken = !!process.env.GITHUB_TOKEN;
 
@@ -138,14 +197,42 @@ export async function findLatestRelease(opts: {
     return { ok: false, error: `GitHub API HTTP ${res.status} from ${url}` };
   }
 
-  let body: GithubReleaseResponse;
+  let payload: unknown;
   try {
-    body = (await res.json()) as GithubReleaseResponse;
+    payload = await res.json();
   } catch (e) {
     return {
       ok: false,
       error: `GitHub API returned non-JSON: ${(e as Error).message}`,
     };
+  }
+
+  // Preview: pick the newest non-draft entry off the list. A DRAFT has no
+  // public assets and no tag on the repo, so installing one is impossible —
+  // skip past it rather than failing the whole check. Prereleases are
+  // exactly what we are here for, so they are NOT skipped.
+  let body: GithubReleaseResponse;
+  if (channel === "preview") {
+    if (!Array.isArray(payload)) {
+      return {
+        ok: false,
+        error: `GitHub API returned a non-array release list from ${url}`,
+      };
+    }
+    const releases = payload as GithubReleaseResponse[];
+    const candidate = releases.find((r) => r && r.draft !== true);
+    if (!candidate) {
+      return {
+        ok: false,
+        error:
+          releases.length === 0
+            ? `no releases found at ${repo}. Has the workflow ever produced one?`
+            : `the newest ${releases.length} release(s) at ${repo} are all drafts`,
+      };
+    }
+    body = candidate;
+  } else {
+    body = payload as GithubReleaseResponse;
   }
 
   if (typeof body.tag_name !== "string" || !Array.isArray(body.assets)) {
@@ -183,6 +270,7 @@ export async function findLatestRelease(opts: {
       publishedAt:
         typeof body.published_at === "string" ? body.published_at : undefined,
       body: typeof body.body === "string" ? body.body : "",
+      prerelease: body.prerelease === true,
       binary: {
         name: binary.name,
         url: binary.browser_download_url,
@@ -255,6 +343,10 @@ interface GithubReleaseResponse {
   tag_name?: string;
   published_at?: string;
   body?: string;
+  /** GitHub's prerelease flag — true until someone presses promote. */
+  prerelease?: boolean;
+  /** Unpublished draft: no tag, no downloadable assets. Preview skips these. */
+  draft?: boolean;
   assets?: Array<{
     name: string;
     browser_download_url: string;

--- a/src/lib/updateNotify.ts
+++ b/src/lib/updateNotify.ts
@@ -40,6 +40,7 @@ import {
 } from "../config.ts";
 import { runUpdate } from "../cli/update.ts";
 import {
+  DEFAULT_UPDATE_CHANNEL,
   detectSupportedTarget,
   findLatestRelease,
 } from "./githubReleases.ts";
@@ -329,8 +330,12 @@ export async function runUpdateFlow(
 
   // 1. Ask GitHub what's latest. Reuse the same client `update --check`
   //    uses so the version comparison agrees byte-for-byte.
+  // Same ring the `update` CLI would install from, so `/update` can never
+  // pull a build the host's configured channel would not have offered.
+  const channel = input.config.updateChannel ?? DEFAULT_UPDATE_CHANNEL;
   const r = await findLatestRelease({
     target,
+    channel,
     fetchImpl: input.fetchImpl,
   });
   if (!r.ok) {
@@ -368,6 +373,10 @@ export async function runUpdateFlow(
   const exitCode = await updateImpl({
     force: true,
     restart: false,
+    // Pass the ring we just resolved rather than letting runUpdate re-read
+    // config: the marker above was written for the release THIS ring
+    // resolved, so the swap must not be free to pick a different one.
+    channel,
     fetchImpl: input.fetchImpl,
     currentVersion: input.currentVersion,
     serviceControl: input.serviceControl,
@@ -477,6 +486,7 @@ export async function checkAndNotifyOnce(
 
   const r = await findLatestRelease({
     target,
+    channel: input.config.updateChannel ?? DEFAULT_UPDATE_CHANNEL,
     fetchImpl: input.fetchImpl,
   });
   if (!r.ok) {

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -189,6 +189,33 @@ describe("runDoctor", () => {
     expect(JSON.parse(out.text).nightly.errors).toBeUndefined();
   });
 
+  test("reports the release ring so a preview bug report is interpretable", async () => {
+    // A config with no updateChannel is a pre-#432 host: it followed
+    // /releases/latest, which IS the stable ring, so that is what doctor
+    // must say — not "unknown".
+    const out = new CaptureStream();
+    await runDoctor({ config, json: true, out });
+    const report = JSON.parse(out.text);
+    expect(report.update.channel).toBe("stable");
+    expect(report.update.version).toBeTypeOf("string");
+
+    const human = new CaptureStream();
+    await runDoctor({ config, out: human });
+    expect(human.text).toContain("stable channel");
+    expect(human.text).toContain("installs only promoted releases");
+  });
+
+  test("a preview host says so, and says where the setting lives", async () => {
+    const previewConfig = { ...config, updateChannel: "preview" as const };
+    const out = new CaptureStream();
+    const code = await runDoctor({ config: previewConfig, out });
+    // Informational only — a ring is a choice, never a health failure.
+    expect(code).toBe(0);
+    expect(out.text).toContain("preview channel");
+    expect(out.text).toContain("every merge to main");
+    expect(out.text).toContain("update_channel");
+  });
+
   test("json mode emits a parseable report with ledger-derived health", async () => {
     await writeDaily("2026-05-01");
     await writeState({

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -21,6 +21,8 @@ import type { ServiceControl } from "../src/lib/systemd.ts";
 
 let workdir: string;
 let binPath: string;
+let savedConfigEnv: string | undefined;
+let savedChannelEnv: string | undefined;
 
 class CaptureStream {
   chunks: string[] = [];
@@ -37,9 +39,24 @@ beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-update-"));
   binPath = join(workdir, "phantombot");
   await writeFile(binPath, "OLD_BINARY", { mode: 0o755 });
+  // runUpdate reads the host's release ring from config when the caller
+  // doesn't pass one (#432). Point it at a path that does not exist so the
+  // suite resolves "stable" deterministically instead of inheriting whatever
+  // ring the developer's own box happens to be on.
+  savedConfigEnv = process.env.PHANTOMBOT_CONFIG;
+  savedChannelEnv = process.env.PHANTOMBOT_UPDATE_CHANNEL;
+  process.env.PHANTOMBOT_CONFIG = join(workdir, "no-such-config.toml");
+  delete process.env.PHANTOMBOT_UPDATE_CHANNEL;
 });
 
 afterEach(async () => {
+  if (savedConfigEnv === undefined) delete process.env.PHANTOMBOT_CONFIG;
+  else process.env.PHANTOMBOT_CONFIG = savedConfigEnv;
+  if (savedChannelEnv === undefined) {
+    delete process.env.PHANTOMBOT_UPDATE_CHANNEL;
+  } else {
+    process.env.PHANTOMBOT_UPDATE_CHANNEL = savedChannelEnv;
+  }
   await rm(workdir, { recursive: true, force: true });
 });
 
@@ -844,5 +861,170 @@ describe("runUpdate installs the bundled editor extensions", () => {
     });
     expect(code).toBe(0);
     expect(err.text).toContain("code CLI wedged");
+  });
+});
+
+describe("runUpdate — release rings (#432)", () => {
+  /**
+   * Records which GitHub API URL the updater asked for, then answers with a
+   * body shaped for that endpoint: an object for /releases/latest, an array
+   * for the preview list.
+   */
+  function ringFetch(opts: { prerelease?: boolean } = {}): {
+    fetchImpl: typeof fetch;
+    apiUrls: string[];
+  } {
+    const apiUrls: string[] = [];
+    const release = {
+      tag_name: "v1.0.99",
+      body: "test release",
+      prerelease: opts.prerelease ?? true,
+      assets: [
+        {
+          name: ASSET,
+          browser_download_url: "https://example/" + ASSET,
+          size: NEW_BYTES.byteLength,
+        },
+        {
+          name: "SHA256SUMS",
+          browser_download_url: "https://example/SHA256SUMS",
+          size: 256,
+        },
+      ],
+    };
+    const fetchImpl = (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (isGitHubApiUrl(u)) {
+        apiUrls.push(u);
+        const body = u.includes("/releases/latest") ? release : [release];
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (u.includes("SHA256SUMS")) {
+        return new Response(`${NEW_SHA}  ${ASSET}\n`, {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      return new Response(NEW_BYTES, {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      });
+    }) as unknown as typeof fetch;
+    return { fetchImpl, apiUrls };
+  }
+
+  test("default (no config) resolves the stable endpoint", async () => {
+    const { fetchImpl, apiUrls } = ringFetch();
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.99",
+      fetchImpl,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      check: true,
+    });
+    expect(code).toBe(0);
+    expect(apiUrls[0]).toContain("/releases/latest");
+  });
+
+  test("update_channel = preview in config makes the CLI resolve the list", async () => {
+    // Exercises the real config path, not the `channel` test seam: this is
+    // the wire between what an operator writes in config.toml and which
+    // endpoint the updater actually hits.
+    await writeFile(
+      join(workdir, "config.toml"),
+      'update_channel = "preview"\n',
+      "utf8",
+    );
+    process.env.PHANTOMBOT_CONFIG = join(workdir, "config.toml");
+    const { fetchImpl, apiUrls } = ringFetch();
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      currentVersion: "1.0.99",
+      fetchImpl,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      check: true,
+    });
+    expect(code).toBe(0);
+    expect(apiUrls[0]).toContain("/releases?per_page=");
+  });
+
+  test("preview labels the version lines so a bug report is interpretable", async () => {
+    const out = new CaptureStream();
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      channel: "preview",
+      currentVersion: "1.0.42",
+      fetchImpl: ringFetch().fetchImpl,
+      out,
+      err: new CaptureStream(),
+      check: true,
+    });
+    expect(code).toBe(2);
+    expect(out.text).toContain("1.0.42 → 1.0.99 (preview)");
+  });
+
+  test("stable output is unchanged — no ring annotation on existing installs", async () => {
+    const out = new CaptureStream();
+    await runUpdate({
+      binPath,
+      procArch: "x64",
+      channel: "stable",
+      currentVersion: "1.0.42",
+      fetchImpl: ringFetch({ prerelease: false }).fetchImpl,
+      out,
+      err: new CaptureStream(),
+      check: true,
+    });
+    expect(out.text).toContain("1.0.42 → 1.0.99");
+    expect(out.text).not.toContain("preview");
+  });
+
+  test("a failed check names the ring it was checking", async () => {
+    const err = new CaptureStream();
+    const failing = (async () => {
+      throw new Error("ENETUNREACH");
+    }) as unknown as typeof fetch;
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      channel: "preview",
+      currentVersion: "1.0.42",
+      fetchImpl: failing,
+      out: new CaptureStream(),
+      err,
+      force: true,
+    });
+    expect(code).toBe(1);
+    expect(err.text).toContain("preview channel");
+  });
+
+  test("switching back to stable INSTALLS A LOWER VERSION (rollback path)", async () => {
+    // The whole rollback story rests on the version gate being equality and
+    // not `>`: a host stranded on preview 1.1.291 must be able to fall back
+    // to stable 1.0.99. If someone "fixes" that compare, this goes red.
+    const code = await runUpdate({
+      binPath,
+      procArch: "x64",
+      channel: "stable",
+      currentVersion: "1.1.291",
+      fetchImpl: ringFetch({ prerelease: false }).fetchImpl,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      force: true,
+      healSystemdUnits: false,
+      refreshCompletions: false,
+      installEditorExtensions: false,
+      resignBinary: false,
+    });
+    expect(code).toBe(0);
+    expect(await readFile(binPath, "utf8")).toBe("NEW_BINARY_VERIFIED");
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -91,6 +91,7 @@ const ENV_KEYS = [
   "PHANTOMBOT_TELEGRAM_BUBBLE_DELAY_MS",
   "PHANTOMBOT_TELEGRAM_VOICE_MAX_SENTENCES",
   "PHANTOMBOT_CHATTINESS",
+  "PHANTOMBOT_UPDATE_CHANNEL",
   "PHANTOMBOT_P2P_ENABLED",
   "PHANTOMBOT_P2P_PORT",
   "PHANTOMBOT_P2P_STUN",
@@ -1102,5 +1103,80 @@ describe("loadConfig — p2p (phantombot#258, #61)", () => {
     process.env.PHANTOMBOT_P2P_STUN = "";
     const c = await loadConfig();
     expect(c.p2p!.stunServers).toEqual([]);
+  });
+});
+
+describe("loadConfig — update_channel (release rings, #432)", () => {
+  async function writeConfig(body: string): Promise<void> {
+    const cfgDir = join(workdir, "config", "phantombot");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(join(cfgDir, "config.toml"), body, "utf8");
+  }
+
+  test("no config file → stable, so an untouched host never moves ring", async () => {
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("stable");
+  });
+
+  test("config.toml omitting the key → stable", async () => {
+    await writeConfig(`default_persona = "robbie"\n`);
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("stable");
+  });
+
+  test("explicit update_channel = \"preview\" is honored", async () => {
+    await writeConfig(`update_channel = "preview"\n`);
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("preview");
+  });
+
+  test("explicit update_channel = \"stable\" is honored", async () => {
+    await writeConfig(`update_channel = "stable"\n`);
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("stable");
+  });
+
+  test("a typo'd channel falls back to stable, not to preview", async () => {
+    // Fail closed: a misspelt ring must never leave a box following a
+    // ring the operator did not choose.
+    await writeConfig(`update_channel = "prevew"\n`);
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("stable");
+  });
+
+  test("a non-string channel falls back to stable", async () => {
+    await writeConfig(`update_channel = true\n`);
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("stable");
+  });
+
+  test("PHANTOMBOT_UPDATE_CHANNEL env wins over the default", async () => {
+    process.env.PHANTOMBOT_UPDATE_CHANNEL = "preview";
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("preview");
+  });
+
+  test("PHANTOMBOT_UPDATE_CHANNEL env wins over config.toml", async () => {
+    await writeConfig(`update_channel = "preview"\n`);
+    process.env.PHANTOMBOT_UPDATE_CHANNEL = "stable";
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("stable");
+  });
+
+  test("an invalid env value falls back to stable and does NOT read the TOML", async () => {
+    // An explicit-but-broken env override is still an explicit override:
+    // silently falling through to a `preview` TOML key would put the host
+    // on a ring the (broken) env var was trying to move it off.
+    await writeConfig(`update_channel = "preview"\n`);
+    process.env.PHANTOMBOT_UPDATE_CHANNEL = "nightly";
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("stable");
+  });
+
+  test("an empty env value defers to config.toml", async () => {
+    await writeConfig(`update_channel = "preview"\n`);
+    process.env.PHANTOMBOT_UPDATE_CHANNEL = "";
+    const c = await loadConfig();
+    expect(c.updateChannel).toBe("preview");
   });
 });

--- a/tests/lib-githubReleases.test.ts
+++ b/tests/lib-githubReleases.test.ts
@@ -5,6 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  asUpdateChannel,
   detectSupportedArch,
   detectSupportedTarget,
   findLatestRelease,
@@ -326,5 +327,185 @@ describe("findLatestRelease", () => {
     }) as unknown as typeof fetch;
     await findLatestRelease({ target: "linux-x64", fetchImpl: recordingFetch });
     expect(seenUrl).toContain("fakeorg/fakerepo");
+  });
+});
+
+/**
+ * Release rings (#432). A stable host resolves `/releases/latest` — which
+ * GitHub filters prereleases out of — while a preview host resolves the
+ * `/releases` LIST and takes its newest non-draft entry.
+ */
+describe("findLatestRelease — release channels", () => {
+  /** A prerelease as release.yml now cuts it. */
+  const PRERELEASE = {
+    ...SAMPLE_RELEASE,
+    tag_name: "v1.1.291",
+    prerelease: true,
+    assets: SAMPLE_RELEASE.assets.map((a) => ({
+      ...a,
+      name: a.name.replace("v1.0.43", "v1.1.291"),
+    })),
+  };
+  /** A promoted release: same shape, prerelease flag cleared. */
+  const PROMOTED = { ...SAMPLE_RELEASE, prerelease: false };
+
+  function recordingFetch(body: unknown): {
+    fetchImpl: typeof fetch;
+    urls: string[];
+  } {
+    const urls: string[] = [];
+    const fetchImpl = (async (url: string | URL | Request) => {
+      urls.push(String(url));
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    return { fetchImpl, urls };
+  }
+
+  test("default channel is stable and hits /releases/latest", async () => {
+    const { fetchImpl, urls } = recordingFetch(PROMOTED);
+    const r = await findLatestRelease({ target: "linux-x64", fetchImpl });
+    expect(r.ok).toBe(true);
+    expect(urls[0]).toContain("/releases/latest");
+    expect(urls[0]).not.toContain("per_page");
+  });
+
+  test("stable channel reports prerelease:false even without the field", async () => {
+    // /releases/latest cannot return a prerelease, so absence of the flag
+    // must read as "not a prerelease", never as undefined leaking out.
+    const { fetchImpl } = recordingFetch(SAMPLE_RELEASE);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "stable",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.release.prerelease).toBe(false);
+  });
+
+  test("preview channel hits the releases LIST, not /releases/latest", async () => {
+    const { fetchImpl, urls } = recordingFetch([PRERELEASE]);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "preview",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(urls[0]).toContain("/releases?per_page=");
+    expect(urls[0]).not.toContain("/releases/latest");
+    expect(r.release.version).toBe("1.1.291");
+    expect(r.release.prerelease).toBe(true);
+    expect(r.release.binary.name).toBe("phantombot-v1.1.291-linux-x64");
+  });
+
+  test("preview takes the NEWEST entry — the list is already newest-first", async () => {
+    const { fetchImpl } = recordingFetch([PRERELEASE, PROMOTED]);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "preview",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.release.tag).toBe("v1.1.291");
+  });
+
+  test("preview skips drafts — they have no public assets to install", async () => {
+    const draft = { ...PRERELEASE, tag_name: "v1.1.292", draft: true };
+    const { fetchImpl } = recordingFetch([draft, PRERELEASE]);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "preview",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.release.tag).toBe("v1.1.291");
+  });
+
+  test("preview accepts an already-promoted release as newest", async () => {
+    // Right after a promotion the newest entry is no longer a prerelease.
+    // A preview host must still install it, not skip past it looking for
+    // one — otherwise promotion would strand the preview ring behind.
+    const { fetchImpl } = recordingFetch([PROMOTED]);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "preview",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.release.tag).toBe("v1.0.43");
+    expect(r.release.prerelease).toBe(false);
+  });
+
+  test("preview errors on an empty release list", async () => {
+    const { fetchImpl } = recordingFetch([]);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "preview",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("no releases found");
+  });
+
+  test("preview errors when every candidate is a draft", async () => {
+    const { fetchImpl } = recordingFetch([{ ...PRERELEASE, draft: true }]);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "preview",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("drafts");
+  });
+
+  test("preview errors when the API returns an object instead of a list", async () => {
+    const { fetchImpl } = recordingFetch(PRERELEASE);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "preview",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("non-array");
+  });
+
+  test("preview enforces the same asset requirements as stable", async () => {
+    const noChecksums = {
+      ...PRERELEASE,
+      assets: PRERELEASE.assets.filter((a) => a.name !== "SHA256SUMS"),
+    };
+    const { fetchImpl } = recordingFetch([noChecksums]);
+    const r = await findLatestRelease({
+      target: "linux-x64",
+      channel: "preview",
+      fetchImpl,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("SHA256SUMS");
+  });
+});
+
+describe("asUpdateChannel", () => {
+  test("accepts exactly the two ring names", () => {
+    expect(asUpdateChannel("stable")).toBe("stable");
+    expect(asUpdateChannel("preview")).toBe("preview");
+  });
+  test("rejects everything else so callers can fail closed", () => {
+    expect(asUpdateChannel("prevew")).toBeUndefined();
+    expect(asUpdateChannel("PREVIEW")).toBeUndefined();
+    expect(asUpdateChannel(true)).toBeUndefined();
+    expect(asUpdateChannel("")).toBeUndefined();
+    expect(asUpdateChannel(undefined)).toBeUndefined();
   });
 });

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -88,6 +88,21 @@ function baseConfig(): Config {
   };
 }
 
+/**
+ * Exact hostname match — `URL.hostname` is the parsed host, so
+ * `https://api.github.com.evil.example/...` and
+ * `https://evil.example/?u=api.github.com` are both correctly rejected.
+ * A substring `u.includes("api.github.com")` tripped CodeQL "incomplete
+ * URL substring sanitization". Invalid URLs are non-matches, not throws.
+ */
+function isGitHubApiUrl(u: string): boolean {
+  try {
+    return new URL(u).hostname === "api.github.com";
+  } catch {
+    return false;
+  }
+}
+
 const ASSET = "phantombot-v1.0.99-linux-x64";
 const NEW_BYTES = Buffer.from("NEW_BINARY_VERIFIED");
 const NEW_SHA = createHash("sha256").update(NEW_BYTES).digest("hex");
@@ -1323,7 +1338,7 @@ describe("release rings (#432) — the heartbeat follows the host's channel", ()
     };
     const fetchImpl = (async (url: string | URL | Request) => {
       const u = String(url);
-      if (u.includes("api.github.com")) {
+      if (isGitHubApiUrl(u)) {
         apiUrls.push(u);
         const body = u.includes("/releases/latest") ? release : [release];
         return new Response(JSON.stringify(body), {

--- a/tests/lib-updateNotify.test.ts
+++ b/tests/lib-updateNotify.test.ts
@@ -1298,3 +1298,101 @@ describe("notifyPhantomchatPostRestart", () => {
     expect(transport.sent.length).toBe(0);
   });
 });
+
+describe("release rings (#432) — the heartbeat follows the host's channel", () => {
+  /** Answers either endpoint shape and records which one was asked for. */
+  function ringFetch(): { fetchImpl: typeof fetch; apiUrls: string[] } {
+    const apiUrls: string[] = [];
+    const release = {
+      tag_name: "v1.0.99",
+      published_at: "2026-05-01T00:00:00Z",
+      body: "test release",
+      prerelease: true,
+      assets: [
+        {
+          name: ASSET,
+          browser_download_url: "https://example/" + ASSET,
+          size: NEW_BYTES.byteLength,
+        },
+        {
+          name: "SHA256SUMS",
+          browser_download_url: "https://example/SHA256SUMS",
+          size: 256,
+        },
+      ],
+    };
+    const fetchImpl = (async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.includes("api.github.com")) {
+        apiUrls.push(u);
+        const body = u.includes("/releases/latest") ? release : [release];
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+    return { fetchImpl, apiUrls };
+  }
+
+  test("a stable host's heartbeat resolves /releases/latest", async () => {
+    const { fetchImpl, apiUrls } = ringFetch();
+    await checkAndNotifyOnce({
+      config: baseConfig(),
+      currentVersion: "1.0.42",
+      now: new Date("2026-05-05T00:00:00Z"),
+      fetchImpl,
+      transport: new FakeTransport(),
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(apiUrls[0]).toContain("/releases/latest");
+  });
+
+  test("a preview host's heartbeat resolves the releases list", async () => {
+    // Otherwise a preview box would be notified about — and offered —
+    // whatever the STABLE ring is on, which is the build it deliberately
+    // opted out of tracking.
+    const { fetchImpl, apiUrls } = ringFetch();
+    await checkAndNotifyOnce({
+      config: { ...baseConfig(), updateChannel: "preview" },
+      currentVersion: "1.0.42",
+      now: new Date("2026-05-05T00:00:00Z"),
+      fetchImpl,
+      transport: new FakeTransport(),
+      lastNotifiedPath: lastNotifiedPathLocal,
+      procPlatform: "linux",
+      procArch: "x64",
+    });
+    expect(apiUrls[0]).toContain("/releases?per_page=");
+  });
+
+  test("/update hands its resolved ring to the swap, not a re-read config", async () => {
+    // The marker is written for the release THIS ring resolved; if the swap
+    // re-derived the channel it could install a different build than the one
+    // the user was just told about.
+    let seenChannel: unknown;
+    const { fetchImpl } = ringFetch();
+    await runUpdateFlow({
+      config: { ...baseConfig(), updateChannel: "preview" },
+      currentVersion: "1.0.42",
+      chatId: 42,
+      fetchImpl,
+      pendingPath: pendingPath,
+      procPlatform: "linux",
+      procArch: "x64",
+      runUpdateImpl: (async (input: { channel?: string }) => {
+        seenChannel = input.channel;
+        return 0;
+      }) as never,
+      serviceControl: {
+        isActive: async () => true,
+        restart: async () => ({ ok: true }),
+        rerenderUnitIfStale: async () => ({ rerendered: false }),
+      } as never,
+    });
+    expect(seenChannel).toBe("preview");
+  });
+});


### PR DESCRIPTION
Closes #432.

Every merge to `main` is now published as a GitHub **prerelease**. Promotion to stable is a human act — a `workflow_dispatch` button that flips `--prerelease=false --latest` on a release that already exists. **Nothing is rebuilt at promotion**, so the binaries the fleet installs are bit-identical to the ones that soaked on the preview ring. A promotion that rebuilt would ship an artifact nobody had run, and the soak would be theatre.

The mechanism is nearly free: GitHub's `/releases/latest` excludes prereleases by design, and that is the endpoint a default host already resolved. **A stable host needs no code change** — it just stops seeing every merge.

## Why promotion is not automated

Green CI is the bar for **merging**. If it were also the bar for stable, the two rings would be the same ring. Stable means a human watched a real host run it for a few days.

## What changed

**CI**
- `release.yml`: `gh release create --prerelease`, plus release notes that say which ring the build is on and how to promote it.
- `promote.yml` (new): pick a tag, or leave it empty to take the newest prerelease. Fails closed on everything it does not fully understand — the tag must exist, must not be a draft, and must carry all six binaries plus `SHA256SUMS` before the flag is flipped. Reads `/releases/latest` back afterwards to prove stable hosts will actually resolve it, rather than trusting the edit's exit code.

**Client**
- `update_channel` in `config.toml` (env `PHANTOMBOT_UPDATE_CHANNEL`). Host-level, not per-persona: it selects which *binary* the box installs, and every persona on a host runs the same one.
- An unrecognised value falls back to `stable` **with a warning**, never to preview. A typo (`"prevew"`) must not opt a host into a ring nobody chose.
- Preview resolves the `/releases` list and takes its newest **non-draft** entry — drafts have no public assets, so they are unreachable, not preferable. An already-promoted release is still accepted as newest, otherwise promotion would strand the preview ring behind.
- `phantombot update`, `/update` and the heartbeat update-check all resolve through the host's ring. `runUpdateFlow` hands its resolved ring to the swap rather than letting `runUpdate` re-read config — the pending-update marker is written for the release *this* ring resolved, and the swap must not be free to pick a different one.
- `phantombot doctor` reports ring + version, human and JSON. Once `latest` stops meaning "newest build", a bug report that does not say which ring it came from is uninterpretable.

## Rollback is free — and load-bearing

No new code and no version arithmetic. `src/cli/update.ts` gates on `release.version === currentVersion` — **equality, not "is newer"** — so a host stranded on preview `1.1.291` flips `update_channel` back to `stable` and installs `1.1.280`, a *lower* number. A bad *promoted* release is handled from the other side: promote the last good tag and stable hosts follow it back down.

This is the one thing in the PR that a future "cleanup" would plausibly break, so it is pinned three ways: a test that installs a lower version and asserts the binary was replaced, an AGENTS.md invariant, and a README note under Versioning telling you not to make it semver-aware.

## Verification

- Full suite: **3430 pass, 2 skip, 0 fail** (189 files). `bun tsc --noEmit` clean. Both workflow files parse.
- Mutation-tested the two guarantees rather than trusting green:
  - `===` → `<=` in the version gate ⇒ the rollback test goes **red**.
  - preview URL hard-coded back to `/releases/latest` ⇒ 3 tests go **red**.
- `tests/cli-update.test.ts` now pins `PHANTOMBOT_CONFIG` at a non-existent path in `beforeEach`, so the suite resolves `stable` deterministically instead of inheriting whatever ring the developer's own box is on.

## Note for the first promotion

The release cut by merging *this* PR is itself a prerelease. A host cannot follow the preview ring until it is running a binary that contains this code, so the intended first move is to promote that release once (which is also a live test of the button), then set `update_channel = "preview"` on one host.
