### PR TITLE
Harness wizard: blank Enter on API-key prompt keeps the saved key

### DIFF
--- a/src/cli/harnessPrompts.ts
+++ b/src/cli/harnessPrompts.ts
@@ -65,7 +65,15 @@ export const clackPrompts: HarnessPrompts = {
   },
   async password(input) {
     const r = await p.password(input);
-    return p.isCancel(r) ? undefined : (r as string);
+    // clack's password prompt resolves `undefined` (NOT the cancel symbol) when
+    // the user submits an empty line — verified against @clack/prompts 1.3:
+    // Enter on empty → undefined with isCancel(undefined) === false. Passing
+    // that through made the harness wizard treat "blank = keep current" as a
+    // cancellation and abort the whole flow. Map it to "" so the caller's
+    // blank-means-keep semantics apply; only a real cancel (Esc / Ctrl+C)
+    // stays undefined.
+    if (p.isCancel(r)) return undefined;
+    return (r as string | undefined) ?? "";
   },
   async confirm(input) {
     const r = await p.confirm({

--- a/tests/cli-harnessPrompts.test.ts
+++ b/tests/cli-harnessPrompts.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression test for the harness wizard's blank-Enter cancellation.
+ *
+ * `phantombot harness` aborted with "cancelled" when the operator pressed
+ * Enter on an empty API-key field — exactly the "blank to keep current" path
+ * the prompt advertises. Root cause: @clack/prompts' password prompt resolves
+ * `undefined` (not the cancel symbol, `isCancel === false`) on an empty
+ * submit, and the `clackPrompts` adapter passed that straight through, so the
+ * flow's `undefined === cancelled` contract misread it.
+ *
+ * These tests drive the REAL adapter against a mocked @clack/prompts and pin
+ * the contract: empty submit → "", genuine cancel → undefined.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+type PasswordResult = string | symbol | undefined;
+
+let passwordResult: PasswordResult;
+let passwordIsCancel = false;
+
+mock.module("@clack/prompts", () => ({
+  password: async () => passwordResult,
+  isCancel: (_r: unknown) => passwordIsCancel,
+}));
+
+const { clackPrompts } = await import("../src/cli/harnessPrompts.ts");
+
+describe("clackPrompts.password — empty submit is '', not a cancellation", () => {
+  test("clack resolving undefined on empty Enter maps to '' (keep current)", async () => {
+    // What @clack/prompts 1.3 actually does on Enter with an empty field:
+    // resolves undefined, isCancel false.
+    passwordResult = undefined;
+    passwordIsCancel = false;
+    expect(await clackPrompts.password({ message: "openrouter API key" })).toBe("");
+  });
+
+  test("a real cancel (symbol + isCancel) stays undefined", async () => {
+    passwordResult = Symbol.for("clack:cancel");
+    passwordIsCancel = true;
+    expect(await clackPrompts.password({ message: "openrouter API key" })).toBeUndefined();
+  });
+
+  test("a pasted key passes through untouched", async () => {
+    passwordResult = "sk-or-v1-test";
+    passwordIsCancel = false;
+    expect(await clackPrompts.password({ message: "openrouter API key" })).toBe("sk-or-v1-test");
+  });
+});


### PR DESCRIPTION
## Problem

Running `phantombot harness` to (re)configure routing, pressing Enter on the labelled API-key prompt (`openrouter API key: ... blank to keep current`) **aborted the whole wizard with "cancelled"** instead of keeping the saved key. Re-running the wizard to change any other setting forced the operator to re-paste the key every time — the exact opposite of the advertised idempotency.

## Root cause

`@clack/prompts`' `password()` prompt resolves `undefined` — **not** the cancel symbol — when the user submits an empty line (`isCancel(undefined) === false`). The `clackPrompts` adapter in `src/cli/harnessPrompts.ts` passed that `undefined` straight through, and the harness flow's contract is `undefined === cancelled` (`harness.ts:545`), so a blank Enter was misread as an abort.

## Fix

One line in the adapter: map clack's empty-submit `undefined` to `""`, so the caller's blank-means-keep semantics apply (`resolvePiApiKeyWrite("", …)` keeps the stored key). Only a genuine cancel (Esc / Ctrl+C, which clack signals with its cancel symbol) stays `undefined`.

## Tests

New `tests/cli-harnessPrompts.test.ts` drives the **real adapter** against a mocked `@clack/prompts` and pins the contract:

- empty submit (`undefined`, `isCancel === false`) → `""` (keep current)
- real cancel (symbol + `isCancel`) → `undefined` (abort)
- pasted key passes through untouched

Full suite: 4079 pass / 0 fail, `tsc --noEmit` clean.

## Scope note

The raw-clack callers (`install.ts`, `telegram.ts`, `voice.ts`, `embedding.ts`) don't use this adapter and handle their own empty/cancel semantics (mostly `validate`-gated), so they're untouched.