### PR TITLE
TUI: MCP servers menu in Configure, and doctor as a grouped checklist

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -68,7 +68,7 @@ import { PersonaDetailScreen } from "./screens/PersonaDetail.tsx";
 import { KeysScreen } from "./screens/Keys.tsx";
 import { DoctorScreen } from "./screens/Doctor.tsx";
 import { gatherStatus, type StatusRows } from "./status.ts";
-import { McpScreen } from "./screens/Mcp.tsx";
+import { McpScreen, type McpServerRow } from "./screens/Mcp.tsx";
 import { SystemScreen } from "./screens/System.tsx";
 import { systemSnapshot } from "./systemSnapshot.ts";
 import { WizardScreen, type WizardAnswers } from "./screens/Wizard.tsx";
@@ -201,6 +201,12 @@ export function App(props: AppProps): React.ReactElement {
   const [doctorReport, setDoctorReport] = useState<DoctorReport | undefined>();
   const [doctorStatus, setDoctorStatus] = useState<StatusRows | undefined>();
   const [doctorRunning, setDoctorRunning] = useState(false);
+  /**
+   * The MCP screen's rows. Undefined until the registry has been read; the
+   * screen renders an empty list, which reads identically to "none
+   * registered" for the fraction of a second a file read takes.
+   */
+  const [mcpServers, setMcpServers] = useState<McpServerRow[] | undefined>();
   // The settings screen's live /status reading for the persona it is open on.
   // Undefined = still gathering; the descriptions read `…` until this lands.
   const [detailStatus, setDetailStatus] = useState<StatusRows | undefined>();
@@ -549,6 +555,117 @@ export function App(props: AppProps): React.ReactElement {
       setDoctorRunning(false);
     }
   }, [personaName, host]);
+
+  /**
+   * The MCP screen's data path: list from disk, probe per row, delete on
+   * confirm. Listing and probing are separate on purpose — see `mcpFlow.ts`.
+   */
+  const loadMcpServers = useCallback(async (personaDirPath: string) => {
+    try {
+      const { listMcpServers } = await import("./mcpFlow.ts");
+      setMcpServers(await listMcpServers(personaDirPath));
+    } catch (e) {
+      // An unreadable registry is NOT an empty one. Empty rows plus a notice
+      // says so; silently painting "none registered" would invite the user to
+      // re-add servers that are already there.
+      setMcpServers([]);
+      setNotice(`mcp registry unreadable: ${(e as Error).message}`);
+    }
+  }, []);
+
+  /**
+   * Probe ONE server. The row flips to `probing` first so the user can see
+   * which one is being waited on, then to its verdict. Rows are matched by
+   * name rather than index: a probe that lands after a delete must not write
+   * its result onto whatever row slid into that slot.
+   */
+  const probeOneMcpServer = useCallback(
+    async (personaDirPath: string, name: string) => {
+      const patch = (row: Partial<McpServerRow>) =>
+        setMcpServers((rows) =>
+          rows?.map((r) => (r.name === name ? { ...r, ...row } : r)),
+        );
+      patch({ status: "probing", detail: undefined });
+      try {
+        const { probeMcpServer } = await import("./mcpFlow.ts");
+        const result = await probeMcpServer(personaDirPath, name);
+        patch({
+          status: result.ok ? "ok" : "bad",
+          detail: result.detail,
+          ...(result.tools === undefined ? {} : { tools: result.tools }),
+        });
+      } catch (e) {
+        patch({ status: "bad", detail: (e as Error).message });
+      }
+    },
+    [],
+  );
+
+  /**
+   * Delete one server, behind the same confirm every destructive setting uses.
+   * The vault keys it references are PURGED only on a second, separate yes —
+   * the registry entry can be re-added from notes, while the vault is the only
+   * copy of the credential.
+   */
+  const removeOneMcpServer = useCallback(
+    async (target: PersonaSnapshot, name: string) => {
+      const row = mcpServers?.find((r) => r.name === name);
+      const secrets = row?.secrets ?? [];
+      const yes = await askConfirmValue({
+        title: `Remove MCP server '${name}' from ${target.name}?`,
+        danger: true,
+        consequence: {
+          summary: `${target.name} loses every tool this server provides`,
+          detail:
+            `The registry entry is deleted from ${target.name}'s mcp.json. ` +
+            "Nothing else changes: the server itself keeps running wherever " +
+            "it runs, and it can be registered again with `phantombot mcp add`.",
+          longRunning: false,
+          restarts: false,
+        },
+      });
+      if (!yes) return;
+      const purgeSecrets =
+        secrets.length > 0 &&
+        (await askConfirmValue({
+          title: `Also delete ${name}'s ${secrets.length} vault secret(s)?`,
+          danger: true,
+          consequence: {
+            summary: `${secrets.join(", ")} are erased from the vault`,
+            detail:
+              "The vault is the only copy of these values, so this cannot be " +
+              "undone. Say no to keep them — an unreferenced secret is inert, " +
+              "and it is what you need to register this server again.",
+            longRunning: false,
+            restarts: false,
+          },
+        }));
+      try {
+        const { deleteMcpServer } = await import("./mcpFlow.ts");
+        const result = await deleteMcpServer({
+          personaDir: target.dir,
+          name,
+          purgeSecrets,
+        });
+        if (!result.ok) {
+          setNotice(result.error ?? `could not remove ${name}`);
+          return;
+        }
+        setMcpServers((rows) => rows?.filter((r) => r.name !== name));
+        setNotice(
+          result.purged.length > 0
+            ? `removed ${name} · purged ${result.purged.join(", ")}`
+            : `removed ${name}`,
+        );
+        // The Configure row's count comes from the snapshot, so it has to be
+        // re-taken or the badge keeps the pre-delete number.
+        await refresh();
+      } catch (e) {
+        setNotice(`could not remove ${name}: ${(e as Error).message}`);
+      }
+    },
+    [mcpServers, askConfirmValue, refresh],
+  );
 
   // The settings screen no longer runs the doctor — its telemetry block shows
   // the persona's /status reading only. The full Doctor screen (from the
@@ -1940,6 +2057,7 @@ export function App(props: AppProps): React.ReactElement {
         <PersonaDetailScreen
           persona={persona}
           status={detailStatus}
+          mcpServers={persona.mcpServers}
           onBack={back}
           onEditIdentity={() => void editIdentity(persona)}
           onChangeBrain={() => void changeBrain(persona)}
@@ -2006,9 +2124,16 @@ export function App(props: AppProps): React.ReactElement {
           }}
           onOpen={(target) => {
             // Memory and Voice are FLOWS now, not screens — the same clack
-            // walkthroughs the Brain and Channels rows run.
+            // walkthroughs the Brain and Channels rows run. MCP is a real
+            // screen: it lists rows, probes them and deletes them.
             if (target === "memory") void changeMemory(persona);
-            else void changeVoice(persona);
+            else if (target === "mcp") {
+              // Clear first: a previous persona's servers flashing as this
+              // one's is the same staleness bug the Doctor row guards against.
+              setMcpServers(undefined);
+              go("mcp");
+              void loadMcpServers(persona.dir);
+            } else void changeVoice(persona);
           }}
         />
       );
@@ -2100,8 +2225,13 @@ export function App(props: AppProps): React.ReactElement {
     return (
       <McpScreen
         personaName={persona.name}
-        servers={[]}
-        onTest={() => setNotice("mcp test not wired yet")}
+        servers={mcpServers ?? []}
+        onTest={(name) => void probeOneMcpServer(persona.dir, name)}
+        onTestAll={() => {
+          for (const server of mcpServers ?? [])
+            void probeOneMcpServer(persona.dir, server.name);
+        }}
+        onDelete={(name) => void removeOneMcpServer(persona, name)}
         onBack={back}
       />
     );

--- a/src/tui/doctorChecklist.ts
+++ b/src/tui/doctorChecklist.ts
@@ -1,0 +1,421 @@
+/**
+ * The Doctor screen's checklist, as DATA.
+ *
+ * The screen used to render four of the report's checks — telegram, the memory
+ * DB, the nightly sweep and its backlog — and drop the rest on the floor.
+ * Everything else `runDoctor` computes (systemd units, timer staleness,
+ * per-persona maintenance, the default persona, harness binaries, the Pi
+ * extension, ACP editor registrations, MCP servers, embeddings, service logs)
+ * was visible ONLY in the CLI's text output, so the screen quietly claimed a
+ * healthy box while doctor's exit code said otherwise.
+ *
+ * Telegram was the one substantive channel check, which read as a leftover
+ * precisely BECAUSE it was alone. The fix is to add its siblings, not to
+ * remove it (Andrew, 2026-09-12).
+ *
+ * Three rules, which is the whole design:
+ *
+ *   1. GROUPED — Core, Channels, Integrations. A flat wall of green ticks is
+ *      as unreadable as no output; a section heading is what makes "20 checks
+ *      passed" skimmable.
+ *   2. ONE LINE per check when healthy. `detail` is a value worth reading at a
+ *      glance (a size, a version, a count), never a sentence.
+ *   3. `hint` — the "here is what to do" line — appears ONLY on a check that
+ *      is not green. Failures are loud; health is quiet.
+ *
+ * `warn` must never read as `bad`. "No Telegram account" is a perfectly good
+ * state for a phantom that does not use Telegram, and an operator who learns
+ * that yellow means nothing stops reading red too.
+ *
+ * Doctor REPAIRS as well as reports, so where a check healed something the
+ * line says so ("re-stamped", "re-armed") rather than just showing green —
+ * otherwise a self-healed fault is indistinguishable from one that never
+ * happened, and the operator loses the fact that something was wrong.
+ *
+ * This is a pure function of the report: no probing, no reading the disk. The
+ * screen renders what it returns, so the CLI and the TUI cannot disagree about
+ * the health of the same box.
+ */
+
+import type { DoctorReport } from "../cli/doctor.ts";
+import { missingHarnesses } from "../lib/harnessAvailability.ts";
+import { editorConnectorBroken } from "../connectors/acp/autoInstall.ts";
+import { humanBytes } from "./theme.ts";
+
+export type CheckState = "ok" | "warn" | "bad";
+
+export interface ChecklistItem {
+  label: string;
+  state: CheckState;
+  /** A value worth a glance. Shown in every state. */
+  detail?: string;
+  /** What to do about it. Shown only when `state` is not "ok". */
+  hint?: string;
+}
+
+export interface ChecklistSection {
+  title: string;
+  items: ChecklistItem[];
+}
+
+/** `3` → `3 personas`, `1` → `1 persona`. */
+function plural(n: number, one: string, many = `${one}s`): string {
+  return `${n} ${n === 1 ? one : many}`;
+}
+
+function coreItems(r: DoctorReport): ChecklistItem[] {
+  const items: ChecklistItem[] = [];
+
+  items.push({
+    label: "memory database",
+    state: r.memory_db.healthy ? "ok" : "bad",
+    detail: `${humanBytes(r.memory_db.bytes)} · ${plural(r.memory_db.restore_points.length, "restore point")}`,
+    ...(r.memory_db.healthy
+      ? {}
+      : {
+          hint: r.memory_db.newest_good
+            ? `${r.memory_db.detail} — newest good snapshot ${r.memory_db.newest_good}; restore with \`phantombot memory backup\``
+            : `${r.memory_db.detail} — no verified snapshot to restore from`,
+        }),
+  });
+
+  if (r.memory_db.unretired_drawers.length > 0)
+    items.push({
+      label: "drawer files",
+      state: "warn",
+      detail: plural(r.memory_db.unretired_drawers.length, "file") + " still on disk",
+      hint: `retirement held back ${r.memory_db.unretired_drawers.join(", ")} — nothing reads them`,
+    });
+
+  items.push({
+    label: "nightly sweep",
+    state:
+      r.nightly.health === "ok"
+        ? "ok"
+        : r.nightly.health === "error"
+          ? "bad"
+          : "warn",
+    detail: r.nightly.detail,
+    ...(r.nightly.health === "ok"
+      ? {}
+      : {
+          hint:
+            r.nightly.errors && r.nightly.errors.length > 0
+              ? r.nightly.errors.join("; ")
+              : "the sweep distils the day into the drawers and kb/ — a backlog means none of that happened",
+        }),
+  });
+
+  // Backlog is the nightly's only real truth, and it is its own line because a
+  // missed 02:00 with nothing pending is still `ok` on the line above.
+  if (r.nightly.backlog > 0)
+    items.push({
+      label: "nightly backlog",
+      state: "warn",
+      detail: `${plural(r.nightly.backlog, "day")} pending${r.nightly.oldest_pending ? `, oldest ${r.nightly.oldest_pending}` : ""}`,
+      hint: "the next sweep catches up on its own; it only needs chasing if this number keeps growing",
+    });
+
+  items.push({
+    label: "capture",
+    state: r.capture.dry_day ? "warn" : "ok",
+    detail: `${r.capture.captures} from ${plural(r.capture.user_turns, "turn")} in ${r.capture.window_hours}h`,
+    ...(r.capture.dry_day
+      ? {
+          hint: "turns but no captures — nothing from today will reach the drawers or MEMORY.md",
+        }
+      : {}),
+  });
+
+  if (r.timers) {
+    // Not `systemctl is-active`: what each timer last WROTE TO DISK. A timer
+    // systemd swears is active but has not fired is the long-uptime failure
+    // this catches, and the only evidence is the marker.
+    for (const [label, t] of [
+      ["heartbeat timer", r.timers.heartbeat],
+      ["tick timer", r.timers.tick],
+    ] as const)
+      items.push({
+        label,
+        state: t.stale ? "warn" : "ok",
+        detail:
+          t.last_fired === undefined
+            ? "never fired"
+            : `fired ${t.age_minutes}m ago`,
+        ...(t.stale
+          ? {
+              hint: `no marker newer than ${t.threshold_minutes}m — doctor re-arms it; systemd can report a timer active while it has stopped firing`,
+            }
+          : {}),
+      });
+  }
+
+  if (r.systemd) {
+    const broken = [
+      ...r.systemd.missing_unit_files,
+      ...r.systemd.drifted_unit_files,
+      ...r.systemd.inactive_timers,
+    ];
+    items.push({
+      label: "systemd units",
+      state: broken.length === 0 ? "ok" : r.systemd.repaired ? "warn" : "bad",
+      detail:
+        broken.length === 0
+          ? "all present and armed"
+          : r.systemd.repaired
+            ? `repaired ${plural(broken.length, "unit")}`
+            : `${plural(broken.length, "unit")} broken`,
+      ...(broken.length === 0
+        ? {}
+        : {
+            hint: r.systemd.repaired
+              ? `re-rendered / re-armed: ${broken.join(", ")}`
+              : `${broken.join(", ")} — run \`phantombot doctor\` without --no-repair`,
+          }),
+    });
+  }
+
+  if (r.maintenance) {
+    // One line for the fleet when it is fine, one line per persona when it is
+    // not: a per-persona list on a healthy box is four lines saying nothing.
+    const behind = r.maintenance.filter(
+      (m) => m.heartbeat_stale || m.nightly_backlog > 0,
+    );
+    if (behind.length === 0)
+      items.push({
+        label: "persona maintenance",
+        state: "ok",
+        detail: `${plural(r.maintenance.length, "persona")} current`,
+      });
+    else
+      for (const m of behind)
+        items.push({
+          label: `maintenance: ${m.persona}`,
+          state: "warn",
+          detail: m.heartbeat_stale
+            ? m.last_heartbeat === undefined
+              ? "heartbeat never fired"
+              : `heartbeat ${m.heartbeat_age_minutes}m ago`
+            : `nightly ${plural(m.nightly_backlog, "date")} pending`,
+          hint: `check \`systemctl --user status phantombot-heartbeat@${m.persona}.timer\``,
+        });
+  }
+
+  const dp = r.default_persona;
+  items.push({
+    label: "default persona",
+    state: dp.healthy ? "ok" : "bad",
+    detail: `${dp.resolved} (from ${dp.provenance})`,
+    ...(dp.healthy
+      ? {}
+      : {
+          hint:
+            dp.defect ??
+            (dp.served
+              ? dp.detail
+              : `${dp.resolved} is the default but is not served — the config contradicts itself`),
+        }),
+  });
+
+  if (r.service_logs)
+    items.push({
+      label: "service logs",
+      state: r.service_logs.over_cap.length === 0 ? "ok" : "warn",
+      detail: `${humanBytes(r.service_logs.bytes)} · cap ${humanBytes(r.service_logs.max_bytes)} × ${r.service_logs.keep}`,
+      ...(r.service_logs.over_cap.length === 0
+        ? {}
+        : {
+            hint: `over cap, rotated on the next heartbeat: ${r.service_logs.over_cap.join(", ")}`,
+          }),
+    });
+
+  items.push({
+    label: "release ring",
+    state: "ok",
+    detail: `${r.update.channel} · v${r.update.version}`,
+  });
+
+  return items;
+}
+
+function channelItems(r: DoctorReport): ChecklistItem[] {
+  const items: ChecklistItem[] = [];
+
+  // Telegram stays, and keeps its per-persona expansion. It answers the one
+  // question no other line does: will this phantom actually RECEIVE a message.
+  const stated = r.telegram.personas.filter((p) => p.stated);
+  items.push({
+    label: "telegram",
+    state: !r.telegram.healthy ? "bad" : stated.length === 0 ? "warn" : "ok",
+    detail:
+      stated.length === 0
+        ? "no account configured"
+        : `${plural(r.telegram.listeners, "listener")} across ${plural(stated.length, "persona")}`,
+    ...(r.telegram.healthy
+      ? stated.length === 0
+        ? {
+            hint: "nothing is wrong — this host simply does not answer on Telegram",
+          }
+        : {}
+      : {
+          hint: r.telegram.personas
+            .filter((p) => !p.healthy)
+            .map((p) => `${p.persona}: ${p.detail}`)
+            .join("; "),
+        }),
+  });
+
+  items.push({
+    label: "embeddings",
+    state: r.embeddings.semantic_search ? "ok" : "warn",
+    detail: r.embeddings.semantic_search
+      ? `${r.embeddings.provider} · semantic search on`
+      : r.embeddings.provider === "none"
+        ? "no provider · keyword search only"
+        : `${r.embeddings.provider} configured but incomplete`,
+    ...(r.embeddings.semantic_search
+      ? {}
+      : {
+          // Explicitly NOT a fault: memory search still works on FTS5/BM25.
+          // But a provider that is configured and still off is usually a
+          // revoked key, and that degradation is silent.
+          hint:
+            r.embeddings.provider === "none"
+              ? "optional — memory search works on keyword matching without it"
+              : "the provider is set but unusable (commonly a revoked or missing API key) — search has silently dropped to keyword-only",
+        }),
+  });
+
+  return items;
+}
+
+function integrationItems(r: DoctorReport): ChecklistItem[] {
+  const items: ChecklistItem[] = [];
+
+  if (r.harnesses) {
+    const missing = missingHarnesses(r.harnesses.checks);
+    items.push({
+      label: "harness binaries",
+      state: missing.length === 0 ? "ok" : "bad",
+      detail:
+        missing.length === 0
+          ? r.harnesses.checks.map((h) => h.id).join(", ") || "none configured"
+          : `${plural(missing.length, "harness", "harnesses")} not found`,
+      ...(missing.length === 0
+        ? {}
+        : {
+            // Resolved against the SERVICE path, not an interactive shell —
+            // which is the whole point of the check.
+            hint: `${missing.map((h) => `${h.id}: '${h.bin}'`).join("; ")} not on the service PATH`,
+          }),
+    });
+  }
+
+  const dp = r.default_persona;
+  items.push({
+    label: "mcp servers",
+    state: dp.mcp_error
+      ? "bad"
+      : dp.mcp_servers === 0 && dp.mcp_elsewhere.length > 0
+        ? "warn"
+        : "ok",
+    detail: dp.mcp_error
+      ? "registry does not load"
+      : plural(dp.mcp_servers, "server") + ` for ${dp.resolved}`,
+    ...(dp.mcp_error
+      ? { hint: dp.mcp_error }
+      : dp.mcp_servers === 0 && dp.mcp_elsewhere.length > 0
+        ? {
+            // The exact shape of a migrated-away default: this persona has
+            // none while another does.
+            hint: `${dp.resolved} has none while ${dp.mcp_elsewhere.join(", ")} does — check the default persona is the one you meant`,
+          }
+        : {}),
+  });
+
+  if (r.piExtension) {
+    const p = r.piExtension;
+    const ok = p.shouldExist
+      ? p.present && (!p.drifted || !!p.repaired)
+      : !p.present || !!p.repaired;
+    items.push({
+      label: "pi extension",
+      state: ok ? "ok" : "bad",
+      detail: !p.shouldExist
+        ? p.present
+          ? "present but not wanted"
+          : "correctly absent"
+        : p.repaired
+          ? p.present
+            ? "re-stamped"
+            : "stamped"
+          : p.drifted
+            ? "drifted"
+            : "present and current",
+      ...(ok
+        ? {}
+        : {
+            hint: `${p.dir} — run \`phantombot doctor\` to ${p.shouldExist ? "re-stamp" : "remove"} it`,
+          }),
+    });
+  }
+
+  // ACP editor connectors. An absent editor is not a fault, so it is `ok`
+  // with "not installed" rather than a yellow row on every headless box.
+  //
+  // `editorConnectorBroken` decides the COLOUR because it also decides
+  // doctor's exit code — a screen that painted a non-zero exit green would be
+  // the same class of bug this file replaced. The individual flags only choose
+  // the hint's WORDING: a registration failure and a missing proposed-api
+  // allow-list are both red, and telling them apart is the whole value of the
+  // hint row.
+  for (const e of r.editorConnectors ?? []) {
+    const registrationBroken = e.action === "error" || e.action === "stale";
+    const proposedBroken = e.proposedApi === "stale" || e.proposedApi === "error";
+    items.push({
+      label: `acp: ${e.editor}`,
+      state: editorConnectorBroken(e) ? "bad" : "ok",
+      detail:
+        e.action === "not-detected"
+          ? "not installed on this machine"
+          : e.action === "current"
+            ? "registered and current"
+            : e.action,
+      ...(registrationBroken
+        ? {
+            hint: `${e.settingsPath}${e.error ? ` — ${e.error}` : " — run `phantombot doctor` without --no-repair"}`,
+          }
+        : proposedBroken
+          ? {
+              hint:
+                e.proposedApi === "stale"
+                  ? "not allow-listed in ~/.vscode/argv.json — falls back to the `@phantombot` participant instead of a native chat session; run `phantombot doctor` without --no-repair"
+                  : `proposed-api could not be allow-listed${e.proposedApiError ? ` — ${e.proposedApiError}` : ""}`,
+            }
+          : {}),
+    });
+  }
+
+  return items;
+}
+
+/**
+ * The whole checklist, in display order. Empty sections are dropped: a macOS
+ * box has no systemd, a headless box no editors, and a heading over nothing
+ * reads as a check that failed to run.
+ */
+export function doctorChecklist(r: DoctorReport): ChecklistSection[] {
+  return [
+    { title: "CORE", items: coreItems(r) },
+    { title: "CHANNELS", items: channelItems(r) },
+    { title: "INTEGRATIONS", items: integrationItems(r) },
+  ].filter((s) => s.items.length > 0);
+}
+
+/** The worst state anywhere in the checklist — the screen's headline verdict. */
+export function checklistVerdict(sections: ChecklistSection[]): CheckState {
+  const states = sections.flatMap((s) => s.items.map((i) => i.state));
+  if (states.includes("bad")) return "bad";
+  if (states.includes("warn")) return "warn";
+  return "ok";
+}

--- a/src/tui/doctorChecklist.ts
+++ b/src/tui/doctorChecklist.ts
@@ -23,9 +23,11 @@
  *   3. `hint` — the "here is what to do" line — appears ONLY on a check that
  *      is not green. Failures are loud; health is quiet.
  *
- * `warn` must never read as `bad`. "No Telegram account" is a perfectly good
- * state for a phantom that does not use Telegram, and an operator who learns
- * that yellow means nothing stops reading red too.
+ * `warn` must never read as `bad`, and a state that is simply NOT CONFIGURED
+ * is neither — it is green. "No Telegram account" is a perfectly good state
+ * for a phantom that does not use Telegram, so yellow is reserved for a check
+ * that is configured and degraded. An operator who learns that yellow means
+ * nothing stops reading red too.
  *
  * Doctor REPAIRS as well as reports, so where a check healed something the
  * line says so ("re-stamped", "re-armed") rather than just showing green —
@@ -246,17 +248,18 @@ function channelItems(r: DoctorReport): ChecklistItem[] {
   const stated = r.telegram.personas.filter((p) => p.stated);
   items.push({
     label: "telegram",
-    state: !r.telegram.healthy ? "bad" : stated.length === 0 ? "warn" : "ok",
+    // A host that does not answer on Telegram is not degraded, so this is
+    // green, not yellow. CHANNELS yellow is reserved for a channel that is
+    // configured and failing to do its job; if "not configured" were yellow,
+    // every Telegram-less phantom would show a permanent warning and the
+    // colour would stop meaning anything (Lena, #544).
+    state: !r.telegram.healthy ? "bad" : "ok",
     detail:
       stated.length === 0
-        ? "no account configured"
+        ? "not configured"
         : `${plural(r.telegram.listeners, "listener")} across ${plural(stated.length, "persona")}`,
     ...(r.telegram.healthy
-      ? stated.length === 0
-        ? {
-            hint: "nothing is wrong — this host simply does not answer on Telegram",
-          }
-        : {}
+      ? {}
       : {
           hint: r.telegram.personas
             .filter((p) => !p.healthy)

--- a/src/tui/mcpFlow.ts
+++ b/src/tui/mcpFlow.ts
@@ -1,0 +1,138 @@
+/**
+ * MCP servers, for the Configure screen's MCP row.
+ *
+ * Two jobs, deliberately split:
+ *
+ *   - `listMcpServers` reads the persona's registry file ONLY. No network, no
+ *     spawned stdio server, so the screen paints the full list instantly and a
+ *     hung server cannot stop the user seeing (or deleting) it.
+ *   - `probeMcpServer` connects to ONE server and counts its tools. Called per
+ *     row after the list is on screen, under its own deadline.
+ *
+ * The first cut probed everything up front and the screen sat blank for as
+ * long as the slowest `npx` cold start — which is exactly the server you
+ * opened this screen to delete.
+ *
+ * Neither function reimplements the registry: `loadRegistry` / `removeServer` /
+ * `saveRegistry` are the same readers and writers `phantombot mcp` uses, so
+ * the CLI and the TUI cannot disagree about what is registered.
+ */
+
+import { openPersonaVault } from "../lib/vault.ts";
+import { McpHub } from "../mcp/hub.ts";
+import {
+  loadRegistry,
+  referencedVaultKeys,
+  removeServer,
+  saveRegistry,
+  type McpServerEntry,
+} from "../mcp/registry.ts";
+import type { McpServerRow } from "./screens/Mcp.tsx";
+
+/** How long one server gets to answer `tools/list` before we call it unreachable. */
+export const PROBE_DEADLINE_MS = 10_000;
+
+/** What a row shows for "where does this server live". */
+function targetOf(entry: McpServerEntry): string {
+  if (entry.transport === "stdio")
+    return `${entry.command ?? ""} ${(entry.args ?? []).join(" ")}`.trim();
+  return entry.url ?? "";
+}
+
+/**
+ * The registered servers, straight off disk, in the CLI's sort order.
+ *
+ * `status: "unknown"` on every row: nothing has been probed yet. The screen
+ * asks for probes itself, so the caller never pays for one it did not want.
+ */
+export async function listMcpServers(
+  personaDir: string,
+): Promise<McpServerRow[]> {
+  const registry = await loadRegistry(personaDir);
+  return Object.keys(registry.mcpServers)
+    .sort()
+    .map((name) => {
+      const entry = registry.mcpServers[name]!;
+      return {
+        name,
+        transport: entry.transport,
+        auth: (entry.auth ?? { type: "none" }).type,
+        target: targetOf(entry),
+        status: "unknown" as const,
+        secrets: referencedVaultKeys(entry),
+      };
+    });
+}
+
+/**
+ * Connect to one server and count its tools.
+ *
+ * The tool COUNT is the proof of life, as `mcp status` uses it: a server that
+ * accepts a connection but answers nothing to `tools/list` is not usable, and
+ * reporting it green because the socket opened is the lie this screen exists
+ * to avoid.
+ *
+ * A fresh hub and vault per probe, closed in a `finally`. Holding one hub open
+ * for the screen's lifetime would leave a spawned stdio child running after
+ * the user navigated away.
+ */
+export async function probeMcpServer(
+  personaDir: string,
+  name: string,
+  deadlineMs: number = PROBE_DEADLINE_MS,
+): Promise<{ ok: boolean; tools?: number; detail: string }> {
+  const registry = await loadRegistry(personaDir);
+  if (!registry.mcpServers[name])
+    return { ok: false, detail: "not registered" };
+  const vault = await openPersonaVault(personaDir);
+  const hub = new McpHub(registry, vault);
+  try {
+    const tools = await Promise.race([
+      hub.tools(name),
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(
+          () => reject(new Error(`no answer in ${Math.round(deadlineMs / 1000)}s`)),
+          deadlineMs,
+        ).unref?.(),
+      ),
+    ]);
+    return { ok: true, tools: tools.length, detail: `${tools.length} tool(s)` };
+  } catch (e) {
+    // The client's errors are already actionable ("401 Unauthorized",
+    // "command not found: uvx") — a wrapper sentence would bury them.
+    return { ok: false, detail: (e as Error).message };
+  } finally {
+    await hub.close();
+    vault.close();
+  }
+}
+
+/**
+ * Drop a server from the persona's registry.
+ *
+ * `purgeSecrets` also unsets the vault keys the entry referenced. Off by
+ * default and asked for separately in the UI: the registry entry is
+ * re-addable from notes, while the vault is the only copy of the credential.
+ */
+export async function deleteMcpServer(input: {
+  personaDir: string;
+  name: string;
+  purgeSecrets?: boolean;
+}): Promise<{ ok: boolean; purged: string[]; error?: string }> {
+  const registry = await loadRegistry(input.personaDir);
+  const entry = registry.mcpServers[input.name];
+  const { registry: next, removed } = removeServer(registry, input.name);
+  if (!removed)
+    return { ok: false, purged: [], error: `no such MCP server: '${input.name}'` };
+  await saveRegistry(input.personaDir, next);
+  if (!input.purgeSecrets || !entry) return { ok: true, purged: [] };
+  const keys = referencedVaultKeys(entry);
+  if (keys.length === 0) return { ok: true, purged: [] };
+  const vault = await openPersonaVault(input.personaDir);
+  try {
+    for (const key of keys) vault.unset(key);
+  } finally {
+    vault.close();
+  }
+  return { ok: true, purged: keys };
+}

--- a/src/tui/screens/Doctor.tsx
+++ b/src/tui/screens/Doctor.tsx
@@ -4,36 +4,77 @@
  * Renders the report `runDoctor` already produces. It does not reimplement a
  * single check: the CLI and this screen must never be able to disagree about
  * the health of the same box.
+ *
+ * The checks themselves are built by `doctorChecklist` — a pure function of
+ * the report, so what is on screen is testable without rendering anything.
+ * This file owns only the paint: section headings, one line per check, the
+ * hint line under the ones that are not green, and the scroll window.
+ *
+ * Before this, four of the report's checks were rendered and the rest were
+ * dropped, so the screen could show all-green while doctor's own exit code
+ * said the box was broken.
  */
 
 import React from "react";
 import { Box, Text, useInput } from "ink";
 
-import { Frame } from "../components/Frame.tsx";
-import { badge, glyph, humanBytes, theme } from "../theme.ts";
+import { Frame, Rule } from "../components/Frame.tsx";
+import { badge, glyph, theme } from "../theme.ts";
 import type { DoctorReport } from "../../cli/doctor.ts";
 import type { StatusRows } from "../status.ts";
+import {
+  checklistVerdict,
+  doctorChecklist,
+  type CheckState,
+  type ChecklistItem,
+} from "../doctorChecklist.ts";
+import { useTerminalSize, viewportRows } from "../terminal.ts";
+import { frameChromeRows } from "../chrome.ts";
 
-function Check(props: {
-  ok: boolean | "warn";
-  label: string;
-  detail?: string;
-}): React.ReactElement {
-  const colour =
-    props.ok === true ? theme.ok : props.ok === "warn" ? theme.warn : theme.bad;
-  const mark =
-    props.ok === true ? glyph.ok : props.ok === "warn" ? glyph.warn : glyph.bad;
+const LABEL_COLS = 22;
+
+function colourOf(state: CheckState): string {
+  return state === "ok" ? theme.ok : state === "warn" ? theme.warn : theme.bad;
+}
+
+function markOf(state: CheckState): string {
+  return state === "ok" ? glyph.ok : state === "warn" ? glyph.warn : glyph.bad;
+}
+
+/** One check: mark, label, detail. The hint, when there is one, is its own row. */
+function Check(props: { item: ChecklistItem }): React.ReactElement {
+  const { item } = props;
   return (
     <Box>
-      <Box width="6%">
-        <Text color={colour}>{mark}</Text>
+      <Box width={2} flexShrink={0}>
+        <Text color={colourOf(item.state)}>{markOf(item.state)}</Text>
       </Box>
-      <Box width="34%">
-        <Text>{props.label}</Text>
+      <Box width={LABEL_COLS} flexShrink={0}>
+        <Text wrap="truncate">{item.label}</Text>
       </Box>
-      <Box flexGrow={1}>
+      <Box flexGrow={1} flexBasis={0}>
         <Text color={theme.dim} wrap="truncate">
-          {props.detail ?? ""}
+          {item.detail ?? ""}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * The "what to do" row. Only rendered for a check that is not green, and
+ * coloured like its check rather than dim: a hint the eye skips is a hint that
+ * may as well not be there.
+ */
+function Hint(props: { item: ChecklistItem }): React.ReactElement {
+  return (
+    <Box>
+      <Box width={2} flexShrink={0}>
+        <Text> </Text>
+      </Box>
+      <Box flexGrow={1} flexBasis={0}>
+        <Text color={colourOf(props.item.state)} wrap="truncate">
+          {`→ ${props.item.hint ?? ""}`}
         </Text>
       </Box>
     </Box>
@@ -48,17 +89,98 @@ export function DoctorScreen(props: {
   onRerun: () => void;
   onBack: () => void;
 }): React.ReactElement {
+  const [offset, setOffset] = React.useState(0);
   useInput((char, key) => {
     if (key.escape || key.leftArrow) return props.onBack();
-    if (char === "a") props.onRerun();
+    if (char === "a") return props.onRerun();
+    if (key.downArrow) setOffset((o) => o + 1);
+    else if (key.upArrow) setOffset((o) => Math.max(0, o - 1));
   });
 
   const r = props.report;
+  const sections = r ? doctorChecklist(r) : [];
+  const verdict = checklistVerdict(sections);
+
+  // One flat row list so the whole report scrolls as a unit. A per-section
+  // focus model is the thing users get lost in (see PersonaDetail).
+  const rows: React.ReactNode[] = [];
+  for (const section of sections) {
+    rows.push(
+      <Text key={`h-${section.title}`} color={theme.accent} bold>
+        {section.title}
+      </Text>,
+    );
+    for (const item of section.items) {
+      rows.push(<Check key={`${section.title}-${item.label}`} item={item} />);
+      // A hint is BY CONSTRUCTION only present on a check that is not green
+      // (`doctorChecklist` owns that, and a test pins it), so there is no
+      // second condition here. Re-checking the state would read as though a
+      // green check might carry one — and the honest place for that rule is
+      // the builder, where it can be asserted once for every check rather
+      // than defended in the paint.
+      if (item.hint)
+        rows.push(
+          <Hint key={`${section.title}-${item.label}-hint`} item={item} />,
+        );
+    }
+  }
+  if (props.status && props.status.length > 0) {
+    rows.push(
+      <Text key="h-status" color={theme.accent} bold>
+        STATUS
+      </Text>,
+    );
+    for (const [label, value] of props.status)
+      rows.push(
+        <Box key={`s-${label}`}>
+          <Box width={2} flexShrink={0}>
+            <Text> </Text>
+          </Box>
+          <Box width={LABEL_COLS} flexShrink={0}>
+            <Text color={theme.dim}>{label}</Text>
+          </Box>
+          <Box flexGrow={1} flexBasis={0}>
+            <Text wrap="truncate">{value}</Text>
+          </Box>
+        </Box>,
+      );
+  }
+
+  // Chrome: the two "more" markers (2) and the rule under the header (1), on
+  // top of what the frame itself consumes. Every row above is exactly one
+  // terminal line (all of them truncate rather than wrap), so the window can
+  // count rows instead of measuring them.
+  // Not `scrollWindow`: that grows a window outward from a CURSOR through
+  // variable-height blocks, and this list has neither — every row is exactly
+  // one line and the user drives a scroll offset, so the window is a slice.
+  // Clamping the offset here (rather than in the key handler) is what keeps
+  // it correct when the terminal is resized or a re-run shortens the report.
+  const size = useTerminalSize();
+  const budget = Math.max(3, viewportRows(size, 3 + frameChromeRows()));
+  const start = Math.min(offset, Math.max(0, rows.length - budget));
+  const view = {
+    start,
+    end: Math.min(rows.length, start + budget),
+    above: start,
+    below: Math.max(0, rows.length - start - budget),
+  };
+
   return (
     <Frame
       title={["phantombot", "doctor"]}
-      status={props.running ? "running..." : undefined}
+      status={
+        props.running
+          ? "running..."
+          : !r
+            ? undefined
+            : verdict === "ok"
+              ? `${glyph.up} healthy`
+              : verdict === "warn"
+                ? `${glyph.warn} check the yellow lines`
+                : `${glyph.bad} needs attention`
+      }
       footer={[
+        { icon: badge.scroll, key: "↑↓", label: "Scroll" },
         { icon: badge.run, key: "a", label: "Run again", onPress: props.onRerun },
         { icon: badge.back, key: "esc", label: "Back" },
       ]}
@@ -72,52 +194,15 @@ export function DoctorScreen(props: {
           <Text color={theme.dim} bold>
             {r.persona.toUpperCase()}
           </Text>
-          <Check
-            ok={r.telegram.healthy}
-            label="telegram reachable"
-            detail={`${r.telegram.listeners} listener(s)`}
-          />
-          <Check
-            ok={r.memory_db.healthy}
-            label="memory db"
-            detail={`${humanBytes(r.memory_db.bytes)} · ${r.memory_db.restore_points.length} restore points`}
-          />
-          <Check
-            ok={
-              r.nightly.health === "ok"
-                ? true
-                : r.nightly.health === "error"
-                  ? false
-                  : "warn"
-            }
-            label="nightly sweep"
-            detail={r.nightly.detail}
-          />
-          {r.nightly.backlog > 0 ? (
-            <Check
-              ok="warn"
-              label="nightly backlog"
-              detail={`${r.nightly.backlog} day(s) pending${r.nightly.oldest_pending ? `, oldest ${r.nightly.oldest_pending}` : ""}`}
-            />
-          ) : null}
-          {props.status && props.status.length > 0 ? (
-            <Box flexDirection="column" marginTop={1}>
-              <Text color={theme.dim} bold>
-                STATUS
-              </Text>
-              {props.status.map(([label, value]) => (
-                <Box key={label}>
-                  <Box width="6%" />
-                  <Box width="34%">
-                    <Text color={theme.dim}>{label}</Text>
-                  </Box>
-                  <Box flexGrow={1}>
-                    <Text wrap="truncate">{value}</Text>
-                  </Box>
-                </Box>
-              ))}
-            </Box>
-          ) : null}
+          <Rule />
+          <Text color={theme.dim}>
+            {view.above > 0 ? `▲ ${view.above} more above` : " "}
+          </Text>
+          {rows.slice(view.start, view.end)}
+          <Box flexGrow={1} />
+          <Text color={theme.dim}>
+            {view.below > 0 ? `▼ ${view.below} more below` : " "}
+          </Text>
         </Box>
       )}
     </Frame>

--- a/src/tui/screens/Mcp.tsx
+++ b/src/tui/screens/Mcp.tsx
@@ -1,101 +1,164 @@
 /**
- * Screen 6 — MCP servers.
+ * Screen 6 — the persona's MCP servers, reached from Configure → MCP Servers.
  *
- * Adding or removing a server re-fetches the tool list and shows the NEW COUNT
- * as proof it worked, rather than reporting a config write and leaving the user
- * to discover at the next turn whether the server actually answers.
+ * A registry LIST first, health second. The rows come off disk and paint
+ * immediately; status starts as a dim `—` and fills in as each probe lands,
+ * because the whole point of opening this screen is often to remove the server
+ * that hangs — and a screen that blocks on probing it cannot be used to do
+ * that.
+ *
+ * The tool COUNT is what "reachable" means here, not a successful socket: a
+ * server that connects and then answers nothing to `tools/list` gives the
+ * agent no tools, and calling that green is the failure this screen exists to
+ * surface.
+ *
+ * Deleting shows the selected server's target and the vault keys it
+ * references BEFORE the confirm, so "remove github" is a decision made with
+ * the command line and the credentials in view rather than from a name alone.
  */
 
 import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 
-import { Frame } from "../components/Frame.tsx";
+import { Frame, Rule } from "../components/Frame.tsx";
 import { Selectable } from "../components/Selectable.tsx";
 import { badge, glyph, theme } from "../theme.ts";
+
+/** Probe state of one row. `unknown` = not probed yet, not "broken". */
+export type McpProbeStatus = "unknown" | "probing" | "ok" | "bad";
 
 export interface McpServerRow {
   name: string;
   transport: string;
   auth?: string;
+  /** Command line (stdio) or endpoint URL (http) — what the entry points at. */
+  target?: string;
   tools?: number;
-  ok: boolean;
+  status: McpProbeStatus;
   detail?: string;
+  /** Vault keys this entry references, for the delete confirm. */
+  secrets?: string[];
+}
+
+function statusCell(row: McpServerRow): { text: string; colour?: string } {
+  if (row.status === "probing") return { text: "probing…", colour: theme.dim };
+  if (row.status === "unknown")
+    return { text: "— not probed", colour: theme.dim };
+  if (row.status === "ok")
+    return { text: `${glyph.ok} ${row.detail ?? "reachable"}`, colour: theme.ok };
+  return { text: `${glyph.bad} ${row.detail ?? "unreachable"}`, colour: theme.bad };
 }
 
 export function McpScreen(props: {
   personaName: string;
   servers: McpServerRow[];
+  /** Probe one server and report its tool count. */
   onTest: (name: string) => void;
+  /** Probe every registered server. */
+  onTestAll: () => void;
+  /** Remove one server from the registry (the caller owns the confirm). */
+  onDelete: (name: string) => void;
   onBack: () => void;
 }): React.ReactElement {
   const [cursor, setCursor] = useState(0);
-  const current = props.servers[cursor];
+  // A delete shortens the list, so a cursor parked on the last row would point
+  // past the end until the next keypress moved it.
+  const index = Math.min(cursor, Math.max(0, props.servers.length - 1));
+  const current = props.servers[index];
 
   useInput((char, key) => {
     if (key.escape || key.leftArrow) return props.onBack();
-    if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
+    if (key.upArrow) setCursor(Math.max(0, index - 1));
     else if (key.downArrow)
-      setCursor((c) => Math.min(props.servers.length - 1, c + 1));
+      setCursor(Math.min(props.servers.length - 1, index + 1));
     else if (char === "t" && current) props.onTest(current.name);
+    else if (char === "a") props.onTestAll();
+    else if (char === "d" && current) props.onDelete(current.name);
   });
 
   return (
     <Frame
       title={["phantombot", props.personaName, "mcp"]}
       footer={[
+        { icon: badge.move, key: "↑↓", label: "Move" },
         { icon: badge.test, key: "t", label: "Test" },
+        { icon: badge.run, key: "a", label: "Test all" },
+        { icon: badge.unset, key: "d", label: "Delete" },
         { icon: badge.back, key: "esc", label: "Back" },
       ]}
     >
+      <Rule />
       <Box>
-        <Box width="28%">
+        <Box width={2} flexShrink={0}>
+          <Text> </Text>
+        </Box>
+        <Box width={18} flexShrink={0}>
           <Text color={theme.dim}>server</Text>
         </Box>
-        <Box width="18%">
+        <Box width={10} flexShrink={0}>
           <Text color={theme.dim}>transport</Text>
         </Box>
-        <Box width="16%">
-          <Text color={theme.dim}>tools</Text>
+        <Box width={10} flexShrink={0}>
+          <Text color={theme.dim}>auth</Text>
         </Box>
-        <Box flexGrow={1}>
+        <Box flexGrow={1} flexBasis={0}>
           <Text color={theme.dim}>status</Text>
         </Box>
       </Box>
+      <Rule />
       {props.servers.length === 0 ? (
         <Text color={theme.dim}>
           No MCP servers registered. `phantombot mcp help` walks through adding
           one.
         </Text>
       ) : (
-        props.servers.map((server, i) => (
-          <Selectable
-            key={server.name}
-            selected={i === cursor}
-            onPress={() => props.onTest(server.name)}
-            fullWidth
-          >
-            <Box width="28%">
-              <Text
-                bold={i === cursor}
-                color={i === cursor ? "whiteBright" : undefined}
-              >
-                {server.name}
-              </Text>
-            </Box>
-            <Box width="18%">
-              <Text color={theme.dim}>{server.transport}</Text>
-            </Box>
-            <Box width="16%">
-              <Text color={theme.dim}>{server.tools ?? "—"}</Text>
-            </Box>
-            <Box flexGrow={1}>
-              <Text color={server.ok ? theme.ok : theme.warn}>
-                {`${server.ok ? glyph.up : glyph.warn} ${server.detail ?? (server.ok ? "ok" : "unreachable")}`}
-              </Text>
-            </Box>
-          </Selectable>
-        ))
+        props.servers.map((server, i) => {
+          const cell = statusCell(server);
+          return (
+            <Selectable
+              key={server.name}
+              selected={i === index}
+              onPress={() => props.onTest(server.name)}
+              fullWidth
+            >
+              <Box width={18} flexShrink={0}>
+                <Text
+                  bold={i === index}
+                  color={i === index ? "whiteBright" : undefined}
+                  wrap="truncate"
+                >
+                  {server.name}
+                </Text>
+              </Box>
+              <Box width={10} flexShrink={0}>
+                <Text color={theme.dim}>{server.transport}</Text>
+              </Box>
+              <Box width={10} flexShrink={0}>
+                <Text color={theme.dim}>{server.auth ?? "none"}</Text>
+              </Box>
+              <Box flexGrow={1} flexBasis={0}>
+                <Text color={cell.colour} wrap="truncate">
+                  {cell.text}
+                </Text>
+              </Box>
+            </Selectable>
+          );
+        })
       )}
+      <Box flexGrow={1} />
+      {current ? (
+        <Box flexDirection="column">
+          <Rule />
+          <Text color={theme.dim} wrap="truncate">
+            {current.target ?? ""}
+          </Text>
+          {current.secrets && current.secrets.length > 0 ? (
+            <Text color={theme.dim} wrap="truncate">
+              {`vault: ${current.secrets.join(", ")}`}
+            </Text>
+          ) : null}
+        </Box>
+      ) : null}
     </Frame>
   );
 }

--- a/src/tui/screens/PersonaDetail.tsx
+++ b/src/tui/screens/PersonaDetail.tsx
@@ -89,7 +89,7 @@ function descriptionLines(desc: string, columns: number): number {
 }
 
 /** Screens this one leads to. */
-export type Target = "memory" | "voice";
+export type Target = "memory" | "voice" | "mcp";
 
 /**
  * Everything the cursor can land on, in screen order.
@@ -104,6 +104,7 @@ export type Row =
   | "channels"
   | "memory"
   | "voice"
+  | "mcp"
   | "autostart"
   | "default"
   | "release";
@@ -119,6 +120,7 @@ const ROWS: Row[] = [
   "channels",
   "memory",
   "voice",
+  "mcp",
 ];
 
 export function PersonaDetailScreen(props: {
@@ -136,6 +138,12 @@ export function PersonaDetailScreen(props: {
   onChangeChannels: () => void;
   onChangeAutostart: () => void;
   onMakeDefault: () => void;
+  /**
+   * How many MCP servers the persona has registered, or undefined when the
+   * registry could not be read. Zero is not a fault: a phantom with no
+   * external tools is a normal phantom, so the row reads `optional`.
+   */
+  mcpServers?: number;
   /** The host's current release ring — shown on the Release Channel row. */
   releaseChannel: string;
   onToggleRelease: () => void;
@@ -353,6 +361,38 @@ export function PersonaDetailScreen(props: {
           {...probeBadge(line("voice"), "configured")}
           selected={row === "voice"}
           onPress={() => press("voice")}
+          {...tableProps}
+        />
+      ),
+    },
+    {
+      id: "mcp",
+      height: h("external tool servers this phantom can call"),
+      node: (
+        <MenuItem
+          icon="⬡"
+          label="MCP Servers"
+          description="external tool servers this phantom can call"
+          // Counted from the persona's own registry file, not probed: a badge
+          // that waits on a network round trip leaves the settings table
+          // half-painted, and "how many are registered" is what this row
+          // answers. Reachability is the MCP screen's job, one row at a time.
+          badge={
+            props.mcpServers === undefined
+              ? "…"
+              : props.mcpServers === 0
+                ? "optional"
+                : `${glyph.ok} ${props.mcpServers}`
+          }
+          badgeColor={
+            props.mcpServers === undefined
+              ? theme.dim
+              : props.mcpServers === 0
+                ? theme.warn
+                : theme.ok
+          }
+          selected={row === "mcp"}
+          onPress={() => press("mcp")}
           {...tableProps}
         />
       ),

--- a/src/tui/snapshot.ts
+++ b/src/tui/snapshot.ts
@@ -221,6 +221,13 @@ export interface PersonaSnapshot {
   nightly?: NightlySnapshot;
   /** Secret NAMES only. Values are never read into the TUI. */
   secretNames?: string[];
+  /**
+   * Registered MCP servers, counted from the persona's own registry file.
+   * Undefined when the registry exists but does not load — which the MCP row
+   * shows as `…` rather than as zero, since "unreadable" and "none" are
+   * different problems.
+   */
+  mcpServers?: number;
   memory: MemorySnapshot;
   completeness: PersonaCompleteness;
   /** Where the effective value came from; absence means inherit. */
@@ -477,6 +484,14 @@ export async function personaSnapshot(
     }
   });
 
+  // Registered MCP servers — a count, off the persona's own registry file.
+  // No hub, no connection: this is on the app's startup path and a cold `npx`
+  // server start would be paid before the first frame.
+  const mcpServers = await safeAsync(async () => {
+    const { loadRegistry } = await import("../mcp/registry.ts");
+    return Object.keys((await loadRegistry(dir)).mcpServers).length;
+  });
+
   // The nightly is the one piece of persona health that is invisible until it
   // has been broken for days — a backlog does not announce itself.
   // Imported on demand: the nightly module pulls the whole memory stack in
@@ -542,6 +557,7 @@ export async function personaSnapshot(
     channelDetails: channelDetailsFor(config, dir),
     ...(nightly ? { nightly } : {}),
     secretNames,
+    mcpServers,
     memory: readMemory(config, name),
     completeness: await personaCompleteness(config, name),
     configSources: configSourcesOf(personaToml, globalToml),

--- a/tests/tui-doctor-checklist.test.tsx
+++ b/tests/tui-doctor-checklist.test.tsx
@@ -1,0 +1,441 @@
+/**
+ * The Doctor screen's checklist (Andrew, 2026-09-12).
+ *
+ * Reported: Telegram looked like a legacy check sitting on its own in the
+ * doctor menu. It was not legacy — it was the only channel check the SCREEN
+ * rendered. `runDoctor` computes a dozen more (systemd, timers, per-persona
+ * maintenance, harness binaries, the Pi extension, ACP editors, MCP servers,
+ * embeddings, service logs) and the screen dropped every one, so it could
+ * paint four green ticks on a box whose doctor exit code was non-zero.
+ *
+ * These tests assert what lands ON SCREEN and what `doctorChecklist` returns
+ * for a given report — never that a branch ran. The broken build's defect was
+ * precisely that all its branches ran correctly on a report it then ignored.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { render } from "ink";
+
+import { DoctorScreen } from "../src/tui/screens/Doctor.tsx";
+import { TerminalSizeContext } from "../src/tui/terminal.ts";
+import {
+  checklistVerdict,
+  doctorChecklist,
+} from "../src/tui/doctorChecklist.ts";
+import type { DoctorReport } from "../src/cli/doctor.ts";
+
+/** A fully healthy report for a Linux box with every optional section present. */
+function healthyReport(): DoctorReport {
+  return {
+    persona: "alice",
+    telegram: {
+      healthy: true,
+      listeners: 2,
+      personas: [
+        { persona: "alice", stated: true, listeners: 1, healthy: true, detail: "runnable" },
+        { persona: "bob", stated: true, listeners: 1, healthy: true, detail: "runnable" },
+      ],
+    },
+    nightly: { age_hours: 2, health: "ok", detail: "no backlog", backlog: 0 },
+    memory_db: {
+      path: "/x/memory.sqlite",
+      healthy: true,
+      detail: "integrity ok",
+      bytes: 44040192,
+      restore_points: [{ taken_at: "2026-09-11T02:00:00Z", bytes: 1, path: "/x/1" }],
+      unretired_drawers: [],
+    },
+    capture: { window_hours: 24, user_turns: 10, captures: 9, dry_day: false },
+    embeddings: { provider: "openai-compatible", semantic_search: true },
+    update: { channel: "stable", version: "1.1.359" },
+    systemd: {
+      missing_unit_files: [],
+      drifted_unit_files: [],
+      inactive_timers: [],
+      repaired: false,
+    },
+    timers: {
+      heartbeat: { last_fired: "t", age_minutes: 4, stale: false, threshold_minutes: 45 },
+      tick: { last_fired: "t", age_minutes: 1, stale: false, threshold_minutes: 10 },
+    },
+    maintenance: [
+      { persona: "alice", heartbeat_stale: false, nightly_backlog: 0, heartbeat_age_minutes: 4 },
+      { persona: "bob", heartbeat_stale: false, nightly_backlog: 0, heartbeat_age_minutes: 6 },
+    ],
+    default_persona: {
+      resolved: "alice",
+      provenance: "state",
+      exists: true,
+      served: true,
+      defect: null,
+      mcp_servers: 3,
+      mcp_elsewhere: [],
+      healthy: true,
+      detail: "resolved from state.json",
+    },
+    harnesses: {
+      path: "/usr/bin",
+      checks: [{ id: "claude", bin: "claude", resolved: "/usr/bin/claude" }],
+    },
+    piExtension: { shouldExist: true, present: true, drifted: false, dir: "/x/.pi" },
+    editorConnectors: [
+      { editor: "zed", action: "current", settingsPath: "/x/zed.json" },
+      { editor: "vscode", action: "current", settingsPath: "/x/vscode", proposedApi: "enabled" },
+    ],
+  };
+}
+
+const flat = (r: DoctorReport) => doctorChecklist(r).flatMap((s) => s.items);
+const item = (r: DoctorReport, label: string) =>
+  flat(r).find((i) => i.label === label);
+
+describe("doctorChecklist", () => {
+  test("a healthy box is all green and every check is one line", () => {
+    const r = healthyReport();
+    const items = flat(r);
+    expect(items.every((i) => i.state === "ok")).toBe(true);
+    // Rule 3: a hint is the "what to do" row, and there is nothing to do.
+    expect(items.some((i) => i.hint)) .toBe(false);
+    expect(checklistVerdict(doctorChecklist(r))).toBe("ok");
+  });
+
+  test("a green check NEVER carries a hint, on any report", () => {
+    // The screen renders a hint whenever one is present, with no second
+    // state check — so this invariant is what keeps a healthy box one line
+    // per check. Asserted across degraded reports, not just the healthy one,
+    // or it only pins a report that has no hints to begin with.
+    const degraded: Array<(r: DoctorReport) => void> = [
+      (r) => void (r.memory_db.healthy = false),
+      (r) => void (r.capture.dry_day = true),
+      (r) => void (r.nightly.health = "error"),
+      (r) => void (r.nightly.backlog = 3),
+      (r) => void (r.telegram.healthy = false),
+      (r) => void (r.embeddings = { provider: "gemini", semantic_search: false }),
+      (r) => void (r.timers!.tick.stale = true),
+      (r) => void (r.systemd!.inactive_timers = ["phantombot-tick.timer"]),
+      (r) => void (r.maintenance![0]!.heartbeat_stale = true),
+      (r) => void (r.default_persona.healthy = false),
+      (r) => void (r.harnesses!.checks = [{ id: "pi", bin: "pi" }]),
+      (r) => void (r.piExtension!.drifted = true),
+      (r) => void (r.default_persona.mcp_error = "bad JSON"),
+      (r) => void (r.memory_db.unretired_drawers = ["people.md"]),
+      (r) =>
+        void (r.editorConnectors = [
+          { editor: "zed", action: "error", settingsPath: "/x", error: "nope" },
+        ]),
+    ];
+    for (const breakIt of degraded) {
+      const r = healthyReport();
+      breakIt(r);
+      const items = flat(r);
+      // The mutation has to actually degrade something, or this proves nothing.
+      expect(items.some((i) => i.state !== "ok")).toBe(true);
+      for (const i of items)
+        if (i.state === "ok") expect(i.hint).toBeUndefined();
+    }
+  });
+
+  test("every section the report computes reaches the checklist", () => {
+    // The regression this whole change exists to prevent: a report section
+    // that no one renders. Named explicitly rather than counted, so ADDING a
+    // check to the report and forgetting the screen fails here.
+    const labels = flat(healthyReport()).map((i) => i.label);
+    for (const expected of [
+      "memory database",
+      "nightly sweep",
+      "capture",
+      "heartbeat timer",
+      "tick timer",
+      "systemd units",
+      "persona maintenance",
+      "default persona",
+      "release ring",
+      "telegram",
+      "embeddings",
+      "harness binaries",
+      "mcp servers",
+      "pi extension",
+      "acp: zed",
+      "acp: vscode",
+    ])
+      expect(labels).toContain(expected);
+  });
+
+  test("telegram is kept, not removed — and it keeps its per-persona detail", () => {
+    const r = healthyReport();
+    r.telegram.healthy = false;
+    r.telegram.personas[1] = {
+      persona: "bob",
+      stated: true,
+      listeners: 0,
+      healthy: false,
+      detail: "account resolved but no listener is planned",
+    };
+    const telegram = item(r, "telegram")!;
+    expect(telegram.state).toBe("bad");
+    expect(telegram.hint).toContain("bob");
+    expect(telegram.hint).toContain("no listener is planned");
+  });
+
+  test("no telegram account is yellow and says nothing is wrong", () => {
+    // The distinction that makes yellow worth having: a phantom that does not
+    // use Telegram is not a broken phantom, and if warn reads as bad the
+    // operator stops reading red too.
+    const r = healthyReport();
+    r.telegram = { healthy: true, listeners: 0, personas: [] };
+    const telegram = item(r, "telegram")!;
+    expect(telegram.state).toBe("warn");
+    expect(telegram.detail).toBe("no account configured");
+    expect(telegram.hint).toContain("nothing is wrong");
+  });
+
+  test("a repaired fault says what was healed, not just green", () => {
+    // Doctor repairs as well as reports. A self-healed unit rendered as plain
+    // green loses the fact that something was broken.
+    const r = healthyReport();
+    r.systemd = {
+      missing_unit_files: ["phantombot-tick.timer"],
+      drifted_unit_files: [],
+      inactive_timers: [],
+      repaired: true,
+    };
+    const units = item(r, "systemd units")!;
+    expect(units.state).toBe("warn");
+    expect(units.hint).toContain("phantombot-tick.timer");
+    expect(units.detail).toContain("repaired");
+  });
+
+  test("an unrepaired systemd fault is red, not yellow", () => {
+    const r = healthyReport();
+    r.systemd = {
+      missing_unit_files: ["phantombot-tick.timer"],
+      drifted_unit_files: [],
+      inactive_timers: [],
+      repaired: false,
+    };
+    expect(item(r, "systemd units")!.state).toBe("bad");
+  });
+
+  test("a configured-but-unusable embeddings provider says the key is the likely cause", () => {
+    // The #516/#522 failure: a revoked key silently degrades search to
+    // keyword-only, and the old screen did not mention embeddings at all.
+    const r = healthyReport();
+    r.embeddings = { provider: "openai-compatible", semantic_search: false };
+    const e = item(r, "embeddings")!;
+    expect(e.state).toBe("warn");
+    expect(e.hint).toContain("revoked");
+  });
+
+  test("no embeddings provider at all is optional, not a degraded one", () => {
+    const r = healthyReport();
+    r.embeddings = { provider: "none", semantic_search: false };
+    const e = item(r, "embeddings")!;
+    expect(e.state).toBe("warn");
+    expect(e.hint).toContain("optional");
+    expect(e.hint).not.toContain("revoked");
+  });
+
+  test("maintenance collapses to one line when current, expands per persona when not", () => {
+    const r = healthyReport();
+    expect(item(r, "persona maintenance")!.detail).toBe("2 personas current");
+    r.maintenance![1] = {
+      persona: "bob",
+      heartbeat_stale: true,
+      nightly_backlog: 0,
+    };
+    expect(item(r, "persona maintenance")).toBeUndefined();
+    const bob = item(r, "maintenance: bob")!;
+    expect(bob.state).toBe("warn");
+    expect(bob.hint).toContain("phantombot-heartbeat@bob.timer");
+  });
+
+  test("an MCP registry that does not load is red; an empty one is only odd next to a full one", () => {
+    const r = healthyReport();
+    r.default_persona.mcp_servers = 0;
+    expect(item(r, "mcp servers")!.state).toBe("ok");
+    r.default_persona.mcp_elsewhere = ["bob"];
+    expect(item(r, "mcp servers")!.state).toBe("warn");
+    r.default_persona.mcp_error = "mcp.json does not load: bad JSON";
+    expect(item(r, "mcp servers")!.state).toBe("bad");
+  });
+
+  test("an editor that is not installed is green, not a warning on every headless box", () => {
+    const r = healthyReport();
+    r.editorConnectors = [
+      { editor: "zed", action: "not-detected", settingsPath: "/x/zed.json" },
+    ];
+    const zed = item(r, "acp: zed")!;
+    expect(zed.state).toBe("ok");
+    expect(zed.detail).toContain("not installed");
+  });
+
+  test("a VS Code extension that is installed but not allow-listed is red, as the CLI counts it", () => {
+    // `editorConnectorBroken` is the authority for BOTH the exit code and this
+    // colour. A proposed-api allow-list miss degrades the extension to the
+    // `@phantombot` participant, and doctor already exits non-zero on it — a
+    // screen that painted that yellow would disagree with its own exit code.
+    const r = healthyReport();
+    r.editorConnectors = [
+      {
+        editor: "vscode",
+        action: "current",
+        settingsPath: "/x/vscode",
+        proposedApi: "stale",
+      },
+    ];
+    const code = item(r, "acp: vscode")!;
+    expect(code.state).toBe("bad");
+    expect(code.hint).toContain("argv.json");
+  });
+
+  test("sections with nothing in them are dropped, not left as empty headings", () => {
+    // macOS has no systemd, a headless box no editors. A heading over nothing
+    // reads as a check that failed to run.
+    const r = healthyReport();
+    delete r.systemd;
+    delete r.timers;
+    delete r.maintenance;
+    delete r.harnesses;
+    delete r.piExtension;
+    delete r.editorConnectors;
+    const sections = doctorChecklist(r);
+    expect(sections.map((s) => s.title)).toEqual([
+      "CORE",
+      "CHANNELS",
+      "INTEGRATIONS",
+    ]);
+    expect(sections.every((s) => s.items.length > 0)).toBe(true);
+  });
+
+  test("the verdict is the worst state anywhere, so the header cannot claim health", () => {
+    const r = healthyReport();
+    expect(checklistVerdict(doctorChecklist(r))).toBe("ok");
+    r.capture.dry_day = true;
+    expect(checklistVerdict(doctorChecklist(r))).toBe("warn");
+    r.memory_db.healthy = false;
+    expect(checklistVerdict(doctorChecklist(r))).toBe("bad");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// And the paint, because a checklist that is correct and off-screen is the bug
+// this replaced.
+// ---------------------------------------------------------------------------
+
+function fakeStdin() {
+  const s = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: () => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  s.isTTY = true;
+  s.setRawMode = () => {};
+  s.ref = () => {};
+  s.unref = () => {};
+  return s;
+}
+
+function fakeStdout(rows = 60) {
+  const frames: string[] = [];
+  const s = new EventEmitter() as EventEmitter & {
+    columns: number;
+    rows: number;
+    write: (c: string) => void;
+    frames: string[];
+  };
+  s.columns = 110;
+  s.rows = rows;
+  s.frames = frames;
+  s.write = (c: string) => void frames.push(c);
+  return s;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function mountDoctor(report: DoctorReport, rows = 60) {
+  const stdin = fakeStdin();
+  const stdout = fakeStdout(rows);
+  const instance = render(
+    // The size comes from the ROOT's context in the real app (terminal.ts is
+    // the only place allowed to measure), so a standalone mount has to supply
+    // it or every screen lays out against the 24-row fallback.
+    <TerminalSizeContext.Provider value={{ rows, columns: 110 }}>
+      <DoctorScreen
+        report={report}
+        running={false}
+        onRerun={() => {}}
+        onBack={() => {}}
+      />
+    </TerminalSizeContext.Provider>,
+    {
+      stdin: stdin as never,
+      stdout: stdout as never,
+      debug: true,
+      exitOnCtrlC: false,
+    },
+  );
+  await sleep(60);
+  return {
+    frame: () => stdout.frames.at(-1) ?? "",
+    press: async (bytes: string) => {
+      stdin.write(bytes);
+      await sleep(60);
+    },
+    unmount: () => instance.unmount(),
+  };
+}
+
+describe("the doctor screen", () => {
+  test("renders the grouped checklist, not four checks out of sixteen", async () => {
+    const app = await mountDoctor(healthyReport());
+    const frame = app.frame();
+    expect(frame).toContain("CORE");
+    expect(frame).toContain("CHANNELS");
+    expect(frame).toContain("INTEGRATIONS");
+    expect(frame).toContain("telegram");
+    expect(frame).toContain("acp: vscode");
+    expect(frame).toContain("mcp servers");
+    expect(frame).toContain("harness binaries");
+    // Green means quiet: no hint rows anywhere on a healthy box.
+    expect(frame).not.toContain("→");
+    expect(frame).toContain("healthy");
+    app.unmount();
+  });
+
+  test("a failing check gets its hint row and the header stops saying healthy", async () => {
+    const r = healthyReport();
+    r.memory_db.healthy = false;
+    r.memory_db.detail = "integrity_check: malformed";
+    const app = await mountDoctor(r);
+    const frame = app.frame();
+    expect(frame).toContain("memory database");
+    expect(frame).toContain("→");
+    expect(frame).toContain("no verified snapshot");
+    expect(frame).toContain("needs attention");
+    expect(frame).not.toContain("✔ healthy");
+    app.unmount();
+  });
+
+  test("a report taller than the window scrolls instead of overwriting rows", async () => {
+    // Yoga shrinks children to fit rather than clipping, so a too-tall body
+    // paints rows on top of each other (see scroll.ts). The marker is the
+    // proof the window is doing its job.
+    const app = await mountDoctor(healthyReport(), 16);
+    // The MARKER alone proves nothing — it is computed from the row count, so
+    // it shows even if every row is still painted. The evidence is that the
+    // rows past the window are genuinely absent, and that scrolling trades
+    // one end for the other.
+    expect(app.frame()).toContain("memory database");
+    expect(app.frame()).not.toContain("acp: vscode");
+    expect(app.frame()).toContain("more below");
+
+    for (let i = 0; i < 12; i++) await app.press("\x1b[B");
+    expect(app.frame()).toContain("acp: vscode");
+    expect(app.frame()).not.toContain("memory database");
+    expect(app.frame()).toContain("more above");
+    app.unmount();
+  });
+});

--- a/tests/tui-doctor-checklist.test.tsx
+++ b/tests/tui-doctor-checklist.test.tsx
@@ -179,16 +179,19 @@ describe("doctorChecklist", () => {
     expect(telegram.hint).toContain("no listener is planned");
   });
 
-  test("no telegram account is yellow and says nothing is wrong", () => {
+  test("an unconfigured channel is green, not yellow — and stays quiet", () => {
     // The distinction that makes yellow worth having: a phantom that does not
-    // use Telegram is not a broken phantom, and if warn reads as bad the
-    // operator stops reading red too.
+    // use Telegram is not a degraded phantom. If "not configured" were yellow
+    // every Telegram-less host would carry a permanent warning, and an
+    // operator who learns yellow means nothing stops reading red too. Yellow
+    // in CHANNELS is for a channel that IS configured and is failing.
     const r = healthyReport();
     r.telegram = { healthy: true, listeners: 0, personas: [] };
     const telegram = item(r, "telegram")!;
-    expect(telegram.state).toBe("warn");
-    expect(telegram.detail).toBe("no account configured");
-    expect(telegram.hint).toContain("nothing is wrong");
+    expect(telegram.state).toBe("ok");
+    expect(telegram.detail).toBe("not configured");
+    // Rule 3: health is quiet. A green row carries no "what to do" line.
+    expect(telegram.hint).toBeUndefined();
   });
 
   test("a repaired fault says what was healed, not just green", () => {

--- a/tests/tui-mcp-flow.test.ts
+++ b/tests/tui-mcp-flow.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The MCP screen's data path (Configure → MCP Servers).
+ *
+ * Listing and probing are separate functions because they have different
+ * failure modes, and the screen has to stay usable when probing is the thing
+ * that is broken — the server you cannot reach is usually the one you opened
+ * the screen to delete.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  deleteMcpServer,
+  listMcpServers,
+  probeMcpServer,
+} from "../src/tui/mcpFlow.ts";
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs.length = 0;
+});
+
+function personaDir(registry: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "phantombot-mcpflow-"));
+  dirs.push(dir);
+  writeFileSync(join(dir, "mcp.json"), JSON.stringify(registry));
+  return dir;
+}
+
+describe("listMcpServers", () => {
+  test("reads the registry without connecting to anything", async () => {
+    // The command here does not exist. If listing probed, this would throw or
+    // hang; it must return a row with status `unknown` instead.
+    const dir = personaDir({
+      mcpServers: {
+        broken: { transport: "stdio", command: "definitely-not-installed" },
+      },
+    });
+    const rows = await listMcpServers(dir);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.name).toBe("broken");
+    expect(rows[0]!.status).toBe("unknown");
+    expect(rows[0]!.target).toBe("definitely-not-installed");
+  });
+
+  test("a persona with no registry file has no servers, and that is not an error", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "phantombot-mcpflow-"));
+    dirs.push(dir);
+    expect(await listMcpServers(dir)).toEqual([]);
+  });
+
+  test("carries the vault keys an entry references, for the delete confirm", async () => {
+    const dir = personaDir({
+      mcpServers: {
+        remote: {
+          transport: "http",
+          url: "https://example.invalid/mcp",
+          auth: {
+            type: "header",
+            header: "Authorization",
+            valueRef: "MCP_REMOTE_TOKEN",
+          },
+        },
+      },
+    });
+    const rows = await listMcpServers(dir);
+    expect(rows[0]!.secrets).toEqual(["MCP_REMOTE_TOKEN"]);
+    expect(rows[0]!.auth).toBe("header");
+  });
+});
+
+describe("probeMcpServer", () => {
+  test("reports the client's own error rather than a generic failure", async () => {
+    // A spawn failure is the most common real one, and the message the client
+    // produces ("command not found", ENOENT) is what the operator needs. A
+    // wrapper sentence would bury it.
+    const dir = personaDir({
+      mcpServers: {
+        broken: { transport: "stdio", command: "definitely-not-installed-xyz" },
+      },
+    });
+    const result = await probeMcpServer(dir, "broken", 8_000);
+    expect(result.ok).toBe(false);
+    expect(result.detail.length).toBeGreaterThan(0);
+    expect(result.detail).not.toBe("unreachable");
+  });
+
+  test("a server that is not registered says so, and does not throw", async () => {
+    const dir = personaDir({ mcpServers: {} });
+    expect(await probeMcpServer(dir, "ghost")).toEqual({
+      ok: false,
+      detail: "not registered",
+    });
+  });
+});
+
+describe("deleteMcpServer", () => {
+  test("removes the entry and leaves the others alone", async () => {
+    const dir = personaDir({
+      mcpServers: {
+        a: { transport: "stdio", command: "a" },
+        b: { transport: "stdio", command: "b" },
+      },
+    });
+    const result = await deleteMcpServer({ personaDir: dir, name: "a" });
+    expect(result).toEqual({ ok: true, purged: [] });
+    expect((await listMcpServers(dir)).map((r) => r.name)).toEqual(["b"]);
+  });
+
+  test("keeps the vault secrets unless purging is asked for", async () => {
+    // Default-off is the point: the registry entry is re-addable from notes,
+    // the vault is the only copy of the credential.
+    const dir = personaDir({
+      mcpServers: {
+        remote: {
+          transport: "http",
+          url: "https://example.invalid/mcp",
+          auth: {
+            type: "header",
+            header: "Authorization",
+            valueRef: "MCP_REMOTE_TOKEN",
+          },
+        },
+      },
+    });
+    const result = await deleteMcpServer({ personaDir: dir, name: "remote" });
+    expect(result.purged).toEqual([]);
+  });
+
+  test("deleting something that is not there is an error, not a silent success", async () => {
+    const dir = personaDir({ mcpServers: {} });
+    const result = await deleteMcpServer({ personaDir: dir, name: "ghost" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("ghost");
+  });
+});

--- a/tests/tui-navigation.test.tsx
+++ b/tests/tui-navigation.test.tsx
@@ -394,12 +394,17 @@ describe("reaching settings and the phantom list", () => {
     expect(app.frame()).toContain("PHANTOMS");
   });
 
-  test("Vault and MCP are gone from both the table and the settings screen", async () => {
-    // They were rows on a settings screen whose job is the setup `phantombot
-    // init` performs — harness, channels, voice, autostart. A secret store and
-    // an external-server registry are neither, and each one on the screen was a
-    // row a first-time user had to decide about. Removed, not moved: the CLI
-    // (`phantombot vault`, `phantombot mcp`) still owns both.
+  test("Vault is gone from the table and the settings screen", async () => {
+    // It was a row on a settings screen whose job is the setup `phantombot
+    // init` performs — harness, channels, voice, autostart. A secret store is
+    // not that, and the row was one more thing a first-time user had to decide
+    // about. Removed, not moved: `phantombot vault` still owns it.
+    //
+    // MCP was removed in the same pass and has since come BACK as a persona
+    // settings row (see the test below) — Andrew's call, 2026-09-12. It is
+    // still absent from the HOST table, which is the part of that decision
+    // that stands: an external-server registry belongs to a phantom, not to
+    // the box.
     const app = await mountApp();
     await app.press("\x13"); // ^s -> the table
     expect(app.frame()).toContain("PHANTOMS");
@@ -413,10 +418,7 @@ describe("reaching settings and the phantom list", () => {
 
     // And not on the phantom's own settings screen either.
     await app.press("c");
-    const frame = app.frame();
-    expect(frame).toContain("▸ alice");
-    expect(frame).not.toContain("MCP");
-    expect(frame).not.toContain("Vault");
+    expect(app.frame()).not.toContain("Vault");
   });
 
   test("the table's 'd' runs the doctor FOR THE ROW under the cursor", async () => {
@@ -465,5 +467,177 @@ describe("reaching settings and the phantom list", () => {
     // And the walk unwinds one level per esc, all the way to the floor.
     await app.press("\x1b");
     expect(app.frame()).toContain("Send");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Configure → MCP Servers (Andrew, 2026-09-12).
+//
+// The screen existed but was UNREACHABLE: no menu row pointed at it, and the
+// router rendered it with `servers={[]}` and an `onTest` that set the notice
+// "mcp test not wired yet". So these tests assert the three things that were
+// each independently missing — the row is there, opening it lists what is on
+// disk, and `d` actually removes it from the registry FILE. Asserting a
+// handler fired would have passed against the dead build.
+// ---------------------------------------------------------------------------
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+
+/** A persona dir on disk with a two-server registry. */
+function personaWithServers(): string {
+  const dir = mkdtempSync(join(tmpdir(), "phantombot-tui-mcp-"));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        github: {
+          transport: "http",
+          url: "https://api.githubcopilot.com/mcp/",
+          auth: {
+            type: "header",
+            header: "Authorization",
+            valueRef: "MCP_GITHUB_TOKEN",
+            prefix: "Bearer ",
+          },
+        },
+        atlassian: {
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "mcp-remote", "https://mcp.atlassian.com/v1/sse"],
+        },
+      },
+    }),
+  );
+  return dir;
+}
+
+/** Walk the settings cursor down to the MCP row and open it. */
+async function openMcpScreen(app: { press: (b: string) => Promise<void> }) {
+  await app.press("\x13"); // ^s -> the table
+  await app.press("c"); // -> alice's settings
+  for (let i = 0; i < 8; i++) await app.press("\x1b[B"); // MCP is the last row
+  await app.press("\r");
+  // The registry read happens behind a dynamic import of the whole MCP stack;
+  // one keypress tick is not always enough for the first frame to carry rows.
+  await sleep(250);
+}
+
+describe("Configure → MCP Servers", () => {
+  test("the settings screen has an MCP row carrying the registered count", async () => {
+    const app = await mountApp({
+      ...HOST,
+      personas: [{ ...ALICE, mcpServers: 2 }],
+    });
+    await app.press("\x13");
+    await app.press("c");
+    const frame = app.frame();
+    expect(frame).toContain("MCP Servers");
+    // The COUNT, not a green tick on its own: "configured" tells the user
+    // nothing they could not guess, and the number is the whole answer.
+    expect(frame).toContain("2");
+  });
+
+  test("zero registered servers reads as optional, never as a fault", async () => {
+    // A phantom with no external tools is a normal phantom. The row this
+    // replaced (before MCP was removed from the screen entirely) was one more
+    // red decision on a first-run screen, which is why it was taken out.
+    const app = await mountApp({
+      ...HOST,
+      personas: [{ ...ALICE, mcpServers: 0 }],
+    });
+    await app.press("\x13");
+    await app.press("c");
+    expect(app.frame()).toContain("MCP Servers");
+    expect(app.frame()).toContain("optional");
+  });
+
+  test("opening it lists the servers in the persona's registry file", async () => {
+    const dir = personaWithServers();
+    const app = await mountApp({
+      ...HOST,
+      personas: [{ ...ALICE, dir, mcpServers: 2 }],
+    });
+    await openMcpScreen(app);
+    const frame = app.frame();
+    expect(frame).toContain("github");
+    expect(frame).toContain("atlassian");
+    expect(frame).toContain("http");
+    expect(frame).toContain("stdio");
+    // Nothing has been probed, and the screen must say exactly that rather
+    // than showing a green or a red it has not earned.
+    expect(frame).toContain("not probed");
+    // The SELECTED row's target, so a delete is decided with the command line
+    // (or endpoint) in view and not from a bare name.
+    expect(frame).toContain("npx -y mcp-remote");
+    expect(frame).not.toContain("api.githubcopilot.com");
+  });
+
+  test("'d' deletes the selected server from the registry file", async () => {
+    const dir = personaWithServers();
+    const app = await mountApp({
+      ...HOST,
+      personas: [{ ...ALICE, dir, mcpServers: 2 }],
+    });
+    await openMcpScreen(app);
+    // Rows are sorted, so the cursor starts on `atlassian`; move to the one
+    // with a vault reference so BOTH questions are exercised.
+    await app.press("\x1b[B");
+    await app.press("d");
+    // A destructive settings change goes through the same confirm screen as
+    // every other one — it is not a bare keypress.
+    expect(app.frame().toLowerCase()).toContain("confirm");
+    expect(app.frame()).toContain("github");
+
+    await app.press("\x1b[A"); // danger starts on No; move to Yes
+    await app.press("\r");
+    // Second, SEPARATE question, because this entry references a vault key:
+    // the registry entry is re-addable, the secret is not.
+    expect(app.frame()).toContain("vault secret");
+    await app.press("n"); // keep the secret
+    await sleep(150);
+
+    const registry = JSON.parse(readFileSync(join(dir, "mcp.json"), "utf8")) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(Object.keys(registry.mcpServers)).toEqual(["atlassian"]);
+  });
+
+  test("a server with no vault reference is never asked about secrets", async () => {
+    // The purge question is asked only when there is something to purge —
+    // a second yes/no on every delete is how users learn to reflex through it.
+    const dir = personaWithServers();
+    const app = await mountApp({
+      ...HOST,
+      personas: [{ ...ALICE, dir, mcpServers: 2 }],
+    });
+    await openMcpScreen(app);
+    await app.press("d"); // `atlassian`: stdio, no auth
+    await app.press("\x1b[A");
+    await app.press("\r");
+    await sleep(150);
+    expect(app.frame()).not.toContain("vault secret");
+    const registry = JSON.parse(readFileSync(join(dir, "mcp.json"), "utf8")) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(Object.keys(registry.mcpServers)).toEqual(["github"]);
+  });
+
+  test("declining the confirm leaves the registry untouched", async () => {
+    const dir = personaWithServers();
+    const app = await mountApp({
+      ...HOST,
+      personas: [{ ...ALICE, dir, mcpServers: 2 }],
+    });
+    await openMcpScreen(app);
+    await app.press("d");
+    await app.press("\r"); // danger cursor sits on No
+    const registry = JSON.parse(readFileSync(join(dir, "mcp.json"), "utf8")) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(Object.keys(registry.mcpServers).sort()).toEqual([
+      "atlassian",
+      "github",
+    ]);
   });
 });


### PR DESCRIPTION
Two TUI changes, one branch, one commit each.

## 1. Configure → MCP Servers (list, probe, delete)

The MCP screen **existed and was unreachable**. No menu row pointed at it, the
router rendered it with `servers={[]}`, and its `onTest` set the notice `"mcp
test not wired yet"`. Every part of it was dead code.

- New **MCP Servers** row on a phantom's settings screen, badged with the count
  from its own `mcp.json`. Zero registered reads `optional`, not red — a
  phantom with no external tools is a normal phantom.
- The screen lists servers with transport, auth method and status, and shows
  the **selected** entry's command line (or endpoint) plus the vault keys it
  references underneath — so a delete is decided with those in view, not from a
  bare name.
- `t` probes one, `a` probes all, `d` deletes.

**Listing and probing are separate.** Rows come off disk and paint immediately;
status starts as a dim `— not probed` and fills in per row. The first cut
probed everything up front and the screen sat blank for as long as the slowest
`npx` cold start — which is exactly the server you opened the screen to delete.

**Reachable means a tool count, not a socket.** A server that connects and then
answers nothing to `tools/list` gives the agent no tools; painting that green is
the thing this screen exists to surface.

**Delete asks twice, and only when there is something to ask about.** Purging
the vault keys is a second, separate question: the registry entry is re-addable
from notes, the vault is the only copy of the credential. Skipped entirely when
the entry references no secrets, so it does not become a reflex.

**An unreadable registry is not an empty one** — no rows *plus* a notice saying
why, rather than inviting the user to re-add servers that are already there.

Nothing is reimplemented: `loadRegistry` / `removeServer` / `saveRegistry` and
`McpHub` are the same readers, writers and client `phantombot mcp` uses.

> ### This reverses a deliberate prior decision
> `tests/tui-navigation.test.tsx` pinned *"Vault and MCP are gone from both the
> table and the settings screen"* — removed as "not the setup `phantombot init`
> performs", and one more row a first-time user had to decide about. That test
> is **updated, not deleted**, and it now records both halves: MCP is back on
> the persona settings screen, and it is still absent from the **host table**,
> which is the part of that reasoning that stands. **Vault stays gone** — it was
> not asked for.

## 2. Doctor is a grouped checklist

Reported: *Telegram looks like a legacy doctor check.* It is not legacy — it was
the **only channel check the screen rendered**, and it read as a leftover
because it had no siblings.

The screen rendered four checks (telegram, memory db, nightly, backlog) and
dropped the rest. Everything else `runDoctor` already computes — systemd units,
timer staleness, per-persona maintenance, the default persona, harness
binaries, the Pi extension, ACP editor registrations, MCP servers, embeddings,
service logs — existed only in the CLI's text output. **So the screen could
paint all-green on a box whose `doctor` exit code was non-zero.** Added, not
removed.

`doctorChecklist` is a pure function of the report in its own module, so what
appears on screen is testable without rendering and the screen owns only the
paint. `editorConnectorBroken` / `missingHarnesses` stay the single authority
for their verdicts — an ACP proposed-api miss is red here **because it is
non-zero there**.

Three rules:

1. Grouped **CORE / CHANNELS / INTEGRATIONS**. A flat wall of ticks is as
   unreadable as no output.
2. One line per check when healthy; `detail` is a value worth a glance (a size,
   a count, a version), never a sentence.
3. The `→ what to do` row appears **only** on a check that is not green.

`warn` deliberately does not read as `bad`: "no Telegram account" is a fine
state for a phantom that does not use Telegram, and an operator who learns
yellow means nothing stops reading red too. Where doctor **repaired** something
the line says so (`repaired 1 unit`, `re-stamped`) — a self-healed fault
rendered as plain green loses the fact that anything was wrong.

The report is now taller than a small window, so the body scrolls (`↑↓`). Yoga
shrinks children rather than clipping, so a too-tall body paints rows on top of
each other; the window is a clamped slice, not `scrollWindow`, which centres on
a cursor through variable-height blocks and has neither here.

A healthy box now renders as:

```
 phantombot ▸ doctor                                          ● healthy
 ALICE
 ──────────────────────────────────────────────────────────────────────
 CORE
 ✓ memory database       42 MB · 1 restore point
 ✓ nightly sweep         no backlog
 ✓ capture               9 from 10 turns in 24h
 ✓ heartbeat timer       fired 4m ago
 ✓ tick timer            fired 1m ago
 ✓ systemd units         all present and armed
 ✓ persona maintenance   2 personas current
 ✓ default persona       alice (from state)
 ✓ release ring          stable · v1.1.359
 CHANNELS
 ✓ telegram              2 listeners across 2 personas
 ✓ embeddings            openai-compatible · semantic search on
 INTEGRATIONS
 ✓ harness binaries      claude
 ✓ mcp servers           3 servers for alice
 ✓ pi extension          present and current
 ✓ acp: zed              registered and current
 ✓ acp: vscode           registered and current
```

## Not in this change

**phantomchat and vault reachability.** Both need *new probes* in `runDoctor` —
there is no phantomchat check anywhere in the codebase today — which changes the
CLI's output and its exit-code surface. That is not a screen change, and a
placeholder behind a green tick is worse than an honest absence. Happy to raise
it as a follow-up issue; phantomchat is the one that has actually been biting
the fleet.

## Proof

`bun tsc --noEmit` clean, full suite **4624 pass / 8 skip / 0 fail**.

Every new test was proven by **neuter**, not by passing:

| neuter | failures |
|---|---|
| drop the MCP row from `ROWS` | 3 |
| restore `servers={[]}` on the MCP screen | 3 |
| ignore the delete confirm's answer | 1 |
| drop the `INTEGRATIONS` section | 6 |
| give a green check a hint | 3 |
| force the verdict never to go red | 2 |
| remove the scroll slice | 1 |

Two of those were **decorative on the first pass** and are recorded here because
the fix is the interesting part:

- The scroll assertion read the `more below` marker — which is computed from the
  row count and shows even when every row is still painted. It now asserts the
  off-window rows are genuinely *absent*, and that scrolling trades one end for
  the other.
- The "no hints on a healthy box" assertion passed against a report that had no
  hints to begin with. It is now an invariant checked across fifteen separately
  degraded reports (each one asserted to actually degrade something first), which
  is what lets the paint drop its redundant second state check.

The MCP fixture also caught a real registry rule on the way through: `env` auth
is stdio-only, so an `http` entry declaring it is rejected at load — which is
how the "unreadable registry ≠ empty registry" notice got exercised for free.
