### PR TITLE
embeddings: resolve the provider API key from the persona's own vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -2040,7 +2040,7 @@ Not every secret is a vault row. Current canonical locations are:
 | Claude/Codex host login | The harness's own OAuth/auth store; Phantombot does not copy it |
 | PhantomChat Nostr secret (`nsec`) | `<persona>/identity.json` (owner-only permissions), shared with vault key derivation |
 | Telegram bot token | Persona or host `config.toml`, or `TELEGRAM_BOT_TOKEN[_PERSONA]`; not in the generic vault |
-| Gemini embedding API key | Host/persona `config.toml`, or `PHANTOMBOT_GEMINI_API_KEY`; not in the generic vault |
+| Embedding provider API key (Gemini / OpenAI-compatible) | `<persona>/vault.sqlite` first, then a host-wide `PHANTOMBOT_GEMINI_API_KEY` / `PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY` export, then host/persona `config.toml`. A key injected from ANOTHER persona's vault is never used |
 | Windows logged-off account password | Persona vault; Task Scheduler also holds the registered task credential |
 
 `~/.env` and `~/.config/phantombot/.env` are legacy import sources only. On
@@ -2468,6 +2468,15 @@ api_key = "AIza..."
 model = "gemini-embedding-001"
 dims = 1536
 ```
+
+The `api_key` here is the LOWEST-precedence source. If this persona's vault
+holds a `PHANTOMBOT_GEMINI_API_KEY` row, that row is the key actually used and
+editing the file changes nothing — Phantombot logs a warning saying so on
+startup. `phantombot vault set PHANTOMBOT_GEMINI_API_KEY` is the place to
+change it, or `phantombot vault unset` it to hand control back to the file.
+The same applies to `[embeddings.openai_compatible] api_key` and
+`PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY`. Keys are per persona: one daemon
+serving several personas resolves each one against its OWN vault.
 
 For a local CPU-only llama.cpp server, start it separately from PhantomBot.
 The server's model and pooling must match the embedding GGUF's model card; for

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@
  * it doesn't exist.
  */
 
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -40,6 +41,10 @@ import {
 import type { TomlObject } from "./lib/configWriter.ts";
 import { loadState } from "./state.ts";
 import { usablePersistedBin } from "./lib/harnessBinPath.ts";
+import {
+  isVaultInjectedEnvKey,
+  isVaultLoadedPersonaDir,
+} from "./lib/vaultEnvTracking.ts";
 
 /**
  * Read the legacy `turn_timeout_s` (TOML) or `PHANTOMBOT_TURN_TIMEOUT_MS`
@@ -1081,6 +1086,12 @@ export async function loadConfig(persona?: string): Promise<Config> {
     asString(globalToml.default_persona) ??
     "phantom";
 
+  const personaDirPath = join(personasDir, personaLayer);
+  // Embedding API keys are resolved VAULT-FIRST (#514). See
+  // `readEmbeddingSecretsFromVault` for why this can't just read process.env.
+  const vaultEmbeddingSecrets =
+    await readEmbeddingSecretsFromVault(personaDirPath);
+
   const rawPersonaToml = await readPersonaToml(personasDir, personaLayer);
   warnDeprecatedConfigKeys(
     rawPersonaToml,
@@ -1453,7 +1464,12 @@ export async function loadConfig(persona?: string): Promise<Config> {
     // is the fail-closed direction.
     updateChannel: resolveUpdateChannel(globalToml.update_channel),
 
-    embeddings: buildEmbeddingsConfig(tomlEmbeddings, tomlGemini, tomlOpenAI),
+    embeddings: buildEmbeddingsConfig(
+      tomlEmbeddings,
+      tomlGemini,
+      tomlOpenAI,
+      { personaDirPath, vaultSecrets: vaultEmbeddingSecrets },
+    ),
 
     retrieval: buildRetrievalConfig(tomlRetrieval, tomlTurnIndexing),
     durableFacts: buildDurableFactsConfig(
@@ -2066,14 +2082,153 @@ export function documentChunkChars(
   return undefined;
 }
 
+/** The embedding API keys, read from ONE persona's vault. */
+export interface EmbeddingVaultSecrets {
+  gemini?: string;
+  openaiCompatible?: string;
+}
+
+/** Env names carrying an embedding provider's API key. */
+const EMBEDDING_KEY_ENV = {
+  gemini: "PHANTOMBOT_GEMINI_API_KEY",
+  openaiCompatible: "PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY",
+} as const;
+
+/**
+ * Read this persona's embedding API keys straight out of ITS OWN vault.
+ *
+ * Only needed for a persona whose vault is NOT the one `loadVaultIntoEnv`
+ * injected at startup — for the loaded persona the values are already in
+ * `process.env` and `personaEmbeddingKey` uses them. One daemon serves several
+ * personas in-process, so without this a secondary persona's key exists on
+ * disk and is unreachable, and (before #514) it silently embedded with the
+ * DEFAULT persona's key instead. Skipping the loaded persona also keeps the
+ * common single-persona path free of a per-`loadConfig` SQLite decrypt.
+ *
+ * Dynamically imported: `vault.ts` imports `loadConfig` from this module, so a
+ * static edge here would close an import cycle. The provenance registry those
+ * two share was split into `vaultEnvTracking.ts` precisely to avoid this for
+ * the SYNC reads; the vault open genuinely needs `vault.ts`.
+ *
+ * Never throws — an unopenable or absent vault is "no key", never a failed
+ * config load.
+ */
+async function readEmbeddingSecretsFromVault(
+  personaDirPath: string,
+): Promise<EmbeddingVaultSecrets> {
+  if (isVaultLoadedPersonaDir(personaDirPath)) return {};
+  try {
+    const { vaultPath, openPersonaVault } = await import("./lib/vault.ts");
+    // Open-existing-only: `openPersonaVault` mints an identity.json (and an
+    // nsec) on demand, so asking about an unprovisioned persona must not
+    // create one. Same rule as readAllVaultValues (#262).
+    if (!existsSync(vaultPath(personaDirPath))) return {};
+    const vault = await openPersonaVault(personaDirPath);
+    try {
+      const read = (name: string): string | undefined => {
+        const v = vault.get(name);
+        return v === undefined || v === "" ? undefined : v;
+      };
+      return {
+        gemini: read(EMBEDDING_KEY_ENV.gemini),
+        openaiCompatible: read(EMBEDDING_KEY_ENV.openaiCompatible),
+      };
+    } finally {
+      vault.close();
+    }
+  } catch (e) {
+    log.warn("config: embedding vault read failed", {
+      error: (e as Error).message,
+    });
+    return {};
+  }
+}
+
+/**
+ * Resolve one embedding API key for `personaDirPath`, vault first.
+ *
+ * Precedence, highest to lowest:
+ *   1. THIS persona's vault — either read directly (a persona whose vault was
+ *      never injected) or via the `process.env` value `loadVaultIntoEnv` put
+ *      there from it.
+ *   2. A host-wide ambient env export (shell, systemd `Environment=`), which
+ *      pre-vault hosts still depend on. Unchanged: env beats TOML everywhere
+ *      else in this file and this key is no exception.
+ *   3. The persona's effective `config.toml` (its own layer, else the host's).
+ *
+ * The case this exists for is the one deliberately MISSING from that list: an
+ * env value injected from a DIFFERENT persona's vault. It used to win outright
+ * (#514), so on a multi-persona host every persona embedded with whichever
+ * vault happened to load at startup — the default one — and that persona's
+ * stale row silently outranked a working key in everyone else's config.toml.
+ * It is now ignored, the same rule `ambientEnvKeyAllowed` already applies to
+ * the audio path and to tick's `--secret`.
+ */
+function personaEmbeddingKey(
+  envName: string,
+  fromVault: string | undefined,
+  fromToml: string | undefined,
+  personaDirPath: string,
+): string | undefined {
+  if (fromVault !== undefined) return fromVault;
+  const fromEnv = process.env[envName];
+  const envUsable =
+    fromEnv !== undefined &&
+    fromEnv !== "" &&
+    // A vault-injected key belongs to exactly one persona. Honour it only for
+    // that persona; an ambient key was never claimed by one, so it is fine.
+    (!isVaultInjectedEnvKey(envName) ||
+      isVaultLoadedPersonaDir(personaDirPath));
+  const resolved = envUsable ? fromEnv : fromToml;
+  // The silent-shadow warning. A key in config.toml that loses to a vault or
+  // an env export is the single most confusing state this resolver can be in:
+  // the operator edits the file (that is what `phantombot embedding` and the
+  // TUI still write), reloads, and nothing changes — which is exactly how a
+  // revoked vault row kept every memory search degraded to FTS-only while a
+  // working key sat in config.toml. Names only, never values, and only when
+  // the two genuinely differ.
+  if (fromToml !== undefined && fromToml !== "" && resolved !== fromToml) {
+    warnShadowedEmbeddingKey(envName, fromVault !== undefined);
+  }
+  return resolved;
+}
+
+/** Once per process per key — this is a config-load path, not a request path. */
+const _warnedShadowedEmbeddingKeys = new Set<string>();
+
+function warnShadowedEmbeddingKey(envName: string, fromVault: boolean): void {
+  if (_warnedShadowedEmbeddingKeys.has(envName)) return;
+  _warnedShadowedEmbeddingKeys.add(envName);
+  log.warn(
+    "config: embeddings api_key in config.toml is being overridden; " +
+      "the key in use comes from " +
+      (fromVault ? "this persona's vault" : "the environment") +
+      ` (${envName}). Update it there, or clear it, to change the key in use.`,
+  );
+}
+
+/** For tests: allow the shadow warning to fire again. */
+export function _resetEmbeddingKeyWarningsForTesting(): void {
+  _warnedShadowedEmbeddingKeys.clear();
+}
+
+export interface BuildEmbeddingsOptions {
+  personaDirPath: string;
+  vaultSecrets: EmbeddingVaultSecrets;
+}
+
 function buildEmbeddingsConfig(
   tomlEmbeddings: Record<string, unknown>,
   tomlGemini: Record<string, unknown>,
   tomlOpenAI: Record<string, unknown>,
+  opts: BuildEmbeddingsOptions,
 ): Config["embeddings"] {
-  const envApiKey = process.env.PHANTOMBOT_GEMINI_API_KEY;
-  const tomlApiKey = asString(tomlGemini.api_key);
-  const apiKey = envApiKey ?? tomlApiKey;
+  const apiKey = personaEmbeddingKey(
+    EMBEDDING_KEY_ENV.gemini,
+    opts.vaultSecrets.gemini,
+    asString(tomlGemini.api_key),
+    opts.personaDirPath,
+  );
 
   const configuredProvider = asString(tomlEmbeddings.provider);
   const provider =
@@ -2100,10 +2255,17 @@ function buildEmbeddingsConfig(
           env("PHANTOMBOT_OPENAI_COMPATIBLE_MODEL") ??
           asString(tomlOpenAI.model) ??
           "",
+        // Same vault-first rule as the Gemini key above: an API key is a
+        // secret, so a value injected from ANOTHER persona's vault must not
+        // stand in. The non-secret overrides beside it (base_url, model,
+        // dims, prefixes) are plain host settings and keep env-wins.
         apiKey:
-          env("PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY") ??
-          asString(tomlOpenAI.api_key) ??
-          "",
+          personaEmbeddingKey(
+            EMBEDDING_KEY_ENV.openaiCompatible,
+            opts.vaultSecrets.openaiCompatible,
+            asString(tomlOpenAI.api_key),
+            opts.personaDirPath,
+          ) ?? "",
         dims:
           asInt(env("PHANTOMBOT_OPENAI_COMPATIBLE_DIMS")) ??
           asInt(tomlOpenAI.dims) ??

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -38,6 +38,11 @@ import {
   type Config,
 } from "../config.ts";
 import { log } from "./logger.ts";
+import {
+  isVaultLoadedPersonaDir,
+  noteVaultLoadedPersonaDir,
+  vaultTrackedKeys,
+} from "./vaultEnvTracking.ts";
 import { getOrCreatePersonaIdentity } from "./personaIdentity.ts";
 
 /** Filename of the per-persona encrypted secrets DB inside a persona dir. */
@@ -425,55 +430,16 @@ function warnConfigOwnedEnvMirrors(
 }
 
 /**
- * Module-scope set of env keys THIS process injected from a vault. Mirrors
- * envBootstrap's `_moduleTracked`: it lets a later reload for a DIFFERENT
- * persona reconcile — updating a key to the new persona's value, or removing it
- * if the new persona doesn't have it — without ever touching a key that was
- * already in the environment at boot (shell export / systemd EnvironmentFile=).
+ * Vault->env provenance lives in `vaultEnvTracking.ts` (a leaf module, so
+ * `config.ts` can read it without closing an import cycle through this file).
+ * Re-exported here because this module is the API surface every caller already
+ * imports, and the writers below are the only code that mutates it.
  */
-const _vaultTracked = new Set<string>();
-
-/** The persona dir whose vault we last successfully injected, for transient-fail handling. */
-let _vaultLoadedPersonaDir: string | undefined;
-
-/**
- * True when `name` in `process.env` was injected there from a VAULT by this
- * process (rather than inherited from the shell / a systemd `Environment=`).
- *
- * The distinction matters wherever code resolves a secret for a persona that
- * is not the one loaded at startup: an ambient key is host-wide and safe to
- * fall back to, but a vault-injected one belongs to exactly one persona and
- * must never stand in for another persona's missing key. See tick's
- * `--secret` resolution.
- */
-export function isVaultInjectedEnvKey(
-  name: string,
-  tracked: Set<string> = _vaultTracked,
-): boolean {
-  return tracked.has(name);
-}
-
-/**
- * True when `personaDirPath` is the persona whose vault this process last
- * injected into `process.env`.
- *
- * Lets a resolver tell the two cases a vault-injected key can be in apart. If
- * the key belongs to a DIFFERENT persona it must never stand in (see
- * `isVaultInjectedEnvKey`); if it belongs to THIS persona it is that persona's
- * own secret, still in the environment because `loadVaultIntoEnv` deliberately
- * leaves injected keys in place when the same persona's vault fails to open
- * transiently. Treating that blip as "no key" would mute a persona over its
- * own credential.
- */
-export function isVaultLoadedPersonaDir(personaDirPath: string): boolean {
-  return _vaultLoadedPersonaDir !== undefined && personaDirPath === _vaultLoadedPersonaDir;
-}
-
-/** For tests: reset the module-scope vault env tracking. */
-export function _resetVaultTrackingForTesting(): void {
-  _vaultTracked.clear();
-  _vaultLoadedPersonaDir = undefined;
-}
+export {
+  isVaultInjectedEnvKey,
+  isVaultLoadedPersonaDir,
+  _resetVaultTrackingForTesting,
+} from "./vaultEnvTracking.ts";
 
 /**
  * Decrypt a persona's vault and RECONCILE it into `env`, so `env` ends up
@@ -499,7 +465,7 @@ export function _resetVaultTrackingForTesting(): void {
 export async function loadVaultIntoEnv(
   personaDirPath: string,
   env: NodeJS.ProcessEnv = process.env,
-  tracked: Set<string> = _vaultTracked,
+  tracked: Set<string> = vaultTrackedKeys(),
 ): Promise<{ updated: string[]; removed: string[]; badKeys: string[] }> {
   const updated: string[] = [];
   const removed: string[] = [];
@@ -509,7 +475,7 @@ export async function loadVaultIntoEnv(
     // A null (unopenable) vault is a distinct failure mode from per-row
     // corruption: there are no decryptable-or-not rows to report, so badKeys
     // is empty. This is what lets a caller tell "no vault" from "1 bad row".
-    if (personaDirPath === _vaultLoadedPersonaDir) {
+    if (isVaultLoadedPersonaDir(personaDirPath)) {
       // Same persona, transient open failure — keep what we already injected.
       return { updated, removed, badKeys: [] };
     }
@@ -519,7 +485,7 @@ export async function loadVaultIntoEnv(
       tracked.delete(k);
       removed.push(k);
     }
-    _vaultLoadedPersonaDir = undefined;
+    noteVaultLoadedPersonaDir(undefined);
     return { updated, removed, badKeys: [] };
   }
 
@@ -553,7 +519,7 @@ export async function loadVaultIntoEnv(
     }
   }
 
-  _vaultLoadedPersonaDir = personaDirPath;
+  noteVaultLoadedPersonaDir(personaDirPath);
   return { updated, removed, badKeys };
 }
 

--- a/src/lib/vaultEnvTracking.ts
+++ b/src/lib/vaultEnvTracking.ts
@@ -1,0 +1,82 @@
+/**
+ * Provenance of the vault secrets THIS process injected into `process.env`.
+ *
+ * Extracted from `vault.ts` so it can be imported by `config.ts` (#514).
+ * `vault.ts` imports `loadConfig`, so a `config.ts -> vault.ts` edge would
+ * close an import cycle; this module deliberately imports NOTHING, which lets
+ * both sides read the same registry without one.
+ *
+ * The registry answers one question, asked wherever code resolves a secret for
+ * a persona that may not be the one loaded at startup: did this value come
+ * from a vault, and if so, WHOSE? An ambient key (shell export, systemd
+ * `Environment=`) is host-wide and safe to fall back to. A vault-injected key
+ * belongs to exactly one persona and must never stand in for another's.
+ *
+ * `vault.ts` owns the writes (`noteVaultInjection` / `forgetVaultInjection` /
+ * `noteVaultLoadedPersonaDir`); everyone else only reads.
+ */
+
+/**
+ * Env keys THIS process injected from a vault. Mirrors envBootstrap's
+ * `_moduleTracked`: it lets a later reload for a DIFFERENT persona reconcile —
+ * updating a key to the new persona's value, or removing it if the new persona
+ * doesn't have it — without ever touching a key that was already in the
+ * environment at boot.
+ */
+const _vaultTracked = new Set<string>();
+
+/** The persona dir whose vault we last successfully injected. */
+let _vaultLoadedPersonaDir: string | undefined;
+
+/**
+ * Record which persona's vault was last injected into `process.env`; pass
+ * `undefined` when a failed open has just stripped the injected keys.
+ */
+export function noteVaultLoadedPersonaDir(
+  personaDirPath: string | undefined,
+): void {
+  _vaultLoadedPersonaDir = personaDirPath;
+}
+
+/**
+ * The live tracking set. `loadVaultIntoEnv` mutates it in place as it
+ * reconciles, and takes it as a defaulted parameter so a test can substitute
+ * an isolated set without touching the process-wide registry.
+ */
+export function vaultTrackedKeys(): Set<string> {
+  return _vaultTracked;
+}
+
+/**
+ * True when `name` in `process.env` was injected there from a VAULT by this
+ * process (rather than inherited from the shell / a systemd `Environment=`).
+ */
+export function isVaultInjectedEnvKey(
+  name: string,
+  tracked: Set<string> = _vaultTracked,
+): boolean {
+  return tracked.has(name);
+}
+
+/**
+ * True when `personaDirPath` is the persona whose vault this process last
+ * injected into `process.env`.
+ *
+ * Lets a resolver tell the two cases a vault-injected key can be in apart. If
+ * the key belongs to a DIFFERENT persona it must never stand in; if it belongs
+ * to THIS persona it is that persona's own secret, still in the environment
+ * because `loadVaultIntoEnv` deliberately leaves injected keys in place when
+ * the same persona's vault fails to open transiently.
+ */
+export function isVaultLoadedPersonaDir(personaDirPath: string): boolean {
+  return (
+    _vaultLoadedPersonaDir !== undefined &&
+    personaDirPath === _vaultLoadedPersonaDir
+  );
+}
+
+/** For tests: reset the module-scope vault env tracking. */
+export function _resetVaultTrackingForTesting(): void {
+  _vaultTracked.clear();
+  _vaultLoadedPersonaDir = undefined;
+}

--- a/tests/cli-doctor-persona-env.test.ts
+++ b/tests/cli-doctor-persona-env.test.ts
@@ -43,13 +43,23 @@ async function writePersonaConfigs(): Promise<void> {
   await writeFile(join(workdir, "config.toml"), "", "utf8");
 }
 
+// Isolate the embedding key: these tests assert "semantic off" for a persona
+// whose config carries no api_key, so a real PHANTOMBOT_GEMINI_API_KEY in the
+// developer's shell (every live phantombot box has one) turns semantic ON and
+// fails the assertion. Saved and restored rather than deleted outright.
+let savedGeminiKey: string | undefined;
+
 function installEnv(): void {
+  savedGeminiKey = process.env.PHANTOMBOT_GEMINI_API_KEY;
+  delete process.env.PHANTOMBOT_GEMINI_API_KEY;
   process.env.PHANTOMBOT_CONFIG = join(workdir, "config.toml");
   process.env.PHANTOMBOT_PERSONAS_DIR = join(workdir, "personas");
   process.env.PHANTOMBOT_STATE = join(workdir, "state.json");
 }
 
 function clearEnv(): void {
+  if (savedGeminiKey === undefined) delete process.env.PHANTOMBOT_GEMINI_API_KEY;
+  else process.env.PHANTOMBOT_GEMINI_API_KEY = savedGeminiKey;
   delete process.env.PHANTOMBOT_CONFIG;
   delete process.env.PHANTOMBOT_PERSONAS_DIR;
   delete process.env.PHANTOMBOT_STATE;

--- a/tests/config-embeddings-vault.test.ts
+++ b/tests/config-embeddings-vault.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Vault-first resolution of the embedding API keys (#514).
+ *
+ * The bug these pin: `buildEmbeddingsConfig` used to read
+ * `process.env.PHANTOMBOT_GEMINI_API_KEY` unconditionally and let it win. On a
+ * multi-persona host `loadVaultIntoEnv` injects exactly ONE persona's vault at
+ * startup, so every other persona embedded with that persona's key — and a
+ * stale row in it silently outranked a working key in everybody's config.toml.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadConfig } from "../src/config.ts";
+import { openPersonaVault } from "../src/lib/vault.ts";
+import {
+  _resetVaultTrackingForTesting,
+  isVaultInjectedEnvKey,
+} from "../src/lib/vaultEnvTracking.ts";
+
+const GEMINI_ENV = "PHANTOMBOT_GEMINI_API_KEY";
+
+let workdir: string;
+let configPath: string;
+let personasDir: string;
+const saved: Record<string, string | undefined> = {};
+
+async function seedVault(persona: string, value: string): Promise<string> {
+  const dir = join(personasDir, persona);
+  await mkdir(dir, { recursive: true });
+  const v = await openPersonaVault(dir);
+  try {
+    v.set(GEMINI_ENV, value);
+  } finally {
+    v.close();
+  }
+  return dir;
+}
+
+beforeEach(async () => {
+  for (const k of [
+    "PHANTOMBOT_CONFIG",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "PHANTOMBOT_PERSONAS_DIR",
+    "PHANTOMBOT_DEFAULT_PERSONA",
+    GEMINI_ENV,
+  ]) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  workdir = await mkdtemp(join(tmpdir(), "phantombot-emb-vault-"));
+  configPath = join(workdir, "config.toml");
+  personasDir = join(workdir, "personas");
+  process.env.PHANTOMBOT_CONFIG = configPath;
+  process.env.XDG_CONFIG_HOME = join(workdir, "xdg-config");
+  process.env.XDG_DATA_HOME = join(workdir, "xdg-data");
+  process.env.PHANTOMBOT_PERSONAS_DIR = personasDir;
+  process.env.PHANTOMBOT_DEFAULT_PERSONA = "phantom";
+  _resetVaultTrackingForTesting();
+});
+
+afterEach(async () => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  _resetVaultTrackingForTesting();
+  await rm(workdir, { recursive: true, force: true });
+});
+
+describe("embedding api key — vault first", () => {
+  test("a persona reads the key from its OWN vault, not the injected one", async () => {
+    const { loadVaultIntoEnv } = await import("../src/lib/vault.ts");
+    await seedVault("phantom", "AIza-DEFAULT-PERSONA");
+    await seedVault("kai", "AIza-KAI");
+    // Startup injects the default persona's vault, exactly as the daemon does.
+    await loadVaultIntoEnv(join(personasDir, "phantom"));
+    expect(process.env[GEMINI_ENV]).toBe("AIza-DEFAULT-PERSONA");
+    expect(isVaultInjectedEnvKey(GEMINI_ENV)).toBe(true);
+
+    const kai = await loadConfig("kai");
+    expect(kai.embeddings.provider).toBe("gemini");
+    expect(kai.embeddings.gemini?.apiKey).toBe("AIza-KAI");
+
+    // ...and the loaded persona still gets its own, out of the environment.
+    const phantom = await loadConfig("phantom");
+    expect(phantom.embeddings.gemini?.apiKey).toBe("AIza-DEFAULT-PERSONA");
+  });
+
+  test("another persona's vault key never stands in; config.toml wins instead", async () => {
+    const { loadVaultIntoEnv } = await import("../src/lib/vault.ts");
+    await seedVault("phantom", "AIza-DEFAULT-PERSONA");
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    await loadVaultIntoEnv(join(personasDir, "phantom"));
+
+    await writeFile(
+      configPath,
+      '[embeddings]\nprovider = "gemini"\n\n[embeddings.gemini]\napi_key = "AIza-FILE"\n',
+      "utf8",
+    );
+
+    // kai has no vault row of its own — before #514 it silently embedded with
+    // AIza-DEFAULT-PERSONA. The file is the next legitimate source.
+    const kai = await loadConfig("kai");
+    expect(kai.embeddings.gemini?.apiKey).toBe("AIza-FILE");
+  });
+
+  test("an ambient (non-vault) env export still wins over config.toml", async () => {
+    // Pre-vault hosts set this in the shell or a systemd Environment=; nothing
+    // ever claimed it for a persona, so the long-standing env-beats-TOML rule
+    // is unchanged.
+    process.env[GEMINI_ENV] = "AIza-AMBIENT";
+    await writeFile(
+      configPath,
+      '[embeddings]\nprovider = "gemini"\n\n[embeddings.gemini]\napi_key = "AIza-FILE"\n',
+      "utf8",
+    );
+    const c = await loadConfig("phantom");
+    expect(isVaultInjectedEnvKey(GEMINI_ENV)).toBe(false);
+    expect(c.embeddings.gemini?.apiKey).toBe("AIza-AMBIENT");
+  });
+
+  test("a vault-only key still infers provider=gemini with no [embeddings] block", async () => {
+    await seedVault("kai", "AIza-KAI");
+    const kai = await loadConfig("kai");
+    expect(kai.embeddings.provider).toBe("gemini");
+    expect(kai.embeddings.gemini?.apiKey).toBe("AIza-KAI");
+  });
+
+  test("no vault, no env, no file: provider stays none", async () => {
+    const c = await loadConfig("kai");
+    expect(c.embeddings.provider).toBe("none");
+  });
+
+  test("an unprovisioned persona is not given an identity by a config load", async () => {
+    const { existsSync } = await import("node:fs");
+    await loadConfig("never-seen");
+    expect(existsSync(join(personasDir, "never-seen", "identity.json"))).toBe(
+      false,
+    );
+    expect(existsSync(join(personasDir, "never-seen", "vault.sqlite"))).toBe(
+      false,
+    );
+  });
+
+  test("a persona's own config.toml key beats the host file", async () => {
+    await writeFile(
+      configPath,
+      '[embeddings]\nprovider = "gemini"\n\n[embeddings.gemini]\napi_key = "AIza-HOST"\n',
+      "utf8",
+    );
+    await mkdir(join(personasDir, "kai"), { recursive: true });
+    await writeFile(
+      join(personasDir, "kai", "config.toml"),
+      '[embeddings.gemini]\napi_key = "AIza-KAI-FILE"\n',
+      "utf8",
+    );
+    const kai = await loadConfig("kai");
+    expect(kai.embeddings.gemini?.apiKey).toBe("AIza-KAI-FILE");
+  });
+});


### PR DESCRIPTION
Part of #514. Read path only — the wizard write target is #515.

## The bug

`buildEmbeddingsConfig` resolved the key as `process.env.PHANTOMBOT_GEMINI_API_KEY ?? toml.api_key`. Env wins, unconditionally, and the name is not persona-suffixed. But `loadVaultIntoEnv()` injects exactly **one** persona's vault into `process.env` at startup — the default persona's. Three consequences:

- every persona on a multi-persona host embeds with the **default persona's** key;
- a secondary persona's own vault row is unreachable — nothing reads that vault for embeddings;
- a stale row in that one vault silently outranks a working `api_key` in **every** persona's `config.toml`. Recall quietly degrades to FTS-only while `/status` and `doctor` still report `provider = "gemini"`.

That last one is how this was found on a live host.

## The fix

Precedence, highest first:

1. **this persona's vault** — via the injected `process.env` value when it is the loaded persona, read directly from `vault.sqlite` when it is not;
2. a **host-wide ambient env export** (shell, systemd `Environment=`) — pre-vault hosts depend on it, and env-beats-TOML is unchanged everywhere else in `config.ts`, so it is unchanged here;
3. the persona's effective `config.toml`.

Deliberately absent: an env value injected from a **different** persona's vault. That is the same rule `ambientEnvKeyAllowed()` already applies to the audio path and to `tick --secret`; embeddings were simply never migrated onto the doctrine.

Applies to `PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY` as well. The non-secret overrides beside it (`base_url`, `model`, `dims`, prefixes) are plain host settings and keep env-wins.

## Notes for review

- **No new per-load cost on the common path.** `readEmbeddingSecretsFromVault` returns early when the persona *is* the loaded one, so a single-persona host never opens the vault during `loadConfig`.
- **Open-existing-only.** `openPersonaVault` mints an `identity.json` (and an nsec) on demand, so the read is gated on `existsSync(vaultPath(dir))` — same rule as `readAllVaultValues` (#262). There is a test that a config load for an unknown persona name provisions nothing.
- **Import cycle.** `vault.ts` imports `loadConfig`, so `config.ts` could not statically import the provenance predicates. The registry (`_vaultTracked`, `_vaultLoadedPersonaDir`, `isVaultInjectedEnvKey`, `isVaultLoadedPersonaDir`) moves to a new **leaf** module `src/lib/vaultEnvTracking.ts` that imports nothing; `vault.ts` re-exports the predicates so no caller changes. The vault *open* still genuinely needs `vault.ts`, so that one is a dynamic `import()` inside the async helper, commented as such.
- **Shadow warning.** Once per process per key, when `config.toml` holds an `api_key` that is being overridden. Names only, never values. This is the state that made the bug invisible, and the wizard still writes to that end until #515 lands.
- **Test isolation fix.** `cli-doctor-persona-env` asserts "semantic off" for a persona with no `api_key`, while inheriting a real `PHANTOMBOT_GEMINI_API_KEY` from the developer's shell — so it failed on every live phantombot box. Saved/restored now, not deleted.

## Verification

- New `tests/config-embeddings-vault.test.ts`, 7 tests: own-vault-over-injected, cross-persona value refused (file wins instead), ambient export still beats TOML, vault-only key still infers `provider = "gemini"`, nothing-anywhere stays `none`, no identity minted for an unprovisioned persona, persona `config.toml` beats host.
- Full suite **4298 pass / 0 fail / 2 skip** (was 4297/1 — the doctor test above), `tsc --noEmit` clean.