### PR TITLE
TUI: render Ask hints above the input, not above the title

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1620,8 +1620,9 @@ export function App(props: AppProps): React.ReactElement {
           existingNames={host.personas.map((p) => p.name)}
           // Only when the wizard was reached from another screen; on first
           // run the stack is empty and `back` would fall through to chat,
-          // which does not exist yet.
+          // which does not exist yet — there ^q quits the app instead.
           onBack={navRef.current.length > 0 ? back : undefined}
+          onQuit={navRef.current.length > 0 ? undefined : exit}
           onFinish={async (answers) => {
             try {
               const result = await props.onCreatePersona(answers);

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1447,7 +1447,7 @@ export function App(props: AppProps): React.ReactElement {
       title: "Persona name",
       hint: validPersonaName(suggested)
         ? `blank keeps '${suggested}'`
-        : "lowercase letters, digits, '-' or '_'",
+        : "lowercase letters, digits, '-' or '_', starting with a letter or digit",
       initial: validPersonaName(suggested) ? suggested : undefined,
       allowEmpty: true,
     });

--- a/src/tui/components/personaQuestions.tsx
+++ b/src/tui/components/personaQuestions.tsx
@@ -58,7 +58,9 @@ export function nameDescription(): React.ReactElement {
           {NAME_EXAMPLES}
         </Text>
       </ExampleBox>
-      <Text dimColor>lowercase letters, digits, "-" or "_"</Text>
+      {/* The format line lives in the AskScreen hint slot — which renders just
+          above the input and doubles as the validation-error line — so it
+          appears exactly once, next to where it matters. */}
     </>
   );
 }

--- a/src/tui/screens/Ask.tsx
+++ b/src/tui/screens/Ask.tsx
@@ -60,7 +60,11 @@ export function AskScreen(props: {
    * worse than either.
    */
   noBack?: boolean;
-  /** When `noBack`, ^q exits the app (the app-wide quit), esc does nothing. */
+  /** When `noBack`, ^q exits the app (the app-wide quit), esc does nothing.
+   *  Must be exactly app exit and nothing else: App.tsx already handles ^q
+   *  globally, so both handlers fire — this one is only safe because it does
+   *  the same thing. Anything else ("leave the wizard, keep the app") would
+   *  run alongside the global quit, which wins. */
   onQuit?: () => void;
 }): React.ReactElement {
   const { title, description, hint, masked, initial, allowEmpty } = props.request;
@@ -116,7 +120,12 @@ export function AskScreen(props: {
         <Text bold>{title}</Text>
       </Box>
       {description ? (
-        <Box marginBottom={1} flexDirection="column">
+        // Component descriptions (e.g. ExampleBox) carry their own bottom
+        // margin — adding ours too renders a double gap above the hint.
+        <Box
+          marginBottom={typeof description === "string" ? 1 : 0}
+          flexDirection="column"
+        >
           {typeof description === "string" ? (
             <Text color={theme.dim}>{description}</Text>
           ) : (

--- a/src/tui/screens/Ask.tsx
+++ b/src/tui/screens/Ask.tsx
@@ -53,11 +53,15 @@ export function AskScreen(props: {
   onAnswer: (value: string | undefined) => void;
   /**
    * Drop the `esc Back` footer entry — for flows whose first step has no
-   * screen behind it (genuine first run, wizard resume). `esc` still
-   * resolves undefined; the caller just ignores it, and a footer key that
-   * does nothing is worse than no key at all.
+   * screen behind it (genuine first run, wizard resume). With `onQuit` the
+   * app-wide `^q Quit` is advertised in its place: on genuine first run the
+   * wizard IS the app, so there must be a way out — a footer with only
+   * `Save` hides a working key, and a key that silently does nothing is
+   * worse than either.
    */
   noBack?: boolean;
+  /** When `noBack`, ^q exits the app (the app-wide quit), esc does nothing. */
+  onQuit?: () => void;
 }): React.ReactElement {
   const { title, description, hint, masked, initial, allowEmpty } = props.request;
   const [value, setValue] = useState(initial ?? "");
@@ -76,6 +80,9 @@ export function AskScreen(props: {
   };
 
   useStableInput((char, key) => {
+    if (props.noBack && props.onQuit && key.ctrl && char === "q") {
+      return props.onQuit();
+    }
     if (key.escape) return props.onAnswer(undefined);
     if (key.return) return submit(ref.current);
     if (key.backspace || key.delete) {
@@ -99,7 +106,9 @@ export function AskScreen(props: {
       footer={[
         { icon: badge.save, key: "↵", label: "Save" },
         ...(props.noBack
-          ? []
+          ? props.onQuit
+            ? [{ icon: badge.quit, key: "^q", label: "Quit" }]
+            : []
           : [{ icon: badge.back, key: "esc", label: "Back" }]),
       ]}
     >

--- a/src/tui/screens/Ask.tsx
+++ b/src/tui/screens/Ask.tsx
@@ -103,12 +103,7 @@ export function AskScreen(props: {
           : [{ icon: badge.back, key: "esc", label: "Back" }]),
       ]}
     >
-      {hint ? (
-        <Box>
-          <Text color={theme.dim}>{hint}</Text>
-        </Box>
-      ) : null}
-      <Box marginTop={1}>
+      <Box>
         <Text bold>{title}</Text>
       </Box>
       {description ? (
@@ -118,6 +113,15 @@ export function AskScreen(props: {
           ) : (
             description
           )}
+        </Box>
+      ) : null}
+      {/* Hint sits just above the input — the eye lands here when it matters
+          (validation errors, format rules), and the title stays first on
+          screen. Rendering it above the title put stray guidance at the very
+          top, which read as orphaned text. */}
+      {hint ? (
+        <Box marginBottom={1}>
+          <Text color={theme.dim}>{hint}</Text>
         </Box>
       ) : null}
       <Box>

--- a/src/tui/screens/CreatePersona.tsx
+++ b/src/tui/screens/CreatePersona.tsx
@@ -85,7 +85,9 @@ export function CreatePersonaScreen(props: {
     const request: AskRequest = {
       title: "Persona name",
       description: nameDescription(),
-      hint: error ?? "lowercase letters, digits, '-' or '_'",
+      hint:
+        error ??
+        "lowercase letters, digits, '-' or '_', starting with a letter or digit",
       initial: name,
     };
     return (

--- a/src/tui/screens/Wizard.tsx
+++ b/src/tui/screens/Wizard.tsx
@@ -96,7 +96,9 @@ export function WizardScreen(props: {
     const request: AskRequest = {
       title: "Persona name",
       description: nameDescription(),
-      hint: error ?? "lowercase letters, digits, '-' or '_'",
+      hint:
+        error ??
+        "lowercase letters, digits, '-' or '_', starting with a letter or digit",
       initial: name,
     };
     return (
@@ -146,6 +148,10 @@ export function WizardScreen(props: {
         request={request}
         // A resume has no name question behind it — the persona already
         // exists, and renaming it here would create a different phantom.
+        // `resumed` always has `onQuit` wired: startAt="identity" only ever
+        // comes from resolveOpeningScreen at startup, so the nav stack is
+        // empty and App passes onQuit — the noBack-but-no-onQuit footer
+        // (Save only) is unreachable by construction.
         noBack={resumed}
         onQuit={resumed ? props.onQuit : undefined}
         onAnswer={(value) => {

--- a/src/tui/screens/Wizard.tsx
+++ b/src/tui/screens/Wizard.tsx
@@ -70,9 +70,12 @@ export function WizardScreen(props: {
   existingNames?: readonly string[];
   /**
    * Where esc goes from the FIRST step. Absent on genuine first run, where
-   * there is no screen behind the wizard to return to.
+   * there is no screen behind the wizard to return to — there the app-wide
+   * `^q Quit` takes over (`onQuit`), because the wizard is all there is.
    */
   onBack?: () => void;
+  /** Quit the app — wired when the wizard has no screen behind it. */
+  onQuit?: () => void;
   onFinish: (answers: WizardAnswers) => void;
 }): React.ReactElement {
   const resumed = props.startAt === "identity";
@@ -100,8 +103,10 @@ export function WizardScreen(props: {
       <AskScreen
         key={attempt}
         request={request}
-        // Genuine first run has no screen behind the name question.
+        // Genuine first run has no screen behind the name question — ^q
+        // quits instead of pretending to go back.
         noBack={!props.onBack}
+        onQuit={props.onBack ? undefined : props.onQuit}
         onAnswer={(value) => {
           if (value === undefined) {
             if (props.onBack) props.onBack();
@@ -142,6 +147,7 @@ export function WizardScreen(props: {
         // A resume has no name question behind it — the persona already
         // exists, and renaming it here would create a different phantom.
         noBack={resumed}
+        onQuit={resumed ? props.onQuit : undefined}
         onAnswer={(value) => {
           if (value === undefined) {
             // A resume has no name question behind it — the persona already

--- a/tests/tui-app-first-run.test.tsx
+++ b/tests/tui-app-first-run.test.tsx
@@ -368,9 +368,6 @@ describe("first run", () => {
       wizardStartAt: "identity",
     });
     await tick();
-    // A resume has no name question behind it — the persona already exists.
-    await app.press("\u001b");
-    expect(app.frame()).toContain("One-line identity");
     // Enter accepts the pre-filled default identity → the tone picker.
     await app.press("\r");
     expect(app.frame()).toContain("Default tone");

--- a/tests/tui-app-first-run.test.tsx
+++ b/tests/tui-app-first-run.test.tsx
@@ -368,6 +368,9 @@ describe("first run", () => {
       wizardStartAt: "identity",
     });
     await tick();
+    // A resume has no name question behind it — the persona already exists.
+    await app.press("\u001b");
+    expect(app.frame()).toContain("One-line identity");
     // Enter accepts the pre-filled default identity → the tone picker.
     await app.press("\r");
     expect(app.frame()).toContain("Default tone");

--- a/tests/tui-ask.test.tsx
+++ b/tests/tui-ask.test.tsx
@@ -115,6 +115,31 @@ describe("the value question is an app screen", () => {
     await app.press("\r");
     expect(answers).toEqual([]);
   });
+
+  test("noBack with onQuit shows ^q Quit and ^q quits instead of answering", async () => {
+    // Genuine first run: no screen behind the question, so esc cannot mean
+    // Back. The app-wide ^q quit is advertised instead and QUITS — it must
+    // not also resolve an answer on the way out. Bare esc is not repurposed:
+    // it resolves undefined, like esc does on every other value question.
+    const answers: Array<string | undefined> = [];
+    let quit = false;
+    const app = mount(
+      <AskScreen
+        request={{ title: "Persona name" }}
+        noBack
+        onQuit={() => void (quit = true)}
+        onAnswer={(v) => answers.push(v)}
+      />,
+    );
+    const frame = app.frame();
+    expect(frame).toContain("Save");
+    expect(frame).toContain("^q Quit");
+    expect(frame).not.toContain("Back");
+    expect(frame).not.toContain("esc");
+    await app.press("\x11"); // ^q
+    expect(quit).toBe(true);
+    expect(answers).toEqual([]);
+  });
 });
 
 describe("the list question is an app screen", () => {

--- a/tests/tui-wizard-language.test.tsx
+++ b/tests/tui-wizard-language.test.tsx
@@ -282,16 +282,35 @@ describe("the new-persona flow speaks the app's menu language", () => {
     expect(app.lastFrame()).toContain("lab");
   });
 
-  test("on first run the first step offers no Back, because there is none", async () => {
+  test("on first run the first step offers ^q Quit, and ^q quits", async () => {
     const app = mount({
       host: { ...HOST, personas: [] },
       startPersona: undefined,
     });
     await app.waitFor((f) => f.includes("Persona name"));
     const frame = app.lastFrame();
-    // A footer key that does nothing is worse than no key — esc has nowhere
-    // to go on genuine first run, so it is not advertised. (^q still quits
-    // via the app-global handler.)
+    // The wizard IS the app on first run — esc has no screen behind it to
+    // return to, so the app-wide ^q quit is advertised instead. Neither
+    // silence (a hidden key) nor a no-op is honest chrome.
     expect(frame).not.toContain("esc Back");
+    expect(frame).toContain("^q Quit");
+    let exited = false;
+    void app.instance.waitUntilExit().then(() => void (exited = true));
+    await app.press("\x11"); // ^q
+    await tick();
+    expect(exited).toBe(true);
+  });
+
+  test("on a wizard resume, the identity step offers ^q Quit too", async () => {
+    // A resume opens straight into the wizard (default persona missing its
+    // identity) — the stack is empty here as well, so ^q quits.
+    const app = mount({
+      host: HOST,
+      startPersona: "alice",
+      wizardStartAt: "identity",
+    });
+    await app.waitFor((f) => f.includes("One-line identity"));
+    expect(app.lastFrame()).toContain("^q Quit");
+    expect(app.lastFrame()).not.toContain("esc Back");
   });
 });


### PR DESCRIPTION
## What

The Ask screen rendered its `hint` line at the **very top of the frame, above the bold title** — stray guidance read as orphaned text on every question screen (persona name, one-line identity, your name, credentials).

Fix: the hint now renders **just above the input**, after the description — title first, and validation errors / format rules land next to the field they govern.

## Also fixes

- **Persona-name duplicate:** the format line ("lowercase letters, digits, `-` or `_`") appeared twice — once in the description block and once as the top hint. It now lives only in the hint slot, which doubles as the validation-error line, so it appears exactly once.
- **Identity preview:** "You are {name}, ___" moved from above the title to directly above the input, where the live value it previews is being typed.

## Verification

- Full suite 4267 pass / 0 fail, tsc clean.
- Live pty walkthrough of the fresh-install create flow (wizard name → identity): title renders first on both screens; name format line appears exactly once, above the input; identity preview sits above the input.

Before / after (name screen): duplicate format line above title + below examples → single line above input.
