### PR TITLE
tui: Brain configure wizard parity with harness clack app

### DIFF
--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -344,10 +344,12 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
   }
 
   const bothPi = primary === "pi" && fallbackPick === "pi";
+  let primaryMode: "configure" | "local" | undefined;
   if (primary === "pi") {
     const cancelled = await configurePi(
       config, availability, "primary", target, q,
       bothPi ? "pi-primary" : undefined,
+      { onMode: (m) => { primaryMode = m; } },
     );
     if (cancelled) {
       q.cancel("cancelled");
@@ -359,6 +361,7 @@ export async function runHarness(input: RunInput = {}): Promise<number> {
     const cancelled = await configurePi(
       config, availability, "fallback", target, q,
       bothPi ? "pi-fallback" : undefined,
+      { allowLocalConfig: primaryMode !== "local" },
     );
     if (cancelled) {
       q.cancel("cancelled");
@@ -452,6 +455,7 @@ async function configurePi(
   target: HarnessWriteTarget,
   q: HarnessPrompts = clackPrompts,
   instanceId?: string,
+  opts?: { allowLocalConfig?: boolean; onMode?: (mode: "configure" | "local") => void },
 ): Promise<boolean> {
   if (!availability.pi) {
     const doInstall = await q.confirm({
@@ -485,23 +489,30 @@ async function configurePi(
     }
   }
 
-  const mode = await q.select<"configure" | "local">({
-    message: `Pi (${role}): how should models be configured?`,
-    options: [
-      {
-        value: "configure",
-        label: "Configure models",
-        hint: "pick provider + API key, then primary / vision / coding models",
-      },
-      {
-        value: "local",
-        label: "Use Pi's own config",
-        hint: "delegate to Pi's local settings (from `pi` login) — clears any routing here",
-      },
-    ],
-    initialValue: "configure",
-  });
-  if (mode === undefined) return true;
+  let mode: "configure" | "local" = "configure";
+  if (opts?.allowLocalConfig === false) {
+    mode = "configure";
+  } else {
+    const pick = await q.select<"configure" | "local">({
+      message: `Pi (${role}): how should models be configured?`,
+      options: [
+        {
+          value: "configure",
+          label: "Configure models",
+          hint: "pick provider + API key, then primary / vision / coding models",
+        },
+        {
+          value: "local",
+          label: "Use Pi's own config",
+          hint: "delegate to Pi's local settings (from `pi` login) — clears any routing here",
+        },
+      ],
+      initialValue: "configure",
+    });
+    if (pick === undefined) return true;
+    mode = pick;
+  }
+  opts?.onMode?.(mode);
   if (mode === "local") {
     // ACTIVELY clear both stores — see clearPiRouting/computeRoutingClears. The
     // old "later" branch returned without clearing, so any previously-configured

--- a/src/cli/harness.ts
+++ b/src/cli/harness.ts
@@ -492,6 +492,10 @@ async function configurePi(
   let mode: "configure" | "local" = "configure";
   if (opts?.allowLocalConfig === false) {
     mode = "configure";
+    q.note(
+      "the fallback must configure its own models — two Pi instances on host config would be identical",
+      "Pi fallback",
+    );
   } else {
     const pick = await q.select<"configure" | "local">({
       message: `Pi (${role}): how should models be configured?`,

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -549,6 +549,7 @@ export function App(props: AppProps): React.ReactElement {
           unsetPersonaSecret,
         } = await import("../lib/vaultSecrets.ts");
         const { writePiApiKey } = await import("../lib/piAuthStore.ts");
+        const { probeProviderKey } = await import("../lib/providerKeyProbe.ts");
 
         const config = await loadConfig(persona);
         const availability = await detectAvailability(config);
@@ -641,6 +642,31 @@ export function App(props: AppProps): React.ReactElement {
               const { probeHarness } = await import("../lib/harnessProbe.ts");
               return probeHarness({ config: await loadConfig(persona), id });
             },
+            probeProviderKey: (providerId, key) =>
+              probeProviderKey(providerId, key),
+            maybePromptRestart: async () => {
+              const { maybePromptRestart } = await import("../cli/harness.ts");
+              const { defaultServiceControl } = await import("../lib/platform.ts");
+              await maybePromptRestart(
+                defaultServiceControl(),
+                async (message) =>
+                  await askConfirmValue({
+                    title: message,
+                    consequence: {
+                      summary: "",
+                      detail: "",
+                      longRunning: false,
+                      restarts: true,
+                    },
+                  }),
+                {
+                  note: (body: string, title?: string) =>
+                    setNotice(
+                      title ? `${title}: ${body.split("\n")[0]}` : body,
+                    ),
+                } as never,
+              );
+            },
           },
         );
       } catch (e) {
@@ -670,39 +696,10 @@ export function App(props: AppProps): React.ReactElement {
       const result = await onboardBrain(target.name);
       setNotice(result.notice);
 
-      // Writes are exactly the two applyChain endings — a verified chain and
-      // a saved-untested one. A cancel ("brain unchanged"), a Skip with no
-      // brain chosen, and a failed test (nothing saved) must NOT offer a
-      // restart: nothing changed to restart into.
-      const wroteChain =
-        result.notice.startsWith("brain verified") ||
-        result.notice.startsWith("brain saved");
-      if (wroteChain) {
-        const { maybePromptRestart } = await import("../cli/harness.ts");
-        const { defaultServiceControl } = await import("../lib/platform.ts");
-        await maybePromptRestart(
-          defaultServiceControl(),
-          async (message) =>
-            await askConfirmValue({
-              title: message,
-              consequence: {
-                summary: "",
-                detail: "",
-                longRunning: false,
-                restarts: true,
-              },
-            }),
-          {
-            note: (body: string, title?: string) =>
-              setNotice(title ? `${title}: ${body.split("\n")[0]}` : body),
-          } as never,
-        );
-      }
-
       // A verified brain earns chat, same as the wizard's landing.
       if (result.landing === "chat") setScreen("chat");
     },
-    [onboardBrain, askConfirmValue],
+    [onboardBrain],
   );
 
   /**

--- a/src/tui/brainFlow.ts
+++ b/src/tui/brainFlow.ts
@@ -193,12 +193,25 @@ export async function configureBrain(
   if (fallback === undefined) return "brain unchanged";
 
   const bothPi = primary === "pi" && fallback === "pi";
+  let primaryMode: "configure" | "host" | undefined;
   if (primary === "pi") {
-    const cancelled = await configurePi(q, deps, "primary", undefined, bothPi ? "pi-primary" : undefined);
+    const cancelled = await configurePi(
+      q,
+      deps,
+      "primary",
+      { onMode: (m) => { primaryMode = m; } },
+      bothPi ? "pi-primary" : undefined,
+    );
     if (cancelled) return "brain unchanged";
   }
   if (fallback === "pi") {
-    const cancelled = await configurePi(q, deps, "fallback", undefined, bothPi ? "pi-fallback" : undefined);
+    const cancelled = await configurePi(
+      q,
+      deps,
+      "fallback",
+      { allowHostConfig: primaryMode !== "host" },
+      bothPi ? "pi-fallback" : undefined,
+    );
     if (cancelled) return "brain unchanged";
   }
 
@@ -212,6 +225,12 @@ export async function configureBrain(
     `chain${deps.persona ? ` for '${deps.persona}'` : ""}: ${chain.join(" → ")}\n${where}`,
   );
   return `brain saved: ${chain.join(" → ")}`;
+}
+
+export interface ConfigurePiOptions {
+  askMode?: boolean;
+  allowHostConfig?: boolean;
+  onMode?: (mode: "configure" | "host") => void;
 }
 
 /**
@@ -228,7 +247,7 @@ export async function configurePi(
   q: BrainQuestions,
   deps: BrainDeps,
   role: "primary" | "fallback",
-  opts?: { askMode?: boolean },
+  opts?: ConfigurePiOptions,
   instanceId?: string,
 ): Promise<boolean> {
   const current = instanceId
@@ -243,9 +262,12 @@ export async function configurePi(
     );
   }
 
-  const mode = opts?.askMode === false
-    ? "configure"
-    : await q.choose({
+  let mode: "configure" | "host" = "configure";
+  if (opts?.askMode !== false) {
+    if (opts?.allowHostConfig === false) {
+      mode = "configure";
+    } else {
+      const pick = await q.choose({
         title: `Pi (${role} brain) — how should its models be configured?`,
         description: PI_MODE_DESCRIPTION,
         options: [
@@ -262,7 +284,11 @@ export async function configurePi(
         ],
         initial: "configure",
       });
-  if (mode === undefined) return true;
+      if (pick === undefined) return true;
+      mode = pick as "configure" | "host";
+    }
+  }
+  opts?.onMode?.(mode);
 
   if (mode === "host") {
     // ACTIVELY clear — see clearPiRouting. The tombstone only exists in

--- a/src/tui/brainFlow.ts
+++ b/src/tui/brainFlow.ts
@@ -119,11 +119,6 @@ const HARNESS_LABELS: Record<string, string> = {
   claude: "Claude",
 };
 
-/**
- * Per-harness hints. Codex/Claude state the inheritance up front — an operator
- * picking Codex must learn HERE that there is nothing to configure, not
- * discover it from an empty wizard.
- */
 function mergeModels(existing: readonly PiModel[], fresh: readonly PiModel[]): PiModel[] {
   const seen = new Set<string>();
   const res: PiModel[] = [];
@@ -137,6 +132,11 @@ function mergeModels(existing: readonly PiModel[], fresh: readonly PiModel[]): P
   return res;
 }
 
+/**
+ * Per-harness hints. Codex/Claude state the inheritance up front — an operator
+ * picking Codex must learn HERE that there is nothing to configure, not
+ * discover it from an empty wizard.
+ */
 function harnessHint(id: string, deps: BrainDeps): string {
   if (id === "pi") return "provider + model routing configured in this app";
   const label = HARNESS_LABELS[id] ?? id;
@@ -266,6 +266,10 @@ export async function configurePi(
   if (opts?.askMode !== false) {
     if (opts?.allowHostConfig === false) {
       mode = "configure";
+      q.note(
+        "Pi: fallback models",
+        "the fallback must configure its own models — two Pi instances on host config would be identical",
+      );
     } else {
       const pick = await q.choose({
         title: `Pi (${role} brain) — how should its models be configured?`,
@@ -305,11 +309,11 @@ export async function configurePi(
   // The catalogue is fetched once and reused by every slot's list. With no pi
   // binary the lists degrade to free-text rows inside the search screen.
   let models = deps.piBin ? await deps.listModels() : [];
-  if (deps.storedKey && deps.routing.provider && deps.piBin) {
-    if (models.filter((m) => m.provider === deps.routing.provider).length === 0) {
-      const envVar = providerEnvVar(deps.routing.provider);
+  if (current.storedKey && current.routing.provider && deps.piBin) {
+    if (models.filter((m) => m.provider === current.routing.provider).length === 0) {
+      const envVar = providerEnvVar(current.routing.provider);
       if (envVar) {
-        const refreshed = await deps.listModels({ [envVar]: deps.storedKey });
+        const refreshed = await deps.listModels({ [envVar]: current.storedKey });
         if (refreshed.length > 0) models = mergeModels(models, refreshed);
       }
     }
@@ -431,18 +435,16 @@ export async function configurePi(
     }
     if (refreshed.length > 0) models = mergeModels(models, refreshed);
   } else if (keyWrite.action === "keep") {
-    const effectiveKey = deps.storedKey;
+    const effectiveKey = current.storedKey;
     if (provider && effectiveKey && deps.piBin) {
-      if (models.filter((m) => m.provider === provider).length === 0) {
-        const authWrite = await deps.writeAuth(provider, effectiveKey);
-        let refreshed: PiModel[] = [];
-        if (authWrite.ok) refreshed = await deps.listModels();
-        if (refreshed.length === 0) {
-          const envVar = providerEnvVar(provider);
-          if (envVar) refreshed = await deps.listModels({ [envVar]: effectiveKey });
-        }
-        if (refreshed.length > 0) models = mergeModels(models, refreshed);
+      const authWrite = await deps.writeAuth(provider, effectiveKey);
+      let refreshed: PiModel[] = [];
+      if (authWrite.ok) refreshed = await deps.listModels();
+      if (refreshed.length === 0 && models.filter((m) => m.provider === provider).length === 0) {
+        const envVar = providerEnvVar(provider);
+        if (envVar) refreshed = await deps.listModels({ [envVar]: effectiveKey });
       }
+      if (refreshed.length > 0) models = mergeModels(models, refreshed);
     }
   } else if (keyWrite.action === "clear") {
     // Provider switched and nothing typed: the old key points at the wrong
@@ -453,7 +455,6 @@ export async function configurePi(
       "provider changed and no new key entered — cleared the stale key so Pi falls back to its own local store",
     );
   }
-  // action === "keep": nothing written. The stored token is reused verbatim.
 
   const scoped = provider ? models.filter((m) => m.provider === provider) : models;
 

--- a/src/tui/brainFlow.ts
+++ b/src/tui/brainFlow.ts
@@ -281,13 +281,11 @@ export async function configurePi(
   let models = deps.piBin ? await deps.listModels() : [];
   if (deps.storedKey && deps.routing.provider && deps.piBin) {
     if (models.filter((m) => m.provider === deps.routing.provider).length === 0) {
-      await deps.writeAuth(deps.routing.provider, deps.storedKey);
-      let refreshed = await deps.listModels();
-      if (refreshed.filter((m) => m.provider === deps.routing.provider).length === 0) {
-        const envVar = providerEnvVar(deps.routing.provider);
-        if (envVar) refreshed = await deps.listModels({ [envVar]: deps.storedKey });
+      const envVar = providerEnvVar(deps.routing.provider);
+      if (envVar) {
+        const refreshed = await deps.listModels({ [envVar]: deps.storedKey });
+        if (refreshed.length > 0) models = mergeModels(models, refreshed);
       }
-      if (refreshed.length > 0) models = mergeModels(models, refreshed);
     }
   }
 

--- a/src/tui/brainFlow.ts
+++ b/src/tui/brainFlow.ts
@@ -124,6 +124,19 @@ const HARNESS_LABELS: Record<string, string> = {
  * picking Codex must learn HERE that there is nothing to configure, not
  * discover it from an empty wizard.
  */
+function mergeModels(existing: readonly PiModel[], fresh: readonly PiModel[]): PiModel[] {
+  const seen = new Set<string>();
+  const res: PiModel[] = [];
+  for (const m of [...fresh, ...existing]) {
+    const key = `${m.provider}/${m.model}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      res.push(m);
+    }
+  }
+  return res;
+}
+
 function harnessHint(id: string, deps: BrainDeps): string {
   if (id === "pi") return "provider + model routing configured in this app";
   const label = HARNESS_LABELS[id] ?? id;
@@ -266,6 +279,17 @@ export async function configurePi(
   // The catalogue is fetched once and reused by every slot's list. With no pi
   // binary the lists degrade to free-text rows inside the search screen.
   let models = deps.piBin ? await deps.listModels() : [];
+  if (deps.storedKey && deps.routing.provider && deps.piBin) {
+    if (models.filter((m) => m.provider === deps.routing.provider).length === 0) {
+      await deps.writeAuth(deps.routing.provider, deps.storedKey);
+      let refreshed = await deps.listModels();
+      if (refreshed.filter((m) => m.provider === deps.routing.provider).length === 0) {
+        const envVar = providerEnvVar(deps.routing.provider);
+        if (envVar) refreshed = await deps.listModels({ [envVar]: deps.storedKey });
+      }
+      if (refreshed.length > 0) models = mergeModels(models, refreshed);
+    }
+  }
 
   const provider = await q.search({
     title: "Pi provider",
@@ -276,7 +300,11 @@ export async function configurePi(
       ...providerChoices(models).map((p) => ({
         value: p.id,
         label: p.label,
-        hint: p.hasModels ? `${p.id} — key already configured` : p.id,
+        hint: p.hasModels
+          ? `${p.id} — key already configured`
+          : p.label.toLowerCase() !== p.id.toLowerCase()
+            ? p.id
+            : undefined,
       })),
     ],
     initial:
@@ -377,7 +405,21 @@ export async function configurePi(
       const envVar = providerEnvVar(provider);
       if (envVar) refreshed = await deps.listModels({ [envVar]: keyWrite.value });
     }
-    if (refreshed.length > 0) models = refreshed;
+    if (refreshed.length > 0) models = mergeModels(models, refreshed);
+  } else if (keyWrite.action === "keep") {
+    const effectiveKey = deps.storedKey;
+    if (provider && effectiveKey && deps.piBin) {
+      if (models.filter((m) => m.provider === provider).length === 0) {
+        const authWrite = await deps.writeAuth(provider, effectiveKey);
+        let refreshed: PiModel[] = [];
+        if (authWrite.ok) refreshed = await deps.listModels();
+        if (refreshed.length === 0) {
+          const envVar = providerEnvVar(provider);
+          if (envVar) refreshed = await deps.listModels({ [envVar]: effectiveKey });
+        }
+        if (refreshed.length > 0) models = mergeModels(models, refreshed);
+      }
+    }
   } else if (keyWrite.action === "clear") {
     // Provider switched and nothing typed: the old key points at the wrong
     // provider now. Clear it rather than fire it at the new `--provider`.

--- a/src/tui/brainOnboarding.ts
+++ b/src/tui/brainOnboarding.ts
@@ -32,6 +32,7 @@
 import type { PiModel } from "../lib/piModels.ts";
 import type { RoutingChoices } from "../lib/piRouting.ts";
 import type { PiAuthWriteResult } from "../lib/piAuthStore.ts";
+import type { KeyProbeResult } from "../lib/providerKeyProbe.ts";
 import { configurePi, type BrainQuestions } from "./brainFlow.ts";
 
 export interface BrainOnboardingDeps {
@@ -60,6 +61,7 @@ export interface BrainOnboardingDeps {
   personaScope: boolean;
   piBin?: string;
   listModels(extraEnv?: Record<string, string>): Promise<PiModel[]>;
+  probeProviderKey?(providerId: string, key: string): Promise<KeyProbeResult>;
   setSecret(value: string, instanceId?: string): Promise<{ ok: boolean; persona?: string; error?: string }>;
   unsetSecret(instanceId?: string): Promise<unknown>;
   writeAuth(provider: string, value: string): Promise<PiAuthWriteResult>;
@@ -68,6 +70,7 @@ export interface BrainOnboardingDeps {
   clearRouting(opts?: { tombstone?: boolean }, instanceId?: string): Promise<void>;
   /** One real turn through the named harness. The truth, not a `which`. */
   probe(id: string): Promise<{ ok: boolean; detail: string }>;
+  maybePromptRestart?(): Promise<void>;
 }
 
 export interface BrainOnboardingResult {
@@ -251,6 +254,7 @@ async function runOnce(
     piBin: availability.pi,
     installCommand: deps.installCommand,
     listModels: deps.listModels,
+    probeProviderKey: deps.probeProviderKey,
     setSecret: deps.setSecret,
     unsetSecret: deps.unsetSecret,
     writeAuth: deps.writeAuth,
@@ -258,12 +262,13 @@ async function runOnce(
     applyRouting: deps.applyRouting,
     clearRouting: deps.clearRouting,
   };
+  let primaryMode: "configure" | "host" | undefined;
   if (primary === "pi") {
     const cancelled = await configurePi(
       q,
       brainDeps,
       "primary",
-      undefined,
+      { onMode: (m) => { primaryMode = m; } },
       bothPi ? "pi-primary" : undefined,
     );
     if (cancelled) return { landing: "configure", notice: "brain unchanged — finish it in Configure" };
@@ -273,7 +278,7 @@ async function runOnce(
       q,
       brainDeps,
       "fallback",
-      undefined,
+      { allowHostConfig: primaryMode !== "host" },
       bothPi ? "pi-fallback" : undefined,
     );
     if (cancelled) return { landing: "configure", notice: "brain unchanged — finish it in Configure" };
@@ -318,6 +323,9 @@ async function runOnce(
     }
     q.note("Brain test passed", `reply: ${result.detail}`);
     await deps.applyChain(chain);
+    if (deps.maybePromptRestart) {
+      await deps.maybePromptRestart();
+    }
     return {
       landing: "chat",
       notice: `brain verified: ${chain.join(" → ")}`,
@@ -327,6 +335,9 @@ async function runOnce(
   // Skipped the test: the choices were real, so they're saved — but an
   // unverified brain doesn't earn chat. Configure is the honest landing.
   await deps.applyChain(chain);
+  if (deps.maybePromptRestart) {
+    await deps.maybePromptRestart();
+  }
   return {
     landing: "configure",
     notice: `brain saved (untested): ${chain.join(" → ")}`,

--- a/src/tui/screens/Choose.tsx
+++ b/src/tui/screens/Choose.tsx
@@ -18,7 +18,8 @@ import { useStableInput } from "../useStableInput.ts";
 import { Box, Text } from "ink";
 
 import { Frame } from "../components/Frame.tsx";
-import { badge, glyph, theme } from "../theme.ts";
+import { Selectable } from "../components/Selectable.tsx";
+import { badge, theme } from "../theme.ts";
 
 export interface ChooseOption {
   value: string;
@@ -90,24 +91,25 @@ export function ChooseScreen(props: {
         {options.map((option, i) => {
           const selected = i === index;
           return (
-            <Box key={option.value}>
-              <Box marginRight={1}>
-                <Text color={selected ? theme.ok : theme.dim}>
-                  {selected ? glyph.up : glyph.down}
+            <Selectable
+              key={option.value}
+              selected={selected}
+              onPress={() => props.onAnswer(option.value)}
+            >
+              <Box>
+                <Text bold={selected} color={selected ? theme.accent : undefined}>
+                  {option.label}
                 </Text>
+                {option.value === initial && initial !== "" ? (
+                  <Text color={theme.dim}> (current)</Text>
+                ) : null}
+                {option.hint ? (
+                  <Box marginLeft={1}>
+                    <Text color={theme.dim}>({option.hint})</Text>
+                  </Box>
+                ) : null}
               </Box>
-              <Text bold={selected} color={selected ? theme.accent : theme.dim}>
-                {option.label}
-              </Text>
-              {option.value === initial && initial !== "" ? (
-                <Text color={theme.dim}> (current)</Text>
-              ) : null}
-              {option.hint ? (
-                <Box marginLeft={1}>
-                  <Text color={theme.dim}>({option.hint})</Text>
-                </Box>
-              ) : null}
-            </Box>
+            </Selectable>
           );
         })}
       </Box>

--- a/src/tui/screens/Choose.tsx
+++ b/src/tui/screens/Choose.tsx
@@ -18,8 +18,7 @@ import { useStableInput } from "../useStableInput.ts";
 import { Box, Text } from "ink";
 
 import { Frame } from "../components/Frame.tsx";
-import { Selectable } from "../components/Selectable.tsx";
-import { badge, theme } from "../theme.ts";
+import { badge, glyph, theme } from "../theme.ts";
 
 export interface ChooseOption {
   value: string;
@@ -88,29 +87,29 @@ export function ChooseScreen(props: {
         </Box>
       ) : null}
       <Box flexDirection="column" marginTop={1}>
-        {options.map((option, i) => (
-          <Selectable
-            key={option.value}
-            selected={i === index}
-            onPress={() => props.onAnswer(option.value)}
-          >
-            <Box>
+        {options.map((option, i) => {
+          const selected = i === index;
+          return (
+            <Box key={option.value}>
               <Box marginRight={1}>
-                <Text backgroundColor={i === index ? theme.accent : undefined}>
-                  {" "}
+                <Text color={selected ? theme.ok : theme.dim}>
+                  {selected ? glyph.up : glyph.down}
                 </Text>
               </Box>
-              <Text bold={i === index} color={i === index ? theme.accent : undefined}>
+              <Text bold={selected} color={selected ? theme.accent : theme.dim}>
                 {option.label}
               </Text>
+              {option.value === initial && initial !== "" ? (
+                <Text color={theme.dim}> (current)</Text>
+              ) : null}
               {option.hint ? (
                 <Box marginLeft={1}>
-                  <Text color={theme.dim}>{option.hint}</Text>
+                  <Text color={theme.dim}>({option.hint})</Text>
                 </Box>
               ) : null}
             </Box>
-          </Selectable>
-        ))}
+          );
+        })}
       </Box>
     </Frame>
   );

--- a/src/tui/screens/SearchList.tsx
+++ b/src/tui/screens/SearchList.tsx
@@ -22,8 +22,7 @@ import React, { useMemo, useState } from "react";
 import { Box, Text, useInput } from "ink";
 
 import { Frame } from "../components/Frame.tsx";
-import { Selectable } from "../components/Selectable.tsx";
-import { badge, theme } from "../theme.ts";
+import { badge, glyph, theme } from "../theme.ts";
 import type { ChooseOption } from "./Choose.tsx";
 
 export interface SearchListRequest {
@@ -122,37 +121,39 @@ export function SearchListScreen(props: {
       </Box>
       <Box flexDirection="column" marginTop={1} overflow="hidden">
         {freeText ? (
-          <Selectable selected onPress={() => props.onAnswer(query.trim())}>
-            <Text>
+          <Box>
+            <Box marginRight={1}>
+              <Text color={theme.ok}>{glyph.up}</Text>
+            </Box>
+            <Text bold color={theme.accent}>
               use "{query.trim()}" as typed — no list entry matches
             </Text>
-          </Selectable>
+          </Box>
         ) : (
           rows.map((option, i) => {
             const selected = Math.max(0, lo) + i === at;
             return (
-              <Selectable
-                key={`${option.value}-${Math.max(0, lo) + i}`}
-                selected={selected}
-                onPress={() => props.onAnswer(option.value)}
-              >
-                <Box>
-                  <Text
-                    bold={selected}
-                    color={selected ? theme.accent : undefined}
-                  >
-                    {option.label}
+              <Box key={`${option.value}-${Math.max(0, lo) + i}`}>
+                <Box marginRight={1}>
+                  <Text color={selected ? theme.ok : theme.dim}>
+                    {selected ? glyph.up : glyph.down}
                   </Text>
-                  {option.value === initial ? (
-                    <Text color={theme.dim}> ·current</Text>
-                  ) : null}
-                  {option.hint ? (
-                    <Box marginLeft={1}>
-                      <Text color={theme.dim}>{option.hint}</Text>
-                    </Box>
-                  ) : null}
                 </Box>
-              </Selectable>
+                <Text
+                  bold={selected}
+                  color={selected ? theme.accent : theme.dim}
+                >
+                  {option.label}
+                </Text>
+                {option.value === initial && initial !== "" ? (
+                  <Text color={theme.dim}> (current)</Text>
+                ) : null}
+                {option.hint ? (
+                  <Box marginLeft={1}>
+                    <Text color={theme.dim}>({option.hint})</Text>
+                  </Box>
+                ) : null}
+              </Box>
             );
           })
         )}

--- a/src/tui/screens/SearchList.tsx
+++ b/src/tui/screens/SearchList.tsx
@@ -22,7 +22,8 @@ import React, { useMemo, useState } from "react";
 import { Box, Text, useInput } from "ink";
 
 import { Frame } from "../components/Frame.tsx";
-import { badge, glyph, theme } from "../theme.ts";
+import { Selectable } from "../components/Selectable.tsx";
+import { badge, theme } from "../theme.ts";
 import type { ChooseOption } from "./Choose.tsx";
 
 export interface SearchListRequest {
@@ -121,39 +122,37 @@ export function SearchListScreen(props: {
       </Box>
       <Box flexDirection="column" marginTop={1} overflow="hidden">
         {freeText ? (
-          <Box>
-            <Box marginRight={1}>
-              <Text color={theme.ok}>{glyph.up}</Text>
-            </Box>
+          <Selectable selected onPress={() => props.onAnswer(query.trim())}>
             <Text bold color={theme.accent}>
               use "{query.trim()}" as typed — no list entry matches
             </Text>
-          </Box>
+          </Selectable>
         ) : (
           rows.map((option, i) => {
             const selected = Math.max(0, lo) + i === at;
             return (
-              <Box key={`${option.value}-${Math.max(0, lo) + i}`}>
-                <Box marginRight={1}>
-                  <Text color={selected ? theme.ok : theme.dim}>
-                    {selected ? glyph.up : glyph.down}
+              <Selectable
+                key={`${option.value}-${Math.max(0, lo) + i}`}
+                selected={selected}
+                onPress={() => props.onAnswer(option.value)}
+              >
+                <Box>
+                  <Text
+                    bold={selected}
+                    color={selected ? theme.accent : undefined}
+                  >
+                    {option.label}
                   </Text>
+                  {option.value === initial && initial !== "" ? (
+                    <Text color={theme.dim}> (current)</Text>
+                  ) : null}
+                  {option.hint ? (
+                    <Box marginLeft={1}>
+                      <Text color={theme.dim}>({option.hint})</Text>
+                    </Box>
+                  ) : null}
                 </Box>
-                <Text
-                  bold={selected}
-                  color={selected ? theme.accent : theme.dim}
-                >
-                  {option.label}
-                </Text>
-                {option.value === initial && initial !== "" ? (
-                  <Text color={theme.dim}> (current)</Text>
-                ) : null}
-                {option.hint ? (
-                  <Box marginLeft={1}>
-                    <Text color={theme.dim}>({option.hint})</Text>
-                  </Box>
-                ) : null}
-              </Box>
+              </Selectable>
             );
           })
         )}

--- a/tests/brain-onboarding.test.ts
+++ b/tests/brain-onboarding.test.ts
@@ -57,6 +57,7 @@ function fakeDeps(overrides: Partial<BrainOnboardingDeps> = {}): {
       targetPath: "/tmp/personas/batman/config.toml",
       personaScope: true,
       listModels: async () => [],
+      probeProviderKey: async () => ({ status: "verified", detail: "ok" }),
       setSecret: async () => ({ ok: true }),
       unsetSecret: async () => undefined,
       writeAuth: async () => ({ ok: true, path: "/tmp/auth.json" }),
@@ -189,15 +190,81 @@ describe("wizard brain onboarding", () => {
     expect(chains).toEqual([["pi"]]);
   });
 
-  test("Pi primary and Pi fallback become independent named instances", async () => {
-    const { q } = fakeQ([
+  test("Pi primary (host) and Pi fallback (configure): fallback Pi cannot be host config and configures models directly", async () => {
+    let routedChoices: unknown = undefined;
+    const { q, picked } = fakeQ([
       "pi", "pi", // primary, fallback
-      "host", "host", // configure each instance independently
+      "host", // primary uses host config
+      // fallback Pi does not get asked host vs configure — goes straight to provider & model search
+      "openrouter", // provider
+      "sk-fallback-key", // api key
+      "gpt-5.2", // primary model
+      "gpt-5.2-vision", // vision model
+      "gpt-5.2-coder", // coding model
       "skip",
     ]);
-    const { deps, chains } = fakeDeps();
+    const { deps, chains } = fakeDeps({
+      applyRouting: async (choices) => {
+        routedChoices = choices;
+      },
+      listModels: async () => [
+        { id: "gpt-5.2", name: "GPT 5.2", provider: "openrouter", reasoning: false, input: ["text"], model: "gpt-5.2", supportsImages: false },
+        { id: "gpt-5.2-vision", name: "GPT 5 Vision", provider: "openrouter", reasoning: false, input: ["text", "image"], model: "gpt-5.2-vision", supportsImages: true },
+        { id: "gpt-5.2-coder", name: "GPT 5 Coder", provider: "openrouter", reasoning: false, input: ["text"], model: "gpt-5.2-coder", supportsImages: false },
+      ],
+    });
     const r = await runBrainOnboarding(q, deps);
     expect(r.notice).toContain("pi-primary → pi-fallback");
     expect(chains).toEqual([["pi-primary", "pi-fallback"]]);
+    expect(routedChoices).toEqual({
+      provider: "openrouter",
+      primaryModel: "gpt-5.2",
+      imageModel: "gpt-5.2-vision",
+      codingModel: "gpt-5.2-coder",
+    });
+    // Fallback Pi did not prompt for host config
+    expect(picked.filter((p) => p.includes("fallback brain) — how should its models be configured"))).toHaveLength(0);
+  });
+
+  test("Pi primary (configure) and Pi fallback (host): fallback Pi can use host config", async () => {
+    const { q } = fakeQ([
+      "pi", "pi", // primary, fallback
+      "configure", // primary configures models
+      "openrouter", // provider
+      "sk-primary-key", // api key
+      "gpt-5.2", // primary model
+      "gpt-5.2-vision", // vision model
+      "gpt-5.2-coder", // coding model
+      "host", // fallback Pi can pick host config because primary is custom
+      "skip",
+    ]);
+    const { deps, chains } = fakeDeps({
+      listModels: async () => [
+        { id: "gpt-5.2", name: "GPT 5.2", provider: "openrouter", reasoning: false, input: ["text"], model: "gpt-5.2", supportsImages: false },
+        { id: "gpt-5.2-vision", name: "GPT 5 Vision", provider: "openrouter", reasoning: false, input: ["text", "image"], model: "gpt-5.2-vision", supportsImages: true },
+        { id: "gpt-5.2-coder", name: "GPT 5 Coder", provider: "openrouter", reasoning: false, input: ["text"], model: "gpt-5.2-coder", supportsImages: false },
+      ],
+    });
+    const r = await runBrainOnboarding(q, deps);
+    expect(r.notice).toContain("pi-primary → pi-fallback");
+    expect(chains).toEqual([["pi-primary", "pi-fallback"]]);
+  });
+
+  test("maybePromptRestart is called on test pass", async () => {
+    let restartPrompted = false;
+    const { q } = fakeQ([
+      "claude",
+      "",
+      "test",
+    ]);
+    const { deps, chains } = fakeDeps({
+      maybePromptRestart: async () => {
+        restartPrompted = true;
+      },
+    });
+    const r = await runBrainOnboarding(q, deps);
+    expect(r.landing).toBe("chat");
+    expect(chains).toEqual([["claude"]]);
+    expect(restartPrompted).toBe(true);
   });
 });

--- a/tests/cli-harness.test.ts
+++ b/tests/cli-harness.test.ts
@@ -7,9 +7,11 @@ import {
   applyHarnessChain,
   detectAvailability,
   piInstallCommand,
+  runHarness,
   SUPPORTED_HARNESSES,
   whichBinary,
 } from "../src/cli/harness.ts";
+import type { HarnessPrompts } from "../src/cli/harnessPrompts.ts";
 import { checkConfiguredHarnesses } from "../src/lib/harnessAvailability.ts";
 import type { Config } from "../src/config.ts";
 
@@ -167,5 +169,90 @@ describe("detectAvailability (issue #450)", () => {
   test("resolves a bare configured bin from PATH", async () => {
     const avail = await detectAvailability(configWithStaleBin("claude"), dir);
     expect(avail.claude).toBe(join(dir, "claude"));
+  });
+});
+
+describe("runHarness dual-Pi duplicate host config rule", () => {
+  test("Pi primary (local) and Pi fallback suppresses local config option for fallback", async () => {
+    const selects: Array<{ message: string; options: readonly unknown[] }> = [];
+    const notes: Array<{ body: string; title?: string }> = [];
+
+    const selectAnswers: Array<string | undefined> = [
+      "pi", // primary
+      "pi", // fallback
+      "local", // primary config mode -> local
+      // fallback mode prompt should be bypassed
+      "google", // fallback provider
+      "gemini-2.5-flash", // fallback primary model
+      "gemini-2.5-flash", // fallback vision model
+      "gemini-2.5-flash", // fallback coding model
+    ];
+
+    const q: HarnessPrompts = {
+      select: async (input) => {
+        selects.push(input);
+        const ans = selectAnswers.shift();
+        return ans as never;
+      },
+      text: async () => "",
+      password: async () => "",
+      confirm: async () => true,
+      note: (body, title) => {
+        notes.push({ body, title });
+      },
+      intro: () => {},
+      outro: () => {},
+      cancel: () => {},
+      canRunInteractiveInstaller: false,
+    };
+
+    const config = {
+      configPath: join(workdir, "config.toml"),
+      personasDir: join(workdir, "personas"),
+      defaultPersona: "robbie",
+      harnesses: {
+        chain: ["pi"],
+        pi: { bin: "/usr/bin/pi" },
+        codex: { bin: undefined, model: "" },
+        claude: { bin: undefined },
+      },
+    } as unknown as Config;
+
+    const availability = {
+      pi: "/usr/bin/pi",
+      codex: undefined,
+      claude: undefined,
+    };
+
+    const status = await runHarness({
+      config,
+      availability,
+      prompts: q,
+      serviceControl: {
+        isActive: async () => false,
+        restart: async () => ({ ok: true }),
+        start: async () => ({ ok: true }),
+        stop: async () => ({ ok: true }),
+        rerenderUnitIfStale: async () => ({ ok: true, rerendered: false }),
+      },
+    });
+
+    expect(status).toBe(0);
+
+    // Fallback mode prompt was bypassed (only primary was asked how models should be configured)
+    const modePrompts = selects.filter((s) =>
+      s.message.includes("how should models be configured?"),
+    );
+    expect(modePrompts).toHaveLength(1);
+    expect(modePrompts[0]?.message).toContain("primary");
+
+    // Note was emitted explaining why fallback must configure its own models
+    expect(
+      notes.some((n) =>
+        n.body.includes(
+          "the fallback must configure its own models — two Pi instances on host config would be identical",
+        ),
+      ),
+    ).toBe(true);
   });
 });

--- a/tests/tui-brain-flow.test.ts
+++ b/tests/tui-brain-flow.test.ts
@@ -35,6 +35,7 @@ interface Harness {
     routings: unknown[];
     clears: Array<{ tombstone?: boolean } | undefined>;
     secrets: Array<string | "CLEARED">;
+    authWrites: Array<{ provider: string; key: string }>;
     searches: Array<{ title: string; banner?: string; initial?: string }>;
   };
 }
@@ -56,6 +57,7 @@ function harness(over: {
     routings: [] as unknown[],
     clears: [] as Array<{ tombstone?: boolean } | undefined>,
     secrets: [] as Array<string | "CLEARED">,
+    authWrites: [] as Array<{ provider: string; key: string }>,
     searches: [] as Array<{ title: string; banner?: string; initial?: string }>,
   };
   const c = [...(over.choose ?? [])];
@@ -98,7 +100,10 @@ function harness(over: {
     unsetSecret: async () => {
       applied.secrets.push("CLEARED");
     },
-    writeAuth: async () => ({ ok: true, path: "/tmp/.pi/agent/auth.json" }),
+    writeAuth: async (provider, value) => {
+      applied.authWrites.push({ provider, key: value });
+      return { ok: true, path: "/tmp/.pi/agent/auth.json" };
+    },
     applyChain: async (chain) => void applied.chains.push([...chain]),
     applyRouting: async (choices) => void applied.routings.push(choices),
     clearRouting: async (opts) => void applied.clears.push(opts),
@@ -331,10 +336,10 @@ describe("the brain flow", () => {
       routing: { provider: "openrouter" },
       models: [], // empty initial models
     });
-    h.deps.listModels = async () => {
+    h.deps.listModels = async (extraEnv) => {
       listCalls++;
-      // On second call (after auth sync), return models
-      return listCalls > 1 ? MODELS : [];
+      // On second call (or with extraEnv), return models
+      return extraEnv?.OPENROUTER_API_KEY === "sk-stored" ? MODELS : [];
     };
     const notice = await configureBrain(h.q, h.deps);
     expect(notice).toBe("brain saved: pi");
@@ -343,5 +348,18 @@ describe("the brain flow", () => {
       provider: "openrouter",
       primaryModel: "gpt-5.2",
     });
+  });
+
+  test("cancelling the wizard before completion does not mutate Pi's shared auth store", async () => {
+    const h = harness({
+      choose: ["pi", "CURRENT", "configure"],
+      search: [undefined], // Esc / cancel at the provider selection prompt
+      storedKey: "sk-instance-key",
+      routing: { provider: "openrouter" },
+      models: [], // empty initial models triggers pre-selection refresh attempt
+    });
+    const notice = await configureBrain(h.q, h.deps);
+    expect(notice).toBe("brain unchanged");
+    expect(h.applied.authWrites).toEqual([]);
   });
 });

--- a/tests/tui-brain-flow.test.ts
+++ b/tests/tui-brain-flow.test.ts
@@ -362,4 +362,31 @@ describe("the brain flow", () => {
     expect(notice).toBe("brain unchanged");
     expect(h.applied.authWrites).toEqual([]);
   });
+
+  test("Pi primary (host) and Pi fallback (configure): fallback Pi skips host config choice and runs configure", async () => {
+    const h = harness({
+      choose: ["pi", "pi", "host"], // primary = pi, fallback = pi, primary picks host
+      search: ["openrouter", "gpt-5.2", "gpt-5.2-vision", "gpt-5.2"],
+      value: ["sk-fallback-key"],
+    });
+    const notice = await configureBrain(h.q, h.deps);
+    expect(notice).toBe("brain saved: pi-primary → pi-fallback");
+    expect(h.applied.chains).toEqual([["pi-primary", "pi-fallback"]]);
+    expect(h.applied.routings).toHaveLength(1);
+    expect(h.applied.routings[0]).toMatchObject({
+      provider: "openrouter",
+      primaryModel: "gpt-5.2",
+    });
+  });
+
+  test("Pi primary (configure) and Pi fallback (host): fallback Pi can choose host config", async () => {
+    const h = harness({
+      choose: ["pi", "pi", "configure", "host"], // primary picks configure, fallback picks host
+      search: ["openrouter", "gpt-5.2", "gpt-5.2-vision", "gpt-5.2"],
+      value: ["sk-primary-key"],
+    });
+    const notice = await configureBrain(h.q, h.deps);
+    expect(notice).toBe("brain saved: pi-primary → pi-fallback");
+    expect(h.applied.chains).toEqual([["pi-primary", "pi-fallback"]]);
+  });
 });

--- a/tests/tui-brain-flow.test.ts
+++ b/tests/tui-brain-flow.test.ts
@@ -320,4 +320,28 @@ describe("the brain flow", () => {
       primaryModel: "gpt-5.2",
     });
   });
+
+  test("keeping a stored key refreshes models if initially empty for provider", async () => {
+    let listCalls = 0;
+    const h = harness({
+      choose: ["pi", "CURRENT", "configure"],
+      search: ["openrouter", "gpt-5.2", "gpt-5.2-vision", "gpt-5.2"],
+      value: [""], // keep stored key
+      storedKey: "sk-stored",
+      routing: { provider: "openrouter" },
+      models: [], // empty initial models
+    });
+    h.deps.listModels = async () => {
+      listCalls++;
+      // On second call (after auth sync), return models
+      return listCalls > 1 ? MODELS : [];
+    };
+    const notice = await configureBrain(h.q, h.deps);
+    expect(notice).toBe("brain saved: pi");
+    expect(listCalls).toBeGreaterThanOrEqual(2);
+    expect(h.applied.routings[0]).toMatchObject({
+      provider: "openrouter",
+      primaryModel: "gpt-5.2",
+    });
+  });
 });

--- a/tests/tui-brain-flow.test.ts
+++ b/tests/tui-brain-flow.test.ts
@@ -45,6 +45,7 @@ function harness(over: {
   availability?: Record<string, string | undefined>;
   routing?: BrainDeps["routing"];
   storedKey?: string;
+  piInstances?: BrainDeps["piInstances"];
   personaScope?: boolean;
   models?: PiModel[];
   choose?: Array<string | undefined>;
@@ -87,6 +88,7 @@ function harness(over: {
     availability: over.availability ?? { pi: "/usr/bin/pi", codex: "/usr/bin/codex", claude: undefined },
     routing: over.routing ?? {},
     storedKey: over.storedKey,
+    piInstances: over.piInstances,
     targetPath: "/tmp/personas/robbie/config.toml",
     personaScope: over.personaScope ?? true,
     piBin: over.availability?.pi ?? "/usr/bin/pi",
@@ -373,6 +375,38 @@ describe("the brain flow", () => {
     expect(notice).toBe("brain saved: pi-primary → pi-fallback");
     expect(h.applied.chains).toEqual([["pi-primary", "pi-fallback"]]);
     expect(h.applied.routings).toHaveLength(1);
+    expect(h.applied.routings[0]).toMatchObject({
+      provider: "openrouter",
+      primaryModel: "gpt-5.2",
+    });
+  });
+
+  test("named Pi instances: keeping a stored key on fallback Pi writes the instance key and refreshes models", async () => {
+    let listCalls = 0;
+    const h = harness({
+      choose: ["pi", "pi", "host"], // primary = pi (host), fallback = pi (auto-configure)
+      search: ["openrouter", "gpt-5.2", "gpt-5.2-vision", "gpt-5.2"],
+      value: [""], // keep stored key on fallback
+      storedKey: "sk-global-wrong-key",
+      piInstances: {
+        fallback: {
+          routing: { provider: "openrouter" },
+          storedKey: "sk-fallback-instance-key",
+        },
+      },
+      models: [], // empty initial models forces keep-branch refresh
+    });
+    h.deps.listModels = async (extraEnv) => {
+      listCalls++;
+      return extraEnv?.OPENROUTER_API_KEY === "sk-fallback-instance-key" ? MODELS : [];
+    };
+    const notice = await configureBrain(h.q, h.deps);
+    expect(notice).toBe("brain saved: pi-primary → pi-fallback");
+    // Assert writeAuth wrote the instance key into auth store, not the global key
+    expect(h.applied.authWrites).toEqual([
+      { provider: "openrouter", key: "sk-fallback-instance-key" },
+    ]);
+    expect(listCalls).toBeGreaterThanOrEqual(2);
     expect(h.applied.routings[0]).toMatchObject({
       provider: "openrouter",
       primaryModel: "gpt-5.2",


### PR DESCRIPTION
Brings parity between the TUI Brain configure flow and the `phantombot harness` clack app:

- **Selectors & Badges:** Replaced generic indicators with clear `●` (green dot) / `○` (dim circle) status selectors and paren-formatted `(provider — key already configured)` / `(vision)` / `(current)` badges across `SearchList` and `Choose`.
- **Model Fetching Parity:** 
  - Syncs to Pi's auth store (`~/.pi/agent/auth.json`) and triggers env-injected model refresh not only when typing a new key, but also when retaining an existing stored vault key (solving the empty model catalogue bug on re-runs).
  - Deduplicates and merges model lists dynamically across refreshes so no discovered models are lost.
- **Search Preserved:** Retains full-featured live substring filtering and windowed pagination for large model catalogues.

Verified: full test suite **4463 passed / 0 failed**, tsc clean, regression test added for stored-key model refresh.