### PR TITLE
fix(phantomchat): one-shot publish leaks a relay socket past close()

### DIFF
--- a/src/channels/phantomchat/transport.ts
+++ b/src/channels/phantomchat/transport.ts
@@ -364,6 +364,14 @@ export interface PhantomchatTransport extends ChannelTransport {
  */
 export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
   readonly relays: string[];
+  /**
+   * Flipped by close(). The publish read-back (verifyStored) is deliberately
+   * detached from the send path so it never blocks delivery, but a one-shot
+   * caller (e.g. `notify`) must be able to fully tear the pool down and exit:
+   * once closed, the read-back must not re-open relay connections — doing so
+   * leaves a live WebSocket in the pool that keeps the process alive forever.
+   */
+  private closed = false;
   /** Our 64-char hex pubkey — the `from` field of every reply envelope. */
   private readonly ourPubHex: string;
   /**
@@ -643,11 +651,17 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     timing?: { settleMs?: number; timeoutMs?: number },
     targets: readonly string[] = this.relays,
   ): Promise<string[]> {
+    if (this.closed) return [];
     if (event.kind >= 20000 && event.kind < 30000) return [];
     const missing: string[] = [];
     await new Promise((r) =>
       setTimeout(r, timing?.settleMs ?? PUBLISH_READBACK_SETTLE_MS),
     );
+    // close() may have run while we settled — a one-shot caller closes the pool
+    // right after the send resolves, and the read-back settle is intentionally
+    // slower than that. Re-opening connections now would leak a live socket
+    // past teardown and keep the process alive; bail out instead.
+    if (this.closed) return [];
     await Promise.all(
       targets.map(async (relay) => {
         const found = await this.readBackOne(relay, event.id, timing?.timeoutMs);
@@ -678,6 +692,7 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
     eventId: string,
     timeoutMs?: number,
   ): Promise<boolean> {
+    if (this.closed) return Promise.resolve(false);
     return new Promise<boolean>((resolve) => {
       let settled = false;
       let sub: { close(): void } | undefined;
@@ -1041,6 +1056,8 @@ export class SimplePoolPhantomchatTransport implements PhantomchatTransport {
   }
 
   close(): void {
+    if (this.closed) return;
+    this.closed = true;
     try {
       this.pool.close(this.relays);
     } catch (e) {

--- a/tests/channels-phantomchat-transport.test.ts
+++ b/tests/channels-phantomchat-transport.test.ts
@@ -14,7 +14,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { generateSecretKey, getPublicKey, verifyEvent } from "nostr-tools/pure";
+import {
+  finalizeEvent,
+  generateSecretKey,
+  getPublicKey,
+  verifyEvent,
+} from "nostr-tools/pure";
 import {
   SimplePoolPhantomchatTransport,
   type NostrFilter,
@@ -640,5 +645,88 @@ describe("phantomchat transport fetchProfiles (kind-0)", () => {
     const map = await transport.fetchProfiles([]);
     expect(map.size).toBe(0);
     expect(subscribed).toBe(false);
+  });
+});
+
+describe("phantomchat transport close teardown (one-shot callers)", () => {
+  // Regression: the publish read-back (verifyStored) is deliberately DETACHED
+  // from the send path so it never blocks delivery. But a one-shot caller like
+  // `phantombot notify` closes the pool right after the send resolves, and the
+  // read-back's settle delay (750ms) outlasts that close. Before the fix, the
+  // read-back then re-opened relay connections via subscribeMany AFTER close(),
+  // leaving a live WebSocket in the pool that kept the process alive forever.
+  // This pins the contract: once closed, the detached read-back must NOT
+  // re-open connections.
+
+  function signedWrap(sk: Uint8Array): NTNostrEvent {
+    return finalizeEvent(
+      {
+        kind: 1059,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [],
+        content: "teardown-test",
+      },
+      sk,
+    ) as unknown as NTNostrEvent;
+  }
+
+  test("close() suppresses the detached read-back (no re-open after teardown)", async () => {
+    let subscribeCalls = 0;
+    const fakePool: RelayPool = {
+      subscribeMany() {
+        subscribeCalls++;
+        return { close() {} };
+      },
+      publish() {
+        return [Promise.resolve("ok")];
+      },
+      close() {},
+    };
+
+    const sk = generateSecretKey();
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      ["wss://relay.example"],
+      fakePool,
+    );
+
+    await transport.publishWrap(signedWrap(sk));
+    transport.close(); // a one-shot caller tears down immediately after the send
+
+    // Settle delay (750ms) + margin. The detached read-back must have bailed.
+    await new Promise((r) => setTimeout(r, 1000));
+    expect(subscribeCalls).toBe(0);
+  });
+
+  test("read-back still runs while the transport stays open", async () => {
+    let subscribeCalls = 0;
+    let received: unknown;
+    const fakePool: RelayPool = {
+      subscribeMany(_relays, filter, params) {
+        subscribeCalls++;
+        received = filter;
+        // Relay confirms the event is stored → read-back resolves immediately.
+        params.onevent(signedWrap(generateSecretKey()));
+        return { close() {} };
+      },
+      publish() {
+        return [Promise.resolve("ok")];
+      },
+      close() {},
+    };
+
+    const sk = generateSecretKey();
+    const transport = new SimplePoolPhantomchatTransport(
+      sk,
+      ["wss://relay.example"],
+      fakePool,
+    );
+
+    await transport.publishWrap(signedWrap(sk));
+    await new Promise((r) => setTimeout(r, 1000));
+
+    expect(subscribeCalls).toBe(1);
+    expect((received as NostrFilter).ids).toBeDefined();
+    transport.close();
   });
 });


### PR DESCRIPTION
## Problem

`phantombot notify` (and any one-shot phantomchat publish) **hung forever** when a relay was flapping.

The publish read-back (`verifyStored`, issue #368/#359) is deliberately *detached* from the send path so it never blocks delivery. But its 750ms settle delay outlasts the caller's immediate `close()`:

1. `sendMessage` → `publishWrap` fires `void this.verifyStored(...)` and returns.
2. The one-shot caller's `finally { transport.close() }` runs ~5ms later.
3. ~750ms later the detached read-back calls `pool.subscribeMany(...)` — **re-opening relay connections after the pool was already torn down**.
4. Those re-opened WebSockets keep the event loop alive, so the CLI never exits.

## Reproduction

Reproduced live against the 6-relay set with `relay.damus.io` flapping (intermittent 503):

```
sendMessage done in 563ms
close() called at 568ms
# ... process still alive 30s later (watchdog killed it)
```

## Fix

Add a `closed` flag to `SimplePoolPhantomchatTransport`:

- `close()` is now idempotent and flips the flag **before** tearing down the pool.
- `verifyStored` and `readBackOne` bail out once closed, so the detached read-back can never resurrect a connection after teardown.

## Verification

- Before: `notify` never exited with the flapping relay in the set.
- After: exits in **~1.3s** with or without the flapping relay.
- Two regression tests pin both directions (read-back suppressed after `close()`, still runs while open).
- Full suite: 2853 pass / 2 skip / 0 fail; `tsc --noEmit` clean.

This is a platform-level fix (not a relay-list band-aid): it makes any future flapping relay harmless to one-shot callers instead of re-hanging `notify`.