### PR TITLE
TUI: exit after restoring the terminal on SIGINT/SIGTERM

### DIFF
--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -137,9 +137,7 @@ export async function startTui(): Promise<number> {
     installed.teardown();
     fullScreen.restore();
   };
-  process.once("exit", restore);
-  process.once("SIGINT", restore);
-  process.once("SIGTERM", restore);
+  installSignalExit(restore);
 
   try {
     await instance.waitUntilExit();
@@ -147,6 +145,42 @@ export async function startTui(): Promise<number> {
   } finally {
     restore();
   }
+}
+
+/**
+ * Wire the TUI's exit paths: plain `exit`, plus SIGINT/SIGTERM from an outside
+ * `kill` or a systemd stop (`^c` and `^q` go through Ink — raw mode means the
+ * terminal generates no SIGINT).
+ *
+ * A signal listener suppresses Node's default termination, so restoring the
+ * terminal and then RETURNING leaves a deaf app painting over the user's shell
+ * — a second signal would be needed because `once` has already consumed the
+ * handler. Restore, then exit with the conventional code (128 + signal). The
+ * `exit` handler is the idempotent backstop; `FullScreen.restore` and
+ * `installed.teardown` are both guarded, so the double call is harmless.
+ *
+ * Returns a teardown that removes the listeners — used by tests.
+ */
+export function installSignalExit(
+  restore: () => void,
+  exit: (code: number) => never = process.exit,
+): () => void {
+  const onSigint = () => {
+    restore();
+    exit(130);
+  };
+  const onSigterm = () => {
+    restore();
+    exit(143);
+  };
+  process.once("exit", restore);
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+  return () => {
+    process.off("exit", restore);
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  };
 }
 
 /**

--- a/tests/tui-signal-exit.test.ts
+++ b/tests/tui-signal-exit.test.ts
@@ -1,0 +1,88 @@
+/**
+ * TUI signal-exit handlers (phantombot#485).
+ *
+ * `process.once("SIGINT", restore)` alone SUPPRESSES Node's default
+ * termination: an outside `kill` restored the terminal and the app kept
+ * running, painting over the user's shell until a second signal arrived.
+ * The handler must restore, then exit with 128 + signal.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { installSignalExit } from "../src/tui/index.tsx";
+
+function fakeExit(calls: string[]): (code: number) => never {
+  return ((code: number) => {
+    calls.push(`exit:${code}`);
+    return undefined as never;
+  }) as (code: number) => never;
+}
+
+describe("installSignalExit", () => {
+  test("SIGINT restores the terminal, then exits 130", () => {
+    const calls: string[] = [];
+    const teardown = installSignalExit(
+      () => calls.push("restore"),
+      fakeExit(calls),
+    );
+    try {
+      process.emit("SIGINT");
+      expect(calls).toEqual(["restore", "exit:130"]);
+    } finally {
+      teardown();
+    }
+  });
+
+  test("SIGTERM restores the terminal, then exits 143", () => {
+    const calls: string[] = [];
+    const teardown = installSignalExit(
+      () => calls.push("restore"),
+      fakeExit(calls),
+    );
+    try {
+      process.emit("SIGTERM");
+      expect(calls).toEqual(["restore", "exit:143"]);
+    } finally {
+      teardown();
+    }
+  });
+
+  test("a second signal does nothing — `once` consumed the handler", () => {
+    const calls: string[] = [];
+    // Other test files share this process and may hold their own SIGINT
+    // listeners, so only the RELATIVE count proves our handler is gone.
+    const countBefore = process.listenerCount("SIGINT");
+    const teardown = installSignalExit(
+      () => calls.push("restore"),
+      fakeExit(calls),
+    );
+    expect(process.listenerCount("SIGINT")).toBe(countBefore + 1);
+    try {
+      process.emit("SIGINT");
+      expect(calls).toEqual(["restore", "exit:130"]);
+      // Emitting a bare second SIGINT could terminate the test runner itself —
+      // the consumed handler is proven by the listener count dropping back.
+      expect(process.listenerCount("SIGINT")).toBe(countBefore);
+    } finally {
+      teardown();
+    }
+  });
+
+  test("teardown removes all listeners, including the exit backstop", () => {
+    const calls: string[] = [];
+    const exitCountBefore = process.listenerCount("exit");
+    const teardown = installSignalExit(
+      () => calls.push("restore"),
+      fakeExit(calls),
+    );
+    expect(process.listenerCount("exit")).toBe(exitCountBefore + 1);
+    teardown();
+    expect(process.listenerCount("exit")).toBe(exitCountBefore);
+    // A sacrificial listener keeps the runner alive if ours is the only
+    // SIGINT listener — a bare emit with zero listeners exits the process.
+    const noop = () => {};
+    process.on("SIGINT", noop);
+    process.emit("SIGINT");
+    process.off("SIGINT", noop);
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #485. Part of #471.

**Bug:** `process.once("SIGINT", restore)` suppresses Node's default termination, and `restore()` never exited — an outside `kill` or systemd stop restored the terminal (alternate screen left, mouse reporting off, log sink and stdin tap removed) and then the app *kept running*, painting over the user's shell until a second signal arrived.

**Fix:** extracted the exit wiring into `installSignalExit()` — the signal handlers now `restore()` then `process.exit(130)` / `process.exit(143)` (128 + signal). The plain `exit` handler stays as the idempotent backstop; `FullScreen.restore` and `installed.teardown` are both guarded, so the double call is harmless. Extraction also makes the behavior unit-testable; the helper returns a teardown for tests.

**Tests:** new `tests/tui-signal-exit.test.ts` — SIGINT exits 130, SIGTERM exits 143, both after restore; `once` semantics verified via listener counts (a bare second synthetic SIGINT would kill the test runner itself); teardown removes all listeners including the exit backstop. Full suite: 3,990 pass, 0 fail. `tsc --noEmit` clean.