### PR TITLE
Surface incomplete Telegram persona accounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,8 @@ If you add a new untrusted entry point (a new inbound channel, a new `ask`-style
 
 `runRun` builds one Telegram listener per persona-with-a-bot and one PhantomChat listener per persona-with-an-identity, all inside the single `phantombot run` process. The `runLock` (`src/lib/runLock.ts`) still prevents two `phantombot run` processes on one box — the multiplexing is inside the process, not across processes. There is no supervisor, no subprocess per persona, and adding one is a rejected design (crash isolation is not worth a supervisor, backoff, orphan handling on update, and the cgroup trap of #415).
 
+Telegram account parsing is deliberately permissive: an account without a token resolves to no `TelegramAccount`. `Config.channels.telegramStated` and `telegramPersonasStated` preserve whether TOML nevertheless stated that account, so `planListeners` can warn and `doctor` can fail without making startup fatal. Do not infer intent from `channels.telegram === undefined`: that shape also describes a valid PhantomChat-only persona. A broken Telegram account disables only that listener; sibling Telegram listeners and PhantomChat must keep running.
+
 **Config is two layers** (`src/lib/personaConfig.ts`, `loadConfig(persona)`):
 
 | File | Holds |

--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ Maintenance:
 | `phantombot tick` | Fire due scheduled tasks |
 | `phantombot heartbeat` | Run mechanical maintenance |
 | `phantombot nightly [--resume]` | Run or resume memory distillation |
-| `phantombot doctor [--no-repair]` | Check memory health and optionally repair |
+| `phantombot doctor [--no-repair]` | Check channel and memory health and optionally repair |
 
 ## Shell completion
 
@@ -757,6 +757,13 @@ either its own `[channels.telegram]` block in
 `<personas-root>/<persona>/config.toml`, its
 `[channels.telegram.personas.<name>]` entry, or its suffixed env vars; with
 none of those, that persona simply has no Telegram.
+
+A persona that states a Telegram table but has no token is different from one
+that states no Telegram account at all. Startup warns and skips only that
+broken listener; it does not throw or stop PhantomChat or other Telegram bots.
+`phantombot doctor` reports the resolved listener count for every boot persona
+and exits non-zero for a stated account with no runnable listener. An
+intentional PhantomChat-only persona remains healthy.
 
 ### Telegram Commands
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -392,7 +392,7 @@ function telegramHealthReport(
     !!config.channels.telegram || !!config.channels.telegramStated;
   if (config.channels.telegram) addAccount(config.defaultPersona);
 
-  const autostartWithListener = new Set<string>();
+  const autostartWithAccount = new Set<string>();
   for (const persona of config.autostartPersonas ?? []) {
     if (persona === config.defaultPersona) continue;
     const current = row(persona);
@@ -403,9 +403,7 @@ function telegramHealthReport(
       !!personaConfig?.channels.telegramStated;
     if (personaConfig?.channels.telegram) {
       addAccount(persona);
-      if (existsSync(personaDir(config, persona))) {
-        autostartWithListener.add(persona);
-      }
+      autostartWithAccount.add(persona);
     }
   }
 
@@ -413,7 +411,7 @@ function telegramHealthReport(
     row(persona).stated = true;
   }
   for (const persona of Object.keys(config.channels.telegramPersonas ?? {})) {
-    if (autostartWithListener.has(persona)) continue;
+    if (autostartWithAccount.has(persona)) continue;
     addAccount(persona);
   }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -98,6 +98,18 @@ const DRY_DAY_TURN_THRESHOLD = 20;
 
 export interface DoctorReport {
   persona: string;
+  /** Telegram reachability for every persona the daemon is configured to boot. */
+  telegram: {
+    healthy: boolean;
+    listeners: number;
+    personas: Array<{
+      persona: string;
+      stated: boolean;
+      listeners: number;
+      healthy: boolean;
+      detail: string;
+    }>;
+  };
   nightly: {
     last_run?: string;
     last_status?: string;
@@ -267,6 +279,8 @@ export interface DoctorReport {
 export interface RunDoctorInput {
   config?: Config;
   persona?: string;
+  /** Already-resolved configs for non-default boot personas (startup seam). */
+  personaConfigs?: Map<string, Config>;
   /**
    * Perform the repairs doctor still owns (systemd units/timers, the managed
    * Pi extension, editor connectors). Default true. The nightly is NOT among
@@ -334,6 +348,122 @@ export interface RunDoctorInput {
     | ((repair: boolean) => DoctorReport["editorConnectors"]);
 }
 
+interface MutableTelegramPersonaHealth {
+  persona: string;
+  stated: boolean;
+  runnableAccounts: number;
+  listeners: number;
+  missingPersonaDir: boolean;
+}
+
+/**
+ * Mirror listener planning closely enough to diagnose zero-listener personas,
+ * without importing run.ts (run.ts already imports doctor.ts for startup).
+ */
+function telegramHealthReport(
+  config: Config,
+  personaConfigs: Map<string, Config>,
+): DoctorReport["telegram"] {
+  const rows = new Map<string, MutableTelegramPersonaHealth>();
+  const row = (persona: string): MutableTelegramPersonaHealth => {
+    let current = rows.get(persona);
+    if (!current) {
+      current = {
+        persona,
+        stated: false,
+        runnableAccounts: 0,
+        listeners: 0,
+        missingPersonaDir: false,
+      };
+      rows.set(persona, current);
+    }
+    return current;
+  };
+  const addAccount = (persona: string): void => {
+    const current = row(persona);
+    current.stated = true;
+    current.runnableAccounts++;
+    if (existsSync(personaDir(config, persona))) current.listeners++;
+    else current.missingPersonaDir = true;
+  };
+
+  const defaultRow = row(config.defaultPersona);
+  defaultRow.stated =
+    !!config.channels.telegram || !!config.channels.telegramStated;
+  if (config.channels.telegram) addAccount(config.defaultPersona);
+
+  const autostartWithListener = new Set<string>();
+  for (const persona of config.autostartPersonas ?? []) {
+    if (persona === config.defaultPersona) continue;
+    const current = row(persona);
+    const personaConfig = personaConfigs.get(persona);
+    current.stated =
+      current.stated ||
+      !!personaConfig?.channels.telegram ||
+      !!personaConfig?.channels.telegramStated;
+    if (personaConfig?.channels.telegram) {
+      addAccount(persona);
+      if (existsSync(personaDir(config, persona))) {
+        autostartWithListener.add(persona);
+      }
+    }
+  }
+
+  for (const persona of config.channels.telegramPersonasStated ?? []) {
+    row(persona).stated = true;
+  }
+  for (const persona of Object.keys(config.channels.telegramPersonas ?? {})) {
+    if (autostartWithListener.has(persona)) continue;
+    addAccount(persona);
+  }
+
+  // A directly requested persona belongs in the report even when it is not in
+  // the boot roster (useful for `doctor --persona <name>` before autostart).
+  for (const [persona, personaConfig] of personaConfigs) {
+    const current = row(persona);
+    current.stated =
+      current.stated ||
+      !!personaConfig.channels.telegram ||
+      !!personaConfig.channels.telegramStated;
+    // Config may be resolved because this persona has PhantomChat or was
+    // selected explicitly, while Telegram planning excludes it from the boot
+    // roster. Preserve that the account itself is complete so doctor reports
+    // "not planned", never the false "no bot_token" diagnosis.
+    if (
+      personaConfig.channels.telegram &&
+      current.runnableAccounts === 0
+    ) {
+      current.runnableAccounts = 1;
+      current.missingPersonaDir = !existsSync(personaDir(config, persona));
+    }
+  }
+
+  const personas = [...rows.values()].map((current) => {
+    const healthy = !current.stated || current.listeners > 0;
+    const detail = !current.stated
+      ? "not configured"
+      : current.listeners > 0
+        ? "runnable"
+        : current.runnableAccounts === 0
+          ? "states an account but has no bot_token"
+          : current.missingPersonaDir
+            ? "account resolved but persona directory is missing"
+            : "account resolved but no listener is planned";
+    return {
+      persona: current.persona,
+      stated: current.stated,
+      listeners: current.listeners,
+      healthy,
+      detail,
+    };
+  });
+  return {
+    healthy: personas.every((entry) => entry.healthy),
+    listeners: personas.reduce((sum, entry) => sum + entry.listeners, 0),
+    personas,
+  };
+}
+
 export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
@@ -341,6 +471,22 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
 
   const config = input.config ?? (await loadConfig());
   const persona = input.persona ?? config.defaultPersona;
+  const personaConfigs = new Map(input.personaConfigs ?? []);
+  if (!input.config) {
+    const names = new Set(config.autostartPersonas ?? []);
+    if (persona !== config.defaultPersona) names.add(persona);
+    for (const name of names) {
+      if (name === config.defaultPersona || personaConfigs.has(name)) continue;
+      try {
+        personaConfigs.set(name, await loadConfig(name));
+      } catch (e) {
+        log.warn("doctor: persona config load failed", {
+          persona: name,
+          error: (e as Error).message,
+        });
+      }
+    }
+  }
   const dir = personaDir(config, persona);
   if (!existsSync(dir)) {
     err.write(`persona '${persona}' not found at ${dir}\n`);
@@ -389,6 +535,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     }
   }
   const dryDay = userTurns >= DRY_DAY_TURN_THRESHOLD && captures === 0;
+  const telegramReport = telegramHealthReport(config, personaConfigs);
 
   // Embeddings status — informational only. Vector search is live only when
   // the provider is gemini AND a key is actually present; everything else
@@ -554,6 +701,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
 
   const report: DoctorReport = {
     persona,
+    telegram: telegramReport,
     nightly: {
       last_run: state.last_run,
       last_status: state.last_status,
@@ -654,6 +802,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   // box installed this afternoon has none yet, and crying WARN there would
   // teach an operator to ignore the line that matters.
   const memoryDbBroken = dbPresent && !dbHealth.ok;
+  const telegramBroken = !telegramReport.healthy;
   const exitCode =
     memoryDbBroken
       ? 1
@@ -669,7 +818,9 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
               ? 1
               : editorConnectorsBroken
                 ? 1
-                : 0;
+                : telegramBroken
+                  ? 1
+                  : 0;
 
   if (input.json) {
     out.write(JSON.stringify(report, null, 2) + "\n");
@@ -679,6 +830,17 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   // Human summary.
   const tick = (ok: boolean) => (ok ? "ok" : "WARN");
   out.write(`phantombot doctor — persona '${persona}'\n`);
+  out.write(
+    `  telegram: ${tick(telegramReport.healthy)} — ` +
+      `${telegramReport.listeners} listener(s) across ` +
+      `${telegramReport.personas.length} persona(s)\n`,
+  );
+  for (const entry of telegramReport.personas) {
+    out.write(
+      `    persona '${entry.persona}': ${entry.listeners} listener(s), ` +
+        `${entry.detail}\n`,
+    );
+  }
   // Health comes off the ledger, not the clock: a box that slept through
   // 02:00 but has nothing pending is healthy.
   const marker =

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -213,6 +213,15 @@ export function planListeners(
   personaConfigs?: Map<string, Config>,
 ): { listeners: ListenerSpec[]; fatal?: string } {
   const listeners: ListenerSpec[] = [];
+  const warnedIncomplete = new Set<string>();
+  const warnIncomplete = (persona: string, source: string): void => {
+    if (warnedIncomplete.has(persona)) return;
+    warnedIncomplete.add(persona);
+    err.write(
+      `warning: persona '${persona}' states ${source} but no bot_token — ` +
+        "no telegram listener will start\n",
+    );
+  };
 
   if (config.channels.telegram) {
     const agentDir = personaDir(config, defaultPersona);
@@ -229,6 +238,8 @@ export function planListeners(
         `warning: default persona '${defaultPersona}' agent dir missing at ${agentDir} — skipping default telegram listener\n`,
       );
     }
+  } else if (config.channels.telegramStated) {
+    warnIncomplete(defaultPersona, "[channels.telegram]");
   }
 
   // Autostart personas (phantombot#439): each brings its OWN
@@ -247,8 +258,12 @@ export function planListeners(
     }
     const account = personaConfig.channels.telegram;
     if (!account) {
-      // Not an error: a persona may autostart for PhantomChat alone. Its
-      // phantomchat listener is planned separately from its persona dir.
+      // A persona with no Telegram statement may autostart for PhantomChat
+      // alone. A stated-but-incomplete account is different and must be loud,
+      // while remaining non-fatal so PhantomChat and sibling bots stay alive.
+      if (personaConfig.channels.telegramStated) {
+        warnIncomplete(persona, "[channels.telegram]");
+      }
       continue;
     }
     const agentDir = personaDir(config, persona);
@@ -305,6 +320,14 @@ export function planListeners(
     });
   }
 
+  for (const persona of config.channels.telegramPersonasStated ?? []) {
+    if (config.channels.telegramPersonas?.[persona]) continue;
+    warnIncomplete(
+      persona,
+      `[channels.telegram.personas.${persona}]`,
+    );
+  }
+
   // Duplicate-token guard. Two listeners on the same Telegram bot would
   // both call getUpdates(offset=...) — the second call's confirmation
   // would mark the first call's batch as read, dropping messages. Fail
@@ -329,10 +352,12 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   const err = input.err ?? process.stderr;
 
   let config = input.config ?? (await loadConfig());
-  const hasDefault = !!config.channels.telegram;
+  const hasDefault =
+    !!config.channels.telegram || !!config.channels.telegramStated;
   const hasPersonas =
-    !!config.channels.telegramPersonas &&
-    Object.keys(config.channels.telegramPersonas).length > 0;
+    (!!config.channels.telegramPersonas &&
+      Object.keys(config.channels.telegramPersonas).length > 0) ||
+    (config.channels.telegramPersonasStated?.length ?? 0) > 0;
 
   // PhantomChat personas are a runnable channel in their own right. Compute
   // this BEFORE the channel guards below: `phantombot init` now makes
@@ -503,7 +528,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   }
   if (plan.listeners.length === 0 && !hasPhantomchat) {
     err.write(
-      "no telegram listeners could be started — every configured bot's persona is missing.\n",
+      "no telegram listeners could be started — check the warnings above.\n",
     );
     return 2;
   }
@@ -753,7 +778,7 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   // Startup health check — read-only for the nightly (it repairs itself by
   // sweeping); still repairs drifted units/timers/connectors. Don't await.
   // Runs against the admin persona for the same reason as notify above.
-  runDoctor({ config, persona: alertPersona, out, err }).then(
+  runDoctor({ config, persona: alertPersona, personaConfigs, out, err }).then(
     (code) => {
       if (code !== 0) log.info("run: startup doctor flagged an issue", { code });
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -654,6 +654,13 @@ export interface Config {
   channels: {
     telegram?: TelegramAccount;
     /**
+     * True when this persona explicitly states a Telegram account source even
+     * if resolution dropped it because no token was available. This keeps
+     * "broken Telegram" distinguishable from intentional PhantomChat-only
+     * configuration after the permissive account parser has run.
+     */
+    telegramStated?: boolean;
+    /**
      * Optional additional Telegram bots, keyed by persona name. Each
      * entry spawns its own listener bound to the named persona, so the
      * same host can run several persona-bound bots from one process.
@@ -661,6 +668,8 @@ export interface Config {
      * resolve to undefined and behave exactly as before.
      */
     telegramPersonas?: Record<string, TelegramAccount>;
+    /** Legacy routing entries stated in TOML, including incomplete entries. */
+    telegramPersonasStated?: string[];
     // phantomchat (Nostr NIP-17 DM) is configured PER-PERSONA in
     // `<persona-dir>/phantomchat.json` (channels/phantomchat/personaStore.ts),
     // not here — so it has no config.toml block.
@@ -890,6 +899,17 @@ function isTomlTable(v: unknown): v is TomlObject {
     !(v instanceof Date);
 }
 
+/**
+ * Whether a TOML `[channels.telegram]` table describes an account rather than
+ * merely acting as the parent for legacy `.personas.<name>` routing entries.
+ * An empty table still counts: it is the broken shape #445 must surface.
+ */
+function statesTelegramAccount(table: TomlObject | undefined): boolean {
+  if (!table) return false;
+  const keys = Object.keys(table);
+  return keys.length === 0 || keys.some((key) => key !== "personas");
+}
+
 
 
 /**
@@ -1096,25 +1116,34 @@ export async function loadConfig(persona?: string): Promise<Config> {
     isDefaultPersona ? undefined : personaEnvSuffix(personaLayer),
   );
   let telegramPersonas = buildTelegramPersonasConfig(tomlTelegram);
+  const globalChannels = isTomlTable(globalToml.channels)
+    ? globalToml.channels
+    : undefined;
+  const globalTelegram = globalChannels && isTomlTable(globalChannels.telegram)
+    ? globalChannels.telegram
+    : undefined;
+  const personaChannels = isTomlTable(personaToml.channels)
+    ? personaToml.channels
+    : undefined;
+  const ownTelegram = personaChannels && isTomlTable(personaChannels.telegram)
+    ? personaChannels.telegram
+    : undefined;
+  const globalRouting = globalTelegram && isTomlTable(globalTelegram.personas)
+    ? globalTelegram.personas
+    : undefined;
+  const legacyEntry = globalRouting && isTomlTable(globalRouting[personaLayer])
+    ? globalRouting[personaLayer] as TomlObject
+    : undefined;
+  const telegramStated = isDefaultPersona
+    ? statesTelegramAccount(globalTelegram) || statesTelegramAccount(ownTelegram)
+    : statesTelegramAccount(ownTelegram) || legacyEntry !== undefined;
+  const statedRouting = isTomlTable(tomlTelegram.personas)
+    ? Object.entries(tomlTelegram.personas)
+      .filter(([, entry]) => isTomlTable(entry))
+      .map(([name]) => name)
+    : [];
 
   if (isDefaultPersona && telegram && telegramPersonas?.[personaLayer]) {
-    const personaChannels = personaToml.channels;
-    const ownTelegram =
-      isTomlTable(personaChannels) && isTomlTable(personaChannels.telegram)
-        ? personaChannels.telegram
-        : undefined;
-    const globalChannels = globalToml.channels;
-    const globalTelegram =
-      isTomlTable(globalChannels) && isTomlTable(globalChannels.telegram)
-        ? globalChannels.telegram
-        : undefined;
-    const routing = globalTelegram && isTomlTable(globalTelegram.personas)
-      ? globalTelegram.personas
-      : undefined;
-    const legacyEntry = routing && isTomlTable(routing[personaLayer])
-      ? routing[personaLayer] as TomlObject
-      : undefined;
-
     // Migration is copy-not-delete for rollback safety. Suppress the old
     // routing entry only when the persona file proves it was copied from that
     // exact account AND both resolve to the same bot after env overrides. A
@@ -1260,7 +1289,9 @@ export async function loadConfig(persona?: string): Promise<Config> {
 
     channels: {
       telegram,
+      telegramStated,
       telegramPersonas,
+      telegramPersonasStated: statedRouting,
     },
 
     telegramStreaming: buildTelegramStreamingConfig(tomlTelegram),

--- a/src/config.ts
+++ b/src/config.ts
@@ -900,14 +900,17 @@ function isTomlTable(v: unknown): v is TomlObject {
 }
 
 /**
- * Whether a TOML `[channels.telegram]` table describes an account rather than
- * merely acting as the parent for legacy `.personas.<name>` routing entries.
- * An empty table still counts: it is the broken shape #445 must surface.
+ * Whether a TOML `[channels.telegram]` table describes an account attempt
+ * rather than merely carrying shared settings or acting as the parent for
+ * legacy `.personas.<name>` routing entries. An empty table still counts: it
+ * is the broken shape #445 must surface.
  */
 function statesTelegramAccount(table: TomlObject | undefined): boolean {
   if (!table) return false;
   const keys = Object.keys(table);
-  return keys.length === 0 || keys.some((key) => key !== "personas");
+  return keys.length === 0 ||
+    Object.hasOwn(table, "token") ||
+    Object.hasOwn(table, "allowed_user_ids");
 }
 
 
@@ -1137,7 +1140,7 @@ export async function loadConfig(persona?: string): Promise<Config> {
   const telegramStated = isDefaultPersona
     ? statesTelegramAccount(globalTelegram) || statesTelegramAccount(ownTelegram)
     : statesTelegramAccount(ownTelegram) || legacyEntry !== undefined;
-  const statedRouting = isTomlTable(tomlTelegram.personas)
+  let statedRouting = isTomlTable(tomlTelegram.personas)
     ? Object.entries(tomlTelegram.personas)
       .filter(([, entry]) => isTomlTable(entry))
       .map(([name]) => name)
@@ -1156,6 +1159,7 @@ export async function loadConfig(persona?: string): Promise<Config> {
     ) {
       const { [personaLayer]: _migrated, ...rest } = telegramPersonas;
       telegramPersonas = Object.keys(rest).length > 0 ? rest : undefined;
+      statedRouting = statedRouting.filter((name) => name !== personaLayer);
     }
   }
 

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -90,6 +90,122 @@ describe("runDoctor", () => {
     expect(out.text).toContain("nothing pending");
   });
 
+  test("stated but incomplete Telegram account is WARN and exits 1", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const broken = {
+      ...config,
+      channels: { telegramStated: true },
+    } satisfies Config;
+
+    const code = await runDoctor({
+      config: broken,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+      checkHarnesses: false,
+      checkPiExtension: false,
+      checkEditorConnectors: false,
+    });
+
+    expect(code).toBe(1);
+    expect(out.text).toContain("telegram: WARN");
+    expect(out.text).toContain("persona 'phantom': 0 listener(s)");
+    expect(out.text).toContain("states an account but has no bot_token");
+  });
+
+  test("intentional PhantomChat-only persona is healthy and silent about missing Telegram", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+      checkHarnesses: false,
+      checkPiExtension: false,
+      checkEditorConnectors: false,
+    });
+
+    expect(code).toBe(0);
+    expect(out.text).toContain("telegram: ok");
+    expect(out.text).toContain("persona 'phantom': 0 listener(s), not configured");
+    expect(out.text).not.toContain("no bot_token");
+  });
+
+  test("doctor reports every boot persona and catches an incomplete autostart bot", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    await mkdir(join(workdir, "personas", "lena"), { recursive: true });
+    const out = new CaptureStream();
+    const host = {
+      ...config,
+      autostartPersonas: ["lena"],
+      channels: {
+        telegram: { token: "default", pollTimeoutS: 30, allowedUserIds: [] },
+        telegramStated: true,
+      },
+    } satisfies Config;
+    const lena = {
+      ...config,
+      personaLayer: "lena",
+      channels: { telegramStated: true },
+    } satisfies Config;
+
+    const code = await runDoctor({
+      config: host,
+      personaConfigs: new Map([["lena", lena]]),
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+      checkHarnesses: false,
+      checkPiExtension: false,
+      checkEditorConnectors: false,
+    });
+
+    expect(code).toBe(1);
+    expect(out.text).toContain("persona 'phantom': 1 listener(s)");
+    expect(out.text).toContain("persona 'lena': 0 listener(s)");
+  });
+
+  test("a complete non-rostered account is reported as unplanned, not tokenless", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    await mkdir(join(workdir, "personas", "lena"), { recursive: true });
+    const out = new CaptureStream();
+    const lena = {
+      ...config,
+      personaLayer: "lena",
+      channels: {
+        telegram: { token: "lena", pollTimeoutS: 30, allowedUserIds: [] },
+        telegramStated: true,
+      },
+    } satisfies Config;
+
+    expect(await runDoctor({
+      config,
+      personaConfigs: new Map([["lena", lena]]),
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+      checkHarnesses: false,
+      checkPiExtension: false,
+      checkEditorConnectors: false,
+    })).toBe(1);
+    expect(out.text).toContain("persona 'lena': 0 listener(s), account resolved but no listener is planned");
+    expect(out.text).not.toContain("persona 'lena': 0 listener(s), states an account but has no bot_token");
+  });
+
   // Backlog is the only truth — a box that slept through 02:00 and swept on
   // boot is healthy, however long ago that was.
   test("a long-idle sweep with an empty backlog is still ok", async () => {

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -139,6 +139,35 @@ describe("runDoctor", () => {
     expect(out.text).not.toContain("no bot_token");
   });
 
+  test("a migrated default account is healthy despite its retained legacy statement", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const migrated = {
+      ...config,
+      channels: {
+        telegram: { token: "default", pollTimeoutS: 30, allowedUserIds: [] },
+        telegramStated: true,
+        telegramPersonasStated: ["phantom"],
+      },
+    } satisfies Config;
+
+    expect(await runDoctor({
+      config: migrated,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+      checkHarnesses: false,
+      checkPiExtension: false,
+      checkEditorConnectors: false,
+    })).toBe(0);
+    expect(out.text).toContain("telegram: ok — 1 listener(s) across 1 persona(s)");
+    expect(out.text).toContain("persona 'phantom': 1 listener(s), runnable");
+    expect(out.text).not.toContain("no bot_token");
+  });
+
   test("doctor reports every boot persona and catches an incomplete autostart bot", async () => {
     await writeState({
       last_run: new Date().toISOString(),

--- a/tests/cli-run.test.ts
+++ b/tests/cli-run.test.ts
@@ -76,6 +76,23 @@ describe("runRun — early exits", () => {
     expect(err.text).toContain("phantombot telegram");
   });
 
+  test("incomplete Telegram-only config warns before exiting with no runnable channel", async () => {
+    const err = new CaptureStream();
+    const code = await runRun({
+      config: { ...config, channels: { telegramStated: true } },
+      lockPath: join(workdir, "run.lock"),
+      out: new CaptureStream(),
+      err,
+    });
+
+    expect(code).toBe(2);
+    expect(err.text).toContain("persona 'phantom'");
+    expect(err.text).toContain("no bot_token");
+    expect(err.text).toContain("no telegram listeners could be started");
+    expect(err.text).toContain("check the warnings above");
+    expect(err.text).not.toContain("no channels configured");
+  });
+
   test("returns 2 when persona dir is missing and no other personas exist", async () => {
     const out = new CaptureStream();
     const err = new CaptureStream();
@@ -685,6 +702,55 @@ describe("runRun — multi-persona telegram", () => {
     );
     expect(plan.fatal).toBeUndefined();
     expect(plan.listeners).toHaveLength(1);
+    expect(err.text).toBe("");
+  });
+
+  test("an autostart persona that states an incomplete bot warns without throwing", async () => {
+    const err = new CaptureStream();
+    await givePersona("lena");
+    const plan = planListeners(
+      {
+        ...config,
+        autostartPersonas: ["lena"],
+        channels: {
+          telegram: { token: "default-tok", pollTimeoutS: 30, allowedUserIds: [] },
+        },
+      },
+      "phantom",
+      err,
+      new Map([["lena", {
+        ...config,
+        channels: { telegramStated: true },
+      }]]),
+    );
+
+    expect(plan.fatal).toBeUndefined();
+    expect(plan.listeners).toHaveLength(1);
+    expect(err.text).toContain("persona 'lena'");
+    expect(err.text).toContain("no bot_token");
+    expect(err.text).toContain("no telegram listener will start");
+  });
+
+  test("incomplete default and legacy accounts warn but do not make planning fatal", async () => {
+    const err = new CaptureStream();
+    await givePersona("lena");
+    const plan = planListeners(
+      {
+        ...config,
+        channels: {
+          telegramStated: true,
+          telegramPersonasStated: ["lena"],
+        },
+      },
+      "phantom",
+      err,
+    );
+
+    expect(plan.fatal).toBeUndefined();
+    expect(plan.listeners).toEqual([]);
+    expect(err.text).toContain("persona 'phantom'");
+    expect(err.text).toContain("persona 'lena'");
+    expect(err.text.match(/no bot_token/g)).toHaveLength(2);
   });
 
   test("an autostart persona with no dir on disk warns and is skipped", async () => {
@@ -899,6 +965,30 @@ describe("runRun — phantomchat-only (no Telegram)", () => {
       allowedNpubs: [generateIdentity().npub],
     });
   }
+
+  test("incomplete Telegram warns and continues with PhantomChat", async () => {
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    await givePhantomchat("phantom");
+    const code = await runRun({
+      config: {
+        ...config,
+        harnesses: { ...config.harnesses, chain: [] },
+        channels: { telegramStated: true },
+      },
+      lockPath: join(workdir, "run.lock"),
+      out,
+      err,
+    });
+
+    // Reaching the harness guard proves the broken Telegram account did not
+    // throw or terminate startup while PhantomChat remained runnable.
+    expect(code).toBe(2);
+    expect(err.text).toContain("no bot_token");
+    expect(err.text).toContain("phantombot harness");
+    expect(err.text).not.toContain("no channels configured");
+    expect(err.text).not.toContain("no telegram listeners could be started");
+  });
 
   test("reused Telegram bot token degrades to PhantomChat-only (does NOT fatal)", async () => {
     const out = new CaptureStream();

--- a/tests/lib-persona-config.test.ts
+++ b/tests/lib-persona-config.test.ts
@@ -453,6 +453,7 @@ describe("loadConfig persona layering", () => {
     const config = await loadConfig();
     expect(config.channels.telegram?.token).toBe("legacy-default-bot");
     expect(config.channels.telegramPersonas?.robbie).toBeUndefined();
+    expect(config.channels.telegramPersonasStated).toEqual(["lena"]);
     expect(config.channels.telegramPersonas?.lena?.token).toBe("lena-bot");
   });
 
@@ -475,6 +476,7 @@ describe("loadConfig persona layering", () => {
     const config = await loadConfig();
     expect(config.channels.telegram?.token).toBe("primary-bot");
     expect(config.channels.telegramPersonas?.robbie?.token).toBe("second-bot");
+    expect(config.channels.telegramPersonasStated).toEqual(["robbie"]);
   });
 
   test("a suffixed env override can keep a copied legacy entry distinct", async () => {
@@ -498,6 +500,7 @@ describe("loadConfig persona layering", () => {
     expect(config.channels.telegramPersonas?.robbie?.token).toBe(
       "second-env-bot",
     );
+    expect(config.channels.telegramPersonasStated).toEqual(["robbie"]);
   });
 
   test("the persona file wins per key; unmentioned keys fall back to global", async () => {
@@ -682,6 +685,23 @@ describe("loadConfig persona layering", () => {
     expect(phantomchatOnly.channels.telegram).toBeUndefined();
     expect(phantomchatOnly.channels.telegramStated).toBe(false);
     expect(phantomchatOnly.channels.telegramPersonasStated).toEqual([]);
+  });
+
+  test("shared Telegram settings do not state a default account", async () => {
+    await writeFile(
+      process.env.PHANTOMBOT_CONFIG!,
+      'default_persona = "robbie"\n\n[channels.telegram]\n' +
+        'poll_timeout_s = 45\ngroup_persona_names = ["robbie", "lena"]\n\n' +
+        '[channels.telegram.streaming]\nbubble_max_sentences = 2\n\n' +
+        '[channels.telegram.personas.lena]\ntoken = "lena-bot"\n',
+      "utf8",
+    );
+
+    const robbie = await loadConfig("robbie");
+    expect(robbie.channels.telegram).toBeUndefined();
+    expect(robbie.channels.telegramStated).toBe(false);
+    expect(robbie.channels.telegramPersonas?.lena?.token).toBe("lena-bot");
+    expect(robbie.telegramStreaming?.bubbleMaxSentences).toBe(2);
   });
 
   test("a persona's own model beats the host's ambient env var", async () => {

--- a/tests/lib-persona-config.test.ts
+++ b/tests/lib-persona-config.test.ts
@@ -642,6 +642,46 @@ describe("loadConfig persona layering", () => {
     // An account with no token of its own is INCOMPLETE, not a licence to
     // borrow the host's: lena simply has no Telegram until she is given a bot.
     expect(lena.channels.telegram).toBeUndefined();
+    expect(lena.channels.telegramStated).toBe(true);
+  });
+
+  test("Telegram statement metadata distinguishes broken accounts from no account", async () => {
+    await writeFile(
+      process.env.PHANTOMBOT_CONFIG!,
+      'default_persona = "robbie"\nautostart_personas = ["lena"]\n\n' +
+        '[channels.telegram.personas.lena]\nallowed_user_ids = [2]\n',
+      "utf8",
+    );
+    // An empty persona table is still an explicit (broken) account statement.
+    await writeFile(
+      personaConfigPath(personasDir, "robbie"),
+      "[channels.telegram]\n",
+      "utf8",
+    );
+
+    const robbie = await loadConfig("robbie");
+    const lena = await loadConfig("lena");
+    expect(robbie.channels.telegram).toBeUndefined();
+    expect(robbie.channels.telegramStated).toBe(true);
+    expect(robbie.channels.telegramPersonas).toBeUndefined();
+    expect(robbie.channels.telegramPersonasStated).toEqual(["lena"]);
+    expect(lena.channels.telegram).toBeUndefined();
+    expect(lena.channels.telegramStated).toBe(true);
+
+    await writeFile(
+      personaConfigPath(personasDir, "lena"),
+      '[voice]\nprovider = "none"\n',
+      "utf8",
+    );
+    await writeFile(
+      process.env.PHANTOMBOT_CONFIG!,
+      'default_persona = "robbie"\nautostart_personas = ["lena"]\n',
+      "utf8",
+    );
+    const phantomchatOnly = await loadConfig("lena");
+    expect(phantomchatOnly.channels.telegram).toBeUndefined();
+    expect(phantomchatOnly.channels.telegramStated).toBe(false);
+    expect(phantomchatOnly.channels.telegramPersonasStated).toEqual([]);
   });
 
   test("a persona's own model beats the host's ambient env var", async () => {


### PR DESCRIPTION
Closes #445

## Summary
- preserve whether default and legacy Telegram account tables were stated even when token resolution drops them
- warn and skip incomplete listeners without throwing or stopping PhantomChat or sibling Telegram bots
- report per-persona Telegram listener health in `phantombot doctor` and return a diagnostic exit failure for stated accounts with no runnable listener
- keep intentional PhantomChat-only personas healthy and quiet

## Verification
- `bun test` — 3,569 pass, 2 Windows-only skipped, 0 fail
- `bun tsc --noEmit`
- `bun run build`
- `bun run build:win`
- compiled Linux runtime: incomplete Megan account warns at startup and doctor JSON reports 0 listeners / unhealthy without throwing
