### PR TITLE
tui: scrollback for the System log pane

### DIFF
--- a/src/tui/logViewport.ts
+++ b/src/tui/logViewport.ts
@@ -1,0 +1,93 @@
+/**
+ * Which slice of a log stream is on screen, and how far it is from the tail.
+ *
+ * The System log pane used to render `filtered.slice(-rows)` — the newest
+ * screenful and nothing else. After #478 the pane reads real sinks (a 5000
+ * line ring, 2000 line file reads, whole task histories), so "newest
+ * screenful only" quietly made almost everything it had just read
+ * unreachable: the lines existed, the pane could not show them.
+ *
+ * This module is the missing viewport. It is anchored to the TAIL rather than
+ * to a cursor, because that is how a log reader behaves: you sit at the
+ * bottom watching new lines land, you scroll UP to read history, and you
+ * expect a way back to live. `offset` is therefore "lines above the tail",
+ * with 0 meaning "following".
+ *
+ * `scroll.ts` solves a different problem — a cursor moving through
+ * variable-height blocks — so it is not reused here; every log row is one
+ * line and there is no selection to keep visible.
+ *
+ * Deliberately pure: no React, no terminal. The caller measures the window
+ * and passes the row budget in.
+ */
+
+export interface LogViewport {
+  /** First line index to render, inclusive. */
+  start: number;
+  /** Last line index to render, exclusive. */
+  end: number;
+  /** Lines hidden above and below the window, for the scroll markers. */
+  above: number;
+  below: number;
+  /** True when the window is pinned to the newest line. */
+  following: boolean;
+  /** `offset` clamped to what this many lines can actually offer. */
+  offset: number;
+}
+
+/**
+ * The window of `rows` lines sitting `offset` lines above the tail.
+ *
+ * The offset is clamped rather than rejected, so a viewport survives the
+ * stream SHRINKING underneath it (a reload returning fewer lines, a filter
+ * being tightened): the pane slides back toward the tail instead of showing
+ * an empty window with a stale scroll position.
+ */
+export function tailViewport(
+  total: number,
+  rows: number,
+  offset: number,
+): LogViewport {
+  const height = Math.max(1, Math.floor(rows));
+  const count = Math.max(0, Math.floor(total));
+  if (count === 0)
+    return { start: 0, end: 0, above: 0, below: 0, following: true, offset: 0 };
+  const clamped = clampOffset(offset, count, height);
+  const end = count - clamped;
+  const start = Math.max(0, end - height);
+  return {
+    start,
+    end,
+    above: start,
+    below: count - end,
+    following: clamped === 0,
+    offset: clamped,
+  };
+}
+
+/** The largest offset that still leaves the oldest line on screen. */
+export function maxOffset(total: number, rows: number): number {
+  return Math.max(0, Math.floor(total) - Math.max(1, Math.floor(rows)));
+}
+
+function clampOffset(offset: number, total: number, rows: number): number {
+  if (!Number.isFinite(offset)) return 0;
+  return Math.min(Math.max(Math.floor(offset), 0), maxOffset(total, rows));
+}
+
+/**
+ * Move the viewport by `delta` lines (positive = back in time), clamped.
+ *
+ * Clamping HERE, not only at render time, is what keeps the keyboard honest:
+ * if holding the up arrow past the oldest line inflated the offset, it would
+ * then take exactly as many down presses to get back to live, and the pane
+ * would look frozen while the user pressed a key that plainly does something.
+ */
+export function nudgeOffset(
+  current: number,
+  delta: number,
+  total: number,
+  rows: number,
+): number {
+  return clampOffset(current + delta, total, rows);
+}

--- a/src/tui/screens/System.tsx
+++ b/src/tui/screens/System.tsx
@@ -14,6 +14,7 @@ import type { HostSnapshot } from "../snapshot.ts";
 import type { SystemSnapshot, SystemState } from "../systemSnapshot.ts";
 import { useTerminalSize, viewportRows } from "../terminal.ts";
 import { frameChromeRows } from "../chrome.ts";
+import { maxOffset, nudgeOffset, tailViewport } from "../logViewport.ts";
 
 const LEVEL_COLOR: Record<string, string> = {
   error: theme.bad,
@@ -104,6 +105,8 @@ export function SystemScreen(props: {
   const [lines, setLines] = useState<readonly LogLine[]>([]);
   const [loading, setLoading] = useState(false);
   const [reloads, setReloads] = useState(0);
+  // Lines above the tail; 0 = following the newest line (see logViewport.ts).
+  const [offset, setOffset] = useState(0);
   const size = useTerminalSize();
   const rows = viewportRows(size, 9 + frameChromeRows());
   const types = useMemo(
@@ -156,11 +159,35 @@ export function SystemScreen(props: {
     };
   }, [tab, source, reloads]);
   const filtered = useMemo(
-    () => filterLogs(lines, { type, persona, time, text }).slice(-rows),
-    [lines, type, persona, time, text, rows],
+    () => filterLogs(lines, { type, persona, time, text }),
+    [lines, type, persona, time, text],
   );
+  // Reserve the two marker rows only when there is something to hide, so a
+  // stream that fits uses the whole window.
+  const bodyRows = filtered.length > rows ? Math.max(1, rows - 2) : rows;
+  const view = tailViewport(filtered.length, bodyRows, offset);
+  const visible = filtered.slice(view.start, view.end);
+  // Changing what is being read is a new stream: go back to live rather than
+  // holding a scroll position that meant something in the previous one.
+  useEffect(() => {
+    setOffset(0);
+  }, [source, type, persona, time, text, reloads]);
 
   useInput((char, key) => {
+    // Scroll first, and before the search branch: arrows and page keys carry
+    // no character, so they are meaningless to the filter box and a user
+    // mid-search still expects to be able to look back through the stream.
+    if (tab === "logs") {
+      const page = Math.max(1, bodyRows - 1);
+      const nudge = (delta: number) =>
+        setOffset((o) => nudgeOffset(o, delta, filtered.length, bodyRows));
+      if (key.upArrow) return nudge(1);
+      if (key.downArrow) return nudge(-1);
+      if (key.pageUp) return nudge(page);
+      if (key.pageDown) return nudge(-page);
+      if (key.home) return setOffset(maxOffset(filtered.length, bodyRows));
+      if (key.end) return setOffset(0);
+    }
     if (tab === "logs" && searchFocused) {
       if (key.escape) return setSearchFocused(false);
       if (key.backspace || key.delete) return setText((s) => s.slice(0, -1));
@@ -191,7 +218,9 @@ export function SystemScreen(props: {
       title={["phantombot", "system", tab]}
       status={
         tab === "logs"
-          ? `${source.label} · ${filtered.length}/${lines.length}${loading ? " · reading…" : ""}`
+          ? `${source.label} · ${filtered.length}/${lines.length} · ${
+              view.following ? "following" : `paused ${view.below} from live`
+            }${loading ? " · reading…" : ""}`
           : `sampled ${shortTime(props.snapshot.capturedAt)}`
       }
       footer={
@@ -211,6 +240,11 @@ export function SystemScreen(props: {
               { icon: badge.phantoms, key: "p", label: `Persona ${persona}` },
               { icon: badge.history, key: "t", label: `Time ${time}` },
               { icon: badge.change, key: "r", label: "Reload" },
+              {
+                icon: badge.history,
+                key: "↑↓ pgup/pgdn",
+                label: view.following ? "Scroll" : "Scroll (end = live)",
+              },
               { icon: badge.back, key: "esc", label: "Back" },
             ]
       }
@@ -310,6 +344,11 @@ export function SystemScreen(props: {
             </Box>
           ) : null}
           <Rule />
+          {view.above > 0 ? (
+            <Text color={theme.dim}>
+              {`▲ ${view.above} older — ↑/pgup, home for oldest`}
+            </Text>
+          ) : null}
           {filtered.length === 0 ? (
             <Text color={theme.dim}>
               {loading
@@ -317,7 +356,7 @@ export function SystemScreen(props: {
                 : `No lines from ${source.id} match these filters. 's' cycles source, 't' widens the time window.`}
             </Text>
           ) : (
-            filtered.map((line, i) => (
+            visible.map((line, i) => (
               <Box key={`${line.at}-${i}`}>
                 <Text color={theme.dim}>{timeOf(line.at)} </Text>
                 <Box width={6}>
@@ -336,6 +375,11 @@ export function SystemScreen(props: {
               </Box>
             ))
           )}
+          {view.below > 0 ? (
+            <Text color={theme.warn}>
+              {`▼ ${view.below} newer — ↓/pgdn, end to follow live`}
+            </Text>
+          ) : null}
         </Box>
       )}
     </Frame>

--- a/tests/tui-log-viewport.test.ts
+++ b/tests/tui-log-viewport.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import { maxOffset, nudgeOffset, tailViewport } from "../src/tui/logViewport.ts";
+
+describe("tailViewport", () => {
+  test("follows the tail at offset 0", () => {
+    const view = tailViewport(100, 10, 0);
+    expect(view.start).toBe(90);
+    expect(view.end).toBe(100);
+    expect(view.above).toBe(90);
+    expect(view.below).toBe(0);
+    expect(view.following).toBe(true);
+  });
+
+  test("scrolling back moves the window off the tail", () => {
+    const view = tailViewport(100, 10, 25);
+    expect(view.start).toBe(65);
+    expect(view.end).toBe(75);
+    expect(view.below).toBe(25);
+    expect(view.following).toBe(false);
+  });
+
+  test("the oldest line is reachable and the window never runs off the top", () => {
+    const view = tailViewport(100, 10, maxOffset(100, 10));
+    expect(view.start).toBe(0);
+    expect(view.end).toBe(10);
+    expect(view.above).toBe(0);
+    expect(view.below).toBe(90);
+  });
+
+  test("a stream shorter than the window is shown whole and stays following", () => {
+    const view = tailViewport(4, 10, 7);
+    expect(view.start).toBe(0);
+    expect(view.end).toBe(4);
+    expect(view.above).toBe(0);
+    expect(view.below).toBe(0);
+    expect(view.following).toBe(true);
+  });
+
+  test("an empty stream yields an empty window rather than a negative one", () => {
+    expect(tailViewport(0, 10, 5)).toEqual({
+      start: 0,
+      end: 0,
+      above: 0,
+      below: 0,
+      following: true,
+      offset: 0,
+    });
+  });
+
+  // A reload returning fewer lines must not strand the pane on an offset that
+  // no longer exists — it slides back toward live instead of going blank.
+  test("a shrinking stream re-clamps a stale offset", () => {
+    const view = tailViewport(12, 10, 500);
+    expect(view.start).toBe(0);
+    expect(view.end).toBe(10);
+    expect(view.offset).toBe(2);
+  });
+});
+
+describe("nudgeOffset", () => {
+  test("clamps at the oldest line so held keys do not inflate the offset", () => {
+    expect(nudgeOffset(90, 1, 100, 10)).toBe(90);
+    expect(nudgeOffset(90, 40, 100, 10)).toBe(90);
+  });
+
+  test("clamps at the tail rather than going negative", () => {
+    expect(nudgeOffset(3, -10, 100, 10)).toBe(0);
+  });
+
+  test("moves by whole pages in both directions", () => {
+    expect(nudgeOffset(0, 9, 100, 10)).toBe(9);
+    expect(nudgeOffset(9, -9, 100, 10)).toBe(0);
+  });
+});

--- a/tests/tui-system-input.test.tsx
+++ b/tests/tui-system-input.test.tsx
@@ -7,6 +7,8 @@ import { SystemScreen } from "../src/tui/screens/System.tsx";
 import type { SystemSnapshot } from "../src/tui/systemSnapshot.ts";
 import { stripAnsi } from "./helpers/ansi.ts";
 import type { HostSnapshot } from "../src/tui/snapshot.ts";
+import type { LogSource } from "../src/tui/logSources.ts";
+import type { LogLine } from "../src/tui/logBuffer.ts";
 
 const TEST_HOST = {
   version: "test",
@@ -23,7 +25,7 @@ afterEach(() => {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-function mount(onBack: () => void) {
+function mount(onBack: () => void, sources: LogSource[] = []) {
   const stdin = new PassThrough() as PassThrough & {
     isTTY: boolean;
     setRawMode: () => void;
@@ -53,7 +55,7 @@ function mount(onBack: () => void) {
       host={TEST_HOST}
       personas={["kai"]}
       onBack={onBack}
-      sources={[]}
+      sources={sources}
     />,
     {
       stdin: stdin as never,
@@ -94,5 +96,106 @@ describe("System log search input", () => {
     expect(app.frame()).toContain("filter: vault (/ to search)");
     await app.press("\x1b");
     expect(backs).toBe(1);
+  });
+});
+
+/** A source with more lines than any terminal window can hold at once. */
+function tallSource(count: number): LogSource {
+  const lines: LogLine[] = Array.from({ length: count }, (_, i) => ({
+    at: Date.UTC(2026, 8, 1, 12, 0, 0) + i * 1000,
+    level: "info",
+    msg: `line-${String(i).padStart(3, "0")}`,
+    type: "test",
+    raw: "",
+  }));
+  return {
+    id: "session",
+    label: "session",
+    location: "/tmp/tall.log",
+    command: "cat /tmp/tall.log",
+    available: true,
+    read: async () => lines,
+  };
+}
+
+const UP = "\x1b[A";
+const DOWN = "\x1b[B";
+const PAGE_UP = "\x1b[5~";
+const PAGE_DOWN = "\x1b[6~";
+const HOME = "\x1b[H";
+const END = "\x1b[F";
+
+describe("System log scrollback", () => {
+  // The bug this pane shipped with: it rendered `slice(-rows)`, so every line
+  // read beyond the last screenful was unreachable. Pressing home must reach
+  // the OLDEST line, not just re-draw the newest ones.
+  test("home reaches the oldest line and end returns to live", async () => {
+    const app = mount(() => {}, [tallSource(200)]);
+    await app.press("\t");
+    expect(app.frame()).toContain("line-199");
+    expect(app.frame()).toContain("following");
+
+    await app.press(HOME);
+    const top = app.frame();
+    expect(top).toContain("line-000");
+    expect(top).not.toContain("line-199");
+    expect(top).toContain("from live");
+
+    await app.press(END);
+    const live = app.frame();
+    expect(live).toContain("line-199");
+    expect(live).toContain("following");
+  });
+
+  test("arrows move one line and page keys move a screenful", async () => {
+    const app = mount(() => {}, [tallSource(200)]);
+    await app.press("\t");
+    await app.press(UP);
+    const oneUp = app.frame();
+    expect(oneUp).toContain("line-198");
+    expect(oneUp).not.toContain("line-199");
+
+    await app.press(PAGE_UP);
+    const paged = app.frame();
+    expect(paged).not.toContain("line-198");
+    expect(paged).toContain("older");
+
+    await app.press(PAGE_DOWN);
+    await app.press(DOWN);
+    expect(app.frame()).toContain("line-199");
+  });
+
+  test("scrolling past the ends clamps instead of stranding the window", async () => {
+    const app = mount(() => {}, [tallSource(200)]);
+    await app.press("\t");
+    await app.press(HOME);
+    // Three pages that have nowhere to go.
+    for (const _ of Array(3)) await app.press(PAGE_UP);
+    expect(app.frame()).toContain("line-000");
+    // One press back down must move exactly one line — proof the offset was
+    // clamped rather than inflated by the presses that had nowhere to go.
+    await app.press(DOWN);
+    expect(app.frame()).not.toContain("line-000");
+  });
+
+  test("scroll keys work while the search box has focus", async () => {
+    const app = mount(() => {}, [tallSource(200)]);
+    await app.press("\t");
+    await app.press("/");
+    await app.press("line");
+    await app.press(HOME);
+    const frame = app.frame();
+    expect(frame).toContain("line-000");
+    expect(frame).toContain("filter: line ◂ typing");
+  });
+
+  test("a stream that fits shows no scroll markers", async () => {
+    const app = mount(() => {}, [tallSource(3)]);
+    await app.press("\t");
+    const frame = app.frame();
+    expect(frame).toContain("line-000");
+    expect(frame).toContain("line-002");
+    expect(frame).not.toContain("older");
+    expect(frame).not.toContain("newer");
   });
 });


### PR DESCRIPTION
Closes #528. Follow-up to #527 (#478): the pane reads real sinks now, but only the newest screenful was reachable.

## What changed

**`src/tui/logViewport.ts` (new, pure)** — a tail-anchored viewport. `offset` is "lines above the tail", `0` = following. Not built on `scroll.ts`: that solves a cursor moving through variable-height blocks, whereas every log row is one line and there is no selection to keep on screen.

**`System.tsx`**
- `up`/`down` one line, `pgup`/`pgdn` one screenful, `home` oldest, `end` back to live.
- `▲ N older` / `▼ N newer` markers, and `following` / `paused N from live` in the status bar.
- `filtered.slice(-rows)` is gone; the pane slices the viewport window.

## Three judgement calls worth reviewing

1. **Scroll keys are handled BEFORE the search branch.** Arrow and page keys carry no character (ink sets `input = ""` for them), so they are meaningless to the filter box, and someone mid-search still expects to be able to look back through what they are filtering. There is a test for this.
2. **The offset is clamped in the key handler as well as at render.** If holding `up` past the oldest line inflated the offset, it would then take exactly as many `down` presses to get back to live and the pane would look frozen. Also means a reload returning fewer lines re-clamps rather than stranding an empty window.
3. **Marker rows are reserved only when something is hidden** (`bodyRows = filtered.length > rows ? rows - 2 : rows`), so a short stream still uses the whole window.

Changing source, filter, time window or reloading resets to live.

## Testing

- `tests/tui-log-viewport.test.ts` — 9 unit tests: follow, scroll back, oldest reachable, short stream, empty stream, shrinking stream re-clamp, nudge clamping both ends.
- `tests/tui-system-input.test.tsx` — 5 new integration tests driving real escape sequences through ink: `home` reaches `line-000` of 200 and `end` returns to `line-199`; arrows vs pages; clamping; scroll while search focused; no markers when the stream fits.
- Mutation-tested 8/8 killed (drop clamp, ignore offset, always-following, dead `home`, dead `end`, up-moves-a-page, always-render-markers, scroll-blocked-while-searching).
- 4450 pass / 0 fail, `tsc` clean.