### PR TITLE
TUI: derive Autostart from the personas the daemon actually serves

### DIFF
--- a/src/lib/personaDefault.ts
+++ b/src/lib/personaDefault.ts
@@ -298,9 +298,18 @@ export async function adoptLegacyDefaultPersona(
 
 /**
  * Legacy-install migration: backfill `[autostart_modes]` when the host has
- * `autostart_personas` but NO mode records at all — the exact signature of a
- * pre-#509 install, where list membership meant "boot via linger/LaunchDaemon/
+ * SERVED personas but NO mode records at all — the exact signature of a
+ * pre-#509 install, where being served meant "boot via linger/LaunchDaemon/
  * boot task".
+ *
+ * "Served" is `servedPersonasOf` — the default persona plus
+ * `autostart_personas` — and NOT list membership alone. The first cut gated
+ * on a non-empty `autostart_personas`, which made the whole migration a
+ * no-op on the commonest install there is: a single-persona `phantombot
+ * install` host that has a `default_persona` and never wrote an
+ * `autostart_personas` key. Those hosts (Matt/macOS, Megan/Windows,
+ * verified 2026-09-01) got no records at all, so the TUI fell back to
+ * reporting Off for a persona the daemon starts at every login (#512).
  *
  * One-time by construction: the gate is "no records exist", and this write
  * CREATES records — from then on the table is the sole source of truth and
@@ -329,7 +338,25 @@ export async function migrateLegacyAutostartModes(
     bootProbe?: (name: string) => Promise<boolean>;
   },
 ): Promise<void> {
-  if (!config.autostartPersonas?.length) return;
+  // The default persona counts as served ONLY when something actually chose
+  // it (env / state.json / config.toml). Provenance "builtin" is the bare
+  // fallback name on a host that configured nothing, so backfilling a record
+  // for it would invent an autostart record for a persona that may not even
+  // exist on disk. `resolveOpeningScreen` runs the default-persona adoption
+  // BEFORE this migration, so a genuine legacy host has already had its
+  // implicit default made explicit by the time we get here.
+  const { servedPersonasOf } = await import("../config.ts");
+  const chosenDefault =
+    (await defaultPersonaProvenance(config)) === "builtin"
+      ? undefined
+      : config.defaultPersona;
+  const served = servedPersonasOf({
+    ...(chosenDefault ? { defaultPersona: chosenDefault } : {}),
+    autostartPersonas: config.autostartPersonas ?? [],
+  } as Pick<Config, "defaultPersona" | "autostartPersonas">).filter(
+    (n) => typeof n === "string" && n.length > 0,
+  );
+  if (!served.length) return;
   if (config.autostartModes && Object.keys(config.autostartModes).length > 0)
     return;
   const { currentPlatform } = await import("./platform.ts");
@@ -341,7 +368,7 @@ export async function migrateLegacyAutostartModes(
   // Probe everything first — probing never writes, so a probe failure here
   // leaves the config untouched and the migration can simply be retried.
   const modes: Record<string, "login" | "boot"> = {};
-  for (const name of config.autostartPersonas) {
+  for (const name of served) {
     modes[name] =
       platform === "linux" ? "login" : (await bootProbe(name)) ? "boot" : "login";
   }
@@ -353,7 +380,7 @@ export async function migrateLegacyAutostartModes(
   log.warn("legacy install: backfilled [autostart_modes]", {
     ...recorded,
     reason:
-      "pre-#509 autostart_personas had no mode records; linux is always login (linger is an installer default, not a Boot choice), mac/win from ours-only probes",
+      "pre-#509 served personas had no mode records; linux is always login (linger is an installer default, not a Boot choice), mac/win from ours-only probes",
   });
 }
 

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -682,14 +682,29 @@ export function App(props: AppProps): React.ReactElement {
     async (target: PersonaSnapshot) => {
       const current = target.autostart ? target.autostartMode : "off";
       const isDefault = target.isDefault;
+      // Off is expressed by leaving `autostart_personas` — which the DEFAULT
+      // persona need never have been on. The daemon serves the default
+      // unconditionally (`servedPersonasOf`), so offering Off there wrote a
+      // list the daemon does not consult and reported success while nothing
+      // changed. Say what is actually true instead (#512). The remaining
+      // Off/Login/Boot choices still work for the default persona; only the
+      // impossible one is withheld, and only when the list is genuinely not
+      // what is keeping it on.
+      const offIsUnavailable = isDefault && target.autostartViaDefault === true;
       const pick = await askChoice({
         title: `Autostart for ${target.name}?`,
         description:
           "Login starts the daemon when you sign in. Boot starts it without " +
-          "a login (needs your password once).",
+          "a login (needs your password once)." +
+          (offIsUnavailable
+            ? " The default persona always starts with the daemon — to stop it," +
+              " make another persona Default, or stop the daemon itself."
+            : ""),
         options: isDefault
           ? [
-              { value: "off", label: "Off", hint: "not started with the daemon" },
+              ...(offIsUnavailable
+                ? []
+                : [{ value: "off", label: "Off", hint: "not started with the daemon" }]),
               { value: "login", label: "Login", hint: "starts at login — no password needed" },
               { value: "boot", label: "Boot", hint: "starts at boot without a login — asks for your password once" },
             ]

--- a/src/tui/snapshot.ts
+++ b/src/tui/snapshot.ts
@@ -176,13 +176,29 @@ export interface PersonaSnapshot {
   name: string;
   dir: string;
   isDefault: boolean;
+  /**
+   * Does the daemon start this persona? This is `servedPersonasOf` — the
+   * SAME predicate the daemon itself uses — not raw `autostart_personas`
+   * membership. The default persona is served unconditionally (config.ts
+   * `servedPersonasOf`), so a single-persona install with no
+   * `autostart_personas` key at all still autostarts; reading membership
+   * alone reported those hosts as Off while the daemon was in fact
+   * starting them at every login (#512).
+   */
   autostart: boolean;
   /**
-   * HOW the persona autostarts when it is on the list: "login" (user-level,
+   * HOW the persona autostarts when it is served: "login" (user-level,
    * the historical default) or "boot" (survives logged-off). No record on
    * disk → "login", so existing agents inherit what they already have.
    */
   autostartMode?: "login" | "boot";
+  /**
+   * Is this persona served ONLY because it is the default? Such a persona
+   * cannot be switched off through `autostart_personas` — removing it from
+   * a list it was never on changes nothing — so the selector must not offer
+   * an Off that would silently do nothing.
+   */
+  autostartViaDefault?: boolean;
   /** Harness chain as configured, and the first one whose binary resolves. */
   chain: string[];
   resolvedHarness?: { id: string; path: string };
@@ -485,9 +501,18 @@ export async function personaSnapshot(
   // the installer, so an enabled unit is the default state, not a Boot
   // choice (review blocker 2026-08-31); unrecorded Linux personas display
   // Login, and only a recorded mode=boot shows Boot. No sudo, no elevation.
+  //
+  // WHETHER it starts: the daemon serves `defaultPersona` plus everything in
+  // `autostart_personas` (config.ts `servedPersonasOf`). Deriving this from
+  // list membership alone mislabelled every `phantombot install` host that
+  // never wrote an `autostart_personas` key — the common single-persona
+  // macOS/Windows install — as Off while its LaunchAgent / logon task was
+  // starting the daemon, and the daemon was starting the default persona.
   const onList = (host.autostartPersonas ?? []).includes(name);
+  const isDefault = host.defaultPersona === name;
+  const served = onList || isDefault;
   let autostartMode = host.autostartModes?.[name];
-  if (autostartMode === undefined && onList) {
+  if (autostartMode === undefined && served) {
     const probe =
       probeBoot ??
       ((p: string) =>
@@ -500,9 +525,10 @@ export async function personaSnapshot(
   return {
     name,
     dir,
-    isDefault: host.defaultPersona === name,
-    autostart: onList,
+    isDefault,
+    autostart: served,
     autostartMode: autostartMode ?? "login",
+    autostartViaDefault: served && !onList,
     chain,
     brainConfigured,
     resolvedHarness,

--- a/tests/lib-persona-snapshot-brain.test.ts
+++ b/tests/lib-persona-snapshot-brain.test.ts
@@ -116,7 +116,41 @@ autostart_personas = ["alice"]
     expect(snap.autostartMode).toBe("login");
   });
 
-  test("not on the list → off, probe never consulted", async () => {
+  test("not served (not default, not on the list) → off, probe never consulted", async () => {
+    setup(`
+default_persona = "bob"
+autostart_personas = ["bob"]
+`);
+    const { config, host } = await loadConfigForPersona("alice");
+    let probed = 0;
+    const snap = await personaSnapshot(config, host, "alice", async () => {
+      probed++;
+      return true;
+    });
+    expect(snap.autostart).toBe(false);
+    expect(snap.autostartViaDefault).toBe(false);
+    expect(snap.autostartMode).toBe("login");
+    expect(probed).toBe(0);
+  });
+
+  // #512: the daemon serves `defaultPersona` plus `autostart_personas`
+  // (config.ts `servedPersonasOf`), so the default persona autostarts even
+  // when it is on no list — the shape a single-persona `phantombot install`
+  // leaves behind on macOS and Windows. Reading membership alone reported
+  // those hosts as Off while their LaunchAgent / logon task was in fact
+  // starting the daemon at every login.
+  test("default persona with NO autostart_personas key at all → served", async () => {
+    setup(`
+default_persona = "alice"
+`);
+    const { config, host } = await loadConfigForPersona("alice");
+    const snap = await personaSnapshot(config, host, "alice", async () => false);
+    expect(snap.autostart).toBe(true);
+    expect(snap.autostartViaDefault).toBe(true);
+    expect(snap.autostartMode).toBe("login");
+  });
+
+  test("default persona off the list is probed for an inherited boot state", async () => {
     setup(`
 default_persona = "alice"
 autostart_personas = ["bob"]
@@ -127,8 +161,37 @@ autostart_personas = ["bob"]
       probed++;
       return true;
     });
-    expect(snap.autostart).toBe(false);
-    expect(snap.autostartMode).toBe("login");
+    expect(snap.autostart).toBe(true);
+    expect(snap.autostartViaDefault).toBe(true);
+    expect(snap.autostartMode).toBe("boot");
+    expect(probed).toBe(1);
+  });
+
+  test("default persona ON the list is served, but not via the default rule", async () => {
+    setup(`
+default_persona = "alice"
+autostart_personas = ["alice"]
+`);
+    const { config, host } = await loadConfigForPersona("alice");
+    const snap = await personaSnapshot(config, host, "alice", async () => false);
+    expect(snap.autostart).toBe(true);
+    expect(snap.autostartViaDefault).toBe(false);
+  });
+
+  test("a recorded mode always wins over the probe", async () => {
+    setup(`
+default_persona = "alice"
+
+[autostart_modes]
+alice = "boot"
+`);
+    const { config, host } = await loadConfigForPersona("alice");
+    let probed = 0;
+    const snap = await personaSnapshot(config, host, "alice", async () => {
+      probed++;
+      return false;
+    });
+    expect(snap.autostartMode).toBe("boot");
     expect(probed).toBe(0);
   });
 });

--- a/tests/tui-legacy-default-migration.test.ts
+++ b/tests/tui-legacy-default-migration.test.ts
@@ -234,7 +234,7 @@ describe("migrateLegacyAutostartModes (legacy-install migration)", () => {
     expect(toml).not.toContain('lena = "boot"');
   });
 
-  test("no autostart_personas → nothing written", async () => {
+  test("no autostart_personas and no chosen default → nothing written", async () => {
     await writeFile(configPath, 'update_channel = "preview"\n', "utf8");
     const config = await loadConfig();
 
@@ -243,6 +243,63 @@ describe("migrateLegacyAutostartModes (legacy-install migration)", () => {
     });
 
     expect(await readFile(configPath, "utf8")).not.toContain("autostart_modes");
+  });
+
+  // #512 — the shape a single-persona `phantombot install` actually leaves:
+  // a default_persona and NO autostart_personas key at all. Verified on Matt
+  // (macOS, LaunchAgent dev.phantombot.phantombot.plist) and Megan (Windows,
+  // \Phantombot\phantombot-megan at logon) on 2026-09-01: both were serving
+  // their persona at every login while the TUI reported Autostart: off,
+  // because the gate here was "autostart_personas is non-empty" and this
+  // migration never ran at all.
+  test("default_persona with NO autostart_personas → the default is backfilled", async () => {
+    await writeFile(configPath, 'default_persona = "lena"\n', "utf8");
+    const config = await loadConfig();
+
+    const { currentPlatform } = await import("../src/lib/platform.ts");
+    await migrateLegacyAutostartModes(config, {
+      bootProbe: async () => true,
+    });
+
+    const toml = await readFile(configPath, "utf8");
+    expect(toml).toContain("[autostart_modes]");
+    // Linux is still login unconditionally (#511 doctrine, unchanged): an
+    // enabled unit is the installer's default, never a Boot choice.
+    expect(toml).toContain(
+      currentPlatform() === "linux" ? 'lena = "login"' : 'lena = "boot"',
+    );
+  });
+
+  test("a builtin-provenance default is NOT treated as served", async () => {
+    // Nothing chose a default — `config.defaultPersona` is only the bare
+    // fallback name, and may not exist on disk. Backfilling a record for it
+    // would invent autostart state nobody asked for.
+    await writeFile(configPath, 'autostart_personas = ["lena"]\n', "utf8");
+    const config = await loadConfig();
+
+    await migrateLegacyAutostartModes(config, { bootProbe: async () => false });
+
+    const toml = await readFile(configPath, "utf8");
+    expect(toml).toContain('lena = "login"');
+    expect(toml).not.toContain("phantom =");
+  });
+
+  test("default already on the list is recorded once, not twice", async () => {
+    await writeFile(
+      configPath,
+      'default_persona = "lena"\nautostart_personas = ["lena", "kai"]\n',
+      "utf8",
+    );
+    const config = await loadConfig();
+
+    await migrateLegacyAutostartModes(config, { bootProbe: async () => false });
+
+    const toml = await readFile(configPath, "utf8");
+    expect(toml.match(/^lena = /gm)?.length).toBe(1);
+    expect(Object.keys(config.autostartModes ?? {}).sort()).toEqual([
+      "kai",
+      "lena",
+    ]);
   });
 });
 


### PR DESCRIPTION
## The report

Andrew updated Megan (Windows), Matt (macOS) and this VPS (Ubuntu) to v1.1.334 and ran the TUI on each:

| host | platform | shows | actually |
|---|---|---|---|
| Matt | macOS | **Autostart: off** | LaunchAgent `dev.phantombot.phantombot.plist`, `RunAtLoad=true` |
| Megan | Windows | **Autostart: off** | task `\Phantombot\phantombot-megan`, *At logon time* |
| Robbie | Linux | Autostart: login | correct |

So #511's detection did not reach two of the three.

## Root cause

Two independent things, one symptom.

**1. The display predicate is the wrong one.** `personaSnapshot` sets `autostart` from `autostart_personas` membership. But the daemon serves `defaultPersona` **plus** that list — `servedPersonasOf` in `config.ts`:

```ts
return [
  config.defaultPersona,
  ...(config.autostartPersonas ?? []).filter((n) => n !== config.defaultPersona),
];
```

A single-persona `phantombot install` writes a `default_persona` and **never writes an `autostart_personas` key at all**. Verified on the two failing hosts — that key is simply absent from both configs. Those personas are served at every daemon start; the TUI just was not asking the question the daemon answers.

**2. #511's migration cannot run there.** Its first line is:

```ts
if (!config.autostartPersonas?.length) return;
```

On Matt and Megan that list is empty, so `migrateLegacyAutostartModes` returns immediately and writes no records — the backfill never had a chance to fire on the exact install shape it exists to rescue. `[autostart_modes]` is absent from both configs today.

## The fix

- **`snapshot.ts`** — `autostart` is now the served predicate (`onList || isDefault`), and the inherited-boot probe runs for a *served* persona rather than a *listed* one, so a Windows default with a password-mode task displays Boot instead of Login. New `autostartViaDefault` flags a persona served only because it is the default.

- **`personaDefault.ts`** — the migration gate becomes "there is at least one served persona", and it backfills a record for each. The default counts as served only when something actually **chose** it (`defaultPersonaProvenance` != `builtin`); the builtin fallback name may not correspond to a persona on disk, and inventing a record for it is exactly the kind of made-up state #509/#511 spent three rounds rejecting. **Linux is unchanged: still `login` unconditionally**, and the existing "linux backfill must never probe boot state" test still throws from the probe seam if that is ever violated.

- **`App.tsx`** — the selector no longer offers **Off** for a persona served only because it is the default. Off is expressed by removing from `autostart_personas`, a list such a persona was never on, so today that option writes nothing, changes nothing, restarts the daemon and reports success. It now explains that the default persona always starts with the daemon. This is strictly an honesty fix — nothing that worked before stops working.

## Scope I deliberately did not take

The platform artifacts (LaunchAgent, logon task, `phantombot.service`) are *ours-only* and could be probed to answer "is the daemon itself set to autostart" — the missing third axis, and the only honest way to implement Off for a default persona. That is a bigger change with real teardown authority attached, and the #509 review history is a long argument for not reaching for teardown without provenance. Worth its own issue if we want it; @lenaparkhodges, interested in your read.

## Verification

- `bunx tsc --noEmit` — exit 0
- full suite: **4288 pass / 1 fail**; the failure is `cli-doctor-persona-env`, confirmed pre-existing on `main` (a Gemini key in my env leaks into the doctor output on this box)
- new/updated tests: 5 in `lib-persona-snapshot-brain` pinning the served predicate, the via-default flag and probe consultation; 3 in `tui-legacy-default-migration` pinning the real install shape, the builtin-provenance exclusion, and no double-recording when the default is also on the list. The test that asserted a default persona off the list reads Off encoded the bug and is rewritten to use a genuinely unserved persona.