### PR TITLE
fix: store embedding keys in persona vault

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -521,6 +521,13 @@ configurable `max_chunk_chars = 5000`. The value is character-based rather
 than an exact token guarantee, and must not be described as a llama.cpp
 protocol limit. Chunking preserves source text exactly, prunes obsolete tail
 chunks, and uses explicit chunk/file accounting.
+The embedding wizard writes credentials
+through `setPersonaSecret` to the RESOLVED persona's vault; only non-secret
+provider settings belong in that persona's `config.toml`. A successful verified
+vault write removes the selected provider's legacy plaintext `api_key`. A
+failed vault write must first preserve the pasted key in `config.toml` and then
+surface the error — never discard the operator's only copy. Keep the startup
+shadow warning while older hosts can still contain file keys.
 
 The TUI creation wizard is transactional from the user's perspective: validate inline, show a review that explicitly says nothing has been written, then create and name the persona directory, `identity.json`, and persona-local `config.toml`. Settings snapshots must preserve config-layer provenance; absence is inheritance, while an explicitly stated empty/tombstone value is still a persona override. Environment overrides are applied after TOML resolution and are not represented by these config-layer labels.
 

--- a/README.md
+++ b/README.md
@@ -2464,19 +2464,20 @@ Equivalent TOML:
 provider = "gemini"
 
 [embeddings.gemini]
-api_key = "AIza..."
 model = "gemini-embedding-001"
 dims = 1536
 ```
 
-The `api_key` here is the LOWEST-precedence source. If this persona's vault
-holds a `PHANTOMBOT_GEMINI_API_KEY` row, that row is the key actually used and
-editing the file changes nothing — Phantombot logs a warning saying so on
-startup. `phantombot vault set PHANTOMBOT_GEMINI_API_KEY` is the place to
-change it, or `phantombot vault unset` it to hand control back to the file.
-The same applies to `[embeddings.openai_compatible] api_key` and
-`PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY`. Keys are per persona: one daemon
-serving several personas resolves each one against its OWN vault.
+`phantombot embedding` writes provider, model, dimensions, prefixes and endpoint
+settings to that persona's `config.toml`, but stores the API key in the
+persona's encrypted vault. After a verified vault write it removes any legacy
+plaintext `api_key` for that provider from the file. If the vault write fails,
+the wizard preserves the pasted key in `config.toml` and reports the failure so
+the credential is recoverable. Existing file keys remain a lowest-precedence
+compatibility source; the startup shadow warning remains during migration.
+Gemini uses `PHANTOMBOT_GEMINI_API_KEY` and OpenAI-compatible uses
+`PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY`. One daemon serving several personas
+resolves each one against its OWN vault.
 
 For a local CPU-only llama.cpp server, start it separately from PhantomBot.
 The server's model and pooling must match the embedding GGUF's model card; for

--- a/src/cli/embedding.ts
+++ b/src/cli/embedding.ts
@@ -17,7 +17,8 @@ import * as p from "@clack/prompts";
 import {
   DEFAULT_OPENAI_COMPATIBLE_MAX_CHUNK_CHARS,
   type Config,
-  loadConfig,
+  loadConfigForPersona,
+  resolvePersona,
 } from "../config.ts";
 import {
   geminiEmbed,
@@ -25,7 +26,13 @@ import {
 } from "../lib/geminiEmbed.ts";
 import { openaiCompatibleEmbed } from "../lib/openaiCompatibleEmbed.ts";
 import { getIn, setIn, updateConfigToml } from "../lib/configWriter.ts";
+import { personaConfigPath } from "../lib/personaConfig.ts";
 import { defaultServiceControl, type ServiceControl } from "../lib/platform.ts";
+import {
+  setPersonaSecret,
+  unsetPersonaSecret,
+  type SetPersonaSecretResult,
+} from "../lib/vaultSecrets.ts";
 import { maybePromptRestart } from "./harness.ts";
 
 const DEFAULT_MODEL = "gemini-embedding-001";
@@ -49,14 +56,62 @@ export interface EmbeddingConfigUpdate {
   openaiCompatible?: OpenAICompatibleConfigUpdate;
 }
 
+export interface ApplyEmbeddingConfigInput {
+  config: Config;
+  persona: string;
+  update: EmbeddingConfigUpdate;
+  /** Test seam for forcing vault failures without touching a real vault. */
+  writeSecret?: (
+    config: Config,
+    name: string,
+    value: string,
+    persona?: string,
+  ) => Promise<SetPersonaSecretResult>;
+  /** Test seam for clearing an optional OpenAI-compatible key. */
+  clearSecret?: typeof unsetPersonaSecret;
+}
+
+function deleteIn(root: Record<string, unknown>, path: readonly string[]): void {
+  let current: Record<string, unknown> = root;
+  for (const key of path.slice(0, -1)) {
+    const next = current[key];
+    if (!next || typeof next !== "object" || Array.isArray(next)) return;
+    current = next as Record<string, unknown>;
+  }
+  delete current[path[path.length - 1]!];
+}
+
 export async function applyEmbeddingConfig(
-  configPath: string,
-  update: EmbeddingConfigUpdate,
+  input: ApplyEmbeddingConfigInput,
 ): Promise<void> {
+  const { config, persona, update } = input;
+  const configPath = personaConfigPath(config.personasDir, persona);
+  const writeSecret = input.writeSecret ?? setPersonaSecret;
+  const clearSecret = input.clearSecret ?? unsetPersonaSecret;
+  let secretResult: SetPersonaSecretResult | undefined;
+  let secretName: string | undefined;
+
+  if (update.provider === "gemini") {
+    secretName = "PHANTOMBOT_GEMINI_API_KEY";
+    secretResult = await writeSecret(
+      config,
+      secretName,
+      update.apiKey ?? "",
+      persona,
+    );
+  } else if (update.provider === "openai-compatible") {
+    secretName = "PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY";
+    const key = update.openaiCompatible?.apiKey ?? "";
+    secretResult = key
+      ? await writeSecret(config, secretName, key, persona)
+      : await clearSecret(config, secretName, persona);
+  }
+
   await updateConfigToml(configPath, (toml) => {
     setIn(toml, ["embeddings", "provider"], update.provider);
     if (update.provider === "gemini") {
-      setIn(toml, ["embeddings", "gemini", "api_key"], update.apiKey ?? "");
+      if (secretResult?.ok) deleteIn(toml, ["embeddings", "gemini", "api_key"]);
+      else setIn(toml, ["embeddings", "gemini", "api_key"], update.apiKey ?? "");
       setIn(
         toml,
         ["embeddings", "gemini", "model"],
@@ -72,7 +127,11 @@ export async function applyEmbeddingConfig(
       if (!o) throw new Error("OpenAI-compatible embedding settings are missing");
       setIn(toml, ["embeddings", "openai_compatible", "base_url"], o.baseUrl);
       setIn(toml, ["embeddings", "openai_compatible", "model"], o.model);
-      setIn(toml, ["embeddings", "openai_compatible", "api_key"], o.apiKey ?? "");
+      if (secretResult?.ok) {
+        deleteIn(toml, ["embeddings", "openai_compatible", "api_key"]);
+      } else {
+        setIn(toml, ["embeddings", "openai_compatible", "api_key"], o.apiKey ?? "");
+      }
       setIn(toml, ["embeddings", "openai_compatible", "dims"], o.dims ?? 0);
       setIn(
         toml,
@@ -96,9 +155,17 @@ export async function applyEmbeddingConfig(
       // the user's key for re-enabling later. Just flip provider to "none".
     }
   });
+
+  if (secretResult && !secretResult.ok) {
+    throw new Error(
+      `embedding: could not store ${secretName} in the ${secretResult.persona ?? persona} vault; ` +
+        `kept the key in config.toml: ${secretResult.error ?? "unknown error"}`,
+    );
+  }
 }
 
 interface RunInput {
+  persona?: string;
   config?: Config;
   validate?: (key: string) => Promise<EmbedResult>;
   validateOpenAI?: (
@@ -118,7 +185,10 @@ interface RunInput {
 }
 
 export async function runEmbedding(input: RunInput = {}): Promise<number> {
-  const config = input.config ?? (await loadConfig());
+  const { config, persona } = input.config
+    ? { config: input.config, persona: resolvePersona(input.persona, input.config) }
+    : await loadConfigForPersona(input.persona);
+  const embeddingConfigPath = personaConfigPath(config.personasDir, persona);
   const svc = input.serviceControl ?? defaultServiceControl();
   const embedded = input.embedded ?? false;
   const validate =
@@ -199,7 +269,7 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
   }
 
   if (provider === "none") {
-    await applyEmbeddingConfig(config.configPath, { provider: "none" });
+    await applyEmbeddingConfig({ config, persona, update: { provider: "none" } });
     p.note(
       `provider set to "none"\n` +
         `search uses OKF field-weighted BM25 + link-graph expansion\n` +
@@ -235,17 +305,22 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
     }
     spinner.stop(`key validated (got ${r.dims} dims)`);
 
-    await applyEmbeddingConfig(config.configPath, {
-      provider: "gemini",
-      apiKey: key as string,
-      model: DEFAULT_MODEL,
-      dims: r.dims,
+    await applyEmbeddingConfig({
+      config,
+      persona,
+      update: {
+        provider: "gemini",
+        apiKey: key as string,
+        model: DEFAULT_MODEL,
+        dims: r.dims,
+      },
     });
     p.note(
       `provider:  gemini\n` +
         `model:     ${DEFAULT_MODEL}\n` +
         `dims:      ${r.dims}\n` +
-        `saved to ${config.configPath}\n\n` +
+        `settings saved to ${embeddingConfigPath}\n` +
+        `API key saved to ${persona}'s encrypted vault\n\n` +
         `cost note: free up to 1500 req/day on the Gemini free tier;\n` +
         `phantombot's nightly cycle re-embeds changed notes only.\n` +
         `After changing provider, model, or document prefix, backfill with:\n` +
@@ -318,16 +393,21 @@ export async function runEmbedding(input: RunInput = {}): Promise<number> {
       return 1;
     }
     spinner.stop(`endpoint validated (got ${r.dims} dims)`);
-    await applyEmbeddingConfig(config.configPath, {
-      provider: "openai-compatible",
-      openaiCompatible: { ...settings, dims: r.dims },
+    await applyEmbeddingConfig({
+      config,
+      persona,
+      update: {
+        provider: "openai-compatible",
+        openaiCompatible: { ...settings, dims: r.dims },
+      },
     });
     p.note(
       `provider:  openai-compatible\n` +
         `base URL:  ${settings.baseUrl}\n` +
         `model:     ${settings.model}\n` +
         `dims:      ${r.dims}\n` +
-        `saved to ${config.configPath}\n\n` +
+        `settings saved to ${embeddingConfigPath}\n` +
+        `${settings.apiKey ? `API key saved to ${persona}'s encrypted vault` : "no API key configured"}\n\n` +
         `After changing provider, model, or document prefix, backfill with:\n` +
         `  phantombot memory index --reembed\n` +
         `Changing query prefix alone does not require rebuilding stored vectors.`,

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -176,7 +176,11 @@ export async function applyEmbedding(
   input: ApplyEmbeddingInput,
 ): Promise<ApplyEmbeddingResult> {
   const needsReembed = embeddingSpaceChanges(input.config, input.change.next);
-  await applyEmbeddingConfig(input.config.configPath, input.change.next);
+  await applyEmbeddingConfig({
+    config: input.config,
+    persona: input.persona,
+    update: input.change.next,
+  });
   if (!needsReembed || input.change.next.provider === "none") {
     return { ok: true, reembedded: false };
   }
@@ -586,4 +590,3 @@ export async function unsetSecret(input: {
     return { ok: false, error: (e as Error).message };
   }
 }
-

--- a/tests/cli-embedding.test.ts
+++ b/tests/cli-embedding.test.ts
@@ -4,23 +4,26 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   applyEmbeddingConfig,
   optionalPromptText,
 } from "../src/cli/embedding.ts";
-import { loadConfig } from "../src/config.ts";
+import { type Config, loadConfig } from "../src/config.ts";
 
 let workdir: string;
 let configPath: string;
+let config: Config;
+const persona = "phantom";
 const SAVED_CONFIG = process.env.PHANTOMBOT_CONFIG;
 // Isolate from the ambient environment: loadConfig() prefers a real
 // PHANTOMBOT_GEMINI_API_KEY over the toml api_key, so a key present in the
 // shell (e.g. on a live phantombot box) would otherwise leak into these
 // config-roundtrip tests and fail them. Clear it per-test, restore after.
 let savedGeminiKey: string | undefined;
+let savedOpenAIKey: string | undefined;
 
 beforeEach(async () => {
   workdir = await mkdtemp(join(tmpdir(), "phantombot-emb-"));
@@ -29,7 +32,11 @@ beforeEach(async () => {
   process.env.XDG_CONFIG_HOME = join(workdir, "xdg-config");
   process.env.XDG_DATA_HOME = join(workdir, "xdg-data");
   savedGeminiKey = process.env.PHANTOMBOT_GEMINI_API_KEY;
+  savedOpenAIKey = process.env.PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY;
   delete process.env.PHANTOMBOT_GEMINI_API_KEY;
+  delete process.env.PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY;
+  config = await loadConfig();
+  configPath = join(config.personasDir, persona, "config.toml");
 });
 
 afterEach(async () => {
@@ -37,52 +44,89 @@ afterEach(async () => {
   else process.env.PHANTOMBOT_CONFIG = SAVED_CONFIG;
   if (savedGeminiKey === undefined) delete process.env.PHANTOMBOT_GEMINI_API_KEY;
   else process.env.PHANTOMBOT_GEMINI_API_KEY = savedGeminiKey;
+  if (savedOpenAIKey === undefined) {
+    delete process.env.PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY;
+  } else {
+    process.env.PHANTOMBOT_OPENAI_COMPATIBLE_API_KEY = savedOpenAIKey;
+  }
   await rm(workdir, { recursive: true, force: true });
 });
 
 describe("applyEmbeddingConfig — gemini", () => {
-  test("writes [embeddings] + [embeddings.gemini]", async () => {
-    await applyEmbeddingConfig(configPath, {
-      provider: "gemini",
-      apiKey: "AIzaTEST123",
-      model: "gemini-embedding-001",
-      dims: 1536,
+  test("stores the key in the persona vault and writes only non-secret settings", async () => {
+    const writes: unknown[][] = [];
+    await applyEmbeddingConfig({
+      config,
+      persona,
+      update: {
+        provider: "gemini",
+        apiKey: "AIzaTEST123",
+        model: "gemini-embedding-001",
+        dims: 1536,
+      },
+      writeSecret: async (...args) => {
+        writes.push(args);
+        return { ok: true, persona };
+      },
     });
     const text = await readFile(configPath, "utf8");
+    expect(writes[0]?.slice(1)).toEqual([
+      "PHANTOMBOT_GEMINI_API_KEY",
+      "AIzaTEST123",
+      persona,
+    ]);
     expect(text).toContain("[embeddings]");
     expect(text).toContain('provider = "gemini"');
     expect(text).toContain("[embeddings.gemini]");
-    expect(text).toContain('api_key = "AIzaTEST123"');
+    expect(text).not.toContain("api_key");
     expect(text).toContain('model = "gemini-embedding-001"');
     expect(text).toContain("dims = 1536");
   });
 
-  test("loadConfig() picks up the gemini config we just wrote", async () => {
-    await applyEmbeddingConfig(configPath, {
-      provider: "gemini",
-      apiKey: "AIzaTEST123",
+  test("clears a legacy plaintext key after the vault write succeeds", async () => {
+    await mkdir(join(config.personasDir, persona), { recursive: true });
+    await writeFile(
+      configPath,
+      '[embeddings]\nprovider = "gemini"\n\n[embeddings.gemini]\napi_key = "OLD"\n',
+    );
+    await applyEmbeddingConfig({
+      config,
+      persona,
+      update: { provider: "gemini", apiKey: "NEW" },
+      writeSecret: async () => ({ ok: true, persona }),
     });
-    const c = await loadConfig();
-    expect(c.embeddings.provider).toBe("gemini");
-    expect(c.embeddings.gemini?.apiKey).toBe("AIzaTEST123");
-    expect(c.embeddings.gemini?.model).toBe("gemini-embedding-001");
-    expect(c.embeddings.gemini?.dims).toBe(1536);
+    expect(await readFile(configPath, "utf8")).not.toContain("api_key");
+  });
+
+  test("keeps the pasted key in config.toml and reports a failed vault write", async () => {
+    await expect(
+      applyEmbeddingConfig({
+        config,
+        persona,
+        update: { provider: "gemini", apiKey: "RECOVERABLE" },
+        writeSecret: async () => ({ ok: false, persona, error: "disk full" }),
+      }),
+    ).rejects.toThrow("kept the key in config.toml: disk full");
+    expect(await readFile(configPath, "utf8")).toContain(
+      'api_key = "RECOVERABLE"',
+    );
   });
 });
 
 describe("applyEmbeddingConfig — none", () => {
   test("flips provider to none, leaves [embeddings.gemini] alone", async () => {
-    await applyEmbeddingConfig(configPath, {
-      provider: "gemini",
-      apiKey: "AIzaTEST123",
+    await applyEmbeddingConfig({
+      config,
+      persona,
+      update: { provider: "gemini", apiKey: "AIzaTEST123" },
+      writeSecret: async () => ({ ok: true, persona }),
     });
-    await applyEmbeddingConfig(configPath, { provider: "none" });
+    await applyEmbeddingConfig({ config, persona, update: { provider: "none" } });
     const text = await readFile(configPath, "utf8");
     expect(text).toContain('provider = "none"');
-    // Old gemini block preserved so re-enabling doesn't require re-validating
-    expect(text).toContain('api_key = "AIzaTEST123"');
+    expect(text).not.toContain("api_key");
 
-    const c = await loadConfig();
+    const c = await loadConfig(persona);
     expect(c.embeddings.provider).toBe("none");
     // gemini sub-config not exposed when provider is none.
     expect(c.embeddings.gemini).toBeUndefined();
@@ -91,31 +135,37 @@ describe("applyEmbeddingConfig — none", () => {
 
 describe("applyEmbeddingConfig — openai-compatible", () => {
   test("writes endpoint settings and detected dimensions", async () => {
-    await applyEmbeddingConfig(configPath, {
-      provider: "openai-compatible",
-      openaiCompatible: {
-        baseUrl: "http://127.0.0.1:8082/v1",
-        model: "example-embedding-model",
-        apiKey: "",
-        dims: 1024,
-        queryPrefix: "query: ",
-        documentPrefix: "passage: ",
+    await applyEmbeddingConfig({
+      config,
+      persona,
+      update: {
+        provider: "openai-compatible",
+        openaiCompatible: {
+          baseUrl: "http://127.0.0.1:8082/v1",
+          model: "example-embedding-model",
+          apiKey: "",
+          dims: 1024,
+          queryPrefix: "query: ",
+          documentPrefix: "passage: ",
+        },
       },
+      clearSecret: async () => ({ ok: true, persona }),
     });
     const text = await readFile(configPath, "utf8");
     expect(text).toContain('provider = "openai-compatible"');
     expect(text).toContain("[embeddings.openai_compatible]");
     expect(text).toContain("dims = 1024");
-    const c = await loadConfig();
-    expect(c.embeddings.openaiCompatible).toEqual({
+    const c = await loadConfig(persona);
+    const { apiKey: _ambientKey, ...settings } = c.embeddings.openaiCompatible!;
+    expect(settings).toEqual({
       baseUrl: "http://127.0.0.1:8082/v1",
       model: "example-embedding-model",
-      apiKey: "",
       dims: 1024,
       queryPrefix: "query: ",
       documentPrefix: "passage: ",
       maxChunkChars: 5000,
     });
+    expect(text).not.toContain("api_key");
   });
 
   test("empty optional prompt values remain empty", () => {


### PR DESCRIPTION
Closes #515.

## Summary
- write Gemini and OpenAI-compatible embedding credentials to the resolved persona vault
- keep non-secret embedding settings in the persona config and remove legacy plaintext keys after verified vault writes
- preserve the pasted key in config.toml and surface an error if the vault write fails
- retain vault-first display and startup shadow-warning behavior during migration

## Verification
- `bun tsc --noEmit`
- `bun test tests/cli-embedding.test.ts tests/tui-actions.test.ts` (22 pass)
- `PATH="$HOME/.bun/bin:$PATH" bun test` (4,346 pass, 2 platform skips)