### PR TITLE
Serialise memory-DB snapshots across personas (#495)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1099,6 +1099,15 @@ export async function runMemoryBackup(input: {
           `\n`,
       );
       return 0;
+    case "fresh":
+      // Only reachable when a sibling process holds the snapshot lock: the CLI
+      // path never coalesces. Saying so is better than barging in and deleting
+      // the file that process is writing.
+      write(
+        `another snapshot of ${config.memoryDbPath} is already in flight — ` +
+          `nothing taken. Check 'phantombot memory backup --list'.\n`,
+      );
+      return 0;
     case "skipped":
       write(`no memory database at ${config.memoryDbPath}\n`);
       return 1;

--- a/src/lib/nightlyMaintenance.ts
+++ b/src/lib/nightlyMaintenance.ts
@@ -29,6 +29,7 @@ import type { WriteSink } from "./io.ts";
 import { log } from "./logger.ts";
 import {
   backupMemoryDb,
+  SNAPSHOT_COALESCE_MS,
   type BackupResult,
 } from "../memory/dbBackup.ts";
 import { openDrawerStore } from "../memory/drawerSync.ts";
@@ -66,6 +67,8 @@ export async function runMemoryMaintenance(input: {
   personaDir?: string;
   keep?: number;
   now?: Date;
+  /** Snapshot coalescing window (#495). Defaults to `SNAPSHOT_COALESCE_MS`. */
+  coalesceMs?: number;
   out?: WriteSink;
 }): Promise<MaintenanceResult> {
   const now = input.now ?? new Date();
@@ -149,6 +152,12 @@ export async function runMemoryMaintenance(input: {
       dbPath: input.dbPath,
       keep: input.keep,
       now,
+      // The database is shared by every persona on the host, and since the
+      // per-persona nightly instances (#490) the siblings roll over together.
+      // One restore point per rollover is the whole point of a restore point,
+      // so a sweep that finds a fresh one — or finds a sibling mid-snapshot —
+      // stands down instead of racing it (#495).
+      coalesceMs: input.coalesceMs ?? SNAPSHOT_COALESCE_MS,
     });
     result.backup = backup;
     if (backup.status === "taken") {
@@ -159,6 +168,15 @@ export async function runMemoryMaintenance(input: {
             ? `, ${backup.pruned.length} older point(s) rotated out`
             : "") +
           `\n`,
+      );
+    } else if (backup.status === "fresh") {
+      // Not an error and deliberately not in `errors`: a sibling sweep took
+      // the snapshot seconds ago, so this host IS backed up. Writing it to the
+      // ledger would leave `doctor` permanently red on a healthy box, which is
+      // how operators learn to stop reading doctor at all.
+      write(
+        `nightly: memory snapshot skipped — a restore point from this ` +
+          `rollover already exists${backup.path ? ` (${backup.path})` : ""}\n`,
       );
     } else if (backup.status === "refused") {
       // Loud on purpose: an unhealthy memory database is the one condition

--- a/src/lib/nightlyMaintenance.ts
+++ b/src/lib/nightlyMaintenance.ts
@@ -174,9 +174,16 @@ export async function runMemoryMaintenance(input: {
       // the snapshot seconds ago, so this host IS backed up. Writing it to the
       // ledger would leave `doctor` permanently red on a healthy box, which is
       // how operators learn to stop reading doctor at all.
+      // Two different shapes share `fresh`: a sibling's restore point already
+      // covers this rollover (we have a path), or the lock stayed held and
+      // nothing was taken at all. Say which — an operator reading the ledger
+      // should not have to guess whether a snapshot exists.
       write(
-        `nightly: memory snapshot skipped — a restore point from this ` +
-          `rollover already exists${backup.path ? ` (${backup.path})` : ""}\n`,
+        backup.path
+          ? `nightly: memory snapshot skipped — a restore point from this ` +
+              `rollover already exists (${backup.path})\n`
+          : `nightly: memory snapshot skipped — another snapshot is in ` +
+              `flight, nothing taken this run\n`,
       );
     } else if (backup.status === "refused") {
       // Loud on purpose: an unhealthy memory database is the one condition

--- a/src/memory/dbBackup.ts
+++ b/src/memory/dbBackup.ts
@@ -52,12 +52,14 @@ import {
   copyFile,
   mkdir,
   open as openFile,
+  readFile,
   readdir,
   rename,
   rm,
   stat,
   unlink,
 } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { basename, dirname, join } from "node:path";
 import { Database } from "bun:sqlite";
 
@@ -120,8 +122,12 @@ function lockPath(dbPath: string): string {
  * "someone else is snapshotting this exact database right now" is good news
  * for the nightly and merely informational for an operator who typed the
  * command.
+ *
+ * Exported for tests: the takeover case (a slow holder's lock cleared as
+ * stale, then re-taken by a sibling) cannot be provoked deterministically
+ * through `backupMemoryDb` alone.
  */
-async function acquireSnapshotLock(
+export async function acquireSnapshotLock(
   dbPath: string,
   waitMs: number,
 ): Promise<(() => Promise<void>) | null> {
@@ -129,10 +135,27 @@ async function acquireSnapshotLock(
   const deadline = Date.now() + waitMs;
   for (;;) {
     try {
+      const token = `${process.pid}:${randomUUID()}`;
       const handle = await openFile(path, "wx");
-      await handle.writeFile(`${process.pid} ${new Date().toISOString()}\n`);
+      await handle.writeFile(`${token} ${new Date().toISOString()}\n`);
       await handle.close();
       return async () => {
+        // Only remove the lock if it is still OURS. A holder whose snapshot
+        // ran past LOCK_STALE_MS has had its lock cleared and re-taken by a
+        // sibling; an unconditional `rm` here would delete the SIBLING's lock
+        // and let a third caller in while it was mid-`VACUUM INTO` — exactly
+        // the race this lock exists to close.
+        try {
+          const held = await readFile(path, "utf8");
+          if (!held.startsWith(`${token} `)) {
+            log.warn("dbBackup: snapshot lock was taken over; not releasing", {
+              path,
+            });
+            return;
+          }
+        } catch {
+          return; // Already gone — nothing to release.
+        }
         await rm(path, { force: true });
       };
     } catch (e) {

--- a/src/memory/dbBackup.ts
+++ b/src/memory/dbBackup.ts
@@ -28,6 +28,17 @@
  * set that only ever grows would be safe by accident, and it also fills a
  * 40 GB VPS with copies of a 300 MB database.
  *
+ * A SNAPSHOT IS A HOST CONCERN, NOT A PERSONA ONE (issue #495). Several
+ * personas can share one `memory.sqlite`, and since the per-persona nightly
+ * instances landed they roll over within milliseconds of each other. The
+ * snapshot name is stamped to the SECOND, so two sweeps in the same second
+ * resolve to the SAME destination — and the second one deletes the file the
+ * first is still writing, which surfaces as `disk I/O error` on an otherwise
+ * healthy database. Snapshots are therefore serialised on a lock file beside
+ * the restore points, and a caller may pass `coalesceMs` to say "a snapshot
+ * this recent already covers me": the loser of the race reports `fresh` and
+ * takes nothing, instead of failing.
+ *
  * RESTORE NEVER OVERWRITES THE LIVE FILE IN PLACE. The current database is
  * moved aside to `<name>.pre-restore-<stamp>` first, so a restore from a
  * snapshot that turns out to be older than the operator thought is itself
@@ -40,6 +51,7 @@ import { existsSync } from "node:fs";
 import {
   copyFile,
   mkdir,
+  open as openFile,
   readdir,
   rename,
   rm,
@@ -66,8 +78,81 @@ const SIDECARS = ["-wal", "-shm"] as const;
 
 const STAMP_RE = /\.(\d{8}T\d{6}Z)\.sqlite$/;
 
+/**
+ * How recent a restore point has to be for a `coalesceMs` caller to accept it
+ * instead of taking its own.
+ *
+ * Sized for the thing it exists to absorb: sibling nightly sweeps fire within
+ * milliseconds of a shared day rollover, so anything above a few seconds
+ * closes the race. Five minutes leaves room for a slow sweep without ever
+ * being long enough to swallow a genuine daily snapshot.
+ */
+export const SNAPSHOT_COALESCE_MS = 5 * 60_000;
+
+/** How long to wait for the lock before deciding a sibling has this covered. */
+const LOCK_WAIT_MS = 15_000;
+
+/**
+ * When a lock file is old enough to be treated as abandoned.
+ *
+ * A holder that died mid-`VACUUM INTO` leaves the file behind, and a lock that
+ * outlives its process would stop every future snapshot — the failure mode
+ * where the safety measure becomes the outage. Far longer than any real
+ * snapshot, far shorter than a day.
+ */
+const LOCK_STALE_MS = 10 * 60_000;
+
 export function backupDir(dbPath: string): string {
   return join(dirname(dbPath), "backups");
+}
+
+function lockPath(dbPath: string): string {
+  return join(backupDir(dbPath), ".snapshot.lock");
+}
+
+/**
+ * Serialise snapshots of one database across processes.
+ *
+ * `open(..., "wx")` is the atomic primitive: exactly one caller can create the
+ * file, so there is no window where two processes both believe they hold it.
+ * Returns a release function, or `null` if the lock stayed held for
+ * `waitMs` — the caller decides whether that means skip or proceed, because
+ * "someone else is snapshotting this exact database right now" is good news
+ * for the nightly and merely informational for an operator who typed the
+ * command.
+ */
+async function acquireSnapshotLock(
+  dbPath: string,
+  waitMs: number,
+): Promise<(() => Promise<void>) | null> {
+  const path = lockPath(dbPath);
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    try {
+      const handle = await openFile(path, "wx");
+      await handle.writeFile(`${process.pid} ${new Date().toISOString()}\n`);
+      await handle.close();
+      return async () => {
+        await rm(path, { force: true });
+      };
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+      // Abandoned by a dead holder? Clear it and try once more this pass.
+      try {
+        const age = Date.now() - (await stat(path)).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          log.warn("dbBackup: clearing a stale snapshot lock", { path, age });
+          await rm(path, { force: true });
+          continue;
+        }
+      } catch {
+        // The holder released it between our open and our stat — retry.
+        continue;
+      }
+      if (Date.now() >= deadline) return null;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
 }
 
 function stampNow(now: Date): string {
@@ -141,8 +226,11 @@ export async function listRestorePoints(
 }
 
 export interface BackupResult {
-  /** `taken` | `skipped` (source missing) | `refused` (source unhealthy). */
-  status: "taken" | "skipped" | "refused";
+  /**
+   * `taken` | `skipped` (source missing) | `refused` (source unhealthy) |
+   * `fresh` (a recent-enough restore point already covers this run — #495).
+   */
+  status: "taken" | "skipped" | "refused" | "fresh";
   path?: string;
   bytes?: number;
   /** Snapshots rotated out by this run. */
@@ -161,6 +249,15 @@ export async function backupMemoryDb(input: {
   dbPath: string;
   keep?: number;
   now?: Date;
+  /**
+   * Accept an existing restore point younger than this instead of taking one
+   * (#495). Callers that share a database with sibling processes — the
+   * nightly — pass it; an operator running `phantombot memory backup` does
+   * not, because an explicit request should always produce a snapshot.
+   */
+  coalesceMs?: number;
+  /** Override the lock wait. Tests use it; nothing else should need to. */
+  lockWaitMs?: number;
 }): Promise<BackupResult> {
   const now = input.now ?? new Date();
   const keep = input.keep ?? DEFAULT_KEEP;
@@ -182,29 +279,69 @@ export async function backupMemoryDb(input: {
 
   const dir = backupDir(input.dbPath);
   await mkdir(dir, { recursive: true });
-  const dest = snapshotPath(input.dbPath, now);
-  // A same-second re-run would otherwise fail the VACUUM INTO, which refuses
-  // an existing target. Overwriting is safe: the existing file was written by
-  // this same code path this same second.
-  if (existsSync(dest)) await rm(dest, { force: true });
 
-  const db = new Database(input.dbPath, { readonly: true, create: false });
+  // Everything from here to the release touches shared paths — the stamped
+  // destination and the rotation set — so it happens under the lock.
+  const release = await acquireSnapshotLock(
+    input.dbPath,
+    input.lockWaitMs ?? LOCK_WAIT_MS,
+  );
+  if (!release) {
+    // Another process has been snapshotting this database for longer than the
+    // wait. For a coalescing caller that is the answer it wanted; for an
+    // operator it is still the honest one, because barging in would delete the
+    // in-flight file out from under the holder.
+    log.info("dbBackup: another snapshot is in flight — skipping", {
+      db: input.dbPath,
+    });
+    return { status: "fresh", pruned: [], integrity };
+  }
+
   try {
-    db.query("VACUUM INTO ?").run(dest);
+    if (input.coalesceMs !== undefined) {
+      const [newest] = await listRestorePoints(input.dbPath);
+      const age = newest ? now.getTime() - newest.takenAt.getTime() : Infinity;
+      if (newest && age >= 0 && age < input.coalesceMs) {
+        log.info("dbBackup: recent restore point already covers this run", {
+          path: newest.path,
+          ageMs: age,
+        });
+        return {
+          status: "fresh",
+          path: newest.path,
+          bytes: newest.bytes,
+          pruned: [],
+          integrity,
+        };
+      }
+    }
+
+    const dest = snapshotPath(input.dbPath, now);
+    // A same-second re-run would otherwise fail the VACUUM INTO, which refuses
+    // an existing target. Overwriting is safe under the lock: no other process
+    // can be writing that file, so the only thing here is our own leftover.
+    if (existsSync(dest)) await rm(dest, { force: true });
+
+    const db = new Database(input.dbPath, { readonly: true, create: false });
+    try {
+      db.query("VACUUM INTO ?").run(dest);
+    } finally {
+      db.close();
+    }
+
+    const pruned: string[] = [];
+    const points = await listRestorePoints(input.dbPath);
+    for (const old of points.slice(keep)) {
+      await rm(old.path, { force: true });
+      pruned.push(old.path);
+    }
+
+    const bytes = (await stat(dest)).size;
+    log.info("dbBackup: snapshot taken", { path: dest, bytes, pruned: pruned.length });
+    return { status: "taken", path: dest, bytes, pruned, integrity };
   } finally {
-    db.close();
+    await release();
   }
-
-  const pruned: string[] = [];
-  const points = await listRestorePoints(input.dbPath);
-  for (const old of points.slice(keep)) {
-    await rm(old.path, { force: true });
-    pruned.push(old.path);
-  }
-
-  const bytes = (await stat(dest)).size;
-  log.info("dbBackup: snapshot taken", { path: dest, bytes, pruned: pruned.length });
-  return { status: "taken", path: dest, bytes, pruned, integrity };
 }
 
 export interface RestoreResult {

--- a/tests/lib-nightlyMaintenance.test.ts
+++ b/tests/lib-nightlyMaintenance.test.ts
@@ -71,4 +71,33 @@ describe("runMemoryMaintenance", () => {
     expect(out.text()).toContain("phantombot memory restore");
     await rm(dir, { recursive: true, force: true });
   });
+
+  test("a sibling's fresh snapshot is not an error in the ledger (#495)", async () => {
+    // Two personas, one shared memory.sqlite, one day rollover: since #490
+    // both sweeps run. The second must not record `snapshot: disk I/O error`,
+    // because that failure sticks in the nightly ledger and leaves
+    // `doctor --persona <p>` permanently red on a host that is in fact backed
+    // up by its sibling.
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    const now = new Date("2026-08-29T14:43:18.000Z");
+
+    const first = await runMemoryMaintenance({ dbPath, persona: "lena", now });
+    expect(first.backup?.status).toBe("taken");
+    expect(first.errors).toEqual([]);
+
+    const out = sink();
+    const second = await runMemoryMaintenance({
+      dbPath,
+      persona: "kai",
+      now: new Date(now.getTime() + 60),
+      out,
+    });
+    expect(second.backup?.status).toBe("fresh");
+    expect(second.errors).toEqual([]);
+    expect(out.text()).toContain("snapshot skipped");
+    expect(await listRestorePoints(dbPath)).toHaveLength(1);
+
+    await rm(dir, { recursive: true, force: true });
+  });
 });

--- a/tests/memory-dbBackup-race.test.ts
+++ b/tests/memory-dbBackup-race.test.ts
@@ -12,13 +12,22 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile, readdir } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 
 import {
+  acquireSnapshotLock,
   backupDir,
   backupMemoryDb,
   listRestorePoints,
@@ -161,12 +170,45 @@ describe("concurrent snapshots (#495)", () => {
     await mkdir(backupDir(dbPath), { recursive: true });
     await writeFile(lock, "999999 old\n");
     // Backdate it past the stale threshold — a holder that died mid-VACUUM.
+    // Backdated with `utimes`, not `touch -d`: coreutils is not on a stock
+    // Windows dev box and this repo supports Windows development.
     const old = new Date(Date.now() - 30 * 60_000);
-    await Bun.spawn(["touch", "-d", old.toISOString(), lock]).exited;
+    await utimes(lock, old, old);
 
     const r = await backupMemoryDb({ dbPath, coalesceMs: 60_000, lockWaitMs: 100 });
     expect(r.status).toBe("taken");
     expect(await listRestorePoints(dbPath)).toHaveLength(1);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("a holder whose lock went stale does not delete its successor's lock", async () => {
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    seed(dbPath, 50);
+    const lock = join(backupDir(dbPath), ".snapshot.lock");
+    await mkdir(backupDir(dbPath), { recursive: true });
+
+    // A: acquires, then runs long enough that its lock reads as abandoned.
+    const releaseA = await acquireSnapshotLock(dbPath, 100);
+    expect(releaseA).not.toBeNull();
+    const stale = new Date(Date.now() - 30 * 60_000);
+    await utimes(lock, stale, stale);
+
+    // B: clears the stale lock and takes it for itself.
+    const releaseB = await acquireSnapshotLock(dbPath, 100);
+    expect(releaseB).not.toBeNull();
+    const heldByB = await readFile(lock, "utf8");
+
+    // A finally finishes. Releasing must not touch B's lock — an
+    // unconditional rm here would let a third caller in mid-snapshot.
+    await releaseA?.();
+    expect(existsSync(lock)).toBe(true);
+    expect(await readFile(lock, "utf8")).toBe(heldByB);
+
+    // B still owns it, and its own release does clear it.
+    await releaseB?.();
+    expect(existsSync(lock)).toBe(false);
 
     await rm(dir, { recursive: true, force: true });
   });

--- a/tests/memory-dbBackup-race.test.ts
+++ b/tests/memory-dbBackup-race.test.ts
@@ -1,0 +1,186 @@
+/**
+ * #495 — concurrent snapshots of one shared memory database.
+ *
+ * Since the per-persona nightly instances landed (#490), every persona on a
+ * host sweeps at the same day rollover against the SAME `memory.sqlite`. The
+ * snapshot name is stamped to the second, so siblings that fire milliseconds
+ * apart resolve to one destination path and the loser deletes the file the
+ * winner is still writing — reported as `disk I/O error` and then pinned in
+ * the persona's nightly ledger, so `doctor` stays red on a healthy host.
+ *
+ * These tests are about that exact shape: same database, same second.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import {
+  backupDir,
+  backupMemoryDb,
+  listRestorePoints,
+  SNAPSHOT_COALESCE_MS,
+} from "../src/memory/dbBackup.ts";
+
+async function workdir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "db-backup-race-"));
+}
+
+/** A database big enough that `VACUUM INTO` is not instantaneous. */
+function seed(path: string, rows = 4000): void {
+  const db = new Database(path, { create: true });
+  db.exec("CREATE TABLE IF NOT EXISTS t (v TEXT)");
+  const ins = db.query("INSERT INTO t (v) VALUES (?)");
+  db.transaction(() => {
+    for (let i = 0; i < rows; i++) ins.run(`row-${i}-${"x".repeat(200)}`);
+  })();
+  db.close();
+}
+
+function rowCount(path: string): number {
+  const db = new Database(path, { readonly: true, create: false });
+  try {
+    return (db.query("SELECT count(*) AS n FROM t").get() as { n: number }).n;
+  } finally {
+    db.close();
+  }
+}
+
+describe("concurrent snapshots (#495)", () => {
+  test("two sweeps in the same second produce one good snapshot, no error", async () => {
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    seed(dbPath);
+    // The reproduction condition: one clock value for both callers, so both
+    // compute the identical stamped destination.
+    const now = new Date("2026-08-29T14:43:18.000Z");
+
+    const [a, b] = await Promise.all([
+      backupMemoryDb({ dbPath, now, coalesceMs: SNAPSHOT_COALESCE_MS }),
+      backupMemoryDb({ dbPath, now, coalesceMs: SNAPSHOT_COALESCE_MS }),
+    ]);
+
+    const statuses = [a.status, b.status].sort();
+    expect(statuses).toEqual(["fresh", "taken"]);
+
+    // Exactly one restore point, and it is a complete database — not the torn
+    // remains of a file that was deleted mid-write.
+    const points = await listRestorePoints(dbPath);
+    expect(points).toHaveLength(1);
+    expect(rowCount(points[0]!.path)).toBe(4000);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("the loser reports the winner's snapshot rather than nothing", async () => {
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    seed(dbPath, 50);
+    const now = new Date("2026-08-29T14:43:18.000Z");
+
+    const first = await backupMemoryDb({ dbPath, now, coalesceMs: 60_000 });
+    expect(first.status).toBe("taken");
+
+    // A sibling arriving a second later: nothing to do, and it should say
+    // WHICH restore point covers it so the caller can log something true.
+    const second = await backupMemoryDb({
+      dbPath,
+      now: new Date(now.getTime() + 1_000),
+      coalesceMs: 60_000,
+    });
+    expect(second.status).toBe("fresh");
+    expect(second.path).toBe(first.path!);
+    expect(await listRestorePoints(dbPath)).toHaveLength(1);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("a snapshot older than the window is not coalesced away", async () => {
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    seed(dbPath, 50);
+    const first = await backupMemoryDb({
+      dbPath,
+      now: new Date("2026-08-28T03:00:00Z"),
+      coalesceMs: 60_000,
+    });
+    expect(first.status).toBe("taken");
+
+    // Tomorrow's rollover is a different night and must get its own point —
+    // the window closes a race, it does not thin the daily schedule.
+    const next = await backupMemoryDb({
+      dbPath,
+      now: new Date("2026-08-29T03:00:00Z"),
+      coalesceMs: 60_000,
+    });
+    expect(next.status).toBe("taken");
+    expect(await listRestorePoints(dbPath)).toHaveLength(2);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("an explicit `memory backup` never coalesces", async () => {
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    seed(dbPath, 50);
+    const now = new Date("2026-08-29T14:43:18.000Z");
+    expect((await backupMemoryDb({ dbPath, now })).status).toBe("taken");
+    // An operator who typed the command wants a snapshot, not a report that
+    // one already exists. Same second, so it lands on the same path.
+    const again = await backupMemoryDb({ dbPath, now });
+    expect(again.status).toBe("taken");
+    expect(rowCount(again.path!)).toBe(50);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("a lock held by a live process is waited out, not barged through", async () => {
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    seed(dbPath, 50);
+    const lock = join(backupDir(dbPath), ".snapshot.lock");
+    await Bun.write(lock, `${process.pid} ${new Date().toISOString()}\n`);
+
+    const r = await backupMemoryDb({ dbPath, coalesceMs: 60_000, lockWaitMs: 100 });
+    expect(r.status).toBe("fresh");
+    expect(await listRestorePoints(dbPath)).toHaveLength(0);
+    // And it left the holder's lock alone.
+    expect(existsSync(lock)).toBe(true);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("a stale lock from a dead holder is cleared rather than blocking forever", async () => {
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    seed(dbPath, 50);
+    const lock = join(backupDir(dbPath), ".snapshot.lock");
+    await mkdir(backupDir(dbPath), { recursive: true });
+    await writeFile(lock, "999999 old\n");
+    // Backdate it past the stale threshold — a holder that died mid-VACUUM.
+    const old = new Date(Date.now() - 30 * 60_000);
+    await Bun.spawn(["touch", "-d", old.toISOString(), lock]).exited;
+
+    const r = await backupMemoryDb({ dbPath, coalesceMs: 60_000, lockWaitMs: 100 });
+    expect(r.status).toBe("taken");
+    expect(await listRestorePoints(dbPath)).toHaveLength(1);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("the lock file is released, and never counted as a restore point", async () => {
+    const dir = await workdir();
+    const dbPath = join(dir, "memory.sqlite");
+    seed(dbPath, 50);
+    await backupMemoryDb({ dbPath, coalesceMs: 60_000 });
+    expect(existsSync(join(backupDir(dbPath), ".snapshot.lock"))).toBe(false);
+    const names = await readdir(backupDir(dbPath));
+    expect(names).toHaveLength(1);
+    expect(await listRestorePoints(dbPath)).toHaveLength(1);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Fixes #495.

## The bug

Since the per-persona nightly instances landed (#490), every persona on a multi-persona host sweeps at the same day rollover against the same shared `memory.sqlite`. The snapshot filename is stamped to the **second**, so two sweeps firing milliseconds apart resolve to the identical destination and the loser `rm`s the file the winner is still writing.

Observed on kw-phantombot after v1.1.320: one sweep succeeds, the other logs `disk I/O error`, and the failure is pinned in that persona's nightly ledger — so `doctor --persona lena` reports a permanent error on a host whose backups are in fact fine (all 5 restore points valid).

## The fix

The snapshot is a **host** concern, not a per-persona one:

- `backupMemoryDb` serialises on a lock file beside the restore points, created with `open(..., "wx")` so exactly one process can hold it. A lock older than 10 minutes is treated as abandoned and cleared, so a holder that dies mid-VACUUM cannot block snapshots forever.
- Callers that share a database may pass `coalesceMs`: a restore point younger than the window (or a sibling currently holding the lock) is accepted as covering this run, returning the new `fresh` status. The nightly passes `SNAPSHOT_COALESCE_MS` (5 min) — long enough to close the race, far short of a day, so the daily restore point is never thinned.
- `fresh` is not an error and is not written to the nightly ledger.
- `phantombot memory backup` deliberately does **not** coalesce: an operator who typed the command gets a snapshot. It still honours the lock rather than deleting an in-flight file.

## Tests

`tests/memory-dbBackup-race.test.ts` (new) reproduces the exact failure shape — same database, same second, two concurrent sweeps — and asserts one complete snapshot and no error. Plus window boundaries, the explicit-CLI path, a live lock, and a stale lock. `tests/lib-nightlyMaintenance.test.ts` gains the ledger assertion for a sibling sweep.

Local: typecheck clean, 10/10 in the two touched suites.
