### PR TITLE
feat(launchd): give the periodic agents their own process names

### DIFF
--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -52,6 +52,10 @@ export interface RunUninstallInput {
   ensureSystemdEnv?: () => UserSystemdEnv;
   platform?: "linux" | "darwin" | "windows" | "unsupported";
   domain?: string;
+  /** Binary whose launchd exec aliases to remove (defaults to process.execPath). */
+  binPath?: string;
+  /** Directory holding the launchd exec aliases (tests). */
+  execAliasDir?: string;
   /** Persona whose Windows tasks to remove (defaults to current persona). */
   persona?: string;
   /** Override the current Windows user's SID (tests). Production resolves
@@ -127,6 +131,8 @@ async function runUninstallDarwin(
     nightlyPlistPath: input.nightlyPlistPath ?? launchdNightlyPath(),
     tickPlistPath: input.tickPlistPath ?? launchdTickPath(),
     domain,
+    binPath: input.binPath,
+    execAliasDir: input.execAliasDir,
     launchctl,
     out,
     err,

--- a/src/lib/launchd.ts
+++ b/src/lib/launchd.ts
@@ -13,6 +13,10 @@
  *   ~/Library/LaunchAgents/dev.phantombot.heartbeat.plist
  *   ~/Library/LaunchAgents/dev.phantombot.tick.plist
  *
+ * The two periodic agents exec the binary through a name-carrying symlink
+ * (phantombot-heartbeat / phantombot-tick) so macOS doesn't report three
+ * indistinguishable "phantombot" processes — see EXEC_ALIASES below.
+ *
  * Logs go to ~/Library/Logs/phantombot/<unit>.{out,err}.log (no journald
  * on Mac, and `log show` is a poor fit for free-form bot output). launchd
  * appends to them forever with no size cap, so the heartbeat rotates them
@@ -25,8 +29,8 @@
  * process.env on every platform without per-plist env entries here.
  */
 
-import { existsSync } from "node:fs";
-import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { existsSync, lstatSync } from "node:fs";
+import { mkdir, readFile, readlink, symlink, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { isPhantombotBinary } from "./binaryIdentity.ts";
@@ -42,6 +46,100 @@ export const HEARTBEAT_PLIST_LABEL = "dev.phantombot.heartbeat";
  */
 export const NIGHTLY_PLIST_LABEL = "dev.phantombot.nightly";
 export const TICK_PLIST_LABEL = "dev.phantombot.tick";
+
+/**
+ * Basenames of the per-unit EXEC ALIASES — symlinks to the phantombot binary
+ * that exist purely so each agent shows up under its own name.
+ *
+ * macOS reports a process by `p_comm`, which the kernel takes from the last
+ * path segment of the file that was exec'd. It is NOT argv[0] and NOT
+ * `process.title`, so nothing the process does at runtime can change it: with
+ * every agent exec'ing the same `phantombot` binary, Activity Monitor / `ps`
+ * show three identical "phantombot" rows and the only way to tell the daemon
+ * apart from the timers is to read the full command line. Exec'ing the timers
+ * through a differently-named symlink makes the kernel record THAT name, so
+ * they self-identify.
+ *
+ * Only the periodic agents get an alias: the long-running daemon is the one
+ * process that *should* be called "phantombot".
+ *
+ * Safe for the rest of the codebase, because a symlinked exec does not change
+ * `process.execPath` — Bun resolves it to the real binary, so
+ * `isPhantombotBinary()` and every self-heal gate hanging off it behave
+ * exactly as before.
+ */
+export const HEARTBEAT_EXEC_ALIAS = "phantombot-heartbeat";
+export const TICK_EXEC_ALIAS = "phantombot-tick";
+
+/** Every alias name install creates and uninstall removes. */
+export const EXEC_ALIASES = [
+  HEARTBEAT_EXEC_ALIAS,
+  TICK_EXEC_ALIAS,
+] as const;
+
+/** Absolute path of `alias`, resolved next to the phantombot binary. */
+export function execAliasPath(binPath: string, alias: string): string {
+  return join(dirname(binPath), alias);
+}
+
+/**
+ * Ensure `<dir of binPath>/<alias>` is a symlink to `binPath`, and return the
+ * path the plist should exec.
+ *
+ * Degrades rather than fails: if the directory is missing or read-only, or if
+ * something that is NOT our symlink already occupies the name, the original
+ * `binPath` comes back and the agent installs exactly as it did before the
+ * alias existed. An unreadable name is never overwritten — a real file there
+ * belongs to someone else.
+ */
+export async function ensureExecAlias(
+  binPath: string,
+  alias: string,
+  aliasDir?: string,
+): Promise<string> {
+  const path = aliasDir ? join(aliasDir, alias) : execAliasPath(binPath, alias);
+  try {
+    if (!existsSync(dirname(path))) return binPath;
+    let existing: string | undefined;
+    try {
+      const st = lstatSync(path);
+      if (!st.isSymbolicLink()) return binPath; // not ours — leave it alone
+      existing = await readlink(path);
+    } catch {
+      existing = undefined;
+    }
+    if (existing === binPath) return path;
+    if (existing !== undefined) await unlink(path);
+    await symlink(binPath, path);
+    return path;
+  } catch {
+    return binPath;
+  }
+}
+
+/**
+ * Remove the exec-alias symlinks. Best-effort and symlink-only: anything that
+ * is not a symlink at that path is left untouched. Returns the paths removed.
+ */
+export async function removeExecAliases(
+  binPath: string,
+  aliasDir?: string,
+): Promise<string[]> {
+  const removed: string[] = [];
+  for (const alias of EXEC_ALIASES) {
+    const path = aliasDir
+      ? join(aliasDir, alias)
+      : execAliasPath(binPath, alias);
+    try {
+      if (!lstatSync(path).isSymbolicLink()) continue;
+      await unlink(path);
+      removed.push(path);
+    } catch {
+      // absent or unreadable — nothing to clean up
+    }
+  }
+  return removed;
+}
 
 function launchAgentsDir(): string {
   return join(homedir(), "Library", "LaunchAgents");
@@ -290,6 +388,11 @@ export interface InstallLaunchdOptions {
   tickPlistPath?: string;
   /** Override gui domain (e.g. gui/501). Defaults to gui/<current uid>. */
   domain?: string;
+  /**
+   * Directory the exec-alias symlinks are written into. Defaults to the
+   * directory holding `binPath`; tests point it at a tmpdir.
+   */
+  execAliasDir?: string;
   launchctl: LaunchctlRunner;
   out: WriteSink;
   err: WriteSink;
@@ -313,6 +416,20 @@ export async function installPhantombotPlists(
   const ngPath = opts.nightlyPlistPath ?? nightlyPlistPath();
   const tkPath = opts.tickPlistPath ?? tickPlistPath();
 
+  // Exec aliases so the periodic agents don't all show up as "phantombot"
+  // in Activity Monitor. Falls back to the binary itself if the symlink
+  // can't be created, so install never fails over cosmetics.
+  const hbBin = await ensureExecAlias(
+    opts.binPath,
+    HEARTBEAT_EXEC_ALIAS,
+    opts.execAliasDir,
+  );
+  const tkBin = await ensureExecAlias(
+    opts.binPath,
+    TICK_EXEC_ALIAS,
+    opts.execAliasDir,
+  );
+
   const plists: Array<{ path: string; label: string; body: string }> = [
     {
       path: mainPath,
@@ -322,12 +439,12 @@ export async function installPhantombotPlists(
     {
       path: hbPath,
       label: HEARTBEAT_PLIST_LABEL,
-      body: generateHeartbeatPlist(opts.binPath),
+      body: generateHeartbeatPlist(hbBin),
     },
     {
       path: tkPath,
       label: TICK_PLIST_LABEL,
-      body: generateTickPlist(opts.binPath),
+      body: generateTickPlist(tkBin),
     },
   ];
 
@@ -380,6 +497,14 @@ export interface UninstallLaunchdOptions {
   nightlyPlistPath?: string;
   tickPlistPath?: string;
   domain?: string;
+  /**
+   * Binary whose sibling exec aliases should be removed. Defaults to
+   * `process.execPath`; pass explicitly when uninstalling on behalf of a
+   * binary other than the running one (and in tests).
+   */
+  binPath?: string;
+  /** Directory holding the exec aliases. Defaults to the dir of `binPath`. */
+  execAliasDir?: string;
   launchctl: LaunchctlRunner;
   out: WriteSink;
   err: WriteSink;
@@ -424,6 +549,13 @@ export async function uninstallPhantombotPlists(
       await unlink(p);
       opts.out.write(`removed ${p}\n`);
     }
+  }
+
+  for (const path of await removeExecAliases(
+    opts.binPath ?? process.execPath,
+    opts.execAliasDir,
+  )) {
+    opts.out.write(`removed ${path}\n`);
   }
 
   return { removed: true };

--- a/tests/lib-launchd.test.ts
+++ b/tests/lib-launchd.test.ts
@@ -6,18 +6,23 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  ensureExecAlias,
+  execAliasPath,
   generateHeartbeatPlist,
   generatePhantombotPlist,
   generateTickPlist,
   installPhantombotPlists,
   type LaunchctlResult,
   type LaunchctlRunner,
+  removeExecAliases,
   uninstallPhantombotPlists,
+  HEARTBEAT_EXEC_ALIAS,
+  TICK_EXEC_ALIAS,
   PHANTOMBOT_PLIST_LABEL,
   HEARTBEAT_PLIST_LABEL,
   NIGHTLY_PLIST_LABEL,
@@ -298,5 +303,151 @@ describe("uninstallPhantombotPlists", () => {
     expect(out.text).toContain("(no plist at");
     // bootout failures are logged but don't fail the uninstall.
     expect(out.text).toContain("returned 1 (continuing)");
+  });
+});
+
+describe("exec aliases", () => {
+  test("execAliasPath resolves next to the binary", () => {
+    expect(execAliasPath("/opt/bin/phantombot", TICK_EXEC_ALIAS)).toBe(
+      "/opt/bin/phantombot-tick",
+    );
+  });
+
+  test("ensureExecAlias creates a symlink to the binary and is idempotent", async () => {
+    const bin = join(workdir, "phantombot");
+    await writeFile(bin, "#!/bin/sh\n", "utf8");
+
+    const first = await ensureExecAlias(bin, TICK_EXEC_ALIAS);
+    expect(first).toBe(join(workdir, TICK_EXEC_ALIAS));
+    expect(await readlink(first)).toBe(bin);
+
+    // Re-running install must not throw on the existing link.
+    const second = await ensureExecAlias(bin, TICK_EXEC_ALIAS);
+    expect(second).toBe(first);
+    expect(await readlink(second)).toBe(bin);
+  });
+
+  test("ensureExecAlias repoints a stale alias at the new binary path", async () => {
+    const oldBin = join(workdir, "phantombot.old");
+    const newBin = join(workdir, "phantombot");
+    await writeFile(oldBin, "", "utf8");
+    await writeFile(newBin, "", "utf8");
+    await ensureExecAlias(oldBin, TICK_EXEC_ALIAS);
+    const path = await ensureExecAlias(newBin, TICK_EXEC_ALIAS);
+    expect(await readlink(path)).toBe(newBin);
+  });
+
+  test("ensureExecAlias falls back to the binary when the alias name is a real file", async () => {
+    const bin = join(workdir, "phantombot");
+    await writeFile(bin, "", "utf8");
+    await writeFile(join(workdir, TICK_EXEC_ALIAS), "not ours", "utf8");
+    expect(await ensureExecAlias(bin, TICK_EXEC_ALIAS)).toBe(bin);
+    // The intruding file survives untouched.
+    expect(await readFile(join(workdir, TICK_EXEC_ALIAS), "utf8")).toBe(
+      "not ours",
+    );
+  });
+
+  test("ensureExecAlias falls back when the directory does not exist", async () => {
+    const bin = "/definitely/not/here/phantombot";
+    expect(await ensureExecAlias(bin, TICK_EXEC_ALIAS)).toBe(bin);
+  });
+
+  test("removeExecAliases deletes only symlinks", async () => {
+    const bin = join(workdir, "phantombot");
+    await writeFile(bin, "", "utf8");
+    await ensureExecAlias(bin, TICK_EXEC_ALIAS);
+    await writeFile(join(workdir, HEARTBEAT_EXEC_ALIAS), "real file", "utf8");
+
+    const removed = await removeExecAliases(bin);
+    expect(removed).toEqual([join(workdir, TICK_EXEC_ALIAS)]);
+    expect(existsSync(join(workdir, TICK_EXEC_ALIAS))).toBe(false);
+    expect(existsSync(join(workdir, HEARTBEAT_EXEC_ALIAS))).toBe(true);
+  });
+
+  test("install points the periodic plists at the aliases, not the binary", async () => {
+    const bin = join(workdir, "phantombot");
+    await writeFile(bin, "", "utf8");
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const lc = new FakeLaunchctl();
+    const result = await installPhantombotPlists({
+      binPath: bin,
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      launchctl: lc,
+      out,
+      err,
+    });
+    expect(result.installed).toBe(true);
+
+    const hb = await readFile(hbPath, "utf8");
+    expect(hb).toContain(`<string>${join(workdir, HEARTBEAT_EXEC_ALIAS)}</string>`);
+    expect(hb).toContain("<string>heartbeat</string>");
+
+    const tk = await readFile(tkPath, "utf8");
+    expect(tk).toContain(`<string>${join(workdir, TICK_EXEC_ALIAS)}</string>`);
+    expect(tk).toContain("<string>tick</string>");
+
+    // The daemon keeps the real binary name — it SHOULD read "phantombot".
+    const main = await readFile(mainPath, "utf8");
+    expect(main).toContain(`<string>${bin}</string>`);
+  });
+
+  test("install still succeeds when the alias cannot be created", async () => {
+    // Binary in a directory that doesn't exist: no symlink is possible, and
+    // the heartbeat plist falls back to the binary path itself.
+    const bin = "/definitely/not/here/phantombot";
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const result = await installPhantombotPlists({
+      binPath: bin,
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      launchctl: new FakeLaunchctl(),
+      out,
+      err,
+    });
+    expect(result.installed).toBe(true);
+    expect(await readFile(hbPath, "utf8")).toContain(`<string>${bin}</string>`);
+  });
+
+  test("uninstall removes the aliases it installed", async () => {
+    const bin = join(workdir, "phantombot");
+    await writeFile(bin, "", "utf8");
+    await installPhantombotPlists({
+      binPath: bin,
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      launchctl: new FakeLaunchctl(),
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+    });
+    expect(existsSync(join(workdir, TICK_EXEC_ALIAS))).toBe(true);
+
+    const out = new CaptureStream();
+    await uninstallPhantombotPlists({
+      plistPath: mainPath,
+      heartbeatPlistPath: hbPath,
+      nightlyPlistPath: ngPath,
+      tickPlistPath: tkPath,
+      domain: "gui/501",
+      binPath: bin,
+      launchctl: new FakeLaunchctl(),
+      out,
+      err: new CaptureStream(),
+    });
+    expect(existsSync(join(workdir, TICK_EXEC_ALIAS))).toBe(false);
+    expect(existsSync(join(workdir, HEARTBEAT_EXEC_ALIAS))).toBe(false);
+    expect(out.text).toContain(TICK_EXEC_ALIAS);
   });
 });


### PR DESCRIPTION
## Problem

On macOS all three LaunchAgents exec the same `phantombot` binary, so Activity Monitor and `ps` show identical `phantombot` rows. The only way to tell the daemon from the heartbeat and tick timers is to read the full command line — which Activity Monitor doesn't show by default.

macOS reports a process by `p_comm`, which the kernel takes from the last path segment of the file that was exec'd. It is **not** argv[0] and **not** `process.title`, so nothing the process does at runtime can rename it. The name has to differ at exec time.

## Change

`phantombot install` (darwin) now creates two symlinks next to the binary:

```
~/.local/bin/phantombot-heartbeat -> ~/.local/bin/phantombot
~/.local/bin/phantombot-tick      -> ~/.local/bin/phantombot
```

and points the two periodic plists' `ProgramArguments[0]` at them. The subcommand argument is unchanged. The long-running daemon keeps the real binary path — it's the one process that *should* be called `phantombot`.

Result in Activity Monitor: `phantombot`, `phantombot-heartbeat`, `phantombot-tick`.

## Why this is safe

- A symlinked exec does **not** change `process.execPath` — Bun resolves it to the real binary (verified against a `bun build --compile` artifact). So `isPhantombotBinary()` and every self-heal gate hanging off it behave exactly as before.
- Degrades instead of failing: missing/read-only directory, or a real file already at the alias name, and the plist falls back to `binPath` — install proceeds exactly as it did before.
- Never overwrites a non-symlink; uninstall unlinks only actual symlinks.
- Linux/Windows untouched — systemd unit names and Task Scheduler task names already distinguish the units.

## Known limitation

Takes effect on the next `phantombot install`. The heartbeat/tick plists aren't re-rendered by `rerenderUnitIfStale()` today (only the main agent is), so an existing install won't pick this up until reinstall. Happy to extend the rerender path to the companion plists in a follow-up if you'd prefer that here.

## Tests

8 new cases in `tests/lib-launchd.test.ts`: alias path resolution, idempotent creation, repointing a stale alias, fallback on a real-file collision, fallback on a missing directory, symlink-only removal, plist bodies pointing at the aliases (and the daemon *not* doing so), and uninstall cleanup. `bun test tests/lib-launchd.test.ts` → 20 pass, `bun tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)