### PR TITLE
Log and document PHANTOMBOT_SANDBOX service suppression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,24 @@ cannot truncate a developer's real logs.
 
 If you change a unit body (any `generate*` function in `src/lib/systemd.ts`), `ensureUnitCurrent` will detect the on-disk unit as stale on the next `phantombot voice` / `phantombot harness` / etc. run and rewrite it automatically. The previous body is preserved as `${unitPath}.bak` for rollback.
 
+**`PHANTOMBOT_SANDBOX` is a GLOBAL kill-switch, not a TUI one (#484).** When it
+is set to anything but `""` or `0`, `defaultServiceControl()` wraps the host
+backend in `sandboxServiceControl()`: `isActive()` still delegates (queries tell
+the truth), while `start`, `stop`, `restart` and `rerenderUnitIfStale` become
+no-ops that report `ok: true`. It exists so a `bun run src/index.ts` dev
+checkout cannot bounce the host's real `phantombot.service` — the daemon serving
+live conversations — when your branch saves config.
+
+The trap is the blast radius. `defaultServiceControl()` has ~15 callers,
+including `cli/update.ts`, `lib/serviceLifecycle.ts` and `channels/commands.ts`,
+and most of them only check `ok`. So on a host with the variable set, `/update`
+and `/restart` report success while restarting nothing. Every suppressed
+mutation therefore logs `platform: service change suppressed` with
+`reason: "PHANTOMBOT_SANDBOX"` and the op name — that warning is the only signal
+a caller who ignores `stderr` will ever see, so **do not remove it when adding
+a mutation to `ServiceControl`**: a new verb that suppresses silently
+reintroduces exactly this bug.
+
 ## Credentials
 
 Credentials live in the per-persona encrypted vault. The agent NEVER appends

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,12 +304,21 @@ live conversations — when your branch saves config.
 The trap is the blast radius. `defaultServiceControl()` has ~15 callers,
 including `cli/update.ts`, `lib/serviceLifecycle.ts` and `channels/commands.ts`,
 and most of them only check `ok`. So on a host with the variable set, `/update`
-and `/restart` report success while restarting nothing. Every suppressed
-mutation therefore logs `platform: service change suppressed` with
-`reason: "PHANTOMBOT_SANDBOX"` and the op name — that warning is the only signal
+and `/restart` report success while restarting nothing. Each of those three
+therefore logs `platform: service change suppressed` at **warn** with
+`reason: "PHANTOMBOT_SANDBOX"` and the op name — that line is the only signal
 a caller who ignores `stderr` will ever see, so **do not remove it when adding
 a mutation to `ServiceControl`**: a new verb that suppresses silently
 reintroduces exactly this bug.
+
+`rerenderUnitIfStale` logs the same fields at **info**
+(`platform: unit re-render skipped`), not warn: it returns `{rerendered: false}`
+rather than a false success, and that is what the real backend returns under
+`bun run` anyway (`defaultRerenderUnitIfStale` bails on `isPhantombotBinary`).
+Warning on a call that would not have written anything is how a warn line
+gets ignored. The line goes to the stderr of whichever process has the
+variable set — your terminal in a dev checkout, the TUI's `^l` pane, and the
+service journal only if the daemon itself was started with it.
 
 ## Credentials
 

--- a/README.md
+++ b/README.md
@@ -572,6 +572,24 @@ in health checks or deploy hooks. These are the *external* controls (run from a
 terminal); the in-chat `/restart` and `/update` commands still bounce the running
 service from inside itself.
 
+**`PHANTOMBOT_SANDBOX` — a global kill-switch for all four verbs.** Set it to
+anything other than `""` or `0` and every service *mutation* in the process
+becomes a no-op: `start`, `stop`, `restart` and the unit-file re-render all
+return success without touching the host's service. Queries still tell the
+truth, so `phantombot doctor` and the TUI keep showing the real service state.
+
+It exists for **development checkouts**. Running `bun run src/index.ts` from a
+working tree gives you a second phantombot *process* but not a second
+*service* — so a config save in your branch would bounce the production daemon
+that is serving live conversations, killing whatever turn was in flight.
+
+Because it is read by `defaultServiceControl()`, it applies to *every* caller,
+not just the TUI: with the variable set, in-chat `/update` and `/restart` also
+stop restarting anything while still reporting success. Every suppressed
+mutation logs `platform: service change suppressed` at warn level, so
+`phantombot logs` tells you why nothing happened. **Never set it on a host
+running the real service** — the daemon will silently stop taking updates.
+
 ## Configuration
 
 Phantombot resolves configuration in this order:

--- a/README.md
+++ b/README.md
@@ -586,9 +586,13 @@ that is serving live conversations, killing whatever turn was in flight.
 Because it is read by `defaultServiceControl()`, it applies to *every* caller,
 not just the TUI: with the variable set, in-chat `/update` and `/restart` also
 stop restarting anything while still reporting success. Every suppressed
-mutation logs `platform: service change suppressed` at warn level, so
-`phantombot logs` tells you why nothing happened. **Never set it on a host
-running the real service** — the daemon will silently stop taking updates.
+mutation logs `platform: service change suppressed`, naming the op. That line
+goes to the **stderr of the process that has the variable set** — your terminal
+for a `bun run src/index.ts` checkout, and the `^l` log pane inside the TUI
+(which swaps the sink for its own ring buffer). It reaches `phantombot logs`
+only if the *daemon itself* was started with the variable set — which is the
+case you never want: **never set it on a host running the real service**, or
+the daemon will silently stop taking updates.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -574,9 +574,10 @@ service from inside itself.
 
 **`PHANTOMBOT_SANDBOX` — a global kill-switch for all four verbs.** Set it to
 anything other than `""` or `0` and every service *mutation* in the process
-becomes a no-op: `start`, `stop`, `restart` and the unit-file re-render all
-return success without touching the host's service. Queries still tell the
-truth, so `phantombot doctor` and the TUI keep showing the real service state.
+becomes a no-op: `start`, `stop` and `restart` return success without touching
+the host's service, while the unit-file re-render writes nothing and reports
+`{ rerendered: false }`. Queries still tell the truth, so `phantombot doctor`
+and the TUI keep showing the real service state.
 
 It exists for **development checkouts**. Running `bun run src/index.ts` from a
 working tree gives you a second phantombot *process* but not a second
@@ -585,10 +586,14 @@ that is serving live conversations, killing whatever turn was in flight.
 
 Because it is read by `defaultServiceControl()`, it applies to *every* caller,
 not just the TUI: with the variable set, in-chat `/update` and `/restart` also
-stop restarting anything while still reporting success. Every suppressed
-mutation logs `platform: service change suppressed`, naming the op. That line
-goes to the **stderr of the process that has the variable set** — your terminal
-for a `bun run src/index.ts` checkout, and the `^l` log pane inside the TUI
+stop restarting anything while still reporting success. Every suppression is
+logged, naming the op: `start`, `stop` and `restart` log
+`platform: service change suppressed` at **warn**, and the re-render logs
+`platform: unit re-render skipped` at **info** — so a process running at
+`PHANTOMBOT_LOG_LEVEL=warn` keeps the three that report a false success and
+drops the one that does not. Those lines go to the **stderr of the process
+that has the variable set** — your terminal for a `bun run src/index.ts`
+checkout, and the `^l` log pane inside the TUI
 (which swaps the sink for its own ring buffer). It reaches `phantombot logs`
 only if the *daemon itself* was started with the variable set — which is the
 case you never want: **never set it on a host running the real service**, or

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -141,6 +141,9 @@ export function isSandbox(
  * warning. Without it, `/update` on a host that happens to have the var
  * set reports success while never restarting anything, and the only
  * explanation goes to a `stderr` field most call sites never read.
+ * `rerenderUnitIfStale()` logs at info instead: it returns
+ * {rerendered:false}, which is honest rather than a false success, and is
+ * what the real backend returns in a dev checkout anyway.
  */
 export function sandboxServiceControl(inner: ServiceControl): ServiceControl {
   const suppressed = (op: string) => async () => {
@@ -158,8 +161,16 @@ export function sandboxServiceControl(inner: ServiceControl): ServiceControl {
     start: suppressed("start"),
     stop: suppressed("stop"),
     restart: suppressed("restart"),
+    // Logged, but NOT at warn — unlike the three verbs above, this one has
+    // no deceptive success to warn about. It answers {rerendered:false},
+    // which is exactly what the real POSIX backend answers in the sandbox's
+    // own headline case: `defaultRerenderUnitIfStale` bails on
+    // `isPhantombotBinary(process.execPath)`, false under `bun run`. Warning
+    // there would fire on a call that was never going to write anything, and
+    // a warn line that cries wolf in the common case is one contributors
+    // learn to ignore — including the three that do matter.
     async rerenderUnitIfStale() {
-      log.warn("platform: service change suppressed", {
+      log.info("platform: unit re-render skipped", {
         reason: "PHANTOMBOT_SANDBOX",
         op: "rerenderUnitIfStale",
       });

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -32,6 +32,7 @@ import {
   launchdLogPaths,
   launchdLogsDir,
 } from "./launchd.ts";
+import { log } from "./logger.ts";
 import {
   defaultSyncHeartbeatInstances as syncSystemdHeartbeatInstances,
   defaultSystemdServiceControl,
@@ -133,18 +134,35 @@ export function isSandbox(
  * The suppressed calls report ok=true rather than an error, because a
  * suppressed restart is the intended outcome here, not a failure the user
  * needs to act on.
+ *
+ * Because ok=true is indistinguishable from a real restart to the ~15
+ * callers of `defaultServiceControl()` — `cli/update.ts` and
+ * `channels/commands.ts` among them — every suppression ALSO logs a
+ * warning. Without it, `/update` on a host that happens to have the var
+ * set reports success while never restarting anything, and the only
+ * explanation goes to a `stderr` field most call sites never read.
  */
 export function sandboxServiceControl(inner: ServiceControl): ServiceControl {
-  const suppressed = async () => ({
-    ok: true,
-    stderr: "sandbox: service change suppressed (PHANTOMBOT_SANDBOX)",
-  });
+  const suppressed = (op: string) => async () => {
+    log.warn("platform: service change suppressed", {
+      reason: "PHANTOMBOT_SANDBOX",
+      op,
+    });
+    return {
+      ok: true,
+      stderr: `sandbox: service change suppressed (PHANTOMBOT_SANDBOX, ${op})`,
+    };
+  };
   return {
     isActive: () => inner.isActive(),
-    start: suppressed,
-    stop: suppressed,
-    restart: suppressed,
+    start: suppressed("start"),
+    stop: suppressed("stop"),
+    restart: suppressed("restart"),
     async rerenderUnitIfStale() {
+      log.warn("platform: service change suppressed", {
+        reason: "PHANTOMBOT_SANDBOX",
+        op: "rerenderUnitIfStale",
+      });
       return { rerendered: false };
     },
   };

--- a/tests/lib-platform.test.ts
+++ b/tests/lib-platform.test.ts
@@ -311,7 +311,7 @@ describe("sandbox service suppression", () => {
     expect(calls).toEqual([]);
   });
 
-  test("every suppressed mutation logs a warning naming the op", async () => {
+  test("every suppressed mutation logs, naming the op", async () => {
     // The whole hazard of this wrapper is that it reports ok=true, which is
     // indistinguishable from a real restart to the ~15 callers of
     // defaultServiceControl() that only check `ok`. The warn line is the only
@@ -335,8 +335,6 @@ describe("sandbox service suppression", () => {
     const lines = captured.map((l) => JSON.parse(l));
     expect(lines).toHaveLength(4);
     for (const line of lines) {
-      expect(line.level).toBe("warn");
-      expect(line.msg).toBe("platform: service change suppressed");
       expect(line.reason).toBe("PHANTOMBOT_SANDBOX");
     }
     expect(lines.map((l) => l.op)).toEqual([
@@ -345,6 +343,19 @@ describe("sandbox service suppression", () => {
       "restart",
       "rerenderUnitIfStale",
     ]);
+
+    // The three verbs that report ok=true are the deceptive ones, so they
+    // warn. rerenderUnitIfStale returns {rerendered:false} — the same answer
+    // the real backend gives under `bun run` — so it only informs; warning on
+    // a call that would not have written anything trains readers to ignore
+    // the line.
+    expect(lines.slice(0, 3).map((l) => [l.level, l.msg])).toEqual([
+      ["warn", "platform: service change suppressed"],
+      ["warn", "platform: service change suppressed"],
+      ["warn", "platform: service change suppressed"],
+    ]);
+    expect(lines[3].level).toBe("info");
+    expect(lines[3].msg).toBe("platform: unit re-render skipped");
   });
 
   test("isActive still delegates, so status is the truth", async () => {

--- a/tests/lib-platform.test.ts
+++ b/tests/lib-platform.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, test } from "bun:test";
 
+import { setLogSink } from "../src/lib/logSink.ts";
 import {
   syncHeartbeatInstances,
   currentPlatform,
@@ -308,6 +309,42 @@ describe("sandbox service suppression", () => {
     });
 
     expect(calls).toEqual([]);
+  });
+
+  test("every suppressed mutation logs a warning naming the op", async () => {
+    // The whole hazard of this wrapper is that it reports ok=true, which is
+    // indistinguishable from a real restart to the ~15 callers of
+    // defaultServiceControl() that only check `ok`. The warn line is the only
+    // signal those callers leave behind, so pin it: a future verb added to
+    // ServiceControl that suppresses SILENTLY reintroduces #484.
+    const captured: string[] = [];
+    const restore = setLogSink((line) => captured.push(line));
+    try {
+      const { control } = trackingBackend(true);
+      const sandboxed = sandboxServiceControl(control);
+      await sandboxed.start();
+      await sandboxed.stop();
+      await sandboxed.restart();
+      await sandboxed.rerenderUnitIfStale();
+      // A query is not a mutation — it must stay silent.
+      await sandboxed.isActive();
+    } finally {
+      restore();
+    }
+
+    const lines = captured.map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(4);
+    for (const line of lines) {
+      expect(line.level).toBe("warn");
+      expect(line.msg).toBe("platform: service change suppressed");
+      expect(line.reason).toBe("PHANTOMBOT_SANDBOX");
+    }
+    expect(lines.map((l) => l.op)).toEqual([
+      "start",
+      "stop",
+      "restart",
+      "rerenderUnitIfStale",
+    ]);
   });
 
   test("isActive still delegates, so status is the truth", async () => {


### PR DESCRIPTION
Closes #484.

`PHANTOMBOT_SANDBOX` turns every service mutation into a no-op that still reports `ok: true`. That is right for a dev checkout — a `bun run src/index.ts` working tree must not bounce the host's real `phantombot.service` — but it is a **global** switch, not a TUI one. `defaultServiceControl()` has ~15 callers, `cli/update.ts`, `lib/serviceLifecycle.ts` and `channels/commands.ts` among them, and most only check `ok`. So on a host with the var set, `/update` and `/restart` report success while restarting nothing, and the only explanation goes to a `stderr` field those call sites never read.

No behaviour change to the suppression itself — this is the discoverability follow-up the #479 review asked for.

### Say something

`suppressed()` now takes the op name and logs before returning:

```json
{"level":"warn","msg":"platform: service change suppressed","reason":"PHANTOMBOT_SANDBOX","op":"restart"}
```

`rerenderUnitIfStale` warns too. The issue only named `suppressed()`, but the re-render is a mutation on the same footing — it writes the real unit file on disk — and it was equally silent, so leaving it out would have left half the landmine armed. The op name is also appended to the existing `stderr` string, so a caller that *does* read stderr now learns which verb was dropped rather than just that something was.

`isActive()` is untouched and stays silent: it delegates, it is a query, and warning on it would make the log noisy enough to be ignored.

### Document it

The var appeared in neither README.md nor AGENTS.md. Now:

- **README** — a block at the end of *Service lifecycle*, next to the four verbs it disables: what it suppresses, that queries still tell the truth, why it exists, that it reaches `/update` and `/restart` too, and a "never set it on a host running the real service" warning.
- **AGENTS.md** — a block at the end of *Service model*, aimed at contributors: the blast radius, and the instruction not to drop the warning when adding a mutation to `ServiceControl`.

### Test

One new test in `tests/lib-platform.test.ts` drives all four mutations plus `isActive()` through a captured log sink and asserts exactly four warn lines, in order, each carrying `reason` and the right `op`. That is the part worth pinning: a verb added to `ServiceControl` later that suppresses silently reintroduces this bug, and now it fails the suite instead of shipping.

### Checks

- `bun run typecheck` clean.
- `bun test` — 4139 pass, 2 skip, 1 fail: `cli-doctor-persona-env`, which fails identically on `main` at `71e657a` (verified by checking out main and re-running). Unrelated to this change.
- The new README prose was caught by `readme-contract.test.ts` for naming a `phantombot status` command that does not exist — fixed to `phantombot doctor` before commit.