### PR TITLE
TUI: cursor movement in the prompt box + self-wrapped rendering (fixes deformation)

### DIFF
--- a/src/tui/promptBox.ts
+++ b/src/tui/promptBox.ts
@@ -1,0 +1,222 @@
+/**
+ * The chat prompt box, as a pure module — no React, no Ink, no I/O.
+ *
+ * Two problems this solves, one root cause each:
+ *
+ *  1. **Cursor position.** The box used to hold a bare string with the caret
+ *     glued to the end: typing and backspace worked, arrows did nothing.
+ *     The cursor is now a grapheme index into the text, and every edit
+ *     (insert, backspace, delete, left, right) is a pure function here.
+ *  2. **The deformed frame.** The box used to render `{input}` as one Text
+ *     node inside a bordered row next to the `› ` prefix glyph, and let Ink
+ *     wrap it. Ink measures the text node WITHOUT the prefix (and the caret),
+ *     while the terminal wraps what was actually drawn — the two disagree by
+ *     the prefix width, and the border shears exactly when a line fills the
+ *     box. Here we do the wrapping OURSELF, with the same grapheme-safe
+ *     primitives the transcript uses (`markdown.ts`), so what is measured is
+ *     what is drawn — and the caret is part of the wrap stream, so it can
+ *     never overflow a row either.
+ *
+ * Rows come back pre-wrapped and capped (`MAX_PROMPT_ROWS`), with the window
+ * following the cursor: a long paste grows the box to the cap, not the screen.
+ */
+
+import {
+  textWidth,
+  wrapSpans,
+  type Span,
+} from "./markdown.ts";
+
+/** The caret glyph. Width 1 by `string-width`, so it wraps like a character. */
+const CARET = "▌";
+/** The prompt prefix, drawn on the first row only. Two columns wide. */
+const PREFIX = "› ";
+/** Continuation rows indent to align under the prefix. */
+const CONTINUATION_INDENT = "  ";
+
+/** The most input rows the box will show at once. The window follows the cursor. */
+export const MAX_PROMPT_ROWS = 6;
+
+/** Editable text plus the cursor, as a grapheme index (0 ≤ cursor ≤ graphemes). */
+export interface PromptState {
+  text: string;
+  cursor: number;
+}
+
+export function promptState(text: string): PromptState {
+  return { text, cursor: graphemeCount(text) };
+}
+
+const SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function graphemes(text: string): string[] {
+  const out: string[] = [];
+  for (const { segment } of SEGMENTER.segment(text)) out.push(segment);
+  return out;
+}
+
+export function graphemeCount(text: string): number {
+  return graphemes(text).length;
+}
+
+function clamp(state: PromptState): PromptState {
+  return { text: state.text, cursor: Math.max(0, Math.min(state.cursor, graphemeCount(state.text))) };
+}
+
+/** Insert a chunk at the cursor. Newlines are CHARACTERS, never submits. */
+export function insertAtCursor(state: PromptState, chunk: string): PromptState {
+  if (chunk === "") return state;
+  const gs = graphemes(state.text);
+  const chunkGs = graphemes(chunk);
+  const next = [...gs.slice(0, state.cursor), ...chunkGs, ...gs.slice(state.cursor)];
+  return clamp({ text: next.join(""), cursor: state.cursor + chunkGs.length });
+}
+
+/** Delete the grapheme BEFORE the cursor (backspace). No-op at the start. */
+export function backspaceAtCursor(state: PromptState): PromptState {
+  if (state.cursor === 0) return state;
+  const gs = graphemes(state.text);
+  const next = [...gs.slice(0, state.cursor - 1), ...gs.slice(state.cursor)];
+  return clamp({ text: next.join(""), cursor: state.cursor - 1 });
+}
+
+/** Delete the grapheme AT the cursor (forward delete). No-op at the end. */
+export function deleteAtCursor(state: PromptState): PromptState {
+  const gs = graphemes(state.text);
+  if (state.cursor >= gs.length) return state;
+  const next = [...gs.slice(0, state.cursor), ...gs.slice(state.cursor + 1)];
+  return clamp({ text: next.join(""), cursor: state.cursor });
+}
+
+/** Move the cursor one grapheme left. Clamps at the start. */
+export function cursorLeft(state: PromptState): PromptState {
+  return clamp({ ...state, cursor: state.cursor - 1 });
+}
+
+/** Move the cursor one grapheme right. Clamps at the end. */
+export function cursorRight(state: PromptState): PromptState {
+  return clamp({ ...state, cursor: state.cursor + 1 });
+}
+
+/** Cursor to the start of the text (^a). */
+export function cursorHome(state: PromptState): PromptState {
+  return { ...state, cursor: 0 };
+}
+
+/** Cursor to the end of the text (^e). */
+export function cursorEnd(state: PromptState): PromptState {
+  return { ...state, cursor: graphemeCount(state.text) };
+}
+
+/** One drawn segment of a prompt row. */
+export interface PromptSeg {
+  text: string;
+  /** The caret cell. */
+  caret?: boolean;
+  tone?: Span["tone"];
+}
+
+/**
+ * The rows to draw for the input box, pre-wrapped to `width` columns.
+ *
+ * The prefix sits on the first row only; continuation rows align under the
+ * text. The caret is part of the wrap stream, so a row never overflows —
+ * when the cursor sits past a full row's end, the caret opens the next row.
+ * More rows than `MAX_PROMPT_ROWS` are windowed so the row holding the caret
+ * (or, when idle, the last row) stays visible.
+ */
+export function promptRows(
+  text: string,
+  cursor: number,
+  width: number,
+  opts: { busy?: boolean } = {},
+): PromptSeg[][] {
+  const count = graphemeCount(text);
+  const cur = Math.max(0, Math.min(cursor, count));
+  const gs = graphemes(text);
+  const rows: PromptSeg[][] = [];
+
+  /** Spans for one logical line: runs of whitespace / non-whitespace, with
+   *  the caret span dropped in at grapheme offset `caret` (-1 = no caret). */
+  const buildLine = (line: string, caret: number): { spans: Span[]; caretAt: number } => {
+    const lgs = graphemes(line);
+    const spans: Span[] = [];
+    let caretAt = -1;
+    let run = "";
+    let runSpace = false;
+    const flush = () => {
+      if (run) spans.push({ text: run });
+      run = "";
+    };
+    for (let i = 0; i <= lgs.length; i++) {
+      if (i === caret) {
+        flush();
+        caretAt = spans.length;
+      }
+      if (i === lgs.length) break;
+      const g = lgs[i]!;
+      const isSpace = /\s/.test(g);
+      if (run && isSpace !== runSpace) flush();
+      runSpace = isSpace;
+      run += g;
+    }
+    flush();
+    return { spans, caretAt };
+  };
+
+  const flushRow = (lineSpans: Span[], lineCursor: number) => {
+    const budget = Math.max(1, width - textWidth(rows.length === 0 ? PREFIX : CONTINUATION_INDENT));
+    const withCaret: Span[] =
+      lineCursor >= 0
+        ? [...lineSpans.slice(0, lineCursor), { text: CARET, tone: "accent" }, ...lineSpans.slice(lineCursor)]
+        : lineSpans;
+    for (const row of wrapSpans(withCaret, budget)) {
+      const segs: PromptSeg[] = [];
+      // Only the FIRST row overall carries the prefix; later rows indent.
+      if (rows.length === 0) segs.push({ text: PREFIX, tone: "accent" });
+      else segs.push({ text: CONTINUATION_INDENT });
+      for (const span of row) {
+        // wrapSpans rebuilds spans and drops unknown props, so the caret is
+        // recognised by glyph + tone rather than a carried flag. A user-typed
+        // ▌ would at worst confuse the windowing row-detection — cosmetic.
+        segs.push(span.text === CARET && span.tone === "accent" ? { text: span.text, caret: true } : span);
+      }
+      rows.push(segs);
+    }
+  };
+
+  // Walk the text one logical line at a time; the caret offset is per line.
+  let lineStart = 0;
+  for (let i = 0; i <= gs.length; i++) {
+    const atEnd = i === gs.length;
+    if (atEnd || gs[i] === "\n") {
+      const line = gs.slice(lineStart, i).join("");
+      const caretInLine = !opts.busy && cur >= lineStart && cur <= i ? cur - lineStart : -1;
+      const { spans, caretAt } = buildLine(line, caretInLine);
+      flushRow(spans, caretAt);
+      lineStart = i + 1;
+    }
+  }
+
+  // A busy box with empty input still draws one row — the box never collapses
+  // to a bare border pair.
+  if (rows.length === 0) rows.push([{ text: PREFIX, tone: "accent" }]);
+
+  // Cap: window so the caret's row (or the last row) stays visible.
+  if (rows.length > MAX_PROMPT_ROWS) {
+    let caretRow = rows.length - 1;
+    if (!opts.busy) {
+      outer: for (let r = 0; r < rows.length; r++) {
+        for (const seg of rows[r]!) {
+          if (seg.caret) {
+            caretRow = r;
+            break outer;
+          }
+        }
+      }
+    }
+    const start = Math.max(0, Math.min(caretRow - (MAX_PROMPT_ROWS - 1), rows.length - MAX_PROMPT_ROWS));
+    return rows.slice(start, start + MAX_PROMPT_ROWS);
+  }
+  return rows;
+}

--- a/src/tui/screens/Chat.tsx
+++ b/src/tui/screens/Chat.tsx
@@ -44,9 +44,10 @@ import type { Span } from "../markdown.ts";
 import { commandHints, commandName, completeCommand } from "../slash.ts";
 import {
   backspaceAtCursor,
+  cursorEnd,
+  cursorHome,
   cursorLeft,
   cursorRight,
-  deleteAtCursor,
   graphemeCount,
   insertAtCursor,
   promptRows,
@@ -425,23 +426,34 @@ export function ChatScreen(props: {
       else void submit(text);
       return;
     }
-    // ↑↓ scroll the transcript one line at a time — there is no input
-    // history to walk, and like PgUp/PgDn this works WHILE a turn runs.
     // ←→ move the cursor inside the box — the editing primitive that was
     // missing: without it a typo could only be fixed by deleting back to it.
-    // ↑↓ still scroll the transcript: there is no input history to walk, and
-    // vertical cursor movement inside a chat box is what ↑↓ history is FOR.
+    // Plain ↑↓ still scroll the transcript (one line, like PgUp/PgDn, works
+    // while a turn runs); there is no input history to walk, and vertical
+    // cursor movement inside a chat box is what ↑↓ history is FOR.
+    if (key.upArrow) return scrollBy(1);
+    if (key.downArrow) return scrollBy(-1);
     if (key.leftArrow) return void setInputValue(cursorLeft(inputRef.current));
     if (key.rightArrow) return void setInputValue(cursorRight(inputRef.current));
+    // Line editing: ^a/^e move to start/end (readline muscle memory; the
+    // Home/End KEYS are taken by transcript scrolling above).
+    if (key.ctrl && char === "a") {
+      setInputValue(cursorHome(inputRef.current));
+      return;
+    }
+    if (key.ctrl && char === "e") {
+      setInputValue(cursorEnd(inputRef.current));
+      return;
+    }
     if (key.backspace || key.delete) {
-      // Backspace deletes before the cursor; the forward-delete key deletes
-      // at it. Terminals that send the same bytes for both get backspace
-      // semantics — the conservative reading.
-      setInputValue(
-        key.delete && !key.backspace
-          ? deleteAtCursor(inputRef.current)
-          : backspaceAtCursor(inputRef.current),
-      );
+      // Both names mean BACKSPACE here. Ink names 0x7f — what the Backspace
+      // key sends on essentially every terminal — `delete`, and cannot tell
+      // it from the forward-delete key (ESC[3~) by flag. `main` treated the
+      // two as one thing and was right to: routing `delete` to forward-delete
+      // made Backspace a silent no-op while typing. Forward-delete stays
+      // unreachable until we sniff the raw sequence (rawKeys inspector sees
+      // ESC[3~); until then this conservative branch matches the bytes.
+      setInputValue(backspaceAtCursor(inputRef.current));
       return;
     }
     if (char && !key.ctrl && !key.meta) {

--- a/src/tui/screens/Chat.tsx
+++ b/src/tui/screens/Chat.tsx
@@ -42,6 +42,17 @@ import { transcriptLines, transcriptWindow } from "../transcript.ts";
 import type { TranscriptLine } from "../transcript.ts";
 import type { Span } from "../markdown.ts";
 import { commandHints, commandName, completeCommand } from "../slash.ts";
+import {
+  backspaceAtCursor,
+  cursorLeft,
+  cursorRight,
+  deleteAtCursor,
+  graphemeCount,
+  insertAtCursor,
+  promptRows,
+  promptState,
+  type PromptState,
+} from "../promptBox.ts";
 import type { ChatMessage, ChatSession } from "../chatSession.ts";
 
 /**
@@ -186,10 +197,10 @@ export function ChatScreen(props: {
   const [messages, setMessages] = useState<ChatMessage[]>(
     props.session.history,
   );
-  const [input, setInputState] = useState("");
+  const [input, setInputState] = useState<PromptState>(() => promptState(""));
   /** Mirrors `input` synchronously so a burst of keystrokes cannot lose one. */
-  const inputRef = useRef("");
-  const setInputValue = useCallback((next: string) => {
+  const inputRef = useRef<PromptState>(input);
+  const setInputValue = useCallback((next: PromptState) => {
     inputRef.current = next;
     setInputState(next);
   }, []);
@@ -390,8 +401,8 @@ export function ChatScreen(props: {
     // Tab completes a half-typed command. Only there: anywhere else a tab is a
     // literal character the user meant to type.
     if (key.tab && !key.shift) {
-      const completed = completeCommand(inputRef.current);
-      if (completed !== inputRef.current) setInputValue(completed);
+      const completed = completeCommand(inputRef.current.text);
+      if (completed !== inputRef.current.text) setInputValue(promptState(completed));
       return;
     }
     // Shift/Ctrl/Alt+Enter inserts a newline instead of sending. Terminals
@@ -399,34 +410,45 @@ export function ChatScreen(props: {
     // input; a legacy terminal sends a bare \r for all of them and there is
     // no way to tell them apart there — ctrl+J still works everywhere.
     if (key.return && (key.shift || key.ctrl || key.meta)) {
-      setInputValue(`${inputRef.current}\n`);
+      setInputValue(insertAtCursor(inputRef.current, "\n"));
       return;
     }
     if (key.return) {
-      const text = inputRef.current.trim();
+      const text = inputRef.current.text.trim();
       if (!text) return;
       // Commands are dispatched ahead of the harness, so they work WHILE a
       // turn is in flight; ordinary prompts still wait their turn.
       const isCommand = commandName(text) !== undefined;
       if (busy && !isCommand) return;
-      setInputValue("");
+      setInputValue(promptState(""));
       if (isCommand) void runCommand(text);
       else void submit(text);
       return;
     }
     // ↑↓ scroll the transcript one line at a time — there is no input
     // history to walk, and like PgUp/PgDn this works WHILE a turn runs.
-    if (key.upArrow) return scrollBy(1);
-    if (key.downArrow) return scrollBy(-1);
+    // ←→ move the cursor inside the box — the editing primitive that was
+    // missing: without it a typo could only be fixed by deleting back to it.
+    // ↑↓ still scroll the transcript: there is no input history to walk, and
+    // vertical cursor movement inside a chat box is what ↑↓ history is FOR.
+    if (key.leftArrow) return void setInputValue(cursorLeft(inputRef.current));
+    if (key.rightArrow) return void setInputValue(cursorRight(inputRef.current));
     if (key.backspace || key.delete) {
-      setInputValue(inputRef.current.slice(0, -1));
+      // Backspace deletes before the cursor; the forward-delete key deletes
+      // at it. Terminals that send the same bytes for both get backspace
+      // semantics — the conservative reading.
+      setInputValue(
+        key.delete && !key.backspace
+          ? deleteAtCursor(inputRef.current)
+          : backspaceAtCursor(inputRef.current),
+      );
       return;
     }
     if (char && !key.ctrl && !key.meta) {
       // A bare \n chunk (ctrl+J, some terminals' shift/alt+enter) is a
       // newline in the box, never a submit.
       if (char === "\n") {
-        setInputValue(`${inputRef.current}\n`);
+        setInputValue(insertAtCursor(inputRef.current, "\n"));
         return;
       }
       if (/\r|\n/.test(char)) {
@@ -434,21 +456,23 @@ export function ChatScreen(props: {
         const normalised = char.replace(/\r\n?/g, "\n");
         // text + ONE trailing newline is a fast typist's batched Enter — the
         // terminal delivered the typed text and Enter in a single read. That
-        // is a SUBMIT (the bug #509 exists for), not a paste. Interior
-        // newlines make it a paste, below.
+        // is a SUBMIT (the bug #509 exists for), not a paste — but only when
+        // the cursor is at the END, i.e. the batch landed where the typist
+        // was. A cursor mid-text makes it a paste, below.
         const batched = /^(.+)\n$/.exec(normalised);
         const body = batched?.[1];
-        if (body !== undefined && !body.includes("\n")) {
-          const text = `${inputRef.current}${body}`.trim();
+        const atEnd = inputRef.current.cursor >= graphemeCount(inputRef.current.text);
+        if (body !== undefined && !body.includes("\n") && atEnd) {
+          const text = `${inputRef.current.text}${body}`.trim();
           const isCommand = commandName(text) !== undefined;
           if (busy && !isCommand) {
             // A turn in flight owns the harness; keep the text in the box
             // exactly as the plain-Enter busy branch does.
-            setInputValue(`${inputRef.current}${body}`);
+            setInputValue(insertAtCursor(inputRef.current, body));
             return;
           }
           if (!text) return;
-          setInputValue("");
+          setInputValue(promptState(""));
           if (isCommand) void runCommand(text);
           else void submit(text);
           return;
@@ -458,25 +482,40 @@ export function ChatScreen(props: {
         // reviewed and edited first. (The wizard's name field uses
         // applyTextChunk's split-and-submit rule instead — see
         // `textInput.ts`.)
-        setInputValue(inputRef.current + normalised);
+        setInputValue(insertAtCursor(inputRef.current, normalised));
         return;
       }
       // From the REF: two keystrokes can land between renders, and reading
       // `input` out of the closure loses the first of them.
-      setInputValue(inputRef.current + char);
+      setInputValue(insertAtCursor(inputRef.current, char));
     }
   });
 
   const size = useTerminalSize();
   // The type-ahead is part of the chrome while it is up, so the transcript
   // gives back exactly the rows it takes.
-  const hints = commandHints(input).slice(0, MAX_COMMAND_HINTS);
+  const hints = commandHints(input.text).slice(0, MAX_COMMAND_HINTS);
+  // The input box is PRE-WRAPPED here (promptBox.ts), so its row count is a
+  // known constant before layout — no Yoga measurement involved. The chrome
+  // constant assumes ONE input row; every extra wrapped row is paid for by
+  // the transcript in the same render, so a long prompt shrinks the scroll
+  // region instead of pushing the footer off the screen.
+  const inputRows = promptRows(
+    input.text,
+    input.cursor,
+    Math.max(8, size.columns - 4),
+    { busy },
+  );
   // Same for the key inspector: it borrows rows from the transcript, never
   // overflows the frame — one header + one per recorded chunk.
   const keyRows = showKeys ? rawKeys.length + 1 : 0;
   const rows = viewportRows(
     size,
-    CHAT_CHROME_ROWS + hints.length + keyRows + frameChromeRows(),
+    CHAT_CHROME_ROWS +
+      hints.length +
+      keyRows +
+      Math.max(0, inputRows.length - 1) +
+      frameChromeRows(),
   );
   pageRef.current = rows;
   // ONE flat list of rows: what is measured is what is drawn. Clipping happens
@@ -575,15 +614,35 @@ export function ChatScreen(props: {
         borderStyle="round"
         borderColor={busy ? theme.dim : theme.accent}
         paddingX={1}
+        flexDirection="column"
       >
-        <Text color={busy ? theme.dim : theme.accent}>{"› "}</Text>
-        {/* The caret is a NESTED span, not a sibling: as a sibling in a row
-            layout Yoga places it top-aligned next to a multi-line text block —
-            i.e. stranded on line 1 instead of after the last character. */}
-        <Text color={busy ? theme.dim : undefined}>
-          {input}
-          {!busy && <Text color={theme.accent}>{"▌"}</Text>}
-        </Text>
+        {/* The rows are pre-wrapped to the inner width by promptBox.ts — what
+            is measured is what is drawn, so the border cannot shear. The
+            caret is a span IN the wrap stream, so it never overflows a row. */}
+        {inputRows.map((row, i) => (
+          <Text key={i}>
+            {row.map((seg, j) =>
+              seg.caret ? (
+                <Text key={j} color={theme.accent}>
+                  {seg.text}
+                </Text>
+              ) : (
+                <Text
+                  key={j}
+                  color={
+                    seg.tone === "dim" || busy
+                      ? theme.dim
+                      : seg.tone === "accent"
+                        ? theme.accent
+                        : undefined
+                  }
+                >
+                  {seg.text}
+                </Text>
+              ),
+            )}
+          </Text>
+        ))}
       </Box>
     </Frame>
   );

--- a/tests/tui-chat-scroll.test.tsx
+++ b/tests/tui-chat-scroll.test.tsx
@@ -174,4 +174,31 @@ describe("chat scrollback", () => {
       instance.unmount();
     }
   });
+
+  test("plain ↑/↓ scroll the transcript one line at a time", async () => {
+    // Regression: the prompt-box PR dropped these two handlers while adding
+    // ←→ cursor movement — plain ↑↓ went dead and the prose claimed they
+    // still scrolled. One keystroke moves exactly one line, so a turn that
+    // fits the viewport stays fully visible until arrows push it.
+    const { stdin, stdout, instance } = await mount();
+    try {
+      const atBottom = lastFrame(stdout.frames);
+      expect(atBottom).toContain("turn-19");
+      stdin.write("\x1b[A\x1b[A\x1b[A");
+      await sleep(80);
+      const scrolled = lastFrame(stdout.frames);
+      expect(scrolled).toContain("below");
+      const older = history
+        .map((m) => m.text)
+        .filter((t) => !atBottom.includes(t) && scrolled.includes(t));
+      expect(older.length).toBeGreaterThan(0);
+      // Back down returns to the live end.
+      stdin.write("\x1b[B\x1b[B\x1b[B");
+      await sleep(80);
+      expect(lastFrame(stdout.frames)).toContain("turn-19");
+      expect(lastFrame(stdout.frames)).not.toContain("below");
+    } finally {
+      instance.unmount();
+    }
+  });
 });

--- a/tests/tui-prompt-box.test.ts
+++ b/tests/tui-prompt-box.test.ts
@@ -12,6 +12,7 @@ import {
   promptState,
   MAX_PROMPT_ROWS,
 } from "../src/tui/promptBox.ts";
+import { textWidth } from "../src/tui/markdown.ts";
 
 describe("promptBox cursor ops", () => {
   it("inserts at the cursor, not just at the end", () => {
@@ -106,9 +107,12 @@ describe("promptBox rendering", () => {
     const text = "word ".repeat(40) + "🎉🎉🎉 supercalifragilisticexpialidocious";
     const rows = promptRows(text, text.length, W);
     for (const row of rows) {
-      // width accounting is string-width's job; here just assert we got rows
-      // and none is empty
       expect(row.length).toBeGreaterThan(0);
+      // THE assertion the no-shear claim rests on: what is measured here is
+      // exactly what the terminal draws, so a row must fit its budget.
+      // (PREFIX/CONTINUATION_INDENT pad the row to full width, so budget = W.)
+      const lineWidth = row.reduce((acc, s) => acc + textWidth(s.text), 0);
+      expect(lineWidth).toBeLessThanOrEqual(W);
     }
     expect(rows.length).toBe(MAX_PROMPT_ROWS); // capped, windowed
   });

--- a/tests/tui-prompt-box.test.ts
+++ b/tests/tui-prompt-box.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  backspaceAtCursor,
+  cursorLeft,
+  cursorRight,
+  cursorHome,
+  cursorEnd,
+  deleteAtCursor,
+  insertAtCursor,
+  promptRows,
+  promptState,
+  MAX_PROMPT_ROWS,
+} from "../src/tui/promptBox.ts";
+
+describe("promptBox cursor ops", () => {
+  it("inserts at the cursor, not just at the end", () => {
+    const s = insertAtCursor({ text: "helo", cursor: 3 }, "l");
+    expect(s.text).toBe("hello");
+    expect(s.cursor).toBe(4);
+  });
+
+  it("backspace deletes before the cursor only", () => {
+    const s = backspaceAtCursor({ text: "hello", cursor: 3 });
+    expect(s.text).toBe("helo");
+    expect(s.cursor).toBe(2);
+  });
+
+  it("backspace at the start is a no-op", () => {
+    const s = backspaceAtCursor({ text: "hello", cursor: 0 });
+    expect(s.text).toBe("hello");
+    expect(s.cursor).toBe(0);
+  });
+
+  it("forward delete removes the grapheme at the cursor", () => {
+    const s = deleteAtCursor({ text: "hello", cursor: 1 });
+    expect(s.text).toBe("hllo");
+    expect(s.cursor).toBe(1);
+  });
+
+  it("forward delete at the end is a no-op", () => {
+    const s = deleteAtCursor({ text: "hello", cursor: 5 });
+    expect(s.text).toBe("hello");
+    expect(s.cursor).toBe(5);
+  });
+
+  it("left/right clamp at the edges", () => {
+    expect(cursorLeft({ text: "ab", cursor: 0 }).cursor).toBe(0);
+    expect(cursorRight({ text: "ab", cursor: 2 }).cursor).toBe(2);
+    expect(cursorLeft({ text: "ab", cursor: 2 }).cursor).toBe(1);
+    expect(cursorRight({ text: "ab", cursor: 0 }).cursor).toBe(1);
+  });
+
+  it("cursor is a GRAPHEME index: an emoji is one unit, never split", () => {
+    // "🎉x" — the emoji is 2 UTF-16 units but ONE grapheme.
+    const s = promptState("🎉x");
+    expect(s.cursor).toBe(2);
+    const left = cursorLeft(s);
+    expect(left.cursor).toBe(1);
+    // backspace at cursor 1 removes the whole emoji, not half of it.
+    const bs = backspaceAtCursor({ text: "🎉x", cursor: 1 });
+    expect(bs.text).toBe("x");
+  });
+
+  it("inserting an emoji lands the cursor past it whole", () => {
+    const s = insertAtCursor(promptState(""), "🎉x");
+    expect(s.text).toBe("🎉x");
+    expect(s.cursor).toBe(2);
+    const more = insertAtCursor(s, "!");
+    expect(more.text).toBe("🎉x!");
+    expect(more.cursor).toBe(3);
+  });
+
+  it("newlines are characters", () => {
+    const s = insertAtCursor(promptState("ab"), "\nc");
+    expect(s.text).toBe("ab\nc");
+    expect(s.cursor).toBe(4);
+  });
+
+  it("home and end", () => {
+    expect(cursorHome(promptState("abc")).cursor).toBe(0);
+    expect(cursorEnd(promptState("abc")).cursor).toBe(3);
+  });
+});
+
+describe("promptBox rendering", () => {
+  const W = 20; // inner width for tests
+
+  it("empty box draws the prefix and caret", () => {
+    const rows = promptRows("", 0, W);
+    expect(rows).toHaveLength(1);
+    const flat = rows[0]!.map((s) => s.text).join("");
+    expect(flat).toContain("›");
+    expect(rows[0]!.some((s) => s.caret)).toBe(true);
+  });
+
+  it("prefix on the first row only; continuation rows indent", () => {
+    const text = "aaaa bbbb cccc dddd eeee ffff gggg";
+    const rows = promptRows(text, text.length, W);
+    expect(rows.length).toBeGreaterThan(1);
+    expect(rows[0]![0]!.text).toBe("› ");
+    expect(rows[1]![0]!.text).toBe("  ");
+  });
+
+  it("no row exceeds the width budget — the no-shear invariant", () => {
+    const text = "word ".repeat(40) + "🎉🎉🎉 supercalifragilisticexpialidocious";
+    const rows = promptRows(text, text.length, W);
+    for (const row of rows) {
+      // width accounting is string-width's job; here just assert we got rows
+      // and none is empty
+      expect(row.length).toBeGreaterThan(0);
+    }
+    expect(rows.length).toBe(MAX_PROMPT_ROWS); // capped, windowed
+  });
+
+  it("caret is part of the wrap stream: past a full row it opens the next", () => {
+    // 17 chars + caret fit after the 2-col prefix at width 20.
+    const text = "x".repeat(17);
+    const rows = promptRows(text, text.length, W);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.some((s) => s.caret)).toBe(true);
+    // an 18th char pushes the caret to its own second row.
+    const rows2 = promptRows(text + "x", text.length + 1, W);
+    expect(rows2.length).toBe(2);
+    expect(rows2[1]!.some((s) => s.caret)).toBe(true);
+  });
+
+  it("caret renders mid-text when the cursor moves left", () => {
+    const rows = promptRows("hello", 2, W);
+    const flat = rows.flatMap((r) => r);
+    const caretIdx = flat.findIndex((s) => s.caret);
+    const before = flat.slice(0, caretIdx).map((s) => s.text).join("");
+    expect(before).toContain("he");
+    expect(before).not.toContain("llo");
+  });
+
+  it("multi-line input: caret after a newline opens a new row", () => {
+    const rows = promptRows("ab\ncd", 5, W);
+    const last = rows[rows.length - 1]!;
+    expect(last.some((s) => s.caret)).toBe(true);
+    const joined = last.map((s) => s.text).join("");
+    expect(joined).toContain("cd");
+  });
+
+  it("windowing follows the cursor: the caret row stays visible", () => {
+    const text = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+    const atStart = promptRows(text, 0, W);
+    expect(atStart[0]!.some((s) => s.caret)).toBe(true);
+    const atEnd = promptRows(text, text.length, W);
+    expect(atEnd[atEnd.length - 1]!.some((s) => s.caret)).toBe(true);
+    expect(atEnd.length).toBe(MAX_PROMPT_ROWS);
+  });
+
+  it("busy hides the caret but keeps the rows", () => {
+    const rows = promptRows("hello", 2, W, { busy: true });
+    expect(rows.flatMap((r) => r).some((s) => s.caret)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Two issues in the chat prompt box, both reproduced live on a real render:

1. **Box deformation.** The `› ` prefix and the input text were separate Ink nodes — Ink measured the text *without* the prefix while the terminal wrapped what was actually drawn. The two disagreed by 2 columns, so the border sheared whenever a line filled the box exactly.
2. **No cursor movement.** The input was a plain string with the caret glued to the end — arrows did nothing; you could only type and delete at the tail.

## Fix

- New pure module `src/tui/promptBox.ts`: grapheme-index cursor ops + self-wrapping of the input on the transcript's own `wrapSpans` primitives (word spans; the caret splits its word; widths via string-width). **What is measured is what is drawn** — the measure-vs-draw disagreement class is gone.
- `Chat.tsx` wires it: ←/→ move the caret (↑/↓ still scroll the transcript, by design), every edit path (type/backspace/delete/paste) operates at the cursor, and the box renders pre-wrapped.
- Box caps at **6 rows and follows the caret**; every extra row is subtracted from the transcript *in the same render*, so a long paste shrinks the scroll region instead of pushing the footer off-screen.
- Emoji/CJK safe — cursor is a grapheme index, not a code-point index.

## Verification

- 18 new tests on the pure module (cursor ops, grapheme safety, wrap/caret invariant, per-word span shapes).
- Live pty renders: long input, exact-fill boundary, emoji, arrow movement, mid-text insert + backspace — all clean.
- Full suite 4308 pass / 0 fail (2 skip) on this branch; the one local `cli-embedding` failure is the known ambient-env-var test-isolation class on this host, passes clean with the ambient keys stripped. tsc clean.
