### PR TITLE
orchestrator: don't cool a harness for an empty reply (#499)

### DIFF
--- a/src/lib/harnessAlert.ts
+++ b/src/lib/harnessAlert.ts
@@ -74,8 +74,20 @@ export const ALERT_SEND_TIMEOUT_MS = 20_000;
  * the reader to the journals to find out which (observed on
  * kw-phantombot 2026-08-20 — a 300s idle kill on a single-harness chain).
  * It changes no policy: like `other` it never fires the degraded alert.
+ *
+ * `empty` marks a harness that exited cleanly but produced no assistant
+ * text — the literal "empty reply" fallback.ts stamps (#499). One empty is
+ * a model-output flake and deliberately gets no cooldown, but a harness
+ * that returns empty on EVERY turn is just as dead as a dead token, so
+ * like `auth` it fires the degraded alert once its run crosses the
+ * threshold.
  */
-export type HarnessFailureCause = "auth" | "rate_limit" | "timeout" | "other";
+export type HarnessFailureCause =
+  | "auth"
+  | "rate_limit"
+  | "timeout"
+  | "empty"
+  | "other";
 
 /**
  * Statuses the claude CLI stamps that mean "this credential/account is not
@@ -104,6 +116,13 @@ const RATE_LIMIT_MARKERS = ["rate_limit", "quota", "resource_exhausted"];
 const TIMEOUT_MARKERS = ["timed out after", "produced no output within"];
 
 /**
+ * The literal fallback.ts stamps into noteFailure() when a harness exits
+ * cleanly with no assistant text (#499). A substring like the lists above,
+ * for the same reason: a reworded stamp must not silently de-classify.
+ */
+const EMPTY_MARKERS = ["empty reply"];
+
+/**
  * Classify a harness error chunk. Matching is on lowercased substrings
  * because the text is harness-authored and varies by CLI ("claude api
  * error: authentication_failed", "pi: 401 unauthorized"). HTTP status
@@ -121,6 +140,7 @@ export function classifyFailure(
   if (AUTH_MARKERS.some((m) => text.includes(m))) return "auth";
   if (RATE_LIMIT_MARKERS.some((m) => text.includes(m))) return "rate_limit";
   if (TIMEOUT_MARKERS.some((m) => text.includes(m))) return "timeout";
+  if (EMPTY_MARKERS.some((m) => text.includes(m))) return "empty";
   return "other";
 }
 
@@ -219,7 +239,10 @@ export class HarnessAlerter {
   /**
    * The primary failed but `servedBy` answered the turn. Alerts once the
    * failure run crosses DEGRADE_AFTER_FAILURES, and only for causes a human
-   * can act on (auth). A transient `other`/`rate_limit` that a fallback
+   * can act on: `auth` (go re-auth) and `empty` (a harness that returns no
+   * text on every turn is dead however clean its exit, #499 — without
+   * this, removing the empty-reply cooldown would bench nothing and say
+   * nothing, forever). A transient `other`/`rate_limit` that a fallback
    * absorbs is exactly the case #284 wanted silent.
    */
   async noteDegraded(input: {
@@ -228,13 +251,13 @@ export class HarnessAlerter {
   }): Promise<void> {
     const state = this.incidents.get(input.harnessId);
     if (!state) return;
-    if (state.cause !== "auth") return;
+    if (state.cause !== "auth" && state.cause !== "empty") return;
     if (state.consecutiveFailures < DEGRADE_AFTER_FAILURES) return;
-    await this.emit(
-      input.harnessId,
-      "degraded",
-      `\u{1f511} ${input.harnessId} auth failure \u00d7${state.consecutiveFailures}${this.hostTag()} \u00b7 ${input.servedBy} serving, run \`${input.harnessId} /login\``,
-    );
+    const line =
+      state.cause === "auth"
+        ? `\u{1f511} ${input.harnessId} auth failure \u00d7${state.consecutiveFailures}${this.hostTag()} \u00b7 ${input.servedBy} serving, run \`${input.harnessId} /login\``
+        : `\u{1f507} ${input.harnessId} empty reply \u00d7${state.consecutiveFailures}${this.hostTag()} \u00b7 ${input.servedBy} serving, harness returns no text`;
+    await this.emit(input.harnessId, "degraded", line);
   }
 
   /**

--- a/src/orchestrator/fallback.ts
+++ b/src/orchestrator/fallback.ts
@@ -351,7 +351,8 @@ export async function* runWithFallback(
           // bench the only healthy fallback while a dead primary gets
           // tried instead on the next turn. A persistently-empty harness
           // is still caught: noteFailure() keeps the alerter's incident
-          // counter going, so 3 consecutive empty turns fire a DEGRADED
+          // counter going, and the alerter classifies "empty reply" as its
+          // own `empty` cause, so 3 consecutive empty turns fire a DEGRADED
           // push. The cost of a flake is one wasted round-trip.
           alerter.noteFailure(harness.id, "empty reply");
           firstFailure ??= { harnessId: harness.id, error: "empty reply" };

--- a/src/orchestrator/fallback.ts
+++ b/src/orchestrator/fallback.ts
@@ -13,9 +13,12 @@
  * which has no payload ceiling).
  *
  * Cooldown semantics (see src/lib/cooldown.ts):
- *   - Each recoverable failure (recoverable error chunk OR empty done
- *     that triggers a non-last fall-through) bumps the harness's
- *     cooldown counter.
+ *   - Each recoverable failure (recoverable error chunk, or a harness
+ *     that throws) bumps the harness's cooldown counter. An empty `done`
+ *     does NOT: the process ran cleanly, so the empty output is a
+ *     model-output flake rather than a health signal — cooling the
+ *     harness for it benches the one working fallback behind a dead
+ *     primary (#499).
  *   - A successful turn (done with non-empty finalText, OR a "best we
  *     can do" empty-done from the last harness) clears the harness's
  *     counter.
@@ -340,7 +343,16 @@ export async function* runWithFallback(
             "orchestrator: harness produced empty reply, falling through",
             { harnessId: harness.id },
           );
-          cooldown.markFailure(harness.id);
+          // Deliberately NO cooldown.markFailure here (#499). An empty
+          // `done` means the harness process exited cleanly — the model
+          // just produced no text. That is usually a transient flake
+          // (reasoning model that spent its whole output budget), not a
+          // harness-health failure, and cooling the harness for it can
+          // bench the only healthy fallback while a dead primary gets
+          // tried instead on the next turn. A persistently-empty harness
+          // is still caught: noteFailure() keeps the alerter's incident
+          // counter going, so 3 consecutive empty turns fire a DEGRADED
+          // push. The cost of a flake is one wasted round-trip.
           alerter.noteFailure(harness.id, "empty reply");
           firstFailure ??= { harnessId: harness.id, error: "empty reply" };
           recoverableError = true;

--- a/tests/lib-harnessAlert.test.ts
+++ b/tests/lib-harnessAlert.test.ts
@@ -87,6 +87,16 @@ describe("classifyFailure", () => {
   test("anything else is 'other'", () => {
     expect(classifyFailure("claude exited with code 1")).toBe("other");
   });
+
+  test("an empty reply is its own cause (#499)", () => {
+    expect(classifyFailure("empty reply")).toBe("empty");
+    expect(classifyFailure("harness produced empty reply")).toBe("empty");
+    // ...but only the stamped literal — a harness error merely mentioning
+    // emptiness stays `other`.
+    expect(classifyFailure("claude exited with code 1: empty file")).toBe(
+      "other",
+    );
+  });
 });
 
 describe("degraded alert", () => {
@@ -165,6 +175,22 @@ describe("degraded alert", () => {
     // deliberate silence, and splitting it out of `other` must not change that.
     expect(sent).toEqual([]);
   });
+
+  test("persistent empty replies degrade like auth (#499)", async () => {
+    const { alerter, sent } = newAlerter();
+    // A single flake stays free — no cooldown (#499), no alert.
+    await failNTimes(alerter, 1, "empty reply");
+    expect(sent.length).toBe(0);
+    // But empty on EVERY turn is dead, however clean the exit.
+    await failNTimes(alerter, DEGRADE_AFTER_FAILURES - 1, "empty reply");
+    expect(sent.length).toBe(1);
+    expect(sent[0]).toContain("empty reply");
+    expect(sent[0]).toContain("pi serving");
+    // A success closes the incident like any other cause.
+    alerter.noteSuccess("claude");
+    await failNTimes(alerter, DEGRADE_AFTER_FAILURES - 1, "empty reply");
+    expect(sent.length).toBe(1);
+  });
 });
 
 describe("mixed causes in one incident", () => {
@@ -206,8 +232,10 @@ describe("mixed causes in one incident", () => {
     expect(sent.length).toBe(1);
     alerter.noteSuccess("claude");
 
-    // An empty reply counts as a failure (fallback.ts) and classifies as
-    // `other`. Landing mid-run must not silence the rest of the incident.
+    // An empty reply counts as a failure (fallback.ts) and is its own
+    // `empty` cause now (#499). Landing mid-run resets the auth tally —
+    // a fresh run then has to build up to the threshold again, and the
+    // re-alert floor keeps the second crossing silent within REALERT_MS.
     await failNTimes(alerter, 2, "claude api error: authentication_failed");
     await failNTimes(alerter, 1, "empty reply");
     await failNTimes(

--- a/tests/orchestrator-fallback.test.ts
+++ b/tests/orchestrator-fallback.test.ts
@@ -26,7 +26,7 @@ class FakeHarness implements Harness {
   invocations = 0;
   constructor(
     public readonly id: string,
-    private readonly script: HarnessChunk[],
+    public script: HarnessChunk[],
     public readonly maxPayloadBytes?: number,
   ) {}
   async available(): Promise<boolean> {
@@ -232,6 +232,57 @@ describe("runWithFallback — empty done falls through", () => {
     expect(empty.invocations).toBe(1);
     expect(chunks.map((c) => c.type)).toEqual(["done"]);
     expect(chunks[0]).toMatchObject({ type: "done", finalText: "" });
+  });
+
+  test("empty done does NOT put the harness into cooldown (#499)", async () => {
+    // An empty `done` means the process ran cleanly — a model-output
+    // flake, not a harness-health failure. Cooling it would bench the
+    // one healthy fallback behind a dead primary on the next turn.
+    const cooldown = new CooldownStore(() => 0.5);
+    const empty = new FakeHarness("pi", [{ type: "done", finalText: "" }]);
+    const filler = new FakeHarness("claude", [
+      { type: "text", text: "real reply" },
+      { type: "done", finalText: "real reply" },
+    ]);
+    await collect(runWithFallback([empty, filler], newRequest(), { cooldown }));
+    expect(empty.invocations).toBe(1);
+    expect(filler.invocations).toBe(1);
+    expect(cooldown.isCooledDown("pi").cooled).toBe(false);
+    expect(cooldown.isCooledDown("pi").consecutiveFailures).toBe(0);
+  });
+
+  test("a harness that emitted an empty reply last turn is tried again next turn (#499)", async () => {
+    // Regression for the kw-phantombot 2026-08-29 incident: one empty
+    // reply from pi (the only healthy harness, primary dead on usage
+    // limit) cooled it, so the NEXT turn skipped pi, hit the dead
+    // primary, and served recovery text. Here: turn 1 pi flakes empty
+    // and claude covers; turn 2 pi must be tried again — and this time
+    // it answers.
+    const cooldown = new CooldownStore(() => 0.5);
+    const flaky = new FakeHarness("pi", [{ type: "done", finalText: "" }]);
+    const cover = new FakeHarness("claude", [
+      { type: "text", text: "cover" },
+      { type: "done", finalText: "cover" },
+    ]);
+    await collect(runWithFallback([flaky, cover], newRequest(), { cooldown }));
+    expect(flaky.invocations).toBe(1);
+    expect(cover.invocations).toBe(1);
+
+    // Turn 2: pi is healthy again (no cooldown from the empty), so it
+    // is invoked first and its real answer is served.
+    flaky.script = [
+      { type: "text", text: "real reply" },
+      { type: "done", finalText: "real reply" },
+    ];
+    const chunks = await collect(
+      runWithFallback([flaky, cover], newRequest(), { cooldown }),
+    );
+    expect(flaky.invocations).toBe(2);
+    expect(cover.invocations).toBe(1); // never reached
+    const last = chunks[chunks.length - 1];
+    expect(last && last.type === "done" ? last.finalText : "").toBe(
+      "real reply",
+    );
   });
 });
 


### PR DESCRIPTION
Closes #499.

## Problem

On kw-phantombot 2026-08-29 (Kai, chain `[codex, pi]`, codex usage-limited): pi produced one genuine empty `done` (transient model-output flake — direct API and one-shot repro both healthy). The orchestrator fell through correctly but called `cooldown.markFailure("pi")`, so the **next** turn skipped the one *healthy* harness, hit the dead primary, and served recovery text.

An empty `done` means the harness process ran cleanly — it is a model-output flake, not a harness-health failure. Cooldown exists for upstream auth/quota/capacity failures; applying it to empty output benches a working fallback behind a dead primary.

## Fix

Remove `cooldown.markFailure()` from the empty-done fall-through path in `runWithFallback`. The fall-through itself, the log line, and the alerter incident accounting (`noteFailure`) are unchanged, so:

- a one-off flake now costs one wasted round-trip instead of benching the healthy harness for 150s+
- a *persistently* empty harness still escalates to a DEGRADED push after 3 consecutive turns (`DEGRADE_AFTER_FAILURES`), since `noteSuccess` on a real reply still closes the incident

## Tests

- `empty done does NOT put the harness into cooldown (#499)` — store stays cold after an empty-done fall-through
- `a harness that emitted an empty reply last turn is tried again next turn (#499)` — regression for the incident: turn 1 pi flakes empty and claude covers; turn 2 pi is invoked first again and serves
- existing empty-done fall-through and cooldown-integration tests unchanged and green

(Note: `FakeHarness.script` became a public mutable field so the regression test can flip the harness from flaky to healthy between turns.)

Verified locally: fallback suite 34/34, `tsc --noEmit` clean. 9 unrelated lock-concurrency tests fail locally on a clean tree too (environmental — real process probes against the live phantombot on this host); CI is the source of truth for the full suite.