### PR TITLE
Multi-persona rigs: per-persona heartbeat instances + maintenance coverage (#486)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ On Linux, `phantombot install` creates **three** systemd-user units:
 | Unit | Cadence | What it does |
 |---|---|---|
 | `phantombot.service` | always-on | `phantombot run` — Telegram listener |
-| `phantombot-heartbeat.timer` → `.service` | every 30 min | mechanical maintenance, no LLM |
+| `phantombot-heartbeat@<persona>.timer` → `@.service` template | every 30 min, one instance per served persona (default ∪ autostart) | mechanical maintenance for that persona, no LLM |
 | `phantombot-tick.timer` → `.service` | every 1 min | fires due scheduled tasks |
 
 There is deliberately no nightly unit. The cognitive pass is event-driven —

--- a/README.md
+++ b/README.md
@@ -2532,7 +2532,7 @@ Installed user units:
 |---|---|---|
 | `phantombot.service` | Always on | Multi-persona Telegram + PhantomChat runtime and P2P nodes |
 | `phantombot-tick.timer` | Every minute | Scheduled task runner |
-| `phantombot-heartbeat.timer` | Every 30 minutes | Mechanical maintenance + fires the nightly sweep on day rollover |
+| `phantombot-heartbeat@<persona>.timer` | Every 30 minutes | Per-persona mechanical maintenance + fires that persona's nightly sweep on day rollover (one instance per served persona; the legacy single `phantombot-heartbeat.timer` is retired automatically) |
 
 Update commands:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,7 +169,7 @@ Three properties worth knowing when touching this code:
    half-finished. It is triggered by startup and by the heartbeat detecting a
    calendar-day rollover — there is no nightly timer. On systemd the sweep is
    launched as its own transient `--user` unit rather than as a detached child:
-   the rollover trigger runs inside `phantombot-heartbeat.service`, which is
+   the rollover trigger runs inside `phantombot-heartbeat@<persona>.service`, which is
    `Type=oneshot`, so its cgroup (and everything left in it) is torn down the
    moment the heartbeat exits. `detached`/`unref` leaves Node's event loop, not
    the cgroup. Per date it runs exactly

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -26,6 +26,7 @@ import {
   loadConfigForPersona,
   personaDir,
   resolvePersona,
+  servedPersonasOf,
 } from "../config.ts";
 import {
   checkConfiguredHarnesses,
@@ -72,7 +73,7 @@ import {
   driftedUnitNames,
   ensureSystemdUnitsCurrent,
   ensureUserSystemdEnv,
-  HEARTBEAT_TIMER_NAME,
+  heartbeatInstanceTimer,
   heartbeatServicePath,
   heartbeatTimerPath,
   phantombotUnitTargets,
@@ -84,7 +85,7 @@ import {
 } from "../lib/systemd.ts";
 import {
   HEARTBEAT_STALE_MINUTES,
-  loadHeartbeatLastFired,
+  loadPersonaHeartbeatLastFired,
   loadTickLastFired,
   TICK_STALE_MINUTES,
   type TimerLastFired,
@@ -246,6 +247,22 @@ export interface DoctorReport {
     };
   };
   /**
+   * Per-persona maintenance coverage (#486): for every persona this host
+   * serves (default ∪ autostart), when its heartbeat instance last fired
+   * (stale = never, or older than the heartbeat threshold) and how far
+   * its nightly ledger is behind. WARN-ONLY — never feeds the exit code;
+   * a persona that is behind is something to surface, not a failure.
+   */
+  maintenance?: Array<{
+    persona: string;
+    last_heartbeat?: string;
+    heartbeat_age_minutes?: number;
+    heartbeat_stale: boolean;
+    nightly_backlog: number;
+    nightly_oldest_pending?: string;
+    nightly_last_run?: string;
+  }>;
+  /**
    * Configured harness binaries resolved from the service/runtime PATH.
    * Catches installs that work in an interactive shell but fail under the
    * daemon environment.
@@ -325,6 +342,15 @@ export interface RunDoctorInput {
   checkTimers?:
     | false
     | (() => Promise<DoctorReport["timers"] | undefined>);
+  /**
+   * Test seam for the per-persona maintenance check (#486). Pass `false`
+   * to skip, a function to substitute a fake report. In production this
+   * is undefined and doctor reads the real per-persona markers + nightly
+   * ledgers.
+   */
+  checkMaintenance?:
+    | false
+    | (() => Promise<DoctorReport["maintenance"] | undefined>);
   /**
    * Test seam for harness binary availability. Pass false to skip. In
    * production, doctor checks the installed service PATH when running as the
@@ -580,7 +606,20 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     if (input.checkTimers) {
       timersReport = await input.checkTimers();
     } else {
-      timersReport = computeTimersReport();
+      timersReport = computeTimersReport(host.defaultPersona);
+    }
+  }
+
+  // Per-persona maintenance coverage (#486) — computed BEFORE the systemd
+  // check so a persona whose heartbeat instance stopped firing can drive a
+  // forced re-arm of that instance (the same zombie-timer repair the
+  // default persona's marker gets below).
+  let maintenanceReport: DoctorReport["maintenance"] | undefined;
+  if (input.checkMaintenance !== false) {
+    if (input.checkMaintenance) {
+      maintenanceReport = await input.checkMaintenance();
+    } else {
+      maintenanceReport = await defaultCheckMaintenance(host, input.nightlyHealth);
     }
   }
 
@@ -597,13 +636,24 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       timersReport.heartbeat.stale &&
       timersReport.heartbeat.last_fired !== undefined
     ) {
-      staleTimerUnits.push(HEARTBEAT_TIMER_NAME);
+      staleTimerUnits.push(heartbeatInstanceTimer(host.defaultPersona));
     }
     if (
       timersReport.tick.stale &&
       timersReport.tick.last_fired !== undefined
     ) {
       staleTimerUnits.push(TICK_TIMER_NAME);
+    }
+  }
+  // Non-default personas' stale instances too (the timers section only
+  // tracks the default persona's heartbeat + tick).
+  for (const m of maintenanceReport ?? []) {
+    if (
+      m.persona !== host.defaultPersona &&
+      m.heartbeat_stale &&
+      m.last_heartbeat !== undefined
+    ) {
+      staleTimerUnits.push(heartbeatInstanceTimer(m.persona));
     }
   }
 
@@ -616,7 +666,11 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     if (input.checkSystemd) {
       systemdReport = await input.checkSystemd(staleTimerUnits);
     } else if (currentPlatform() === "linux") {
-      systemdReport = await defaultCheckSystemd(repair, staleTimerUnits);
+      systemdReport = await defaultCheckSystemd(
+        repair,
+        staleTimerUnits,
+        servedPersonasOf(host),
+      );
     }
   }
 
@@ -780,6 +834,7 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     },
     ...(systemdReport ? { systemd: systemdReport } : {}),
     ...(timersReport ? { timers: timersReport } : {}),
+    ...(maintenanceReport ? { maintenance: maintenanceReport } : {}),
     ...(harnessReport ? { harnesses: harnessReport } : {}),
     ...(piExtensionReport ? { piExtension: piExtensionReport } : {}),
     ...(editorConnectors ? { editorConnectors } : {}),
@@ -1015,6 +1070,30 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     renderTimer("tick", timersReport.tick);
   }
 
+  // Per-persona maintenance coverage (#486) — warn-only, never exit-code.
+  if (maintenanceReport && maintenanceReport.length > 0) {
+    out.write("  maintenance per persona:\n");
+    for (const m of maintenanceReport) {
+      const hbOk = !m.heartbeat_stale;
+      const hb =
+        m.last_heartbeat === undefined
+          ? "heartbeat never fired"
+          : `heartbeat ${m.heartbeat_age_minutes}m ago${hbOk ? "" : " — STALE"}`;
+      const nightly =
+        m.nightly_backlog > 0
+          ? `nightly ${m.nightly_backlog} date(s) pending (oldest ${m.nightly_oldest_pending})`
+          : "nightly ledger current";
+      out.write(`    ${m.persona}: ${tick(hbOk && m.nightly_backlog === 0)} — ${hb}; ${nightly}\n`);
+    }
+    const stale = maintenanceReport.filter((m) => m.heartbeat_stale);
+    if (stale.length > 0) {
+      out.write(
+        `  → ${stale.map((m) => m.persona).join(", ")}: heartbeat maintenance is behind — ` +
+          "check `systemctl --user status phantombot-heartbeat@<persona>.timer`\n",
+      );
+    }
+  }
+
   if (harnessReport) {
     const missing = missingHarnesses(harnessReport.checks);
     out.write(`  harnesses: ${tick(missing.length === 0)} — `);
@@ -1160,6 +1239,7 @@ async function computeHarnessReport(
 async function defaultCheckSystemd(
   repair: boolean,
   staleTimers: string[] = [],
+  personas: readonly string[] = [],
 ): Promise<DoctorReport["systemd"] | undefined> {
   const sysEnv = ensureUserSystemdEnv();
   if (!sysEnv.ready) return undefined;
@@ -1188,7 +1268,7 @@ async function defaultCheckSystemd(
   const drifted = driftedUnitNames(phantombotUnitTargets(binPath), (p) =>
     existsSync(p) ? readFileSync(p, "utf8") : undefined,
   );
-  const inactive = await listInactiveTimers(systemctl);
+  const inactive = await listInactiveTimers(systemctl, personas);
   let repaired = false;
   if (
     repair &&
@@ -1201,12 +1281,14 @@ async function defaultCheckSystemd(
       const heal = await ensureSystemdUnitsCurrent({
         binPath,
         systemctl,
+        personas,
         forceRearmTimers: staleTimers,
       });
       repaired =
         heal.rewrote.length > 0 ||
         heal.repairedTimers.length > 0 ||
-        heal.removedRetired.length > 0;
+        heal.removedRetired.length > 0 ||
+        heal.disabledInstances.length > 0;
     } catch (e) {
       log.warn("doctor: systemd heal failed", {
         error: (e as Error).message,
@@ -1232,15 +1314,75 @@ async function defaultCheckSystemd(
  * same gate `defaultCheckSystemd` uses so the check stays inert in
  * dev contexts and tests don't need to clean up marker files.
  */
-function computeTimersReport(): DoctorReport["timers"] | undefined {
+function computeTimersReport(
+  defaultPersona: string,
+): DoctorReport["timers"] | undefined {
   if (!isPhantombotBinary()) return undefined;
   const now = new Date();
-  const heartbeat = loadHeartbeatLastFired(now);
+  // The heartbeat section tracks the DEFAULT persona's instance marker
+  // (with the pre-#486 timer-scoped marker as upgrade fallback); other
+  // personas are covered per-persona in the maintenance section.
+  const heartbeat = loadPersonaHeartbeatLastFired(defaultPersona, {
+    isDefault: true,
+    now,
+  });
   const tickFired = loadTickLastFired(now);
   return {
     heartbeat: timerSection(heartbeat, HEARTBEAT_STALE_MINUTES),
     tick: timerSection(tickFired, TICK_STALE_MINUTES),
   };
+}
+
+/**
+ * Per-persona maintenance coverage (#486). For every persona this host
+ * serves: its heartbeat instance's last-fire marker, and its nightly
+ * ledger backlog. Pure reads (marker files + persona dirs) — the systemd
+ * half of coverage (is the instance enabled?) lives in
+ * `defaultCheckSystemd`. Gated on the real phantombot binary like the
+ * other service-manager checks, so dev/test runs stay silent.
+ */
+async function defaultCheckMaintenance(
+  host: Config,
+  nightlyHealthFn: typeof nightlyHealth = nightlyHealth,
+): Promise<DoctorReport["maintenance"]> {
+  if (!isPhantombotBinary()) return undefined;
+  const now = new Date();
+  const entries: NonNullable<DoctorReport["maintenance"]> = [];
+  for (const persona of servedPersonasOf(host)) {
+    const dir = personaDir(host, persona);
+    if (!existsSync(dir)) continue;
+    const marker = loadPersonaHeartbeatLastFired(persona, {
+      isDefault: persona === host.defaultPersona,
+      now,
+    });
+    const heartbeatStale =
+      marker.ageMinutes === undefined ||
+      marker.ageMinutes > HEARTBEAT_STALE_MINUTES;
+    let health: NightlyHealth | undefined;
+    try {
+      const state = await loadNightlyState(dir);
+      health = await nightlyHealthFn(dir, { state });
+    } catch (e) {
+      log.warn("doctor: maintenance nightly-health read failed", {
+        persona,
+        error: (e as Error).message,
+      });
+    }
+    entries.push({
+      persona,
+      ...(marker.iso !== undefined ? { last_heartbeat: marker.iso } : {}),
+      ...(marker.ageMinutes !== undefined
+        ? { heartbeat_age_minutes: marker.ageMinutes }
+        : {}),
+      heartbeat_stale: heartbeatStale,
+      nightly_backlog: health?.backlog ?? 0,
+      ...(health?.oldest_pending
+        ? { nightly_oldest_pending: health.oldest_pending }
+        : {}),
+      ...(health?.last_run ? { nightly_last_run: health.last_run } : {}),
+    });
+  }
+  return entries;
 }
 
 function timerSection(
@@ -1259,12 +1401,19 @@ function timerSection(
 
 async function listInactiveTimers(
   systemctl: SystemctlRunner,
+  personas: readonly string[] = [],
 ): Promise<string[]> {
   const out: string[] = [];
-  // Two timers, not three: the nightly timer is retired (the sweep runs on
-  // startup and on the heartbeat's day-rollover check), so an absent one is
-  // correct rather than a fault to repair.
-  for (const t of [HEARTBEAT_TIMER_NAME, TICK_TIMER_NAME]) {
+  // Tick + one heartbeat instance per served persona (#486). The nightly
+  // timer is retired (the sweep runs on startup and on the heartbeat's
+  // day-rollover check), so an absent one is correct rather than a fault
+  // to repair. A persona whose instance is missing or disabled reads as
+  // "not active" here, which routes it into the same repair path.
+  const units = [
+    TICK_TIMER_NAME,
+    ...personas.map((p) => heartbeatInstanceTimer(p)),
+  ];
+  for (const t of units) {
     const r = await systemctl.run(["--user", "is-active", t]);
     if (r.exitCode !== 0 || r.stdout.trim() !== "active") {
       out.push(t);

--- a/src/cli/heartbeat.ts
+++ b/src/cli/heartbeat.ts
@@ -20,6 +20,7 @@ import {
   personaDir,
   loadConfigForPersona,
   resolvePersona,
+  servedPersonasOf,
 } from "../config.ts";
 import { isPhantombotBinary } from "../lib/binaryIdentity.ts";
 import { defaultEmbedder, runEmbedJob } from "../lib/embedJob.ts";
@@ -50,7 +51,7 @@ import {
   ensureTasksCurrent,
 } from "../lib/taskScheduler.ts";
 import {
-  loadHeartbeatLastFired,
+  loadPersonaHeartbeatLastFired,
   recordHeartbeatFired,
 } from "../lib/timerHealth.ts";
 import { VERSION } from "../version.ts";
@@ -225,7 +226,7 @@ export async function runHeartbeatCli(
       if (input.healSystemd) {
         await input.healSystemd();
       } else {
-        await defaultHealService(persona);
+        await defaultHealService(config, persona);
       }
     } catch (e) {
       log.warn("heartbeat: service self-heal threw unexpectedly", {
@@ -279,7 +280,12 @@ export async function runHeartbeatCli(
   let rolloverLine = "";
   if (input.triggerNightly !== false) {
     try {
-      const prev = loadHeartbeatLastFired(new Date()).iso;
+      // PER-PERSONA marker (#486): every persona's heartbeat instance tracks
+      // its own last fire, so one persona firing first after midnight can't
+      // consume the rollover and starve the others of their nightly sweep.
+      const prev = loadPersonaHeartbeatLastFired(persona, {
+        isDefault: persona === config.defaultPersona,
+      }).iso;
       if (dayRolledOver(prev)) {
         (input.triggerNightly ?? spawnNightlySweep)(persona, "rollover");
         rolloverLine = ", day rolled over → nightly sweep";
@@ -296,8 +302,10 @@ export async function runHeartbeatCli(
   }
 
   // Record the fire AFTER the primary work succeeded. Doctor uses
-  // this marker's mtime to flag a dead heartbeat timer.
-  await recordHeartbeatFired();
+  // this marker's mtime to flag a dead heartbeat timer. Per-persona
+  // (#486): each instance's marker backs doctor's per-persona
+  // maintenance report.
+  await recordHeartbeatFired(persona);
 
   const updateLine =
     r.updateCheck?.status === "notified"
@@ -353,10 +361,13 @@ async function defaultEmbedNotes(
  * Silent on healthy boxes; logs a notice only on repair. A no-op on any
  * platform without a backend.
  */
-async function defaultHealService(persona?: string): Promise<void> {
+async function defaultHealService(
+  config: Config,
+  persona?: string,
+): Promise<void> {
   switch (currentPlatform()) {
     case "linux":
-      return defaultHealSystemd();
+      return defaultHealSystemd(config);
     case "windows":
       return defaultHealTaskScheduler(persona);
     default:
@@ -366,20 +377,30 @@ async function defaultHealService(persona?: string): Promise<void> {
 
 /**
  * Idempotently ensure all phantombot systemd units are present and timers are
- * armed. Skips on Linux hosts where the user-systemd bus isn't reachable (e.g.
- * SSH without lingering).
+ * armed — including one heartbeat instance per served persona (#486). Skips on
+ * Linux hosts where the user-systemd bus isn't reachable (e.g. SSH without
+ * lingering).
  */
-async function defaultHealSystemd(): Promise<void> {
+async function defaultHealSystemd(config: Config): Promise<void> {
   const binPath = process.execPath;
   if (!isPhantombotBinary(binPath)) return;
   const sysEnv = ensureUserSystemdEnv();
   if (!sysEnv.ready) return;
   const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
-  const r = await ensureSystemdUnitsCurrent({ binPath, systemctl });
-  if (r.rewrote.length > 0 || r.repairedTimers.length > 0) {
+  const r = await ensureSystemdUnitsCurrent({
+    binPath,
+    systemctl,
+    personas: servedPersonasOf(config),
+  });
+  if (
+    r.rewrote.length > 0 ||
+    r.repairedTimers.length > 0 ||
+    r.disabledInstances.length > 0
+  ) {
     log.info("heartbeat: healed systemd units", {
       rewrote: r.rewrote,
       repairedTimers: r.repairedTimers,
+      disabledInstances: r.disabledInstances,
     });
   }
 }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -49,6 +49,11 @@ import {
 } from "../lib/taskScheduler.ts";
 import { openPersonaVault, vaultPath } from "../lib/vault.ts";
 import { resolveVaultPersonaDir } from "./vault.ts";
+import {
+  loadConfig,
+  personaDir,
+  servedPersonasOf,
+} from "../config.ts";
 import { existsSync } from "node:fs";
 import type { WriteSink } from "../lib/io.ts";
 
@@ -90,10 +95,19 @@ export interface RunInstallInput {
    */
   heartbeatServicePath?: string;
   heartbeatTimerPath?: string;
+  /** Test overrides for the retired pre-#486 heartbeat units (Linux). */
+  legacyHeartbeatServicePath?: string;
+  legacyHeartbeatTimerPath?: string;
   nightlyServicePath?: string;
   nightlyTimerPath?: string;
   tickServicePath?: string;
   tickTimerPath?: string;
+  /**
+   * Personas to arm heartbeat instances for (Linux, #486). Production
+   * leaves this undefined and install derives it from the loaded config;
+   * tests pass it explicitly to stay hermetic.
+   */
+  personas?: readonly string[];
   heartbeatPlistPath?: string;
   nightlyPlistPath?: string;
   tickPlistPath?: string;
@@ -229,11 +243,31 @@ async function runInstallLinux(
   const systemctl =
     input.systemctl ?? new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
 
+  // One heartbeat timer instance per served persona (#486). A config that
+  // can't be loaded yet (pre-init box) must not fail the install — skip
+  // instance arming; the startup doctor / first heartbeat heal provisions
+  // instances once a config exists. Personas with no directory on disk
+  // (stale autostart entries) are skipped: their services would only fail.
+  let personas = input.personas;
+  if (personas === undefined) {
+    try {
+      const config = await loadConfig();
+      personas = servedPersonasOf(config).filter((name) =>
+        existsSync(personaDir(config, name)),
+      );
+    } catch {
+      personas = undefined;
+    }
+  }
+
   const result = await installPhantombotUnit({
     binPath,
     unitPath,
+    personas,
     heartbeatServicePath: input.heartbeatServicePath,
     heartbeatTimerPath: input.heartbeatTimerPath,
+    legacyHeartbeatServicePath: input.legacyHeartbeatServicePath,
+    legacyHeartbeatTimerPath: input.legacyHeartbeatTimerPath,
     nightlyServicePath: input.nightlyServicePath,
     nightlyTimerPath: input.nightlyTimerPath,
     tickServicePath: input.tickServicePath,

--- a/src/cli/persona-new.ts
+++ b/src/cli/persona-new.ts
@@ -18,13 +18,14 @@
 
 import { defineCommand } from "citty";
 
-import { type Config, loadConfig } from "../config.ts";
+import { type Config, loadConfig, servedPersonasOf } from "../config.ts";
 import { applyPersona } from "./create-persona.ts";
 import type { WriteSink } from "../lib/io.ts";
 import {
   listPersonaDirs,
   writeAutostartPersonas,
 } from "../lib/personaDefault.ts";
+import { defaultSyncHeartbeatInstances } from "../lib/systemd.ts";
 import type { PersonaTone } from "../lib/personaTemplate.ts";
 
 export interface RunPersonaNewInput {
@@ -39,6 +40,8 @@ export interface RunPersonaNewInput {
   config?: Config;
   out?: WriteSink;
   err?: WriteSink;
+  /** Test seam for the heartbeat-instance sync (#486). */
+  syncHeartbeatInstances?: (personas: string[]) => Promise<unknown>;
 }
 
 /** Persona directory names must survive being a directory name. */
@@ -83,6 +86,22 @@ export async function runPersonaNew(
       name,
     ]);
     out.write(`autostart: ${list.join(", ")}\n`);
+    // Provision the new persona's heartbeat timer instance right away
+    // (#486) — best-effort; the next heartbeat heal reconciles the same
+    // state if this fails.
+    const sync = input.syncHeartbeatInstances ?? defaultSyncHeartbeatInstances;
+    try {
+      await sync(
+        servedPersonasOf({
+          defaultPersona: config.defaultPersona,
+          autostartPersonas: list,
+        }),
+      );
+    } catch (e) {
+      err.write(
+        `warning: could not provision the heartbeat timer instance: ${(e as Error).message}\n`,
+      );
+    }
   }
 
   out.write(`created ${result.name} at ${result.dir}\n`);

--- a/src/cli/persona.ts
+++ b/src/cli/persona.ts
@@ -29,9 +29,11 @@ import {
   type Config,
   loadConfig,
   personaDir,
+  servedPersonasOf,
 } from "../config.ts";
 import type { WriteSink } from "../lib/io.ts";
 import { writeAutostartPersonas } from "../lib/personaDefault.ts";
+import { defaultSyncHeartbeatInstances } from "../lib/systemd.ts";
 import personaNewCmd from "./persona-new.ts";
 import { log } from "../lib/logger.ts";
 import { listArchives } from "../lib/personaArchive.ts";
@@ -385,6 +387,12 @@ export interface RunAutostartPickerInput {
     selected: string[];
     defaultPersona: string;
   }) => Promise<string[] | null>;
+  /**
+   * Test seam for the heartbeat-instance sync after the autostart set
+   * changes (#486). Production leaves this undefined and the real sync
+   * runs (it self-gates to the installed binary on Linux).
+   */
+  syncHeartbeatInstances?: (personas: string[]) => Promise<unknown>;
 }
 
 /**
@@ -436,6 +444,24 @@ export async function runAutostartPicker(
   // Ordering (preserve what is on disk, append what is new) lives in the
   // writer, so the TUI and this picker cannot drift apart on it.
   const chosen = await writeAutostartPersonas(config, picked);
+
+  // Provision the heartbeat timer instance for newly-served personas (and
+  // retire removed ones) right away (#486). Best-effort: the next
+  // heartbeat heal reconciles the same state if this fails.
+  const sync =
+    input.syncHeartbeatInstances ?? defaultSyncHeartbeatInstances;
+  try {
+    await sync(
+      servedPersonasOf({
+        defaultPersona: config.defaultPersona,
+        autostartPersonas: chosen,
+      }),
+    );
+  } catch (e) {
+    input.err.write(
+      `warning: could not sync heartbeat timer instances: ${(e as Error).message}\n`,
+    );
+  }
 
   input.out.write(
     chosen.length === 0

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -40,6 +40,7 @@ import {
   DEFAULT_P2P,
   loadConfig,
   personaDir,
+  servedPersonasOf,
   type TelegramAccount,
   withHostHarnessBins,
 } from "../config.ts";
@@ -795,7 +796,15 @@ export async function runRun(input: RunInput = {}): Promise<number> {
   // Detached, so a long backlog sweep outlives neither this promise nor the
   // daemon's own lifecycle concerns, and a crash there can never take the
   // channel loop with it.
-  spawnStartupNightly(alertPersona);
+  //
+  // One sweep per SERVED persona (#486) — the startup trigger used to fire
+  // only for the default persona, so a non-default persona whose heartbeat
+  // never ran got no nightly at all. Skips personas with no directory (a
+  // stale autostart entry) — their sweeps would only log an error.
+  for (const p of servedPersonasOf(config)) {
+    if (p !== alertPersona && !existsSync(personaDir(config, p))) continue;
+    spawnStartupNightly(p);
+  }
 
   // Self-provision the managed Pi capability-routing extension: when a routable
   // capability (image and/or coding model) is configured, stamp the embedded

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -38,7 +38,7 @@ import {
   type LatestRelease,
   type UpdateChannel,
 } from "../lib/githubReleases.ts";
-import { loadConfig } from "../config.ts";
+import { loadConfig, servedPersonasOf } from "../config.ts";
 import {
   defaultServiceControl,
   restartCommand,
@@ -468,7 +468,17 @@ async function defaultHealUnits(
   const sysEnv = ensureUserSystemdEnv();
   if (!sysEnv.ready) return null;
   const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
-  return ensureSystemdUnitsCurrent({ binPath, systemctl });
+  // The heal arms one heartbeat instance per served persona (#486), so it
+  // needs the roster. A config that won't load must not fail the update —
+  // skip instance management; the next heartbeat/doctor heal completes it.
+  let personas: string[] | undefined;
+  try {
+    const config = await loadConfig();
+    personas = servedPersonasOf(config);
+  } catch {
+    personas = undefined;
+  }
+  return ensureSystemdUnitsCurrent({ binPath, systemctl, personas });
 }
 
 async function defaultConfirmInstall(

--- a/src/config.ts
+++ b/src/config.ts
@@ -2325,6 +2325,25 @@ export function resolvePersona(
 }
 
 /**
+ * Personas this host serves — `{default_persona} ∪ autostart_personas`,
+ * DEFAULT FIRST (#486). This is the set that gets per-persona host
+ * maintenance: a `phantombot-heartbeat@<persona>.timer` instance each,
+ * per-persona doctor coverage, and a startup nightly sweep. The default
+ * leads because migrations key off it (the legacy single-persona
+ * heartbeat unit is only retired once the default's instance is armed).
+ */
+export function servedPersonasOf(
+  config: Pick<Config, "defaultPersona" | "autostartPersonas">,
+): string[] {
+  return [
+    config.defaultPersona,
+    ...(config.autostartPersonas ?? []).filter(
+      (n) => n !== config.defaultPersona,
+    ),
+  ];
+}
+
+/**
  * Path to the per-persona FTS5 + embeddings index. One file per persona so a
  * single persona can be rebuilt without touching others. Shared by
  * `phantombot memory ...` and the turn-time auto-retrieval so both read and

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -13,8 +13,28 @@ import { isPhantombotBinary } from "./binaryIdentity.ts";
 import type { WriteSink } from "./io.ts";
 
 export const PHANTOMBOT_UNIT_NAME = "phantombot.service";
-export const HEARTBEAT_SERVICE_NAME = "phantombot-heartbeat.service";
-export const HEARTBEAT_TIMER_NAME = "phantombot-heartbeat.timer";
+/**
+ * Heartbeat units are systemd TEMPLATES (#486): one
+ * `phantombot-heartbeat@<persona>.timer` instance per served persona
+ * (default_persona ∪ autostart_personas), so every persona on a
+ * multi-persona rig gets its own 30-minute maintenance pass — drawer
+ * promotion, index refresh, turn-flush, day-rollover nightly trigger —
+ * instead of only the default persona being swept.
+ */
+export const HEARTBEAT_SERVICE_NAME = "phantombot-heartbeat@.service";
+export const HEARTBEAT_TIMER_NAME = "phantombot-heartbeat@.timer";
+/** Pre-#486 single-persona heartbeat units — retired by the heal path once
+ * the default persona's instance is verified active. */
+export const LEGACY_HEARTBEAT_SERVICE_NAME = "phantombot-heartbeat.service";
+export const LEGACY_HEARTBEAT_TIMER_NAME = "phantombot-heartbeat.timer";
+/** Name of the heartbeat timer instance serving one persona. */
+export function heartbeatInstanceTimer(persona: string): string {
+  return `phantombot-heartbeat@${persona}.timer`;
+}
+/** Name of the heartbeat service instance serving one persona. */
+export function heartbeatInstanceService(persona: string): string {
+  return `phantombot-heartbeat@${persona}.service`;
+}
 /**
  * RETIRED units. The nightly no longer runs on a clock — it is triggered by
  * startup and by the heartbeat noticing the calendar day rolled over (see
@@ -62,6 +82,28 @@ export function heartbeatServicePath(): string {
 
 export function heartbeatTimerPath(): string {
   return join(homedir(), ".config", "systemd", "user", HEARTBEAT_TIMER_NAME);
+}
+
+/** Path of the retired pre-#486 heartbeat service (kept for cleanup only). */
+export function legacyHeartbeatServicePath(): string {
+  return join(
+    homedir(),
+    ".config",
+    "systemd",
+    "user",
+    LEGACY_HEARTBEAT_SERVICE_NAME,
+  );
+}
+
+/** Path of the retired pre-#486 heartbeat timer (kept for cleanup only). */
+export function legacyHeartbeatTimerPath(): string {
+  return join(
+    homedir(),
+    ".config",
+    "systemd",
+    "user",
+    LEGACY_HEARTBEAT_TIMER_NAME,
+  );
 }
 
 /** Path of the retired nightly service (kept for cleanup only). */
@@ -143,11 +185,17 @@ function quoteArg(s: string): string {
   return `"${s.replace(/(["\\$`])/g, "\\$1")}"`;
 }
 
-/** Generate the heartbeat oneshot service body. */
+/**
+ * Generate the heartbeat oneshot service TEMPLATE body (#486). The `%i`
+ * instance specifier becomes the persona name, so one template serves
+ * every `phantombot-heartbeat@<persona>.timer` instance on the host.
+ */
 export function generateHeartbeatService(binPath: string): string {
-  const exec = [binPath, "heartbeat"].map(quoteArg).join(" ");
+  const exec = [binPath, "heartbeat", "--persona", "%i"]
+    .map(quoteArg)
+    .join(" ");
   return `[Unit]
-Description=Phantombot heartbeat — mechanical 30-minute maintenance pass
+Description=Phantombot heartbeat — mechanical 30-minute maintenance pass (%i)
 
 [Service]
 Type=oneshot
@@ -170,7 +218,7 @@ StandardError=journal
  */
 export function generateHeartbeatTimer(): string {
   return `[Unit]
-Description=Phantombot heartbeat timer (every 30 min)
+Description=Phantombot heartbeat timer (every 30 min, %i)
 
 [Timer]
 OnCalendar=*:0/30
@@ -668,6 +716,26 @@ export interface EnsureUnitsCurrentOptions extends PhantombotUnitPathOverrides {
   binPath: string;
   systemctl: SystemctlRunner;
   /**
+   * Personas this host serves — `{default_persona} ∪ autostart_personas`,
+   * DEFAULT PERSONA FIRST (the legacy heartbeat unit is only retired once
+   * the default's instance is verified active, so a failed migration never
+   * leaves a host with no heartbeat at all). Each persona gets an enabled
+   * `phantombot-heartbeat@<persona>.timer` instance; enabled instances
+   * naming a persona NOT in this list are disabled (a persona removed from
+   * autostart loses its maintenance with it). When omitted, instance
+   * management is skipped entirely — the template files are still
+   * reconciled, but no instances are armed or retired (callers without a
+   * config in scope use this; the next heartbeat/doctor heal completes the
+   * migration).
+   */
+  personas?: readonly string[];
+  /**
+   * Where the RETIRED pre-#486 heartbeat units live. Only consulted so the
+   * migration can delete them out of a tmpdir under test.
+   */
+  legacyHeartbeatServicePath?: string;
+  legacyHeartbeatTimerPath?: string;
+  /**
    * Timer unit names (e.g. "phantombot-heartbeat.timer") that must be
    * re-armed even when systemd reports them enabled AND active.
    *
@@ -694,6 +762,9 @@ export interface EnsureUnitsCurrentResult {
   repairedTimers: string[];
   /** Retired unit files removed from disk (upgrade cleanup). Usually empty. */
   removedRetired: string[];
+  /** Heartbeat timer instances disabled because their persona is no longer
+   * served (empty when `personas` was not passed). */
+  disabledInstances: string[];
 }
 
 /**
@@ -709,6 +780,7 @@ export interface EnsureUnitsCurrentResult {
 export async function removeRetiredUnits(
   systemctl: SystemctlRunner,
   paths: readonly string[] = [nightlyTimerPath(), nightlyServicePath()],
+  timersToStop: readonly string[] = RETIRED_TIMER_NAMES,
 ): Promise<string[]> {
   const present = paths.filter((p) => existsSync(p));
   // Nothing on disk → nothing systemd can run, so skip the IPC entirely. This
@@ -716,7 +788,7 @@ export async function removeRetiredUnits(
   // because the heal path runs on every heartbeat.
   if (present.length === 0) return [];
 
-  for (const unit of RETIRED_TIMER_NAMES) {
+  for (const unit of timersToStop) {
     await systemctl.run(["--user", "stop", unit]);
     await systemctl.run(["--user", "disable", unit]);
   }
@@ -779,10 +851,14 @@ export async function ensureSystemdUnitsCurrent(
   // armed. Anything else means the timer isn't actually running and we
   // need to enable --now to repair it. Cheap to recheck — systemctl is
   // local IPC and these calls take ~ms.
+  //
+  // The heartbeat TEMPLATE timer (`phantombot-heartbeat@.timer`) is
+  // skipped here — a template can never be enabled itself; its instances
+  // are reconciled per persona below.
   const forceRearm = new Set(opts.forceRearmTimers ?? []);
   const repairedTimers: string[] = [];
   for (const t of targets) {
-    if (!t.isTimer) continue;
+    if (!t.isTimer || t.unit.includes("@")) continue;
     const enabled = await opts.systemctl.run([
       "--user",
       "is-enabled",
@@ -814,12 +890,132 @@ export async function ensureSystemdUnitsCurrent(
     repairedTimers.push(t.unit);
   }
 
-  return { rewrote, backups, repairedTimers, removedRetired };
+  // Per-persona heartbeat instances (#486). One enabled
+  // `phantombot-heartbeat@<persona>.timer` per served persona; instances
+  // for personas no longer served are disabled; and the retired
+  // single-persona heartbeat unit is removed only AFTER the default
+  // persona's instance is verified armed — a migration that can't arm the
+  // replacement keeps the legacy unit rather than leaving the host with
+  // no heartbeat at all (it is retried on the next heal pass).
+  let disabledInstances: string[] = [];
+  if (opts.personas) {
+    const templateRewrote = rewroteTimerUnits.has(HEARTBEAT_TIMER_NAME);
+    let defaultInstanceReady = false;
+    for (let i = 0; i < opts.personas.length; i++) {
+      const unit = heartbeatInstanceTimer(opts.personas[i]!);
+      const enabled = await opts.systemctl.run(["--user", "is-enabled", unit]);
+      const active = await opts.systemctl.run(["--user", "is-active", unit]);
+      const isEnabled =
+        enabled.exitCode === 0 && enabled.stdout.trim() === "enabled";
+      const isActive =
+        active.exitCode === 0 && active.stdout.trim() === "active";
+      let ready = isEnabled && isActive;
+      if (ready) {
+        if (forceRearm.has(unit) || templateRewrote) {
+          await opts.systemctl.run(["--user", "restart", unit]);
+          repairedTimers.push(unit);
+        }
+      } else {
+        const r = await opts.systemctl.run(["--user", "enable", "--now", unit]);
+        if (r.exitCode === 0) {
+          repairedTimers.push(unit);
+          ready = true;
+        }
+      }
+      if (i === 0) defaultInstanceReady = ready;
+    }
+
+    disabledInstances = await disableUnservedHeartbeatInstances(
+      opts.systemctl,
+      opts.personas,
+    );
+
+    if (defaultInstanceReady) {
+      const removedLegacy = await removeRetiredUnits(
+        opts.systemctl,
+        [
+          opts.legacyHeartbeatTimerPath ?? legacyHeartbeatTimerPath(),
+          opts.legacyHeartbeatServicePath ?? legacyHeartbeatServicePath(),
+        ],
+        [LEGACY_HEARTBEAT_TIMER_NAME],
+      );
+      if (removedLegacy.length > 0) {
+        removedRetired.push(...removedLegacy);
+        await opts.systemctl.run(["--user", "daemon-reload"]);
+      }
+    }
+  }
+
+  return { rewrote, backups, repairedTimers, removedRetired, disabledInstances };
+}
+
+/**
+ * Persona names with an ENABLED `phantombot-heartbeat@<persona>.timer`
+ * instance, parsed from `systemctl --user list-unit-files`. The template
+ * itself (`@.timer`, empty instance name) is never returned. Pure IPC +
+ * parse — no files touched — so it works for both the heal path and
+ * persona-lifecycle callers.
+ */
+export async function listEnabledHeartbeatInstances(
+  systemctl: SystemctlRunner,
+): Promise<string[]> {
+  const r = await systemctl.run([
+    "--user",
+    "list-unit-files",
+    "--no-legend",
+    "--no-pager",
+    "phantombot-heartbeat@*.timer",
+  ]);
+  if (r.exitCode !== 0) return [];
+  const personas: string[] = [];
+  for (const line of r.stdout.split("\n")) {
+    const cols = line.trim().split(/\s+/);
+    if (cols.length < 2) continue;
+    const [unit, state] = cols;
+    if (!unit!.startsWith("phantombot-heartbeat@") || !unit!.endsWith(".timer")) {
+      continue;
+    }
+    if (state !== "enabled" && state !== "enabled-runtime") continue;
+    const persona = unit!.slice(
+      "phantombot-heartbeat@".length,
+      -".timer".length,
+    );
+    if (persona.length > 0) personas.push(persona);
+  }
+  return personas;
+}
+
+/**
+ * Disable (and stop) every enabled heartbeat instance whose persona is NOT
+ * in `served` — the "removed from autostart loses its maintenance" half of
+ * instance reconciliation. Returns the disabled unit names.
+ */
+export async function disableUnservedHeartbeatInstances(
+  systemctl: SystemctlRunner,
+  served: readonly string[],
+): Promise<string[]> {
+  const servedSet = new Set(served);
+  const enabled = await listEnabledHeartbeatInstances(systemctl);
+  const disabled: string[] = [];
+  for (const persona of enabled) {
+    if (servedSet.has(persona)) continue;
+    const unit = heartbeatInstanceTimer(persona);
+    const r = await systemctl.run(["--user", "disable", "--now", unit]);
+    if (r.exitCode === 0) disabled.push(unit);
+  }
+  return disabled;
 }
 
 export interface InstallOptions {
   binPath: string;
   unitPath: string;
+  /**
+   * Personas to arm heartbeat instances for (#486) — default persona
+   * FIRST, same contract as `ensureSystemdUnitsCurrent`. When omitted (no
+   * config on a pre-init box), no instances are armed; the startup doctor
+   * / first heartbeat heal provisions them once a config exists.
+   */
+  personas?: readonly string[];
   /**
    * Optional path overrides for the heartbeat/nightly companion units.
    * Default to the per-user XDG locations (~/.config/systemd/user/...).
@@ -829,6 +1025,8 @@ export interface InstallOptions {
    */
   heartbeatServicePath?: string;
   heartbeatTimerPath?: string;
+  legacyHeartbeatServicePath?: string;
+  legacyHeartbeatTimerPath?: string;
   nightlyServicePath?: string;
   nightlyTimerPath?: string;
   tickServicePath?: string;
@@ -860,15 +1058,25 @@ export async function installPhantombotUnit(
     opts.out.write(`removed retired unit: ${name}\n`);
   }
 
-  for (const args of [
+  const enableSteps: string[][] = [
     ["--user", "daemon-reload"],
     ["--user", "enable", PHANTOMBOT_UNIT_NAME],
     ["--user", "start", PHANTOMBOT_UNIT_NAME],
-    ["--user", "enable", HEARTBEAT_TIMER_NAME],
-    ["--user", "start", HEARTBEAT_TIMER_NAME],
+  ];
+  // One heartbeat timer instance per served persona (#486).
+  for (const persona of opts.personas ?? []) {
+    enableSteps.push(
+      ["--user", "enable", heartbeatInstanceTimer(persona)],
+      ["--user", "start", heartbeatInstanceTimer(persona)],
+    );
+  }
+  enableSteps.push(
     ["--user", "enable", TICK_TIMER_NAME],
     ["--user", "start", TICK_TIMER_NAME],
-  ]) {
+  );
+  let defaultInstanceReady = opts.personas === undefined;
+  for (let i = 0; i < enableSteps.length; i++) {
+    const args = enableSteps[i]!;
     const r = await opts.systemctl.run(args);
     if (r.exitCode !== 0) {
       opts.err.write(
@@ -876,9 +1084,35 @@ export async function installPhantombotUnit(
       );
       return { installed: false };
     }
+    if (
+      opts.personas !== undefined &&
+      opts.personas.length > 0 &&
+      args[1] === "start" &&
+      args[2] === heartbeatInstanceTimer(opts.personas[0]!)
+    ) {
+      defaultInstanceReady = true;
+    }
+  }
+
+  // Only retire the pre-#486 single-persona heartbeat unit once its
+  // replacement (the default persona's instance) is armed — same migration
+  // rule as the heal path, so a failed install never strands a host
+  // heartbeat-less.
+  if (defaultInstanceReady) {
+    const removedLegacy = await removeRetiredUnits(
+      opts.systemctl,
+      [
+        opts.legacyHeartbeatTimerPath ?? legacyHeartbeatTimerPath(),
+        opts.legacyHeartbeatServicePath ?? legacyHeartbeatServicePath(),
+      ],
+      [LEGACY_HEARTBEAT_TIMER_NAME],
+    );
+    for (const name of removedLegacy) {
+      opts.out.write(`removed retired unit: ${name}\n`);
+    }
   }
   opts.out.write(
-    "enabled and started phantombot.service + heartbeat.timer + tick.timer\n",
+    `enabled and started phantombot.service + ${opts.personas?.length ?? 0} heartbeat instance(s) + tick.timer\n`,
   );
   return { installed: true };
 }
@@ -894,16 +1128,30 @@ export async function uninstallPhantombotUnit(
   opts: UninstallOptions,
 ): Promise<{ removed: boolean }> {
   // stop + disable are best-effort: a half-installed unit is fine to remove.
-  for (const args of [
+  const stopSteps: string[][] = [
     ["--user", "stop", TICK_TIMER_NAME],
     ["--user", "disable", TICK_TIMER_NAME],
     ["--user", "stop", NIGHTLY_TIMER_NAME],
     ["--user", "disable", NIGHTLY_TIMER_NAME],
-    ["--user", "stop", HEARTBEAT_TIMER_NAME],
-    ["--user", "disable", HEARTBEAT_TIMER_NAME],
+    // The retired pre-#486 single-persona heartbeat units, in case an
+    // uninstall runs on a host that never got the migration heal.
+    ["--user", "stop", LEGACY_HEARTBEAT_TIMER_NAME],
+    ["--user", "disable", LEGACY_HEARTBEAT_TIMER_NAME],
+    ["--user", "stop", LEGACY_HEARTBEAT_SERVICE_NAME],
+    ["--user", "disable", LEGACY_HEARTBEAT_SERVICE_NAME],
+  ];
+  // Every per-persona heartbeat instance (#486).
+  for (const persona of await listEnabledHeartbeatInstances(opts.systemctl)) {
+    stopSteps.push(
+      ["--user", "stop", heartbeatInstanceTimer(persona)],
+      ["--user", "disable", heartbeatInstanceTimer(persona)],
+    );
+  }
+  stopSteps.push(
     ["--user", "stop", PHANTOMBOT_UNIT_NAME],
     ["--user", "disable", PHANTOMBOT_UNIT_NAME],
-  ]) {
+  );
+  for (const args of stopSteps) {
     const r = await opts.systemctl.run(args);
     if (r.exitCode !== 0) {
       opts.out.write(
@@ -924,6 +1172,8 @@ export async function uninstallPhantombotUnit(
   for (const path of [
     heartbeatServicePath(),
     heartbeatTimerPath(),
+    legacyHeartbeatServicePath(),
+    legacyHeartbeatTimerPath(),
     nightlyServicePath(),
     nightlyTimerPath(),
     tickServicePath(),
@@ -1017,4 +1267,47 @@ export function ensureUserSystemdEnv(
     env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${runtimeDir}/bus`;
   }
   return { ready: true, autoSet: true, runtimeDir };
+}
+
+/**
+ * Provision/tear down heartbeat timer instances to match the served
+ * persona set — the persona-lifecycle caller of the #486 machinery.
+ * Invoked after `autostart_personas` changes (persona picker,
+ * `persona new`, the TUI autostart action) so a newly-served persona's
+ * first maintenance pass is at most 30 minutes away instead of waiting
+ * for the next heal, and a removed persona's instance dies with it.
+ *
+ * Light by design: only instance enable/disable, no unit-file rendering
+ * (the templates are install's/heal's job — if they're absent the enable
+ * fails and the caller warns). Returns null when instance management
+ * isn't possible here (no user-systemd bus), so callers can stay silent
+ * on dev boxes and headless sessions.
+ */
+export async function defaultSyncHeartbeatInstances(
+  personas: readonly string[],
+): Promise<{ armed: string[]; disabled: string[] } | null> {
+  // Real installed service only: unit management from a dev `bun` run or a
+  // test would arm timers on the developer's actual host. The periodic
+  // heal (which runs from the compiled binary's own heartbeat) reconciles
+  // the same state, so skipping here never strands anyone.
+  if (process.platform !== "linux") return null;
+  if (!isPhantombotBinary()) return null;
+  const sysEnv = ensureUserSystemdEnv();
+  if (!sysEnv.ready) return null;
+  const systemctl = new BunSystemctlRunner(buildSystemctlEnv(sysEnv));
+  const armed: string[] = [];
+  for (const persona of personas) {
+    const unit = heartbeatInstanceTimer(persona);
+    const enabled = await systemctl.run(["--user", "is-enabled", unit]);
+    if (enabled.exitCode === 0 && enabled.stdout.trim() === "enabled") continue;
+    const r = await systemctl.run(["--user", "enable", "--now", unit]);
+    if (r.exitCode === 0) armed.push(unit);
+    else {
+      throw new Error(
+        `systemctl enable --now ${unit} failed: ${r.stderr.trim() || `exit ${r.exitCode}`}`,
+      );
+    }
+  }
+  const disabled = await disableUnservedHeartbeatInstances(systemctl, personas);
+  return { armed, disabled };
 }

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -912,8 +912,17 @@ export async function ensureSystemdUnitsCurrent(
       let ready = isEnabled && isActive;
       if (ready) {
         if (forceRearm.has(unit) || templateRewrote) {
-          await opts.systemctl.run(["--user", "restart", unit]);
-          repairedTimers.push(unit);
+          // A failed restart can leave the instance stopped; only keep
+          // `ready` when the unit is verifiably active afterwards, so the
+          // legacy retirement below never fires on a dead replacement.
+          const r = await opts.systemctl.run(["--user", "restart", unit]);
+          if (r.exitCode === 0) {
+            const re = await opts.systemctl.run(["--user", "is-active", unit]);
+            ready = re.exitCode === 0 && re.stdout.trim() === "active";
+          } else {
+            ready = false;
+          }
+          if (ready) repairedTimers.push(unit);
         }
       } else {
         const r = await opts.systemctl.run(["--user", "enable", "--now", unit]);

--- a/src/lib/taskScheduler.ts
+++ b/src/lib/taskScheduler.ts
@@ -588,7 +588,14 @@ export function generateLoginFallbackTaskXml(
   });
 }
 
-/** Generate the heartbeat task XML — fires every 30 minutes. */
+/**
+ * Generate the heartbeat task XML — fires every 30 minutes.
+ *
+ * The task is named per-persona (`heartbeat-<persona>`) and now also RUNS
+ * per-persona (#486): without the explicit `--persona`, the heartbeat CLI
+ * resolves PHANTOMBOT_PERSONA → default persona, so a non-default
+ * persona's task would silently sweep the default persona's memory.
+ */
 export function generateHeartbeatTaskXml(
   sid: string,
   binPath: string,
@@ -602,7 +609,7 @@ export function generateHeartbeatTaskXml(
     persona,
     label: "heartbeat",
     binPath,
-    args: ["heartbeat"],
+    args: ["heartbeat", "--persona", persona],
     triggersXml: repeatingTimeTrigger("PT30M"),
     executionTimeLimit: "PT1H",
     logon,

--- a/src/lib/timerHealth.ts
+++ b/src/lib/timerHealth.ts
@@ -10,10 +10,12 @@
  * We write one cheap, atomic marker file per timer in XDG_STATE_HOME.
  * No JSON parsing on read — we just stat() the mtime — but the file
  * also contains the ISO timestamp + a "runs=" counter for forensic
- * tail -F use. Marker files are TIMER-scoped (not persona-scoped) on
- * purpose: heartbeat may eventually run multi-persona, and tick has
- * no persona at all. We're tracking the timer's heartbeat, not any
- * one persona's memory.
+ * tail -F use. Heartbeat markers are PERSONA-scoped
+ * (`heartbeat.<persona>.last-fired`) because each persona has its own
+ * `phantombot-heartbeat@<persona>.timer` instance (#486) and its own
+ * day-rollover nightly trigger — one shared marker would let the
+ * first-firing persona consume the rollover for everyone. Tick has no
+ * persona at all, so its marker stays timer-scoped.
  *
  * Staleness thresholds are passed in by callers (doctor picks them)
  * rather than hard-coded here, because the heartbeat-firing-every-30m
@@ -27,8 +29,18 @@ import { dirname, join } from "node:path";
 import { xdgStateHome } from "../config.ts";
 import { log } from "./logger.ts";
 
-export function heartbeatMarkerPath(): string {
-  return join(xdgStateHome(), "phantombot", "heartbeat.last-fired");
+/**
+ * Path of the heartbeat fire marker. With a persona, the per-persona
+ * marker written by that persona's heartbeat instance; without one, the
+ * legacy timer-scoped marker — kept solely so installs from before the
+ * per-persona instances (#486) still report the default persona's last
+ * fire instead of going falsely stale at upgrade.
+ */
+export function heartbeatMarkerPath(persona?: string): string {
+  const file = persona
+    ? `heartbeat.${persona}.last-fired`
+    : "heartbeat.last-fired";
+  return join(xdgStateHome(), "phantombot", file);
 }
 
 export function tickMarkerPath(): string {
@@ -97,8 +109,8 @@ async function recordFired(path: string): Promise<void> {
   }
 }
 
-export function recordHeartbeatFired(): Promise<void> {
-  return recordFired(heartbeatMarkerPath());
+export function recordHeartbeatFired(persona?: string): Promise<void> {
+  return recordFired(heartbeatMarkerPath(persona));
 }
 
 export function recordTickFired(): Promise<void> {
@@ -146,8 +158,31 @@ function loadLastFired(path: string, now: Date): TimerLastFired {
   }
 }
 
-export function loadHeartbeatLastFired(now: Date = new Date()): TimerLastFired {
-  return loadLastFired(heartbeatMarkerPath(), now);
+export function loadHeartbeatLastFired(
+  now: Date = new Date(),
+  persona?: string,
+): TimerLastFired {
+  return loadLastFired(heartbeatMarkerPath(persona), now);
+}
+
+/**
+ * Last-fire info for one persona's heartbeat instance. The default
+ * persona falls back to the legacy timer-scoped marker when its
+ * per-persona file doesn't exist yet — that marker tracked exactly its
+ * fires on pre-#486 installs. A NON-default persona gets no fallback:
+ * the legacy marker says nothing about when (or whether) its instance
+ * ever fired, and borrowing it would report a never-maintained persona
+ * as healthy.
+ */
+export function loadPersonaHeartbeatLastFired(
+  persona: string,
+  opts: { isDefault?: boolean; now?: Date } = {},
+): TimerLastFired {
+  const now = opts.now ?? new Date();
+  const own = loadLastFired(heartbeatMarkerPath(persona), now);
+  if (own.iso !== undefined) return own;
+  if (opts.isDefault) return loadLastFired(heartbeatMarkerPath(), now);
+  return own;
 }
 
 export function loadTickLastFired(now: Date = new Date()): TimerLastFired {

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -30,13 +30,14 @@
  * untested surface.
  */
 
-import { type Config, personaDir } from "../config.ts";
+import { type Config, personaDir, servedPersonasOf } from "../config.ts";
 import { applyEmbeddingConfig } from "../cli/embedding.ts";
 import type { EmbeddingConfigUpdate } from "../cli/embedding.ts";
 import { applyVoiceConfig } from "../cli/voice.ts";
 import { runMemoryIndex } from "../cli/memory.ts";
 import type { EmbedProgress } from "../lib/embedJob.ts";
 import { writeAutostartPersonas } from "../lib/personaDefault.ts";
+import { defaultSyncHeartbeatInstances } from "../lib/systemd.ts";
 import { setPersonaSecret } from "../lib/vaultSecrets.ts";
 import { openPersonaVault } from "../lib/vault.ts";
 import { loadState, saveState } from "../state.ts";
@@ -263,11 +264,27 @@ export async function applyAutostart(input: {
   persona: string;
   on: boolean;
   serviceControl?: ServiceControl;
+  /** Test seam for the heartbeat-instance sync (#486). */
+  syncHeartbeatInstances?: (personas: string[]) => Promise<unknown>;
 }): Promise<{ ok: boolean; list: string[]; error?: string }> {
   const current = new Set(input.config.autostartPersonas ?? []);
   if (input.on) current.add(input.persona);
   else current.delete(input.persona);
   const list = await writeAutostartPersonas(input.config, [...current]);
+  // Provision/retire the persona's heartbeat timer instance right away
+  // (#486) — best-effort; the next heartbeat heal reconciles regardless.
+  try {
+    const sync = input.syncHeartbeatInstances ?? defaultSyncHeartbeatInstances;
+    await sync(
+      servedPersonasOf({
+        defaultPersona: input.config.defaultPersona,
+        autostartPersonas: list,
+      }),
+    );
+  } catch {
+    // The restart below still applies the autostart change; a failed
+    // instance sync is healed on the next heartbeat pass.
+  }
   const svc = input.serviceControl ?? defaultServiceControl();
   const r = await svc.restart();
   return r.ok

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -724,8 +724,9 @@ describe("runDoctor zombie-timer re-arm wiring", () => {
         },
       }),
     });
-    // The stale heartbeat (with a real last_fired) was passed down.
-    expect(receivedStale).toEqual(["phantombot-heartbeat.timer"]);
+    // The stale heartbeat (with a real last_fired) was passed down — as
+    // the DEFAULT persona's instance unit (#486).
+    expect(receivedStale).toEqual(["phantombot-heartbeat@phantom.timer"]);
     // Marker is still stale this run, so exit 1 (visibility) — the
     // re-arm fires a catch-up that refreshes the marker for next time.
     expect(code).toBe(1);
@@ -1261,5 +1262,130 @@ describe("runDoctor — memory database (#417)", () => {
       expect(report.service_logs.max_bytes).toBe(1000);
       expect(report.service_logs.over_cap).toEqual(["tick.out.log"]);
     });
+  });
+});
+
+describe("runDoctor per-persona maintenance coverage (#486)", () => {
+  test("renders the per-persona section, warns on a stale persona, exit stays 0", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+      checkMaintenance: async () => [
+        {
+          persona: "phantom",
+          last_heartbeat: new Date().toISOString(),
+          heartbeat_age_minutes: 4,
+          heartbeat_stale: false,
+          nightly_backlog: 0,
+        },
+        {
+          persona: "kai",
+          heartbeat_stale: true,
+          nightly_backlog: 3,
+          nightly_oldest_pending: "2026-08-26",
+        },
+      ],
+    });
+    // Warn-only: a persona behind on maintenance never fails doctor.
+    expect(code).toBe(0);
+    expect(out.text).toContain("maintenance per persona:");
+    expect(out.text).toContain("phantom: ok");
+    expect(out.text).toContain("kai: WARN — heartbeat never fired");
+    expect(out.text).toContain("nightly 3 date(s) pending (oldest 2026-08-26)");
+    expect(out.text).toContain("phantombot-heartbeat@<persona>.timer");
+  });
+
+  test("a stale non-default persona drives a force-re-arm of ITS instance", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    let receivedStale: string[] | undefined;
+    await runDoctor({
+      config,
+      out: new CaptureStream(),
+      checkSystemd: async (staleTimers) => {
+        receivedStale = staleTimers;
+        return {
+          missing_unit_files: [],
+          drifted_unit_files: [],
+          inactive_timers: [],
+          repaired: true,
+        };
+      },
+      checkTimers: false,
+      checkMaintenance: async () => [
+        {
+          persona: "phantom",
+          last_heartbeat: new Date().toISOString(),
+          heartbeat_age_minutes: 4,
+          heartbeat_stale: false,
+          nightly_backlog: 0,
+        },
+        {
+          persona: "kai",
+          last_heartbeat: "2026-05-14T06:52:00.000Z",
+          heartbeat_age_minutes: 11_520,
+          heartbeat_stale: true,
+          nightly_backlog: 0,
+        },
+      ],
+    });
+    expect(receivedStale).toEqual(["phantombot-heartbeat@kai.timer"]);
+  });
+
+  test("checkMaintenance=false omits the section", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({
+      config,
+      out,
+      checkSystemd: false,
+      checkTimers: false,
+      checkMaintenance: false,
+    });
+    expect(out.text).not.toContain("maintenance per persona:");
+  });
+
+  test("json mode emits the maintenance block", async () => {
+    await writeState({
+      last_run: new Date().toISOString(),
+      last_status: "ok",
+    });
+    const out = new CaptureStream();
+    await runDoctor({
+      config,
+      out,
+      json: true,
+      checkSystemd: false,
+      checkTimers: false,
+      checkMaintenance: async () => [
+        {
+          persona: "kai",
+          heartbeat_stale: true,
+          nightly_backlog: 2,
+          nightly_oldest_pending: "2026-08-27",
+        },
+      ],
+    });
+    const report = JSON.parse(out.text);
+    expect(report.maintenance).toEqual([
+      {
+        persona: "kai",
+        heartbeat_stale: true,
+        nightly_backlog: 2,
+        nightly_oldest_pending: "2026-08-27",
+      },
+    ]);
   });
 });

--- a/tests/cli-heartbeat.test.ts
+++ b/tests/cli-heartbeat.test.ts
@@ -112,7 +112,9 @@ describe("runHeartbeatCli", () => {
       healSystemd: false,
     });
     expect(code).toBe(0);
-    expect(existsSync(heartbeatMarkerPath())).toBe(true);
+    // Per-persona marker (#486): the fire is recorded against the persona
+    // the heartbeat swept, not a host-global file.
+    expect(existsSync(heartbeatMarkerPath("phantom"))).toBe(true);
   });
 
   test("healSystemd seam runs after the heartbeat body", async () => {
@@ -161,6 +163,51 @@ describe("runHeartbeatCli", () => {
     expect(code).toBe(0);
     expect(spawned).toEqual([["phantom", "rollover"]]);
     expect(out.text).toContain("day rolled over");
+  });
+
+  test("a non-default persona's rollover is not consumed by the default's marker (#486)", async () => {
+    // The legacy timer-scoped marker (written by the default persona's
+    // fires) must NOT satisfy a non-default persona's rollover check —
+    // sharing it was how the first-firing persona after midnight starved
+    // every other persona of its nightly sweep. Kai has no marker of his
+    // own yet → no rollover, no sweep.
+    await mkdir(join(workdir, "personas", "kai", "memory"), { recursive: true });
+    await writeMarker(new Date(Date.now() - 36 * 3_600_000));
+    const spawned: string[] = [];
+    const code = await runHeartbeatCli({
+      config,
+      persona: "kai",
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+      triggerNightly: (persona) => spawned.push(persona),
+    });
+    expect(code).toBe(0);
+    expect(spawned).toEqual([]);
+  });
+
+  test("a non-default persona rolls over on its OWN marker (#486)", async () => {
+    await mkdir(join(workdir, "personas", "kai", "memory"), { recursive: true });
+    const p = heartbeatMarkerPath("kai");
+    await mkdir(dirname(p), { recursive: true });
+    await writeFile(
+      p,
+      `ISO=${new Date(Date.now() - 36 * 3_600_000).toISOString()} runs=1\n`,
+      "utf8",
+    );
+    const spawned: string[] = [];
+    const code = await runHeartbeatCli({
+      config,
+      persona: "kai",
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      healSystemd: false,
+      embedNotes: false,
+      triggerNightly: (persona) => spawned.push(persona),
+    });
+    expect(code).toBe(0);
+    expect(spawned).toEqual(["kai"]);
   });
 
   test("a fire earlier the same day does not spawn a sweep", async () => {

--- a/tests/cli-install.test.ts
+++ b/tests/cli-install.test.ts
@@ -93,6 +93,8 @@ let unitPath: string;
 let installPaths: {
   heartbeatServicePath: string;
   heartbeatTimerPath: string;
+  legacyHeartbeatServicePath: string;
+  legacyHeartbeatTimerPath: string;
   nightlyServicePath: string;
   nightlyTimerPath: string;
   tickServicePath: string;
@@ -103,10 +105,14 @@ beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-install-"));
   unitPath = join(workdir, "phantombot.service");
   // Without these, runInstall would write companion units into the real
-  // ~/.config/systemd/user/ on the test runner — see #44.
+  // ~/.config/systemd/user/ on the test runner — see #44. The retired
+  // pre-#486 heartbeat paths are overridden for the same reason: an
+  // upgrade-migration test would otherwise DELETE the real files.
   installPaths = {
-    heartbeatServicePath: join(workdir, "phantombot-heartbeat.service"),
-    heartbeatTimerPath: join(workdir, "phantombot-heartbeat.timer"),
+    heartbeatServicePath: join(workdir, "phantombot-heartbeat@.service"),
+    heartbeatTimerPath: join(workdir, "phantombot-heartbeat@.timer"),
+    legacyHeartbeatServicePath: join(workdir, "phantombot-heartbeat.service"),
+    legacyHeartbeatTimerPath: join(workdir, "phantombot-heartbeat.timer"),
     nightlyServicePath: join(workdir, "phantombot-nightly.service"),
     nightlyTimerPath: join(workdir, "phantombot-nightly.timer"),
     tickServicePath: join(workdir, "phantombot-tick.service"),
@@ -184,6 +190,8 @@ describe("runInstall (linux/systemd)", () => {
       err,
       ensureSystemdEnv: sysEnvAutoSet,
       platform: "linux",
+      // Hermetic: never let a test derive personas from the real config.
+      personas: [],
     });
     expect(code).toBe(0);
     expect(out.text).toContain(
@@ -199,6 +207,8 @@ describe("runInstall (linux/systemd)", () => {
       binPath: "/usr/local/bin/phantombot",
       unitPath,
       ...installPaths,
+      // Hermetic: never let a test derive personas from the real config.
+      personas: ["testbot", "helper"],
       systemctl: sys,
       out,
       err,
@@ -210,8 +220,11 @@ describe("runInstall (linux/systemd)", () => {
       "--user daemon-reload",
       "--user enable phantombot.service",
       "--user start phantombot.service",
-      "--user enable phantombot-heartbeat.timer",
-      "--user start phantombot-heartbeat.timer",
+      // One heartbeat timer instance per served persona (#486).
+      "--user enable phantombot-heartbeat@testbot.timer",
+      "--user start phantombot-heartbeat@testbot.timer",
+      "--user enable phantombot-heartbeat@helper.timer",
+      "--user start phantombot-heartbeat@helper.timer",
       "--user enable phantombot-tick.timer",
       "--user start phantombot-tick.timer",
     ]);
@@ -459,12 +472,17 @@ describe("runUninstall (linux/systemd)", () => {
     });
     expect(code).toBe(0);
     expect(sys.calls.map((a) => a.join(" "))).toEqual([
+      // Heartbeat instances are enumerated first (#486); none enabled here.
+      "--user list-unit-files --no-legend --no-pager phantombot-heartbeat@*.timer",
       "--user stop phantombot-tick.timer",
       "--user disable phantombot-tick.timer",
       "--user stop phantombot-nightly.timer",
       "--user disable phantombot-nightly.timer",
+      // The retired pre-#486 heartbeat units.
       "--user stop phantombot-heartbeat.timer",
       "--user disable phantombot-heartbeat.timer",
+      "--user stop phantombot-heartbeat.service",
+      "--user disable phantombot-heartbeat.service",
       "--user stop phantombot.service",
       "--user disable phantombot.service",
       "--user daemon-reload",

--- a/tests/cli-persona-new.test.ts
+++ b/tests/cli-persona-new.test.ts
@@ -102,6 +102,22 @@ describe("runPersonaNew", () => {
     expect(out.lines.join("")).toContain("autostart: lena");
   });
 
+  test("--autostart provisions the heartbeat timer instance for the served set (#486)", async () => {
+    const config = freshConfig("robbie");
+    let synced: string[] | undefined;
+    await runPersonaNew({
+      name: "lena",
+      autostart: true,
+      config,
+      out: sink(),
+      err: sink(),
+      syncHeartbeatInstances: async (personas) => {
+        synced = personas;
+      },
+    });
+    expect(synced).toEqual(["robbie", "lena"]);
+  });
+
   test("refuses a duplicate name rather than archiving the existing one", async () => {
     const config = freshConfig("robbie");
     const err = sink();

--- a/tests/cli-persona.test.ts
+++ b/tests/cli-persona.test.ts
@@ -464,6 +464,23 @@ describe("runAutostartPicker", () => {
     expect(out.text).toContain("phantom + lena");
   });
 
+  test("syncs heartbeat timer instances to the new served set (#486)", async () => {
+    let synced: string[] | undefined;
+    await runAutostartPicker({
+      config: makeConfig(),
+      personas: ["phantom", "lena", "kai"],
+      serviceControl: svcInactive,
+      out: new CaptureStream(),
+      err: new CaptureStream(),
+      choose: async () => ["kai"],
+      syncHeartbeatInstances: async (personas) => {
+        synced = personas;
+      },
+    });
+    // Default first, then the chosen autostart set.
+    expect(synced).toEqual(["phantom", "kai"]);
+  });
+
   test("clearing the selection removes the key rather than writing []", async () => {
     await runAutostartPicker({
       config: makeConfig({ autostartPersonas: ["lena"] }),

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -597,6 +597,7 @@ describe("runUpdate post-swap systemd heal", () => {
           backups: [],
           repairedTimers: [],
           removedRetired: [],
+          disabledInstances: [],
         };
       },
     });
@@ -623,6 +624,7 @@ describe("runUpdate post-swap systemd heal", () => {
         rewrote: ["phantombot-tick.timer", "phantombot.service"],
         backups: [],
         repairedTimers: ["phantombot-tick.timer"],
+        disabledInstances: [],
         removedRetired: [],
       }),
     });

--- a/tests/config-resolvePersona.test.ts
+++ b/tests/config-resolvePersona.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, afterEach } from "bun:test";
 
-import { resolvePersona, type Config } from "../src/config.ts";
+import { resolvePersona, servedPersonasOf, type Config } from "../src/config.ts";
 
 const config = { defaultPersona: "phantom" } as Config;
 
@@ -34,5 +34,31 @@ describe("resolvePersona", () => {
   test("empty-string env var does not shadow the default", () => {
     process.env.PHANTOMBOT_PERSONA = "";
     expect(resolvePersona(undefined, config)).toBe("phantom");
+  });
+});
+
+describe("servedPersonasOf (#486)", () => {
+  test("default first, then autostart, deduplicated", () => {
+    expect(
+      servedPersonasOf({
+        defaultPersona: "lena",
+        autostartPersonas: ["kai", "jake"],
+      }),
+    ).toEqual(["lena", "kai", "jake"]);
+  });
+
+  test("the default listed in autostart is not duplicated", () => {
+    expect(
+      servedPersonasOf({
+        defaultPersona: "lena",
+        autostartPersonas: ["lena", "kai"],
+      }),
+    ).toEqual(["lena", "kai"]);
+  });
+
+  test("no autostart → only the default", () => {
+    expect(
+      servedPersonasOf({ defaultPersona: "lena", autostartPersonas: undefined }),
+    ).toEqual(["lena"]);
   });
 });

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -913,14 +913,16 @@ describe("ensureSystemdUnitsCurrent", () => {
       { exitCode: 0, stdout: "", stderr: "" }, // daemon-reload
       isEnabledActive(), // tick: unchanged → left alone
       isActiveActive(),
-      // lena: enabled + active, template rewrote → restart
+      // lena: enabled + active, template rewrote → restart + active re-probe
       isEnabledActive(),
       isActiveActive(),
       { exitCode: 0, stdout: "", stderr: "" },
-      // kai: enabled + active, template rewrote → restart
+      isActiveActive(),
+      // kai: enabled + active, template rewrote → restart + active re-probe
       isEnabledActive(),
       isActiveActive(),
       { exitCode: 0, stdout: "", stderr: "" },
+      isActiveActive(),
       { exitCode: 0, stdout: "", stderr: "" }, // list-unit-files
     ];
     const r = await ensureSystemdUnitsCurrent({
@@ -944,6 +946,90 @@ describe("ensureSystemdUnitsCurrent", () => {
       "restart",
       "phantombot-heartbeat@kai.timer",
     ]);
+  });
+
+  test("a failed instance restart keeps the legacy heartbeat unit", async () => {
+    // Migration ordering, restart path: the default persona's instance was
+    // enabled+active, the template rewrite triggers a restart, and that
+    // restart FAILS (or leaves the unit dead). The pre-restart probe said
+    // active, but the replacement is now unverifiable — the legacy unit
+    // must stay, or the host goes heartbeat-less.
+    const bin = "/usr/local/bin/phantombot";
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    await writeFile(legacyHbServicePath, "[Service]\nExecStart=old\n", "utf8");
+    await writeFile(legacyHbTimerPath, "[Timer]\nOnCalendar=*:0/30\n", "utf8");
+    // Corrupt the TEMPLATE timer so the heal rewrites it and restarts the
+    // instances.
+    await writeFile(hbTimerPath, "OnUnitActiveSec=30min\n", "utf8");
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      { exitCode: 0, stdout: "", stderr: "" }, // daemon-reload
+      isEnabledActive(), // tick: unchanged → left alone
+      isActiveActive(),
+      // lena: enabled + active, template rewrote → restart FAILS
+      isEnabledActive(),
+      isActiveActive(),
+      { exitCode: 1, stdout: "", stderr: "Job for phantombot-heartbeat@lena.timer failed" },
+      // kai: enabled + active, restart ok + active re-probe
+      isEnabledActive(),
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" },
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" }, // list-unit-files
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+      personas: ["lena", "kai"],
+    });
+    expect(r.rewrote).toEqual(["phantombot-heartbeat@.timer"]);
+    // Only kai's verified restart counts as repaired.
+    expect(r.repairedTimers).toEqual(["phantombot-heartbeat@kai.timer"]);
+    // The legacy unit and its files survive — retried on the next heal.
+    expect(r.removedRetired).toEqual([]);
+    expect(existsSync(legacyHbServicePath)).toBe(true);
+    expect(existsSync(legacyHbTimerPath)).toBe(true);
+  });
+
+  test("a restart that exits 0 but leaves the instance inactive keeps the legacy unit", async () => {
+    // Same guarantee via the re-probe: restart claims success but the unit
+    // did not come back active — `ready` must drop to false.
+    const bin = "/usr/local/bin/phantombot";
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    await writeFile(legacyHbServicePath, "[Service]\nExecStart=old\n", "utf8");
+    await writeFile(legacyHbTimerPath, "[Timer]\nOnCalendar=*:0/30\n", "utf8");
+    await writeFile(hbTimerPath, "OnUnitActiveSec=30min\n", "utf8");
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      { exitCode: 0, stdout: "", stderr: "" }, // daemon-reload
+      isEnabledActive(), // tick
+      isActiveActive(),
+      // lena: enabled + active → restart ok, but re-probe says inactive
+      isEnabledActive(),
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 3, stdout: "inactive\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" }, // list-unit-files
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+      personas: ["lena"],
+    });
+    expect(r.repairedTimers).toEqual([]);
+    expect(r.removedRetired).toEqual([]);
+    expect(existsSync(legacyHbServicePath)).toBe(true);
+    expect(existsSync(legacyHbTimerPath)).toBe(true);
   });
 });
 

--- a/tests/lib-systemd.test.ts
+++ b/tests/lib-systemd.test.ts
@@ -56,6 +56,8 @@ let workdir: string;
 let unitPath: string;
 let hbServicePath: string;
 let hbTimerPath: string;
+let legacyHbServicePath: string;
+let legacyHbTimerPath: string;
 let ngServicePath: string;
 let ngTimerPath: string;
 let tickServicePath: string;
@@ -70,6 +72,8 @@ function tmpInstallPaths() {
   return {
     heartbeatServicePath: hbServicePath,
     heartbeatTimerPath: hbTimerPath,
+    legacyHeartbeatServicePath: legacyHbServicePath,
+    legacyHeartbeatTimerPath: legacyHbTimerPath,
     nightlyServicePath: ngServicePath,
     nightlyTimerPath: ngTimerPath,
     tickServicePath: tickServicePath,
@@ -80,8 +84,12 @@ function tmpInstallPaths() {
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-systemd-"));
   unitPath = join(workdir, "phantombot.service");
-  hbServicePath = join(workdir, "phantombot-heartbeat.service");
-  hbTimerPath = join(workdir, "phantombot-heartbeat.timer");
+  // #486: the heartbeat units are systemd TEMPLATES — one
+  // `phantombot-heartbeat@<persona>.timer` instance per served persona.
+  hbServicePath = join(workdir, "phantombot-heartbeat@.service");
+  hbTimerPath = join(workdir, "phantombot-heartbeat@.timer");
+  legacyHbServicePath = join(workdir, "phantombot-heartbeat.service");
+  legacyHbTimerPath = join(workdir, "phantombot-heartbeat.timer");
   ngServicePath = join(workdir, "phantombot-nightly.service");
   ngTimerPath = join(workdir, "phantombot-nightly.timer");
   tickServicePath = join(workdir, "phantombot-tick.service");
@@ -275,18 +283,79 @@ describe("installPhantombotUnit", () => {
     const unit = await readFile(unitPath, "utf8");
     expect(unit).toContain("ExecStart=/usr/local/bin/phantombot run");
 
+    // No personas passed (pre-init box): no heartbeat instances are armed —
+    // the startup doctor / first heartbeat heal provisions them later.
     expect(sys.calls).toEqual([
       ["--user", "daemon-reload"],
       ["--user", "enable", "phantombot.service"],
       ["--user", "start", "phantombot.service"],
-      ["--user", "enable", "phantombot-heartbeat.timer"],
-      ["--user", "start", "phantombot-heartbeat.timer"],
       ["--user", "enable", "phantombot-tick.timer"],
       ["--user", "start", "phantombot-tick.timer"],
     ]);
     expect(out.text).toContain("wrote phantombot.service");
     expect(out.text).toContain("wrote phantombot-tick.timer");
     expect(out.text).toContain("enabled and started");
+  });
+
+  test("arms one heartbeat timer instance per served persona (#486)", async () => {
+    const sys = new FakeSystemctl();
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const result = await installPhantombotUnit({
+      binPath: "/usr/local/bin/phantombot",
+      unitPath,
+      personas: ["lena", "kai"],
+      ...tmpInstallPaths(),
+      systemctl: sys,
+      out,
+      err,
+    });
+    expect(result.installed).toBe(true);
+    expect(sys.calls).toEqual([
+      ["--user", "daemon-reload"],
+      ["--user", "enable", "phantombot.service"],
+      ["--user", "start", "phantombot.service"],
+      ["--user", "enable", "phantombot-heartbeat@lena.timer"],
+      ["--user", "start", "phantombot-heartbeat@lena.timer"],
+      ["--user", "enable", "phantombot-heartbeat@kai.timer"],
+      ["--user", "start", "phantombot-heartbeat@kai.timer"],
+      ["--user", "enable", "phantombot-tick.timer"],
+      ["--user", "start", "phantombot-tick.timer"],
+    ]);
+  });
+
+  test("retires the legacy heartbeat unit only after the default instance is armed", async () => {
+    // Upgrade over a pre-#486 layout: the plain heartbeat units are on
+    // disk. Install arms the default persona's instance, then removes
+    // them — never the other way around.
+    await writeFile(legacyHbServicePath, "[Service]\nExecStart=old\n", "utf8");
+    await writeFile(legacyHbTimerPath, "[Timer]\nOnCalendar=*:0/30\n", "utf8");
+    const sys = new FakeSystemctl();
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    const result = await installPhantombotUnit({
+      binPath: "/usr/local/bin/phantombot",
+      unitPath,
+      personas: ["lena"],
+      ...tmpInstallPaths(),
+      systemctl: sys,
+      out,
+      err,
+    });
+    expect(result.installed).toBe(true);
+    expect(existsSync(legacyHbServicePath)).toBe(false);
+    expect(existsSync(legacyHbTimerPath)).toBe(false);
+    expect(out.text).toContain("removed retired unit: phantombot-heartbeat.timer");
+    // The legacy timer was stopped BEFORE its file was removed, and the
+    // instance was armed BEFORE either happened.
+    const startIdx = sys.calls.findIndex(
+      (c) => c[1] === "start" && c[2] === "phantombot-heartbeat@lena.timer",
+    );
+    const stopIdx = sys.calls.findIndex(
+      (c) => c[1] === "stop" && c[2] === "phantombot-heartbeat.timer",
+    );
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(stopIdx).toBeGreaterThan(startIdx);
   });
 
   test("aborts on systemctl failure", async () => {
@@ -320,6 +389,8 @@ describe("ensureSystemdUnitsCurrent", () => {
       unitPath,
       heartbeatServicePath: hbServicePath,
       heartbeatTimerPath: hbTimerPath,
+      legacyHeartbeatServicePath: legacyHbServicePath,
+      legacyHeartbeatTimerPath: legacyHbTimerPath,
       nightlyServicePath: ngServicePath,
       nightlyTimerPath: ngTimerPath,
       tickServicePath,
@@ -365,11 +436,10 @@ describe("ensureSystemdUnitsCurrent", () => {
     expect(r.rewrote).toEqual([]);
     expect(r.backups).toEqual([]);
     expect(r.repairedTimers).toEqual([]);
-    // No daemon-reload, no enable, no start — only the 4 inspect calls
-    // (is-enabled + is-active for each of the 2 timers).
+    // No daemon-reload, no enable, no start — only the 2 inspect calls
+    // for the tick timer (the heartbeat TEMPLATE is never armed itself;
+    // without `personas` no instances are managed).
     expect(sys.calls).toEqual([
-      ["--user", "is-enabled", "phantombot-heartbeat.timer"],
-      ["--user", "is-active", "phantombot-heartbeat.timer"],
       ["--user", "is-enabled", "phantombot-tick.timer"],
       ["--user", "is-active", "phantombot-tick.timer"],
     ]);
@@ -378,16 +448,13 @@ describe("ensureSystemdUnitsCurrent", () => {
   test("rewrites every missing unit file, runs daemon-reload once, enables timers", async () => {
     const sys = new FakeSystemctl();
     // Workdir is empty; every target file is missing. After running:
-    // daemon-reload + for each of 3 timers we'll see is-enabled
-    // returning "disabled" (exit 1) + enable --now.
+    // daemon-reload + for the tick timer we'll see is-enabled
+    // returning "disabled" (exit 1) + enable --now. The heartbeat
+    // TEMPLATE is written but never armed itself (#486).
     sys.responses = [
       // daemon-reload after rewrite
       { exitCode: 0, stdout: "", stderr: "" },
-      // heartbeat: is-enabled, is-active, enable --now
-      { exitCode: 1, stdout: "disabled\n", stderr: "" },
-      { exitCode: 3, stdout: "inactive\n", stderr: "" },
-      { exitCode: 0, stdout: "", stderr: "" },
-      // tick
+      // tick: is-enabled, is-active, enable --now
       { exitCode: 1, stdout: "disabled\n", stderr: "" },
       { exitCode: 3, stdout: "inactive\n", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" },
@@ -399,18 +466,15 @@ describe("ensureSystemdUnitsCurrent", () => {
     });
     expect(r.rewrote.sort()).toEqual(
       [
-        "phantombot-heartbeat.service",
-        "phantombot-heartbeat.timer",
+        "phantombot-heartbeat@.service",
+        "phantombot-heartbeat@.timer",
         "phantombot-tick.service",
         "phantombot-tick.timer",
         "phantombot.service",
       ].sort(),
     );
     expect(r.backups).toEqual([]); // nothing pre-existing to back up
-    expect(r.repairedTimers).toEqual([
-      "phantombot-heartbeat.timer",
-      "phantombot-tick.timer",
-    ]);
+    expect(r.repairedTimers).toEqual(["phantombot-tick.timer"]);
     // Verify each canonical body landed on disk.
     expect(await readFile(unitPath, "utf8")).toContain(
       "ExecStart=/usr/local/bin/phantombot run",
@@ -452,7 +516,7 @@ describe("ensureSystemdUnitsCurrent", () => {
   });
 
   test("re-arms a timer whose is-active reports inactive", async () => {
-    // All unit files in place and current, but the heartbeat timer
+    // All unit files in place and current, but the tick timer
     // claims active=no — simulates a rotted timers.target.wants/ symlink.
     const bin = "/usr/local/bin/phantombot";
     await ensureSystemdUnitsCurrent({
@@ -462,13 +526,10 @@ describe("ensureSystemdUnitsCurrent", () => {
     });
     const sys = new FakeSystemctl();
     sys.responses = [
-      // heartbeat: enabled but inactive → enable --now
+      // tick: enabled but inactive → enable --now
       isEnabledActive(),
       { exitCode: 3, stdout: "inactive\n", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" },
-      // tick OK
-      isEnabledActive(),
-      isActiveActive(),
     ];
     const r = await ensureSystemdUnitsCurrent({
       binPath: bin,
@@ -476,14 +537,14 @@ describe("ensureSystemdUnitsCurrent", () => {
       systemctl: sys,
     });
     expect(r.rewrote).toEqual([]);
-    expect(r.repairedTimers).toEqual(["phantombot-heartbeat.timer"]);
+    expect(r.repairedTimers).toEqual(["phantombot-tick.timer"]);
     // Verify the repair call was enable --now (not just start), which
     // both arms the symlink and starts the timer in one shot.
     expect(sys.calls).toContainEqual([
       "--user",
       "enable",
       "--now",
-      "phantombot-heartbeat.timer",
+      "phantombot-tick.timer",
     ]);
   });
 
@@ -502,27 +563,24 @@ describe("ensureSystemdUnitsCurrent", () => {
     });
     const sys = new FakeSystemctl();
     sys.responses = [
-      // heartbeat: enabled + active, but in the force set → restart
+      // tick: enabled + active, but in the force set → restart
       isEnabledActive(),
       isActiveActive(),
       { exitCode: 0, stdout: "", stderr: "" }, // restart
-      // tick OK, not in the force set → left alone
-      isEnabledActive(),
-      isActiveActive(),
     ];
     const r = await ensureSystemdUnitsCurrent({
       binPath: bin,
       ...paths(),
       systemctl: sys,
-      forceRearmTimers: ["phantombot-heartbeat.timer"],
+      forceRearmTimers: ["phantombot-tick.timer"],
     });
     expect(r.rewrote).toEqual([]);
-    // Only the listed zombie is touched; the other healthy timers aren't.
-    expect(r.repairedTimers).toEqual(["phantombot-heartbeat.timer"]);
+    // Only the listed zombie is touched.
+    expect(r.repairedTimers).toEqual(["phantombot-tick.timer"]);
     expect(sys.calls).toContainEqual([
       "--user",
       "restart",
-      "phantombot-heartbeat.timer",
+      "phantombot-tick.timer",
     ]);
     // It must NOT have used enable --now, which can't recover an
     // already-active timer.
@@ -530,7 +588,7 @@ describe("ensureSystemdUnitsCurrent", () => {
       "--user",
       "enable",
       "--now",
-      "phantombot-heartbeat.timer",
+      "phantombot-tick.timer",
     ]);
   });
 
@@ -548,34 +606,26 @@ describe("ensureSystemdUnitsCurrent", () => {
       ...paths(),
       systemctl: new FakeSystemctl(),
     });
-    // Now corrupt only the heartbeat *timer* so its content drifts.
-    await writeFile(hbTimerPath, "OnUnitActiveSec=30min\n", "utf8");
+    // Now corrupt only the tick *timer* so its content drifts.
+    await writeFile(tickTimerPath, "OnUnitActiveSec=30min\n", "utf8");
     const sys = new FakeSystemctl();
     sys.responses = [
       { exitCode: 0, stdout: "", stderr: "" }, // daemon-reload (content changed)
-      // heartbeat: enabled + active, but its content was just rewritten → restart
+      // tick: enabled + active, but its content was just rewritten → restart
       isEnabledActive(),
       isActiveActive(),
       { exitCode: 0, stdout: "", stderr: "" }, // restart
-      // tick: unchanged, enabled + active → left alone
-      isEnabledActive(),
-      isActiveActive(),
     ];
     const r = await ensureSystemdUnitsCurrent({
       binPath: bin,
       ...paths(),
       systemctl: sys,
     });
-    expect(r.rewrote).toEqual(["phantombot-heartbeat.timer"]);
-    expect(r.backups).toEqual([`${hbTimerPath}.bak`]);
-    // The rewritten timer was restarted; the untouched ones were not.
-    expect(r.repairedTimers).toEqual(["phantombot-heartbeat.timer"]);
+    expect(r.rewrote).toEqual(["phantombot-tick.timer"]);
+    expect(r.backups).toEqual([`${tickTimerPath}.bak`]);
+    // The rewritten timer was restarted.
+    expect(r.repairedTimers).toEqual(["phantombot-tick.timer"]);
     expect(sys.calls).toContainEqual([
-      "--user",
-      "restart",
-      "phantombot-heartbeat.timer",
-    ]);
-    expect(sys.calls).not.toContainEqual([
       "--user",
       "restart",
       "phantombot-tick.timer",
@@ -594,31 +644,28 @@ describe("ensureSystemdUnitsCurrent", () => {
     });
     const sys = new FakeSystemctl();
     sys.responses = [
-      // heartbeat: enabled but inactive → enable --now (force set is moot)
+      // tick: enabled but inactive → enable --now (force set is moot)
       isEnabledActive(),
       { exitCode: 3, stdout: "inactive\n", stderr: "" },
       { exitCode: 0, stdout: "", stderr: "" }, // enable --now
-      // tick OK
-      isEnabledActive(),
-      isActiveActive(),
     ];
     const r = await ensureSystemdUnitsCurrent({
       binPath: bin,
       ...paths(),
       systemctl: sys,
-      forceRearmTimers: ["phantombot-heartbeat.timer"],
+      forceRearmTimers: ["phantombot-tick.timer"],
     });
-    expect(r.repairedTimers).toEqual(["phantombot-heartbeat.timer"]);
+    expect(r.repairedTimers).toEqual(["phantombot-tick.timer"]);
     expect(sys.calls).toContainEqual([
       "--user",
       "enable",
       "--now",
-      "phantombot-heartbeat.timer",
+      "phantombot-tick.timer",
     ]);
     expect(sys.calls).not.toContainEqual([
       "--user",
       "restart",
-      "phantombot-heartbeat.timer",
+      "phantombot-tick.timer",
     ]);
   });
 
@@ -626,11 +673,20 @@ describe("ensureSystemdUnitsCurrent", () => {
     const targets = phantombotUnitTargets("/usr/local/bin/phantombot");
     expect(targets.map((t) => t.unit)).toEqual([
       "phantombot.service",
-      "phantombot-heartbeat.service",
-      "phantombot-heartbeat.timer",
+      "phantombot-heartbeat@.service",
+      "phantombot-heartbeat@.timer",
       "phantombot-tick.service",
       "phantombot-tick.timer",
     ]);
+  });
+
+  test("the heartbeat service template sweeps its instance persona (#486)", () => {
+    const targets = phantombotUnitTargets("/usr/local/bin/phantombot");
+    const hb = targets.find((t) => t.unit === "phantombot-heartbeat@.service");
+    if (!hb) throw new Error("heartbeat service template missing");
+    expect(hb.content).toContain(
+      'ExecStart=/usr/local/bin/phantombot heartbeat --persona "%i"',
+    );
   });
 
   test("tears down a nightly timer left behind by an older install", async () => {
@@ -683,6 +739,212 @@ describe("ensureSystemdUnitsCurrent", () => {
       sys.calls.filter((c) => c.some((a) => a.includes("nightly"))),
     ).toEqual([]);
   });
+
+  test("arms one heartbeat instance per served persona (#486)", async () => {
+    const bin = "/usr/local/bin/phantombot";
+    // All unit files current; instances not yet enabled.
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      // tick: healthy
+      isEnabledActive(),
+      isActiveActive(),
+      // lena instance: not enabled → enable --now
+      { exitCode: 1, stdout: "disabled\n", stderr: "" },
+      { exitCode: 3, stdout: "inactive\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      // kai instance: not enabled → enable --now
+      { exitCode: 1, stdout: "disabled\n", stderr: "" },
+      { exitCode: 3, stdout: "inactive\n", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      // list-unit-files: no stray instances
+      { exitCode: 0, stdout: "", stderr: "" },
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+      personas: ["lena", "kai"],
+    });
+    expect(r.repairedTimers).toEqual([
+      "phantombot-heartbeat@lena.timer",
+      "phantombot-heartbeat@kai.timer",
+    ]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "enable",
+      "--now",
+      "phantombot-heartbeat@lena.timer",
+    ]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "enable",
+      "--now",
+      "phantombot-heartbeat@kai.timer",
+    ]);
+  });
+
+  test("disables the heartbeat instance of a persona no longer served", async () => {
+    const bin = "/usr/local/bin/phantombot";
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      // tick: healthy
+      isEnabledActive(),
+      isActiveActive(),
+      // lena instance: enabled + active → left alone
+      isEnabledActive(),
+      isActiveActive(),
+      // list-unit-files: jake still enabled from before his removal
+      {
+        exitCode: 0,
+        stdout:
+          "phantombot-heartbeat@lena.timer enabled\n" +
+          "phantombot-heartbeat@jake.timer enabled\n",
+        stderr: "",
+      },
+      // disable --now jake
+      { exitCode: 0, stdout: "", stderr: "" },
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+      personas: ["lena"],
+    });
+    expect(r.disabledInstances).toEqual(["phantombot-heartbeat@jake.timer"]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "disable",
+      "--now",
+      "phantombot-heartbeat@jake.timer",
+    ]);
+    // Lena's instance is NOT touched beyond the inspect calls.
+    expect(sys.calls).not.toContainEqual([
+      "--user",
+      "disable",
+      "--now",
+      "phantombot-heartbeat@lena.timer",
+    ]);
+  });
+
+  test("retires the legacy heartbeat unit only once the default instance is active", async () => {
+    // The migration ordering rule: a host whose default persona's instance
+    // can't be armed keeps its legacy heartbeat — never left heartbeat-less.
+    const bin = "/usr/local/bin/phantombot";
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    await writeFile(legacyHbServicePath, "[Service]\nExecStart=old\n", "utf8");
+    await writeFile(legacyHbTimerPath, "[Timer]\nOnCalendar=*:0/30\n", "utf8");
+
+    // Case 1: default instance arms fine → legacy retired.
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      isEnabledActive(), // tick
+      isActiveActive(),
+      isEnabledActive(), // lena instance
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" }, // list-unit-files: no strays
+      { exitCode: 0, stdout: "", stderr: "" }, // stop legacy timer
+      { exitCode: 0, stdout: "", stderr: "" }, // disable legacy timer
+      { exitCode: 0, stdout: "", stderr: "" }, // daemon-reload
+    ];
+    const ok = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+      personas: ["lena", "kai"],
+    });
+    expect(ok.removedRetired.sort()).toEqual([
+      "phantombot-heartbeat.service",
+      "phantombot-heartbeat.timer",
+    ]);
+    expect(existsSync(legacyHbServicePath)).toBe(false);
+    expect(existsSync(legacyHbTimerPath)).toBe(false);
+
+    // Case 2: default instance will NOT arm → legacy stays.
+    await writeFile(legacyHbServicePath, "[Service]\nExecStart=old\n", "utf8");
+    await writeFile(legacyHbTimerPath, "[Timer]\nOnCalendar=*:0/30\n", "utf8");
+    const sys2 = new FakeSystemctl();
+    sys2.responses = [
+      isEnabledActive(), // tick
+      isActiveActive(),
+      { exitCode: 1, stdout: "disabled\n", stderr: "" }, // lena: not enabled
+      { exitCode: 3, stdout: "inactive\n", stderr: "" }, // not active
+      { exitCode: 1, stdout: "", stderr: "bus gone" }, // enable --now FAILS
+      // kai instance: enabled + active (irrelevant — only the default gates)
+      isEnabledActive(),
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" }, // list-unit-files
+    ];
+    const failed = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys2,
+      personas: ["lena", "kai"],
+    });
+    expect(failed.removedRetired).toEqual([]);
+    expect(existsSync(legacyHbServicePath)).toBe(true);
+    expect(existsSync(legacyHbTimerPath)).toBe(true);
+  });
+
+  test("restarts every instance when the heartbeat timer template was rewritten", async () => {
+    const bin = "/usr/local/bin/phantombot";
+    await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: new FakeSystemctl(),
+    });
+    // Corrupt the TEMPLATE timer so it drifts.
+    await writeFile(hbTimerPath, "OnUnitActiveSec=30min\n", "utf8");
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      { exitCode: 0, stdout: "", stderr: "" }, // daemon-reload
+      isEnabledActive(), // tick: unchanged → left alone
+      isActiveActive(),
+      // lena: enabled + active, template rewrote → restart
+      isEnabledActive(),
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" },
+      // kai: enabled + active, template rewrote → restart
+      isEnabledActive(),
+      isActiveActive(),
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 0, stdout: "", stderr: "" }, // list-unit-files
+    ];
+    const r = await ensureSystemdUnitsCurrent({
+      binPath: bin,
+      ...paths(),
+      systemctl: sys,
+      personas: ["lena", "kai"],
+    });
+    expect(r.rewrote).toEqual(["phantombot-heartbeat@.timer"]);
+    expect(r.repairedTimers).toEqual([
+      "phantombot-heartbeat@lena.timer",
+      "phantombot-heartbeat@kai.timer",
+    ]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "restart",
+      "phantombot-heartbeat@lena.timer",
+    ]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "restart",
+      "phantombot-heartbeat@kai.timer",
+    ]);
+  });
 });
 
 describe("driftedUnitNames", () => {
@@ -699,13 +961,13 @@ describe("driftedUnitNames", () => {
     const targets = phantombotUnitTargets(bin);
     const byPath = new Map(targets.map((t) => [t.path, t.content]));
     const heartbeat = targets.find(
-      (t) => t.unit === "phantombot-heartbeat.timer",
+      (t) => t.unit === "phantombot-heartbeat@.timer",
     );
     if (!heartbeat) throw new Error("heartbeat timer target missing");
     // Simulate the pre-OnCalendar body left behind by an in-place update.
     byPath.set(heartbeat.path, "OnUnitActiveSec=30min\n");
     const drifted = driftedUnitNames(targets, (p) => byPath.get(p));
-    expect(drifted).toEqual(["phantombot-heartbeat.timer"]);
+    expect(drifted).toEqual(["phantombot-heartbeat@.timer"]);
   });
 
   test("a missing file (reader returns undefined) is not counted as drift", () => {
@@ -939,17 +1201,62 @@ describe("uninstallPhantombotUnit", () => {
     });
     expect(result.removed).toBe(true);
     expect(sys.calls).toEqual([
+      // Enabled heartbeat instances are enumerated first (#486) — none
+      // here (empty stdout from the fake).
+      [
+        "--user",
+        "list-unit-files",
+        "--no-legend",
+        "--no-pager",
+        "phantombot-heartbeat@*.timer",
+      ],
       ["--user", "stop", "phantombot-tick.timer"],
       ["--user", "disable", "phantombot-tick.timer"],
       ["--user", "stop", "phantombot-nightly.timer"],
       ["--user", "disable", "phantombot-nightly.timer"],
+      // The retired pre-#486 single-persona heartbeat units.
       ["--user", "stop", "phantombot-heartbeat.timer"],
       ["--user", "disable", "phantombot-heartbeat.timer"],
+      ["--user", "stop", "phantombot-heartbeat.service"],
+      ["--user", "disable", "phantombot-heartbeat.service"],
       ["--user", "stop", "phantombot.service"],
       ["--user", "disable", "phantombot.service"],
       ["--user", "daemon-reload"],
     ]);
     await expect(readFile(unitPath, "utf8")).rejects.toThrow();
+  });
+
+  test("stops and disables every enabled heartbeat instance", async () => {
+    const sys = new FakeSystemctl();
+    sys.responses = [
+      {
+        exitCode: 0,
+        stdout:
+          "phantombot-heartbeat@lena.timer enabled\n" +
+          "phantombot-heartbeat@kai.timer enabled\n" +
+          "phantombot-heartbeat@.timer static\n",
+        stderr: "",
+      },
+    ];
+    const out = new CaptureStream();
+    const err = new CaptureStream();
+    await uninstallPhantombotUnit({ unitPath, systemctl: sys, out, err });
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "stop",
+      "phantombot-heartbeat@lena.timer",
+    ]);
+    expect(sys.calls).toContainEqual([
+      "--user",
+      "disable",
+      "phantombot-heartbeat@kai.timer",
+    ]);
+    // The template itself is never stopped/disabled.
+    expect(sys.calls).not.toContainEqual([
+      "--user",
+      "stop",
+      "phantombot-heartbeat@.timer",
+    ]);
   });
 
   test("does not fail when there's no unit file to remove", async () => {

--- a/tests/lib-taskScheduler.test.ts
+++ b/tests/lib-taskScheduler.test.ts
@@ -256,6 +256,10 @@ describe("companion task schedules", () => {
     expect(xml).toContain("<Interval>PT30M</Interval>");
     expect(xml).toContain("heartbeat.out.log");
     expect(xml).not.toContain("<RestartOnFailure>");
+    // #486: the per-persona-named task also RUNS per-persona — without the
+    // explicit flag the heartbeat CLI would resolve the default persona and
+    // silently sweep the wrong memory.
+    expect(xml).toContain(`heartbeat --persona ${PERSONA}`);
   });
 
   test("tick repeats every minute", () => {

--- a/tests/lib-timerHealth.test.ts
+++ b/tests/lib-timerHealth.test.ts
@@ -8,6 +8,7 @@ import {
   TICK_STALE_MINUTES,
   heartbeatMarkerPath,
   loadHeartbeatLastFired,
+  loadPersonaHeartbeatLastFired,
   loadTickLastFired,
   recordHeartbeatFired,
   recordTickFired,
@@ -88,6 +89,38 @@ describe("timerHealth", () => {
     // Falls back to mtime-derived iso, age should be small.
     expect(r.iso).toBeDefined();
     expect(r.ageMinutes).toBeLessThanOrEqual(1);
+  });
+
+  test("per-persona markers are separate files (#486)", async () => {
+    await recordHeartbeatFired("lena");
+    await recordHeartbeatFired("kai");
+    expect(heartbeatMarkerPath("lena")).not.toBe(heartbeatMarkerPath("kai"));
+    expect(existsSync(heartbeatMarkerPath("lena"))).toBe(true);
+    expect(existsSync(heartbeatMarkerPath("kai"))).toBe(true);
+    // And distinct from the legacy timer-scoped marker.
+    expect(heartbeatMarkerPath("lena")).not.toBe(heartbeatMarkerPath());
+  });
+
+  test("loadPersonaHeartbeatLastFired reads only the persona's own marker", async () => {
+    await recordHeartbeatFired("kai");
+    const own = loadPersonaHeartbeatLastFired("kai");
+    expect(own.iso).toBeDefined();
+    // Another persona with no marker sees nothing — not kai's fire.
+    expect(loadPersonaHeartbeatLastFired("lena").iso).toBeUndefined();
+  });
+
+  test("the default persona falls back to the legacy marker; a non-default does not (#486)", async () => {
+    // Pre-#486 upgrade state: only the timer-scoped marker exists.
+    await recordHeartbeatFired();
+    expect(
+      loadPersonaHeartbeatLastFired("lena", { isDefault: true }).iso,
+    ).toBeDefined();
+    expect(loadPersonaHeartbeatLastFired("kai").iso).toBeUndefined();
+    // Once the default has its own per-persona marker, it wins over legacy.
+    await recordHeartbeatFired("lena");
+    const r = loadPersonaHeartbeatLastFired("lena", { isDefault: true });
+    expect(r.iso).toBeDefined();
+    expect(r.runs).toBe(1); // the persona file's own counter, not legacy's
   });
 
   test("default thresholds are sane (heartbeat > tick)", () => {


### PR DESCRIPTION
Closes #486.

## The bug

`phantombot run` serves every persona in one process, but the maintenance side was still single-persona: one `phantombot-heartbeat.timer` swept only the default persona. On a multi-persona rig, every non-default persona silently got **no** drawer promotion, **no** memory-index refresh, **no** turn-flush, **no** log rotation — and **no nightly at all**, because the rollover trigger read a host-global last-fired marker: the first persona to fire after midnight consumed the rollover for everyone.

## The fix

**systemd — `phantombot-heartbeat@` template + per-persona instances**
- `phantombot-heartbeat@.service` runs `heartbeat --persona %i`; one enabled `phantombot-heartbeat@<persona>.timer` per served persona (`{default_persona} ∪ autostart_personas`, new `servedPersonasOf()` in config).
- `ensureSystemdUnitsCurrent` (the 30-min heal shared by heartbeat/doctor/update) reconciles instances: arms served personas, **disables instances of personas removed from autostart**, restarts every instance when the template is rewritten, and retires the legacy `phantombot-heartbeat.{service,timer}` **only after the default persona's instance is verified active** — a failed migration never leaves a host heartbeat-less (issue point 3).
- `install` arms instances per persona; `uninstall` tears down all instances + templates + legacy units.
- The autostart picker, `persona new --autostart`, and the TUI autostart action provision/retire the instance immediately (issue point 2 / invariant 21); the heal is the backstop.

**Rollover starvation** — heartbeat fire-markers are now per-persona (`heartbeat.<persona>.last-fired`). The default persona falls back to the legacy marker at upgrade so it doesn't read falsely stale; non-default personas deliberately get **no** fallback — the legacy marker says nothing about their fires.

**doctor (point 4)** — new warn-only `maintenance per persona` section: each served persona's heartbeat last-fire/staleness + nightly ledger backlog. A stale persona drives a force-re-arm of *its* instance through the existing zombie-timer path; a missing instance is armed by the same heal.

**run** — the startup nightly sweep now fires per served persona, not only the default.

**Windows** — the heartbeat task was already *named* per-persona (`\Phantombot\heartbeat-<persona>`) but ran bare `phantombot heartbeat`, silently sweeping the default persona. It now passes `--persona`; the existing `ensureTasksCurrent` heal re-registers drifted tasks.

## Decisions the issue asked for

- **Backfill (point 5): no cap.** The sweep is detached and ledger-driven — a persona blind for weeks drains its backlog in the background without wedging the first heartbeat after upgrade.
- **`/update` + `/restart` gate (point 6): already fixed.** `lifecycleRefusal` (#439) declines with an explanation naming the default persona; verified, no change needed.
- **macOS launchd per-persona plists: deferred** — no Mac in the fleet to verify against (follow-up issue to be filed). macOS keeps the current single heartbeat (default persona) — status quo, not a regression.

## Acceptance mapping

- Fresh install + in-place upgrade → instances armed per served persona; legacy retired only when safe. ✅ (`installPhantombotUnit` / `ensureSystemdUnitsCurrent`, pinned by tests)
- `doctor` reports maintenance coverage per persona and flags missing/stale. ✅ (new section + instance checks)
- Removing a persona from autostart removes its maintenance instance. ✅ (`disableUnservedHeartbeatInstances` + lifecycle hooks)
- Single-persona hosts see no behavioural change. ✅ (one instance replaces the plain unit; Windows task gains a flag that resolves to the same persona; markers fall back for the default persona)

## Verification

- 4003 tests pass, 0 fail; tsc clean. (9 lock/workspace concurrency tests fail identically on `main` on this dev host — pre-existing, unrelated.)
- New tests: instance arming/disable/migration-ordering, template ExecStart, per-persona markers + fallback, per-persona rollover isolation, doctor maintenance section (text + JSON + force-re-arm wiring), lifecycle-hook sync, Windows task args, `servedPersonasOf`.
- Real-rig verification (kw-phantombot: lena + kai under supervisor) happens on the next `/update` after merge — the heartbeat heal performs the migration.
