### PR TITLE
Fix promote workflow failing with "not a git repository"

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -40,12 +40,20 @@ jobs:
   promote:
     runs-on: ubuntu-latest
 
+    # Job-wide so no step can forget it. This workflow never checks out the
+    # repo (promotion touches only the GitHub API), so `gh` has no git remote
+    # to infer the repository from: without GH_REPO it dies with
+    # "fatal: not a git repository". Setting it here rather than per step is
+    # deliberate — the original bug was one step out of four missing it.
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      REPO: ${{ github.repository }}
+
     steps:
       - name: Resolve the tag to promote
         id: resolve
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
@@ -67,8 +75,6 @@ jobs:
 
       - name: Verify the release is promotable
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
@@ -114,7 +120,6 @@ jobs:
 
       - name: Promote to stable
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
@@ -122,13 +127,11 @@ jobs:
           # is by publish date among non-prereleases, and we want the pointer
           # to land on the tag we just promoted even when an older release is
           # flipped (a rollback promotion).
-          gh release edit "$TAG" --prerelease=false --latest
+          gh release edit "$TAG" --repo "$REPO" --prerelease=false --latest
           echo "promoted $TAG to stable"
 
       - name: Confirm and summarize
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
           TAG: ${{ steps.resolve.outputs.tag }}
           SERVER_URL: ${{ github.server_url }}
         run: |


### PR DESCRIPTION
Promoting v1.1.292 failed on the last step of `promote.yml` ([run 32593690165](https://github.com/phantomyard/phantombot/actions/runs/32593690165)):

```
gh release edit "$TAG" --prerelease=false --latest
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The workflow never checks out the repo — promotion is a pure GitHub API operation — so `gh` has no git remote to infer the repository from. The other three steps all pass `REPO` explicitly into a `gh api` path; the `gh release edit` step was the only one that didn't.

**Blast radius: none.** Resolve and verify both passed first, so `v1.1.292` is untouched — still a prerelease, all 7 assets present. Nothing was half-flipped.

**Fix:** `GH_TOKEN`, `GH_REPO` and `REPO` move to the job-level `env` block, per-step duplicates removed, and `gh release edit` gains an explicit `--repo "$REPO"`. Job-wide because the bug was exactly one step out of four forgetting it — a per-step fix leaves the next added step able to repeat it.

Not caught in review because a `workflow_dispatch` workflow can't be exercised until it's on the default branch. First promotion was always going to be the live test; this is what it found.

Part of #432.
