### PR TITLE
tui: frameless chat prompt strip + reserved notice slot above footer

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -37,7 +37,7 @@ import {
   unsetSecret,
   type Consequence,
 } from "./actions.ts";
-import { Frame } from "./components/Frame.tsx";
+import { Frame, NoticeContext } from "./components/Frame.tsx";
 import { ConfirmScreen, type ConfirmRequest } from "./screens/Confirm.tsx";
 import {
   FileEditorScreen,
@@ -2141,14 +2141,20 @@ export function App(props: AppProps): React.ReactElement {
           It is the window MINUS one row (`renderRows`): a frame exactly as
           tall as the terminal puts Ink on its clear-and-redraw path, which is
           what made typing and the spinner flicker. */}
-      <Box flexDirection="column" height={renderRows(size)}>
-        {body}
-        {notice ? (
-          <Box paddingX={2}>
-            <Text color={theme.warn}>{notice}</Text>
-          </Box>
-        ) : null}
-      </Box>
+      {/* Notices render INSIDE the frame, in the reserved slot above the
+          footer (see NoticeContext) — never below the footer bar. The
+          trailing fallback below is only for the frameless no-phantom
+          placeholder, where no Frame exists to own the notice slot. */}
+      <NoticeContext.Provider value={notice}>
+        <Box flexDirection="column" height={renderRows(size)}>
+          {body}
+          {notice && !persona ? (
+            <Box paddingX={2}>
+              <Text color={theme.warn}>{notice}</Text>
+            </Box>
+          ) : null}
+        </Box>
+      </NoticeContext.Provider>
     </TerminalSizeContext.Provider>
   );
 }

--- a/src/tui/chrome.ts
+++ b/src/tui/chrome.ts
@@ -31,13 +31,16 @@ export function frameVariant(
  *
  * The box spends two on its top and bottom border; the bare frame spends none,
  * because its header line replaces the border's title row rather than adding
- * to it. Screens add this to their own chrome constant, so dropping the border
+ * to it. Both variants also spend one on the RESERVED notice slot above the
+ * footer (see `NoticeContext` in `Frame.tsx`) — always drawn, blank when
+ * empty, so an arriving notice never shifts the layout. Screens add this to
+ * their own chrome constant, so dropping the border
  * gives the transcript two more rows instead of leaving a gap.
  */
 export function frameChromeRows(
   variant: FrameVariant = frameVariant(),
 ): number {
-  return variant === "boxed" ? 2 : 0;
+  return variant === "boxed" ? 3 : 1;
 }
 
 /**

--- a/src/tui/components/Frame.tsx
+++ b/src/tui/components/Frame.tsx
@@ -57,7 +57,12 @@ export function Frame(props: {
   const noticeRow = (
     <Box width="100%" paddingX={1}>
       {notice ? (
-        <Text color={theme.warn}>{notice}</Text>
+        /* Truncate, never wrap: the slot is exactly one row, so a long
+           notice (a path, an error) must clip here instead of spilling into
+           a second row and pushing the footer out of the fixed chrome. */
+        <Text color={theme.warn} wrap="truncate">
+          {notice}
+        </Text>
       ) : (
         <Text> </Text>
       )}

--- a/src/tui/components/Frame.tsx
+++ b/src/tui/components/Frame.tsx
@@ -15,7 +15,7 @@
  * resize listener in `App.tsx` that asks for a re-render — and nowhere else.
  */
 
-import React from "react";
+import React, { createContext, useContext } from "react";
 import { Box, Text } from "ink";
 
 import { theme } from "../theme.ts";
@@ -50,6 +50,19 @@ export function Frame(props: {
   children: React.ReactNode;
 }): React.ReactElement {
   const boxed = frameVariant() === "boxed";
+  // The notice slot is RESERVED — always exactly one row, blank when empty —
+  // so a notice appearing never pushes the footer off the bottom of the
+  // window (the layout-shift class of bug). `frameChromeRows` counts it.
+  const notice = useContext(NoticeContext);
+  const noticeRow = (
+    <Box width="100%" paddingX={1}>
+      {notice ? (
+        <Text color={theme.warn}>{notice}</Text>
+      ) : (
+        <Text> </Text>
+      )}
+    </Box>
+  );
   // The bare header prints the product name itself, so a breadcrumb that also
   // starts with it would read `phantombot v1.1.316 ▸ phantombot ▸ robbie`.
   const crumbs = props.title.filter((c) => c !== "phantombot");
@@ -106,6 +119,7 @@ export function Frame(props: {
         <Box flexDirection="column" flexGrow={1} paddingX={1}>
           {body}
         </Box>
+        {noticeRow}
         {footer}
       </Box>
     );
@@ -123,10 +137,18 @@ export function Frame(props: {
         {header}
         {body}
       </Box>
+      {noticeRow}
       {footer}
     </Box>
   );
 }
+
+/**
+ * One-line status text rendered between the frame's bottom edge and the
+ * footer bar. Set from `App.tsx` via `NoticeContext`; `undefined` renders the
+ * reserved blank row, so an arriving notice never shifts the layout.
+ */
+export const NoticeContext = createContext<string | undefined>(undefined);
 
 /** A labelled value line: `label   value`, aligned by the layout engine. */
 export function Field(props: {

--- a/src/tui/components/Frame.tsx
+++ b/src/tui/components/Frame.tsx
@@ -54,14 +54,16 @@ export function Frame(props: {
   // so a notice appearing never pushes the footer off the bottom of the
   // window (the layout-shift class of bug). `frameChromeRows` counts it.
   const notice = useContext(NoticeContext);
+  /* The slot is exactly one row: collapse embedded newlines FIRST
+     (wrap="truncate" only clips width — it never flattens a multiline
+     string) and truncate width, so no notice can ever spill into a
+     second row and push the footer out of the fixed chrome. */
+  const oneLineNotice = notice?.replace(/[\r\n\u2028\u2029]+/g, " ⏎ ");
   const noticeRow = (
     <Box width="100%" paddingX={1}>
-      {notice ? (
-        /* Truncate, never wrap: the slot is exactly one row, so a long
-           notice (a path, an error) must clip here instead of spilling into
-           a second row and pushing the footer out of the fixed chrome. */
+      {oneLineNotice ? (
         <Text color={theme.warn} wrap="truncate">
-          {notice}
+          {oneLineNotice}
         </Text>
       ) : (
         <Text> </Text>

--- a/src/tui/screens/Chat.tsx
+++ b/src/tui/screens/Chat.tsx
@@ -622,15 +622,23 @@ export function ChatScreen(props: {
           )}
         </Box>
       ) : null}
+      {/* FRAMELESS prompt strip: a rule above and below, open at the sides —
+          the claude/codex/pi look. No corners to shear, and the two rule rows
+          cost exactly what the old border's top+bottom rows cost, so the
+          chrome budget is unchanged. Each rule is a border-only box sized by
+          the layout engine (never a run of `─` characters). The marginBottom
+          on the lower rule keeps a blank row of air above the footer. */}
       <Box
-        borderStyle="round"
+        borderStyle="single"
         borderColor={busy ? theme.dim : theme.accent}
-        paddingX={1}
-        flexDirection="column"
-      >
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+      />
+      <Box paddingX={1} flexDirection="column">
         {/* The rows are pre-wrapped to the inner width by promptBox.ts — what
-            is measured is what is drawn, so the border cannot shear. The
-            caret is a span IN the wrap stream, so it never overflows a row. */}
+            is measured is what is drawn. The caret is a span IN the wrap
+            stream, so it never overflows a row. */}
         {inputRows.map((row, i) => (
           <Text key={i}>
             {row.map((seg, j) =>
@@ -656,6 +664,14 @@ export function ChatScreen(props: {
           </Text>
         ))}
       </Box>
+      <Box
+        borderStyle="single"
+        borderColor={busy ? theme.dim : theme.accent}
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+        marginBottom={1}
+      />
     </Frame>
   );
 }

--- a/src/tui/screens/PersonaDetail.tsx
+++ b/src/tui/screens/PersonaDetail.tsx
@@ -520,9 +520,9 @@ export function PersonaDetailScreen(props: {
       </Text>
       <Rule />
       <StatusBlock status={props.status} />
-      {/* One blank row between the STATUS telemetry and the footer — the same
-          breathing room the footer gets on every other screen. */}
-      <Box height={1} />
+      {/* Breathing room before the footer is the frame's RESERVED notice
+          slot now — a second blank row here over-paints the border on short
+          windows (the 20-row boxed regression). */}
     </Frame>
   );
 }

--- a/tests/tui-chat-markdown.test.tsx
+++ b/tests/tui-chat-markdown.test.tsx
@@ -113,8 +113,10 @@ describe("a rendered reply", () => {
     for (const row of frame.split("\n")) {
       expect(row.length).toBeLessThanOrEqual(COLUMNS);
     }
-    // The bottom border is still the bottom border: it is drawn by
-    // `borderStyle`, and a compressed row is what used to push it off screen.
-    expect(frame).toContain("╰");
+    // The bottom rule is still the bottom rule: it is drawn by
+    // `borderStyle`, and a compressed row is what used to push the bottom
+    // chrome off screen — the footer must still be the last thing rendered.
+    const nonEmpty = frame.split("\n").filter((l) => l.trim().length > 0);
+    expect(nonEmpty.at(-1)).toContain("Send");
   });
 });

--- a/tests/tui-frame-variant.test.tsx
+++ b/tests/tui-frame-variant.test.tsx
@@ -185,9 +185,9 @@ describe("frame variants", () => {
     const frame = (await openChat(24)).join("\n");
     expect(frame).toContain("phantombot v");
     expect(frame).toContain("channel: stable");
-    // The chat input keeps its own little box, so count corners rather than
-    // looking for any: bare = the input box only, boxed = that plus the frame.
-    expect((frame.match(/╭/g) ?? []).length).toBe(1);
+    // The frameless prompt strip draws no corners at all, so count them
+    // rather than looking for any: bare = 0, boxed = the frame border only.
+    expect((frame.match(/╭/g) ?? []).length).toBe(0);
     // The first line is the header itself, not a border.
     expect(frame.split("\n")[0]).toContain("phantombot v");
   });
@@ -195,7 +195,7 @@ describe("frame variants", () => {
   test("boxed still draws the border", async () => {
     process.env.PHANTOMBOT_TUI_FRAME = "boxed";
     const frame = (await openChat(24)).join("\n");
-    expect((frame.match(/╭/g) ?? []).length).toBe(2);
+    expect((frame.match(/╭/g) ?? []).length).toBe(1);
     expect(frame.split("\n")[0]).toContain("╭");
   });
 });

--- a/tests/tui-notice-slot.test.tsx
+++ b/tests/tui-notice-slot.test.tsx
@@ -93,6 +93,37 @@ describe("reserved notice slot", () => {
     expect(last).toContain("quit");
   });
 
+  test("embedded newlines collapse to one row — footer stays last", () => {
+    /* wrap="truncate" only clips WIDTH; a multiline notice would still
+       consume one row per line and shove the footer out. The Frame must
+       flatten the notice to a single line before rendering. */
+    const MULTILINE = "channels updated\nreembed failed\nat /tmp/x.sqlite";
+    const out = renderFrame(80, 12, MULTILINE);
+    const lines = out.split("\n");
+    if (lines[lines.length - 1] === "") lines.pop();
+    // Each original line is present (joined), but on ONE row only.
+    const joined = out.replace(/[\n\r]+/g, "");
+    expect(joined).toContain("channels updated");
+    expect(joined).toContain("reembed failed");
+    expect(joined).toContain("at /tmp/x.sqlite");
+    // No row contains only the tail line — it was flattened, not stacked.
+    expect(lines.filter((l) => l.trim() === "at /tmp/x.sqlite").length).toBe(0);
+    // Exactly one notice row, and the footer is still last.
+    const noticeRows = lines.filter((l) => l.includes("reembed failed"));
+    expect(noticeRows.length).toBe(1);
+    const last = lines[lines.length - 1];
+    expect(last).toContain("quit");
+  });
+
+  test("a CRLF notice collapses to one row too", () => {
+    const out = renderFrame(80, 12, "first\r\nsecond");
+    const lines = out.split("\n");
+    if (lines[lines.length - 1] === "") lines.pop();
+    expect(lines.filter((l) => l.trim() === "second").length).toBe(0);
+    const last = lines[lines.length - 1];
+    expect(last).toContain("quit");
+  });
+
   test("an empty notice still reserves exactly one row", () => {
     const out = renderFrame(40, 12, undefined);
     const last =

--- a/tests/tui-notice-slot.test.tsx
+++ b/tests/tui-notice-slot.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * The reserved notice slot must stay EXACTLY one row.
+ *
+ * Kai's review on the notice-slot PR reproduced the failure at 40 columns:
+ * a 65-character notice (a path, an error message) wrapped onto two rows
+ * inside the slot and pushed the footer out of the fixed-height root — the
+ * exact layout-shift bug the reserved slot exists to prevent. The notice is
+ * therefore rendered with `wrap="truncate"`, and this test pins it: at a
+ * narrow width a long notice must clip to one row with the footer still the
+ * last row on screen.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { Box, render } from "ink";
+
+import { Frame, NoticeContext } from "../src/tui/components/Frame.tsx";
+import { stripAnsi } from "./helpers/ansi.ts";
+
+function fakeStdout(rows: number, columns: number) {
+  const frames: string[] = [];
+  const s = new EventEmitter() as EventEmitter & {
+    columns: number;
+    rows: number;
+    write: (chunk: string) => void;
+  };
+  s.columns = columns;
+  s.rows = rows;
+  s.write = (chunk: string) => {
+    frames.push(chunk);
+  };
+  return { stream: s as unknown as NodeJS.WriteStream, frames };
+}
+
+function fakeStdin() {
+  const s = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: () => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  s.isTTY = true;
+  s.setRawMode = () => {};
+  s.ref = () => {};
+  s.unref = () => {};
+  return s as unknown as NodeJS.ReadStream;
+}
+
+function renderFrame(columns: number, rows: number, notice: string | undefined) {
+  const { stream, frames } = fakeStdout(rows, columns);
+  const instance = render(
+    /* Fixed height, exactly like the App root (App.tsx:2149) — that is what
+       makes an extra notice row overflow instead of just growing the block. */
+    <Box flexDirection="column" height={rows}>
+      <NoticeContext.Provider value={notice}>
+        <Frame title={["phantombot", "lab"]} footer={[{ key: "^c", label: "quit" }]}>
+          <>{null}</>
+        </Frame>
+      </NoticeContext.Provider>
+    </Box>,
+    {
+      stdout: stream,
+      stdin: fakeStdin(),
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+  instance.unmount();
+  /* The LAST frame only: unmount repaints a cleared screen, so joining all
+     frames would double-count every row. The erase prefix (not an SGR code,
+     so stripAnsi keeps it) is dropped with the split. */
+  return stripAnsi(frames[frames.length - 1] ?? "");
+}
+
+describe("reserved notice slot", () => {
+  const LONG_NOTICE =
+    "/home/supervisor/.local/share/phantombot/personas/lab/memory-index/index.sqlite reembedded";
+
+  test("a long notice truncates to one row — footer stays last", () => {
+    const out = renderFrame(40, 12, LONG_NOTICE);
+    const lines = out.split("\n");
+    if (lines[lines.length - 1] === "") lines.pop();
+    // The notice appears, but only ONCE — a wrap would repeat its tail.
+    expect(out).toContain(LONG_NOTICE.slice(0, 10));
+    const noticeRows = lines.filter((l) => l.includes(LONG_NOTICE.slice(0, 10)));
+    expect(noticeRows.length).toBe(1);
+    // Truncated, not wrapped: the tail past the 40-column clip is absent.
+    const tail = LONG_NOTICE.slice(-12);
+    expect(lines.filter((l) => l.includes(tail)).length).toBe(0);
+    // Footer is still the last rendered row.
+    const last = lines[lines.length - 1];
+    expect(last).toContain("quit");
+  });
+
+  test("an empty notice still reserves exactly one row", () => {
+    const out = renderFrame(40, 12, undefined);
+    const last =
+      out
+        .split("\n")
+        .filter((l) => l.trim().length > 0)
+        .pop() ?? "";
+    expect(last).toContain("quit");
+  });
+});

--- a/tests/tui-settings-badges.test.tsx
+++ b/tests/tui-settings-badges.test.tsx
@@ -158,7 +158,9 @@ describe("settings badge semantics", () => {
   });
 
   test("an omitted voice line is optional too", async () => {
-    const text = await renderSettings([]);
+    // The reserved notice slot costs the window one row, so Voice — the last
+    // row — sits just below the fold at the default cursor; scroll to it.
+    const text = await renderSettings([], 7);
     const row = rowOf(text, "Voice");
     expect(row.endsWith("optional")).toBe(true);
   });


### PR DESCRIPTION
## What

Two related TUI layout changes, driven by visual walkthrough feedback:

### 1. Frameless chat prompt strip
The chat prompt drops its `borderStyle="round"` box for a **frameless strip** — a full-width horizontal rule above and below, open at the sides, prompt starting with `›` at the left edge. The rounded box was deforming when the prompt wrapped or grew (corners misaligning); with no corners and no side glyphs there is nothing left to shear. Rule accent/dim signalling on idle/busy is preserved.

The two rule rows cost exactly what the old border's top/bottom cost, so the chrome budget and the pre-wrap width (`columns - 4`) are unchanged — nothing else moves.

### 2. Reserved notice slot above the footer (app-wide)
Notifications previously rendered **after** the whole screen in `App.tsx`, i.e. below the footer. `Frame` now reserves exactly one notice row between each screen's bottom edge and the footer bar, fed via `NoticeContext`:

```
 ──────────────────────────────────────────────
  › ▌
 ──────────────────────────────────────────────
 channels updated · telegram connected   ← notice slot (blank padding when empty)
 ➤ ↵ Send   ➤ Alt+↵ Newline   ▶ / Commands ...
```

Layout never shifts — the row is always present, blank when idle. `App` keeps a trailing-notice fallback **only** for the frameless `!persona` placeholder (the wizard test asserted the created-persona notice there). `PersonaDetail` drops its own pre-footer blank row — the reserved slot replaces it; keeping both over-painted the 20-row boxed settings window and merged rows.

## Verification
- `tsc --noEmit` clean
- Full suite: **4450 pass / 0 fail / 8 skip** on the rebased head
- Corner-counting tests updated to the frameless expectation; visual smoke render of empty + filled notice slot in chat

## Notes for review
- Rebasing risk: #527/#529 landed while this was in flight; rebased cleanly on top and re-verified.
- Not exercised against every screen variant by hand — the Frame slot is generic, so any screen drawing through Frame inherits it automatically.