### PR TITLE
Finish resumed persona setup after #493

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -84,7 +84,9 @@ export interface AppProps {
   startPersona?: string;
   /** Where the wizard resumes, when it is the opening screen. */
   wizardStartAt?: WizardStep;
-  onCreatePersona: (answers: WizardAnswers) => Promise<void>;
+  onCreatePersona: (
+    answers: WizardAnswers,
+  ) => Promise<void | { created: boolean }>;
   /**
    * Seam for tests only; production always uses `openChat`. Injectable so the
    * session gate can be pinned by a test that FAILS when the gate regresses —
@@ -705,11 +707,13 @@ export function App(props: AppProps): React.ReactElement {
           onQuit={exit}
           onFinish={async (answers) => {
             try {
-              await props.onCreatePersona(answers);
+              const result = await props.onCreatePersona(answers);
               await refresh();
               setPersonaName(answers.name);
               setNotice(
-                `created ${host.personasDir}/${answers.name} · identity.json · config.toml`,
+                result?.created === false
+                  ? `updated ${answers.name} · config.toml`
+                  : `created ${host.personasDir}/${answers.name} · identity.json · config.toml`,
               );
               // A finished wizard is not a place to go back to.
               navRef.current = [];

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -24,7 +24,11 @@ import { setLogSink } from "../lib/logSink.ts";
 import { hostSnapshot } from "./snapshot.ts";
 import { openChat } from "./chatSession.ts";
 import type { WizardAnswers } from "./screens/Wizard.tsx";
-import { loadConfig, loadConfigForPersona } from "../config.ts";
+import {
+  loadConfig,
+  loadConfigForPersona,
+  servedPersonasOf,
+} from "../config.ts";
 import {
   personaCompleteness,
   type WizardStep,
@@ -33,7 +37,11 @@ import { runPersonaNew } from "../cli/persona-new.ts";
 import { log } from "../lib/logger.ts";
 import { personaConfigPath } from "../lib/personaConfig.ts";
 import { updateConfigToml, setIn } from "../lib/configWriter.ts";
-import { listPersonaDirs } from "../lib/personaDefault.ts";
+import {
+  listPersonaDirs,
+  writeAutostartPersonas,
+} from "../lib/personaDefault.ts";
+import { defaultSyncHeartbeatInstances } from "../lib/systemd.ts";
 
 /**
  * Decide what the app opens on.
@@ -81,7 +89,7 @@ export async function startTui(): Promise<number> {
       startPersona={opening.persona}
       wizardStartAt={opening.wizardStartAt}
       onCreatePersona={async (answers: WizardAnswers) => {
-        await createPhantomFromWizard(answers);
+        return await createPhantomFromWizard(answers);
       }}
     />
   );
@@ -203,17 +211,24 @@ export function installSignalExit(
  */
 export async function createPhantomFromWizard(
   answers: WizardAnswers,
-): Promise<void> {
+  syncHeartbeatInstances: (
+    personas: readonly string[],
+  ) => Promise<unknown> = defaultSyncHeartbeatInstances,
+): Promise<{ created: boolean }> {
   // Load the target's effective layer before creating it. With no persona file
   // yet this is the host chain; on a retry it also preserves any partial layer
   // that did make it to disk instead of borrowing the current default's chain.
   const target = await loadConfig(answers.name);
-  if (!listPersonaDirs(target).includes(answers.name)) {
+  const created = !listPersonaDirs(target).includes(answers.name);
+  if (created) {
     let stderr = "";
     const code = await runPersonaNew({
       name: answers.name,
       harness: answers.brain,
-      autostart: true,
+      // Applied below for both new and resumed personas. Keeping this outside
+      // the creation-only branch preserves the side effects on an incomplete
+      // existing persona without asking `persona new` to overwrite it.
+      autostart: false,
       makeDefault: answers.makeDefault,
       // The wizard's own output is the summary screen; the subcommand's stdout
       // would land underneath the rendered frame.
@@ -225,6 +240,26 @@ export async function createPhantomFromWizard(
         stderr.trim() || `could not create persona '${answers.name}'`,
       );
     }
+  }
+
+  const autostartPersonas = await writeAutostartPersonas(target, [
+    ...(target.autostartPersonas ?? []),
+    answers.name,
+  ]);
+  try {
+    await syncHeartbeatInstances(
+      servedPersonasOf({
+        defaultPersona: answers.makeDefault
+          ? answers.name
+          : target.defaultPersona,
+        autostartPersonas,
+      }),
+    );
+  } catch (e) {
+    log.warn("could not provision wizard persona heartbeat instance", {
+      persona: answers.name,
+      error: (e as Error).message,
+    });
   }
 
   // The review screen promises a persona-local config file. Record the chosen
@@ -240,6 +275,7 @@ export async function createPhantomFromWizard(
     personaConfigPath(target.personasDir, answers.name),
     (toml) => setIn(toml, ["harnesses", "chain"], chain),
   );
+  return { created };
 }
 
 /**

--- a/tests/tui-app-first-run.test.tsx
+++ b/tests/tui-app-first-run.test.tsx
@@ -323,6 +323,18 @@ describe("first run", () => {
     expect(app.frame()).not.toContain("already exists");
   });
 
+  test("a resumed persona reports an update, not newly created identity files", async () => {
+    const app = mount({
+      startPersona: "alice",
+      wizardStartAt: "done",
+      onCreatePersona: async () => ({ created: false }),
+    });
+    await app.waitFor((f) => f.includes("nothing has been written yet"));
+    await app.press("\r");
+    await app.waitFor((f) => f.includes("updated alice · config.toml"));
+    expect(app.lastFrame()).not.toContain("created /tmp/does-not-exist/alice");
+  });
+
   test("a complete persona opens chat", async () => {
     const app = mount({ startPersona: "alice" });
     await tick();

--- a/tests/tui-create-persona.test.ts
+++ b/tests/tui-create-persona.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createPhantomFromWizard } from "../src/tui/index.tsx";
+
+const saved = {
+  config: process.env.PHANTOMBOT_CONFIG,
+  state: process.env.PHANTOMBOT_STATE,
+  personas: process.env.PHANTOMBOT_PERSONAS_DIR,
+};
+let root: string | undefined;
+
+afterEach(() => {
+  if (saved.config === undefined) delete process.env.PHANTOMBOT_CONFIG;
+  else process.env.PHANTOMBOT_CONFIG = saved.config;
+  if (saved.state === undefined) delete process.env.PHANTOMBOT_STATE;
+  else process.env.PHANTOMBOT_STATE = saved.state;
+  if (saved.personas === undefined) delete process.env.PHANTOMBOT_PERSONAS_DIR;
+  else process.env.PHANTOMBOT_PERSONAS_DIR = saved.personas;
+  if (root) rmSync(root, { recursive: true, force: true });
+  root = undefined;
+});
+
+describe("TUI persona creation", () => {
+  test("a resumed persona is autostarted and gets heartbeat synchronization", async () => {
+    root = mkdtempSync(join(tmpdir(), "phantombot-tui-create-"));
+    const configPath = join(root, "config.toml");
+    const personasDir = join(root, "personas");
+    process.env.PHANTOMBOT_CONFIG = configPath;
+    process.env.PHANTOMBOT_STATE = join(root, "state.json");
+    process.env.PHANTOMBOT_PERSONAS_DIR = personasDir;
+    writeFileSync(configPath, 'default_persona = "kai"\n');
+    mkdirSync(join(personasDir, "kai"), { recursive: true });
+
+    let synced: string[] | undefined;
+    const result = await createPhantomFromWizard(
+      {
+        name: "kai",
+        brain: "codex",
+        channel: "cli",
+        memory: "none",
+        voice: "none",
+        makeDefault: false,
+      },
+      async (personas) => void (synced = [...personas]),
+    );
+
+    expect(result).toEqual({ created: false });
+    expect(readFileSync(configPath, "utf8")).toMatch(
+      /autostart_personas = \[\s*"kai"\s*\]/,
+    );
+    expect(synced).toEqual(["kai"]);
+    expect(
+      readFileSync(join(personasDir, "kai", "config.toml"), "utf8"),
+    ).toMatch(/chain = \[\s*"codex"/);
+  });
+});


### PR DESCRIPTION
Follow-up for the two approved review notes on #493 that GitHub merged before the fix commit landed.

- preserve autostart registration and heartbeat provisioning when resuming an incomplete persona
- report resumed personas as updated rather than claiming identity files were created
- add focused runtime-boundary and rendered-copy regressions

Verification: focused 9 tests pass; typecheck passes; full suite 4,083 pass / 2 platform skips with one known timing-only wizard test that passed alone.