### PR TITLE
channels: rename TELEGRAM_REPLY_INSTRUCTION and drop its skip-narration line

### DIFF
--- a/src/channels/core/engine.ts
+++ b/src/channels/core/engine.ts
@@ -97,7 +97,7 @@ import type { GroupChatState } from "./routing.ts";
 import {
   captureNudgeForTurn,
   languageReplyInstruction,
-  TELEGRAM_REPLY_INSTRUCTION,
+  CHAT_REPLY_INSTRUCTION,
   VOICE_REPLY_INSTRUCTION,
   voiceUnavailableMessage,
 } from "./prompts.ts";
@@ -1389,7 +1389,7 @@ async function processChatMessage(
         input.agentDir,
       ),
       // Channel-layer prompt suffix:
-      //   - Always: TELEGRAM_REPLY_INSTRUCTION — short conversational
+      //   - Always: CHAT_REPLY_INSTRUCTION — short conversational
       //     replies + plan-then-confirm before long jobs (git/build/
       //     deploy or anything that would spawn more than one tool call).
       //   - Voice-out: stack VOICE_REPLY_INSTRUCTION on top — stricter
@@ -1407,8 +1407,8 @@ async function processChatMessage(
       // exactly the salience boost weak harnesses need.
       systemPromptSuffix: [
         willReplyWithVoice
-          ? `${TELEGRAM_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
-          : TELEGRAM_REPLY_INSTRUCTION,
+          ? `${CHAT_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
+          : CHAT_REPLY_INSTRUCTION,
         replyLanguage ? languageReplyInstruction(replyLanguage.name) : undefined,
         captureNudge,
       ]

--- a/src/channels/core/prompts.ts
+++ b/src/channels/core/prompts.ts
@@ -4,7 +4,7 @@
  * These standing instructions live at the channel layer (not in persona
  * files) so they apply to chat turns without leaking into unattended CLI /
  * nightly turns. The names are kept IDENTICAL to their original form
- * (including TELEGRAM_REPLY_INSTRUCTION) and re-exported from
+ * (including CHAT_REPLY_INSTRUCTION) and re-exported from
  * channels/telegram.ts so the public API is unchanged (#162).
  */
 
@@ -13,15 +13,22 @@ import { log } from "../../lib/logger.ts";
 import type { MemoryStore } from "../../memory/store.ts";
 
 /**
- * System-prompt suffix applied to EVERY Telegram turn.
+ * System-prompt suffix applied to EVERY chat turn (Telegram and
+ * phantomchat today; any future chat transport tomorrow).
  *
  * Two purposes:
  *
  * 1. Reply style. The user is on a phone with a narrow column. Long
- *    walls of text and meta-narration ("Let me check…", "Right,
- *    here's what I found…") read poorly there. Default to short,
- *    conversational answers; structured-and-clear is fine when the
- *    user explicitly asks for a detailed report.
+ *    walls of text read poorly there. Default to short, conversational
+ *    answers; structured-and-clear is fine when the user explicitly
+ *    asks for a detailed report.
+ *
+ *    It does NOT tell the model to skip narration. Every interactive
+ *    turn carries the orchestrator's PRE_TOOL_NARRATION_INSTRUCTION
+ *    ("before each tool call, say ONE short sentence"), and a
+ *    channel-local "skip narration" line directly contradicted it —
+ *    a contradiction only a strong model reconciles. The orchestrator
+ *    overlay is the single owner of that rule.
  *
  * 2. Voice/text reply-mode routing.
  *
@@ -38,13 +45,12 @@ import type { MemoryStore } from "../../memory/store.ts";
  * Lives at the channel layer (not in persona files) so CLI / nightly
  * turns aren't affected — verbose CLI output is fine there.
  */
-export const TELEGRAM_REPLY_INSTRUCTION =
-  `# Reply style (Telegram chat)
+export const CHAT_REPLY_INSTRUCTION =
+  `# Reply style (chat)
 
-You're chatting via Telegram. Default to short, conversational
-replies — typically 1-4 sentences. The user is usually on a phone,
-and the narrow column makes long walls of text hard to read. Skip
-narration ("Let me…", "Right, here's what I found…"); answer directly.
+You're in a chat app. Default to short, conversational replies —
+typically 1-4 sentences. The user is usually on a phone, and the
+narrow column makes long walls of text hard to read.
 
 Longer replies are fine when the user explicitly asks for a detailed
 report or analysis. Use clear structure (headings, lists) when the
@@ -133,7 +139,7 @@ export async function captureNudgeForTurn(
 }
 
 /**
- * Voice-only overlay, stacked on top of TELEGRAM_REPLY_INSTRUCTION
+ * Voice-only overlay, stacked on top of CHAT_REPLY_INSTRUCTION
  * when the reply will be synthesized via TTS.
  *
  * Why this exists separately: the chat-style instruction allows

--- a/src/channels/phantomchat/server.ts
+++ b/src/channels/phantomchat/server.ts
@@ -47,7 +47,7 @@ import type { LifecycleAccount } from "../../lib/lifecycleBroadcast.ts";
 import { ConversationBacklog } from "../core/backlog.ts";
 import {
   languageReplyInstruction,
-  TELEGRAM_REPLY_INSTRUCTION,
+  CHAT_REPLY_INSTRUCTION,
   VOICE_REPLY_INSTRUCTION,
   voiceUnavailableMessage,
 } from "../core/prompts.ts";
@@ -1047,8 +1047,8 @@ export async function runPhantomchatServer(
         // (short, no-markdown, TTS-friendly) when this reply will be spoken.
         systemPromptSuffix: [
           willReplyWithVoice
-            ? `${TELEGRAM_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
-            : TELEGRAM_REPLY_INSTRUCTION,
+            ? `${CHAT_REPLY_INSTRUCTION}\n\n${VOICE_REPLY_INSTRUCTION}`
+            : CHAT_REPLY_INSTRUCTION,
           replyLanguage
             ? languageReplyInstruction(replyLanguage.name)
             : undefined,

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -77,7 +77,7 @@ export {
 
 // --- Channel-layer prompts + capture nudge (core/prompts.ts) ---------------
 export {
-  TELEGRAM_REPLY_INSTRUCTION,
+  CHAT_REPLY_INSTRUCTION,
   CAPTURE_NUDGE_INTERVAL,
   CAPTURE_NUDGE_TEXT,
   captureNudgeForTurn,

--- a/src/persona/builder.ts
+++ b/src/persona/builder.ts
@@ -610,7 +610,7 @@ is in, just answer.`;
  * Channel-agnostic conduct overlay: plan-then-confirm before a long or
  * state-changing job, and keep direct answers short.
  *
- * This is the block PR #443 removed from `TELEGRAM_REPLY_INSTRUCTION`,
+ * This is the block PR #443 removed from `CHAT_REPLY_INSTRUCTION`,
  * restored deliberately and in a different shape. #443's three
  * complaints were real, and each is answered here:
  *

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -2385,7 +2385,7 @@ describe("runTelegramServer voice round-trip", () => {
 
 // ---------------------------------------------------------------------------
 // Channel-layer system-prompt suffixes:
-//   - TELEGRAM_REPLY_INSTRUCTION applies to every Telegram turn
+//   - CHAT_REPLY_INSTRUCTION applies to every Telegram turn
 //     (short conversational + voice/text routing). The plan-then-confirm
 //     gate is NOT in it — it comes from the orchestrator overlay, which is
 //     why these tests assert it is present on a Telegram turn all the same.
@@ -2452,7 +2452,7 @@ describe("runTelegramServer system-prompt suffixes", () => {
       expect(harness.invocations).toBe(1);
       const prompt = harness.lastRequest?.systemPrompt ?? "";
       // Telegram chat-style suffix is present.
-      expect(prompt).toContain("Reply style (Telegram chat)");
+      expect(prompt).toContain("Reply style (chat)");
       // The channel-agnostic confirm gate rides along on a chat turn too
       // (orchestrator overlay, not the Telegram suffix — AGENTS invariant 29).
       expect(prompt).toContain("Confirm before long jobs");
@@ -2487,7 +2487,7 @@ describe("runTelegramServer system-prompt suffixes", () => {
     });
     const prompt = harness.lastRequest?.systemPrompt ?? "";
     // The chat-style instruction is always applied for Telegram turns.
-    expect(prompt).toContain("Reply style (Telegram chat)");
+    expect(prompt).toContain("Reply style (chat)");
     // The confirm gate is injected by the orchestrator on every interactive
     // turn, Telegram included — with the threshold at more than THREE tool
     // calls and an explicit "the user outranks this" clause (invariant 29).
@@ -2497,6 +2497,13 @@ describe("runTelegramServer system-prompt suffixes", () => {
     expect(prompt).toContain("This is a default, not a cage");
     // ...and the 50-word answer-length rule travels with it.
     expect(prompt).toContain("50 words or");
+    // The chat suffix must NOT contradict the orchestrator's narration
+    // rule. A channel-local "skip narration" line used to ship right
+    // alongside "before each tool call, say ONE short sentence"; a weak
+    // model resolved that by narrating once and stopping without ever
+    // calling a tool. The orchestrator overlay owns this rule alone.
+    expect(prompt).not.toContain("Skip narration");
+    expect(prompt).toContain("Narration before tool calls");
     // The voice-only overlay must NOT leak into text replies.
     expect(prompt).not.toContain("text-to-speech");
     expect(prompt).not.toContain("Reply length (this turn only)");


### PR DESCRIPTION
## Problem

`TELEGRAM_REPLY_INSTRUCTION` is the chat-style system-prompt suffix. It has three call sites: `channels/telegram.ts`, `channels/core/engine.ts` (Telegram) and `channels/phantomchat/server.ts`. So the Telegram-specific name — and the literal opener "You're chatting via Telegram" — are wrong for a third of its uses. TUI (`tui/chatSession.ts`) and ACP (`acp/turnBridge.ts`) pass no reply-style suffix at all.

It also contained:

> Skip narration ("Let me…", "Right, here's what I found…"); answer directly.

while every interactive turn additionally carries the orchestrator overlay `PRE_TOOL_NARRATION_INSTRUCTION`:

> before each tool call, say ONE short sentence describing what you're about to do.

Two owners of the same rule, saying opposite things, in one prompt. A strong model reconciles it. A model already short on completion budget takes the loudest, shortest reading: emit one narration sentence, "answer directly", stop — **zero tool calls, clean exit, no error**. Nothing downstream catches that: the harness chain only advances on a *failure*, and #541's recovery reply only fires on a thrown error. Observed in the field on a persona running a reasoning-heavy model over phantomchat, never over TUI.

## Change

- Rename `TELEGRAM_REPLY_INSTRUCTION` → `CHAT_REPLY_INSTRUCTION`; heading `# Reply style (Telegram chat)` → `# Reply style (chat)`; opener made transport-neutral.
- Delete the "Skip narration" sentence. Narration is now owned solely by the orchestrator overlay.
- Doc comment updated to say why the line must not come back.

Everything else in the block is unchanged and deliberately kept — the brevity rule (phones, narrow column) and the voice/text reply-mode section, which is the only place `phantombot reply-mode text|voice|default|disable` is documented to the model.

No behaviour change beyond the prompt text: same call sites, same stacking with `VOICE_REPLY_INSTRUCTION`, same re-export from `channels/telegram.ts`.

## Tests

Two assertions added to the text-in/text-out Telegram prompt test: the chat suffix must NOT contain "Skip narration", and the orchestrator's narration section must be present. Proven by restoring the deleted sentence in `prompts.ts` — 1 fail. Full suite: **4592 pass, 0 fail**. `tsc --noEmit` clean.
