### PR TITLE
doctor: probe phantomchat and the per-persona vault (relands #545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1030,6 +1030,16 @@ before the key existed: every configured identity starts. Once the key is
 present — even as an empty list — it is the whole truth, and a persona outside
 it is skipped with a warning naming the fix.
 
+`phantombot doctor` treats that skip as a FAILURE, not a note: a persona that
+holds a `phantomchat.json` (or a stated Telegram account) but sits outside the
+roster is configured to talk and silently mute, which is a misconfiguration far
+more often than it is a choice. If muting it IS the choice, unstate the channel
+rather than leaving the two halves disagreeing — delete
+`<persona-dir>/phantomchat.json` (or clear the persona's Telegram account) and
+doctor stops reporting it, because a persona with no channel file is not using
+the channel at all. Keeping the file as a parked config is what earns the red
+row; there is no separate "configured but intentionally off" state.
+
 A persona name is CASE-SENSITIVE everywhere it is used as a key — persona
 directory, memory rows, vault, tasks — even though macOS and Windows
 filesystems are not. `default_persona = "robbie"` against a directory named

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -17,7 +17,7 @@
  */
 
 import { defineCommand } from "citty";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 
 import {
@@ -71,6 +71,13 @@ import {
   listPersonaDirs,
 } from "../lib/personaDefault.ts";
 import { loadRegistry } from "../mcp/registry.ts";
+import {
+  loadPhantomchatPersonaConfig,
+  phantomchatConfigPath,
+} from "../channels/phantomchat/personaStore.ts";
+import { identityFromNsec } from "../lib/nostrIdentity.ts";
+import { readPersonaIdentityNsec } from "../lib/personaIdentity.ts";
+import { openVaultWithSecret, vaultPath } from "../lib/vault.ts";
 import { saveHarnessBins } from "../state.ts";
 import {
   BunSystemctlRunner,
@@ -119,6 +126,79 @@ export interface DoctorReport {
       persona: string;
       stated: boolean;
       listeners: number;
+      healthy: boolean;
+      detail: string;
+    }>;
+  };
+  /**
+   * PhantomChat (Nostr NIP-17) reachability, the sibling of the Telegram
+   * check above. Telegram was for a long time the ONLY channel doctor could
+   * see, which made it look like a leftover when it was simply alone.
+   *
+   * PhantomChat is configured PER-PERSONA in `<persona-dir>/phantomchat.json`
+   * with the key in `identity.json` — there is deliberately no
+   * `[channels.phantomchat]` block in config.toml — so nothing in the host
+   * config tells you whether a persona can talk. The failures this catches are
+   * all silent by construction: an unparseable file and a missing/invalid nsec
+   * both make `loadPhantomchatPersonaConfig` return undefined, which the boot
+   * path reads as "not configured" and skips without an error; and a persona
+   * that IS configured but absent from `autostart_personas` is gated out with
+   * a warning on stderr that nobody sees after the service has started.
+   *
+   * Only personas that HAVE a phantomchat.json appear here. A persona that
+   * does not use the channel is not a finding, and listing every one of them
+   * as green would bury the one line that matters.
+   */
+  phantomchat: {
+    healthy: boolean;
+    /** Personas that would actually get a listener on this host. */
+    listeners: number;
+    personas: Array<{
+      persona: string;
+      /** A phantomchat.json exists for this persona. */
+      stated: boolean;
+      /** The persona's public npub — safe to print; the nsec never is. */
+      npub?: string;
+      /** Relays this persona would connect to (defaults applied). */
+      relays: number;
+      /** Senders allowed to address it (allowed + relay tiers). */
+      allowed: number;
+      /** Trust-on-first-use is on, so an empty allowlist still pairs. */
+      tofu: boolean;
+      /** This host would start a listener for it. */
+      listener: boolean;
+      healthy: boolean;
+      detail: string;
+    }>;
+  };
+  /**
+   * Per-persona encrypted secrets vault reachability (#516/#522).
+   *
+   * The vault key is DERIVED from the persona's nsec in `identity.json`, so
+   * `identity.json` missing while `vault.sqlite` is present means every secret
+   * in it is unreadable — and the way that surfaces today is not an error but
+   * a capability quietly going away: a credential that will not decrypt is
+   * simply absent from the environment, and the feature it powered degrades.
+   * That is exactly how a revoked embeddings key dropped memory search to
+   * keyword-only with doctor reporting "semantic search off" and no reason.
+   *
+   * So this check answers "can this persona read its own secrets", per
+   * persona, by deriving the key and decrypting every row. Values are never
+   * read into the report — only names, counts and whether each row decrypts.
+   * A persona with no vault yet is NOT a fault (a fresh box has none).
+   */
+  vault: {
+    healthy: boolean;
+    personas: Array<{
+      persona: string;
+      /** vault.sqlite exists for this persona. */
+      present: boolean;
+      /** identity.json exists — without it the key cannot be derived. */
+      identity: boolean;
+      /** Rows that decrypted cleanly. */
+      secrets: number;
+      /** NAMES (never values) of rows that would not decrypt. */
+      undecryptable: string[];
       healthy: boolean;
       detail: string;
     }>;
@@ -422,6 +502,18 @@ export interface RunDoctorInput {
   checkEditorConnectors?:
     | false
     | ((repair: boolean) => DoctorReport["editorConnectors"]);
+  /**
+   * Test seam for the PhantomChat channel check. Pass `false` to skip, a
+   * function to substitute a fake. In production this is undefined and doctor
+   * scans the real persona directories for `phantomchat.json`.
+   */
+  checkPhantomchat?: false | (() => DoctorReport["phantomchat"]);
+  /**
+   * Test seam for the per-persona vault check. Pass `false` to skip, a
+   * function to substitute a fake. In production this is undefined and doctor
+   * opens each served persona's real vault (read-only, never creating one).
+   */
+  checkVault?: false | (() => Promise<DoctorReport["vault"]>);
 }
 
 interface MutableTelegramPersonaHealth {
@@ -538,6 +630,179 @@ function telegramHealthReport(
   };
 }
 
+/**
+ * PhantomChat health, the sibling of `telegramHealthReport`.
+ *
+ * Scans the persona directories for `phantomchat.json` rather than reading the
+ * host config, because that file IS the configuration — there is no
+ * `[channels.phantomchat]` block to consult. A persona with no such file is
+ * not reported at all: it simply does not use the channel.
+ *
+ * The autostart gate is MIRRORED here rather than imported from `run.ts`, for
+ * the same reason `telegramHealthReport` mirrors listener planning: `run.ts`
+ * already imports this module, so reaching the other way would close a cycle.
+ * Keep the two in step — the rule is "`autostart_personas` absent means every
+ * configured identity starts; present (even empty) makes it the whole truth".
+ */
+function phantomchatHealthReport(host: Config): DoctorReport["phantomchat"] {
+  const personas: DoctorReport["phantomchat"]["personas"] = [];
+  let names: string[] = [];
+  if (existsSync(host.personasDir)) {
+    try {
+      names = readdirSync(host.personasDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name)
+        .sort();
+    } catch (e) {
+      log.warn("doctor: phantomchat persona scan failed", {
+        error: (e as Error).message,
+      });
+    }
+  }
+  const roster =
+    host.autostartPersonas === undefined
+      ? undefined
+      : new Set([host.defaultPersona, ...host.autostartPersonas]);
+
+  for (const persona of names) {
+    const agentDir = personaDir(host, persona);
+    if (!existsSync(phantomchatConfigPath(agentDir))) continue;
+    const pc = loadPhantomchatPersonaConfig(agentDir);
+    if (!pc) {
+      // The boot path reads this exact state as "not configured" and skips the
+      // persona silently, so it is the one worth being loudest about.
+      personas.push({
+        persona,
+        stated: true,
+        relays: 0,
+        allowed: 0,
+        tofu: false,
+        listener: false,
+        healthy: false,
+        detail: existsSync(join(agentDir, "identity.json"))
+          ? "phantomchat.json is unparseable, or identity.json holds an invalid nsec"
+          : "phantomchat.json present but identity.json is missing — no usable key",
+      });
+      continue;
+    }
+    const listener = roster === undefined || roster.has(persona);
+    const allowed = pc.allowedHex.length + pc.relayHex.length;
+    // Reachability is reported but never fatal: a persona created moments ago
+    // and not yet paired is legitimately in this state, and a check that is
+    // permanently lit on a healthy box is one nobody reads.
+    const unpaired = allowed === 0 && !pc.tofu;
+    personas.push({
+      persona,
+      stated: true,
+      npub: pc.identity.npub,
+      relays: pc.relays.length,
+      allowed,
+      tofu: pc.tofu,
+      listener,
+      healthy: listener,
+      detail: !listener
+        ? "configured but not in autostart_personas — no listener is started"
+        : unpaired
+          ? `runnable on ${pc.relays.length} relay(s), but no allowed npubs and TOFU off — nothing can reach it yet`
+          : `runnable on ${pc.relays.length} relay(s), ${allowed} allowed sender(s)`,
+    });
+  }
+
+  return {
+    healthy: personas.every((p) => p.healthy),
+    listeners: personas.filter((p) => p.listener && p.healthy).length,
+    personas,
+  };
+}
+
+/**
+ * Per-persona vault reachability.
+ *
+ * READ-ONLY BY CONSTRUCTION: it resolves the nsec with
+ * `readPersonaIdentityNsec` and opens the vault with `openVaultWithSecret`,
+ * never `openPersonaVault` — that one calls `getOrCreatePersonaIdentity` and
+ * would GENERATE an identity (and a vault) for a persona that has neither,
+ * turning a health check into provisioning. Same reasoning as the guard in
+ * `readAllVaultValues`.
+ *
+ * Decryption is per-row: one poisoned row is collected by name, not allowed to
+ * abort the persona's check, so the report can say WHICH secret is unreadable.
+ */
+async function defaultCheckVault(host: Config): Promise<DoctorReport["vault"]> {
+  const personas: DoctorReport["vault"]["personas"] = [];
+  for (const persona of servedPersonasOf(host)) {
+    const agentDir = personaDir(host, persona);
+    if (!existsSync(agentDir)) continue;
+    const present = existsSync(vaultPath(agentDir));
+    const nsec = readPersonaIdentityNsec(agentDir);
+    if (!present) {
+      // A box installed this afternoon has no vault. Not a fault, and saying
+      // so in red would teach an operator to ignore this line.
+      personas.push({
+        persona,
+        present: false,
+        identity: nsec !== undefined,
+        secrets: 0,
+        undecryptable: [],
+        healthy: true,
+        detail: "no vault yet",
+      });
+      continue;
+    }
+    if (!nsec) {
+      personas.push({
+        persona,
+        present: true,
+        identity: false,
+        secrets: 0,
+        undecryptable: [],
+        healthy: false,
+        detail:
+          "vault.sqlite present but identity.json is missing — its key derives from that nsec, so nothing in it can be decrypted",
+      });
+      continue;
+    }
+    let secrets = 0;
+    const undecryptable: string[] = [];
+    let openError: string | undefined;
+    try {
+      const identity = identityFromNsec(nsec);
+      const vault = openVaultWithSecret(agentDir, identity.secretKey);
+      try {
+        for (const name of vault.list()) {
+          try {
+            if (vault.get(name) !== undefined) secrets++;
+            else undecryptable.push(name);
+          } catch {
+            undecryptable.push(name);
+          }
+        }
+      } finally {
+        vault.close();
+      }
+    } catch (e) {
+      openError = (e as Error).message;
+    }
+    personas.push({
+      persona,
+      present: true,
+      identity: true,
+      secrets,
+      undecryptable,
+      healthy: openError === undefined && undecryptable.length === 0,
+      detail: openError
+        ? `vault could not be opened: ${openError}`
+        : undecryptable.length > 0
+          ? `${secrets} secret(s) readable, ${undecryptable.length} will NOT decrypt: ${undecryptable.join(", ")}`
+          : `${secrets} secret(s) readable`,
+    });
+  }
+  return {
+    healthy: personas.every((p) => p.healthy),
+    personas,
+  };
+}
+
 export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   const out = input.out ?? process.stdout;
   const err = input.err ?? process.stderr;
@@ -626,6 +891,18 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
   }
   const dryDay = userTurns >= DRY_DAY_TURN_THRESHOLD && captures === 0;
   const telegramReport = telegramHealthReport(host, personaConfigs);
+  const phantomchatReport =
+    input.checkPhantomchat === false
+      ? undefined
+      : input.checkPhantomchat
+        ? input.checkPhantomchat()
+        : phantomchatHealthReport(host);
+  const vaultReport =
+    input.checkVault === false
+      ? undefined
+      : input.checkVault
+        ? await input.checkVault()
+        : await defaultCheckVault(host);
 
   // Embeddings status — informational only. Vector search is live only when
   // the selected provider has enough configuration to make a request.
@@ -824,9 +1101,17 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
     existsSync(join(dir, rel)),
   );
 
+  const emptyPhantomchat: DoctorReport["phantomchat"] = {
+    healthy: true,
+    listeners: 0,
+    personas: [],
+  };
+  const emptyVault: DoctorReport["vault"] = { healthy: true, personas: [] };
   const report: DoctorReport = {
     persona,
     telegram: telegramReport,
+    phantomchat: phantomchatReport ?? emptyPhantomchat,
+    vault: vaultReport ?? emptyVault,
     nightly: {
       last_run: state.last_run,
       last_status: state.last_status,
@@ -938,6 +1223,14 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
 
   const memoryDbBroken = dbPresent && !dbHealth.ok;
   const telegramBroken = !telegramReport.healthy;
+  // A configured channel that cannot receive is a failure, exactly as for
+  // Telegram. An UNCONFIGURED one never reaches here: personas without a
+  // phantomchat.json are not in the report at all.
+  const phantomchatBroken = !!phantomchatReport && !phantomchatReport.healthy;
+  // Secrets that will not decrypt are in the same class as an unreadable
+  // memory database: not a process to restart, but data the box cannot get
+  // back. Every credential-shaped feature degrades silently behind it.
+  const vaultBroken = !!vaultReport && !vaultReport.healthy;
   const exitCode =
     memoryDbBroken
       ? 1
@@ -957,7 +1250,11 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
                 ? 1
                 : telegramBroken
                   ? 1
-                  : 0;
+                  : vaultBroken
+                    ? 1
+                    : phantomchatBroken
+                      ? 1
+                      : 0;
 
   if (input.json) {
     out.write(JSON.stringify(report, null, 2) + "\n");
@@ -991,6 +1288,33 @@ export async function runDoctor(input: RunDoctorInput = {}): Promise<number> {
       `    persona '${entry.persona}': ${entry.listeners} listener(s), ` +
         `${entry.detail}\n`,
     );
+  }
+  if (phantomchatReport) {
+    out.write(
+      `  phantomchat: ${tick(phantomchatReport.healthy)} — ` +
+        (phantomchatReport.personas.length === 0
+          ? "not configured on any persona\n"
+          : `${phantomchatReport.listeners} listener(s) across ` +
+            `${phantomchatReport.personas.length} persona(s)\n`),
+    );
+    for (const entry of phantomchatReport.personas) {
+      out.write(
+        `    persona '${entry.persona}': ${entry.detail}` +
+          (entry.npub ? ` (${entry.npub})` : "") +
+          "\n",
+      );
+    }
+  }
+  if (vaultReport) {
+    out.write(`  vault: ${tick(vaultReport.healthy)} — `);
+    out.write(
+      vaultReport.personas.length === 0
+        ? "no personas to check\n"
+        : `${vaultReport.personas.length} persona(s) checked\n`,
+    );
+    for (const entry of vaultReport.personas) {
+      out.write(`    persona '${entry.persona}': ${entry.detail}\n`);
+    }
   }
   // Health comes off the ledger, not the clock: a box that slept through
   // 02:00 but has nothing pending is healthy.

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -631,6 +631,28 @@ function telegramHealthReport(
 }
 
 /**
+ * Why `loadPhantomchatPersonaConfig` returned undefined.
+ *
+ * It folds three distinct causes into one falsy value, and they need different
+ * fixes: a missing key, a key that is present but not a valid nsec, and a
+ * `phantomchat.json` that will not parse. Re-resolve the identity the same way
+ * the loader does so the report names the actual cause instead of offering the
+ * operator a guess between two.
+ */
+function phantomchatLoadFailure(agentDir: string): string {
+  const nsec = readPersonaIdentityNsec(agentDir);
+  if (nsec === undefined) {
+    return "phantomchat.json present but identity.json is missing — no usable key";
+  }
+  try {
+    identityFromNsec(nsec);
+  } catch (e) {
+    return `identity.json holds an invalid nsec: ${(e as Error).message}`;
+  }
+  return "phantomchat.json is unparseable — identity.json itself is fine";
+}
+
+/**
  * PhantomChat health, the sibling of `telegramHealthReport`.
  *
  * Scans the persona directories for `phantomchat.json` rather than reading the
@@ -679,9 +701,7 @@ function phantomchatHealthReport(host: Config): DoctorReport["phantomchat"] {
         tofu: false,
         listener: false,
         healthy: false,
-        detail: existsSync(join(agentDir, "identity.json"))
-          ? "phantomchat.json is unparseable, or identity.json holds an invalid nsec"
-          : "phantomchat.json present but identity.json is missing — no usable key",
+        detail: phantomchatLoadFailure(agentDir),
       });
       continue;
     }
@@ -701,7 +721,8 @@ function phantomchatHealthReport(host: Config): DoctorReport["phantomchat"] {
       listener,
       healthy: listener,
       detail: !listener
-        ? "configured but not in autostart_personas — no listener is started"
+        ? "configured but not in autostart_personas — no listener is started; " +
+          "delete phantomchat.json if muting it is deliberate"
         : unpaired
           ? `runnable on ${pc.relays.length} relay(s), but no allowed npubs and TOFU off — nothing can reach it yet`
           : `runnable on ${pc.relays.length} relay(s), ${allowed} allowed sender(s)`,

--- a/src/tui/doctorChecklist.ts
+++ b/src/tui/doctorChecklist.ts
@@ -13,6 +13,10 @@
  * precisely BECAUSE it was alone. The fix is to add its siblings, not to
  * remove it (Andrew, 2026-09-12).
  *
+ * Its siblings now exist for real: `runDoctor` grew a PhantomChat probe and a
+ * per-persona vault probe, so CHANNELS answers "can this phantom be reached"
+ * on both channels, and CORE answers "can it read its own secrets".
+ *
  * Three rules, which is the whole design:
  *
  *   1. GROUPED — Core, Channels, Integrations. A flat wall of green ticks is
@@ -88,6 +92,29 @@ function coreItems(r: DoctorReport): ChecklistItem[] {
       detail: plural(r.memory_db.unretired_drawers.length, "file") + " still on disk",
       hint: `retirement held back ${r.memory_db.unretired_drawers.join(", ")} — nothing reads them`,
     });
+
+  // The vault is data, not a process: its key derives from the persona's nsec,
+  // so a lost identity.json does not throw anywhere — every secret simply
+  // stops arriving and the features behind them degrade quietly. That is why
+  // it sits in CORE next to the memory database rather than under a channel.
+  {
+    const broken = r.vault.personas.filter((p) => !p.healthy);
+    const withVault = r.vault.personas.filter((p) => p.present);
+    const secrets = r.vault.personas.reduce((n, p) => n + p.secrets, 0);
+    items.push({
+      label: "secrets vault",
+      state: broken.length > 0 ? "bad" : "ok",
+      detail:
+        withVault.length === 0
+          ? "no vault yet"
+          : `${plural(secrets, "secret")} across ${plural(withVault.length, "persona")}`,
+      ...(broken.length === 0
+        ? {}
+        : {
+            hint: broken.map((p) => `${p.persona}: ${p.detail}`).join("; "),
+          }),
+    });
+  }
 
   items.push({
     label: "nightly sweep",
@@ -262,6 +289,28 @@ function channelItems(r: DoctorReport): ChecklistItem[] {
       ? {}
       : {
           hint: r.telegram.personas
+            .filter((p) => !p.healthy)
+            .map((p) => `${p.persona}: ${p.detail}`)
+            .join("; "),
+        }),
+  });
+
+  // PhantomChat is the other half of "can this phantom be reached", and the
+  // half no host config mentions: it is configured per-persona on disk, so
+  // without this line an unparseable phantomchat.json or a persona left out of
+  // `autostart_personas` is invisible — the boot path treats both as "not
+  // configured" and starts nothing.
+  items.push({
+    label: "phantomchat",
+    state: !r.phantomchat.healthy ? "bad" : "ok",
+    detail:
+      r.phantomchat.personas.length === 0
+        ? "not configured"
+        : `${plural(r.phantomchat.listeners, "listener")} across ${plural(r.phantomchat.personas.length, "persona")}`,
+    ...(r.phantomchat.healthy
+      ? {}
+      : {
+          hint: r.phantomchat.personas
             .filter((p) => !p.healthy)
             .map((p) => `${p.persona}: ${p.detail}`)
             .join("; "),

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -1556,6 +1556,62 @@ describe("runDoctor — phantomchat channel health", () => {
     expect(out.text).toContain("identity.json is missing");
   });
 
+  test("an invalid nsec is named as such, not as a parse failure", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const dir = join(workdir, "personas", "phantom");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "identity.json"),
+      JSON.stringify({ nsec: "nsec1notactuallyakey" }),
+      "utf8",
+    );
+    await writeFile(
+      join(dir, "phantomchat.json"),
+      JSON.stringify({ relays: ["wss://a"], allowed_npubs: [] }),
+      "utf8",
+    );
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(1);
+    // The two causes need different fixes, so the report must not offer the
+    // operator a guess between them.
+    expect(out.text).toContain("identity.json holds an invalid nsec");
+    expect(out.text).not.toContain("phantomchat.json is unparseable");
+  });
+
+  test("an unparseable phantomchat.json clears a healthy identity", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const dir = join(workdir, "personas", "phantom");
+    await mkdir(dir, { recursive: true });
+    const identity = generateIdentity();
+    await writeFile(
+      join(dir, "identity.json"),
+      JSON.stringify({ nsec: identity.nsec }),
+      "utf8",
+    );
+    await writeFile(join(dir, "phantomchat.json"), "{ not json", "utf8");
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(1);
+    expect(out.text).toContain("phantomchat.json is unparseable");
+    expect(out.text).toContain("identity.json itself is fine");
+  });
+
+  test("the autostart skip names the escape hatch", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    await writePhantomchatPersona("phantom", { allowed_npubs: ["npub1a"] });
+    await writePhantomchatPersona("kai", { allowed_npubs: ["npub1b"] });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config: { ...config, autostartPersonas: [] },
+      out,
+      ...skips,
+    });
+    expect(code).toBe(1);
+    // A red row an operator cannot clear is one they learn to ignore.
+    expect(out.text).toContain("delete phantomchat.json");
+  });
+
   test("configured but outside autostart_personas fails doctor", async () => {
     await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
     await writePhantomchatPersona("phantom", { allowed_npubs: ["npub1a"] });

--- a/tests/cli-doctor.test.ts
+++ b/tests/cli-doctor.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runDoctor } from "../src/cli/doctor.ts";
 import type { Config } from "../src/config.ts";
+import { generateIdentity } from "../src/lib/nostrIdentity.ts";
+import { openVaultWithSecret } from "../src/lib/vault.ts";
 
 class CaptureStream {
   chunks: string[] = [];
@@ -1482,5 +1485,227 @@ describe("runDoctor — the host default persona (#505)", () => {
     expect(report.default_persona.served).toBe(true);
     expect(report.default_persona.defect).toBeNull();
     expect(report.default_persona.provenance).toBe("builtin");
+  });
+});
+
+describe("runDoctor — phantomchat channel health", () => {
+  /** Write a persona dir with an identity and a phantomchat.json. */
+  async function writePhantomchatPersona(
+    persona: string,
+    file: Record<string, unknown> = {},
+  ): Promise<string> {
+    const dir = join(workdir, "personas", persona);
+    await mkdir(join(dir, "memory"), { recursive: true });
+    const identity = generateIdentity();
+    await writeFile(
+      join(dir, "identity.json"),
+      JSON.stringify({ nsec: identity.nsec }),
+      "utf8",
+    );
+    await writeFile(
+      join(dir, "phantomchat.json"),
+      JSON.stringify({ relays: ["wss://a"], allowed_npubs: [], ...file }),
+      "utf8",
+    );
+    return identity.npub;
+  }
+
+  const skips = {
+    checkSystemd: false,
+    checkTimers: false,
+    checkMaintenance: false,
+    checkVault: false,
+  } as const;
+
+  test("a persona with no phantomchat.json is not a finding", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(0);
+    expect(out.text).toContain("phantomchat: ok — not configured on any persona");
+  });
+
+  test("a runnable persona is reported with its npub", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const npub = await writePhantomchatPersona("phantom", {
+      allowed_npubs: ["npub1qqqqq"],
+    });
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(0);
+    expect(out.text).toContain("phantomchat: ok — 1 listener(s)");
+    expect(out.text).toContain(npub);
+    // The npub is public; the nsec must never reach the report.
+    expect(out.text).not.toContain("nsec1");
+  });
+
+  test("phantomchat.json without identity.json fails doctor", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const dir = join(workdir, "personas", "phantom");
+    await writeFile(
+      join(dir, "phantomchat.json"),
+      JSON.stringify({ relays: ["wss://a"] }),
+      "utf8",
+    );
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    // The boot path reads this as "not configured" and starts nothing, which
+    // is precisely why doctor has to say it out loud.
+    expect(code).toBe(1);
+    expect(out.text).toContain("phantomchat: WARN");
+    expect(out.text).toContain("identity.json is missing");
+  });
+
+  test("configured but outside autostart_personas fails doctor", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    await writePhantomchatPersona("phantom", { allowed_npubs: ["npub1a"] });
+    await writePhantomchatPersona("kai", { allowed_npubs: ["npub1b"] });
+    const out = new CaptureStream();
+    const code = await runDoctor({
+      config: { ...config, autostartPersonas: [] },
+      out,
+      ...skips,
+    });
+    expect(code).toBe(1);
+    expect(out.text).toContain("kai");
+    expect(out.text).toContain("not in autostart_personas");
+    // The default persona is in the roster by definition, so it stays green.
+    expect(out.text).toContain("persona 'phantom': runnable");
+  });
+
+  test("an absent autostart roster starts every configured identity", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    await writePhantomchatPersona("phantom", { allowed_npubs: ["npub1a"] });
+    await writePhantomchatPersona("kai", { allowed_npubs: ["npub1b"] });
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(0);
+    expect(out.text).toContain("phantomchat: ok — 2 listener(s)");
+  });
+
+  test("no allowed npubs and no TOFU is surfaced but not fatal", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    await writePhantomchatPersona("phantom", { allowed_npubs: [] });
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    // A persona created moments ago and not yet paired is legitimately here;
+    // a permanently-lit failure is one nobody reads.
+    expect(code).toBe(0);
+    expect(out.text).toContain("nothing can reach it yet");
+  });
+
+  test("json mode carries the phantomchat block", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    await writePhantomchatPersona("phantom", { allowed_npubs: ["npub1a"] });
+    const out = new CaptureStream();
+    await runDoctor({ config, out, json: true, ...skips });
+    const report = JSON.parse(out.text);
+    expect(report.phantomchat.healthy).toBe(true);
+    expect(report.phantomchat.listeners).toBe(1);
+    expect(report.phantomchat.personas[0].relays).toBe(1);
+    expect(JSON.stringify(report)).not.toContain("nsec1");
+  });
+});
+
+describe("runDoctor — per-persona secrets vault", () => {
+  const skips = {
+    checkSystemd: false,
+    checkTimers: false,
+    checkMaintenance: false,
+    checkPhantomchat: false,
+  } as const;
+
+  /** Give a persona an identity.json and return its secret key. */
+  async function writeIdentity(persona: string): Promise<Uint8Array> {
+    const dir = join(workdir, "personas", persona);
+    await mkdir(dir, { recursive: true });
+    const identity = generateIdentity();
+    await writeFile(
+      join(dir, "identity.json"),
+      JSON.stringify({ nsec: identity.nsec }),
+      "utf8",
+    );
+    return identity.secretKey;
+  }
+
+  test("a persona with no vault yet is healthy", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(0);
+    expect(out.text).toContain("vault: ok");
+    expect(out.text).toContain("no vault yet");
+  });
+
+  test("readable secrets are counted, never printed", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const secretKey = await writeIdentity("phantom");
+    const vault = openVaultWithSecret(join(workdir, "personas", "phantom"), secretKey);
+    vault.set("OPENAI_API_KEY", "sk-super-secret-value");
+    vault.set("GITHUB_TOKEN", "ghp_another_secret");
+    vault.close();
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(0);
+    expect(out.text).toContain("2 secret(s) readable");
+    expect(out.text).not.toContain("sk-super-secret-value");
+    expect(out.text).not.toContain("ghp_another_secret");
+  });
+
+  test("a vault whose identity.json is gone fails doctor", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const secretKey = await writeIdentity("phantom");
+    const dir = join(workdir, "personas", "phantom");
+    const vault = openVaultWithSecret(dir, secretKey);
+    vault.set("OPENAI_API_KEY", "sk-value");
+    vault.close();
+    await rm(join(dir, "identity.json"));
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(1);
+    expect(out.text).toContain("vault: WARN");
+    expect(out.text).toContain("identity.json is missing");
+  });
+
+  test("a row written under a different key is named, not silently dropped", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const dir = join(workdir, "personas", "phantom");
+    const first = await writeIdentity("phantom");
+    const vault = openVaultWithSecret(dir, first);
+    vault.set("STALE_KEY", "written-under-the-old-identity");
+    vault.close();
+    // Re-mint the identity: the vault file survives, its rows do not decrypt.
+    await rm(join(dir, "identity.json"));
+    await writeIdentity("phantom");
+    const out = new CaptureStream();
+    const code = await runDoctor({ config, out, ...skips });
+    expect(code).toBe(1);
+    expect(out.text).toContain("will NOT decrypt: STALE_KEY");
+    expect(out.text).not.toContain("written-under-the-old-identity");
+  });
+
+  test("doctor never provisions a persona it only inspected", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const dir = join(workdir, "personas", "phantom");
+    const code = await runDoctor({ config, out: new CaptureStream(), ...skips });
+    expect(code).toBe(0);
+    // openPersonaVault would have minted both of these as a side effect.
+    expect(existsSync(join(dir, "identity.json"))).toBe(false);
+    expect(existsSync(join(dir, "vault.sqlite"))).toBe(false);
+  });
+
+  test("json mode carries the vault block without values", async () => {
+    await writeState({ last_run: new Date().toISOString(), last_status: "ok" });
+    const secretKey = await writeIdentity("phantom");
+    const vault = openVaultWithSecret(join(workdir, "personas", "phantom"), secretKey);
+    vault.set("OPENAI_API_KEY", "sk-secret");
+    vault.close();
+    const out = new CaptureStream();
+    await runDoctor({ config, out, json: true, ...skips });
+    const report = JSON.parse(out.text);
+    expect(report.vault.healthy).toBe(true);
+    expect(report.vault.personas[0].secrets).toBe(1);
+    expect(report.vault.personas[0].undecryptable).toEqual([]);
+    expect(out.text).not.toContain("sk-secret");
   });
 });

--- a/tests/tui-doctor-checklist.test.tsx
+++ b/tests/tui-doctor-checklist.test.tsx
@@ -38,6 +38,48 @@ function healthyReport(): DoctorReport {
         { persona: "bob", stated: true, listeners: 1, healthy: true, detail: "runnable" },
       ],
     },
+    phantomchat: {
+      healthy: true,
+      listeners: 2,
+      personas: [
+        {
+          persona: "alice",
+          stated: true,
+          npub: "npub1alice",
+          relays: 3,
+          allowed: 1,
+          tofu: false,
+          listener: true,
+          healthy: true,
+          detail: "runnable on 3 relay(s), 1 allowed sender(s)",
+        },
+        {
+          persona: "bob",
+          stated: true,
+          npub: "npub1bob",
+          relays: 3,
+          allowed: 2,
+          tofu: false,
+          listener: true,
+          healthy: true,
+          detail: "runnable on 3 relay(s), 2 allowed sender(s)",
+        },
+      ],
+    },
+    vault: {
+      healthy: true,
+      personas: [
+        {
+          persona: "alice",
+          present: true,
+          identity: true,
+          secrets: 7,
+          undecryptable: [],
+          healthy: true,
+          detail: "7 secret(s) readable",
+        },
+      ],
+    },
     nightly: { age_hours: 2, health: "ok", detail: "no backlog", backlog: 0 },
     memory_db: {
       path: "/x/memory.sqlite",
@@ -153,6 +195,8 @@ describe("doctorChecklist", () => {
       "default persona",
       "release ring",
       "telegram",
+      "phantomchat",
+      "secrets vault",
       "embeddings",
       "harness binaries",
       "mcp servers",
@@ -192,6 +236,81 @@ describe("doctorChecklist", () => {
     expect(telegram.detail).toBe("not configured");
     // Rule 3: health is quiet. A green row carries no "what to do" line.
     expect(telegram.hint).toBeUndefined();
+  });
+
+  test("phantomchat gets the same treatment telegram does", () => {
+    // Telegram read as legacy because it was ALONE, so the fix is only real
+    // if its sibling is rendered to the same standard.
+    const r = healthyReport();
+    r.phantomchat.healthy = false;
+    r.phantomchat.listeners = 1;
+    r.phantomchat.personas[1] = {
+      persona: "bob",
+      stated: true,
+      relays: 0,
+      allowed: 0,
+      tofu: false,
+      listener: false,
+      healthy: false,
+      detail: "configured but not in autostart_personas — no listener is started",
+    };
+    const pc = item(r, "phantomchat")!;
+    expect(pc.state).toBe("bad");
+    expect(pc.hint).toContain("bob");
+    expect(pc.hint).toContain("autostart_personas");
+  });
+
+  test("a persona that does not use phantomchat is green and quiet", () => {
+    const r = healthyReport();
+    r.phantomchat = { healthy: true, listeners: 0, personas: [] };
+    const pc = item(r, "phantomchat")!;
+    expect(pc.state).toBe("ok");
+    expect(pc.detail).toBe("not configured");
+    expect(pc.hint).toBeUndefined();
+  });
+
+  test("a vault that will not decrypt is red and names the persona", () => {
+    const r = healthyReport();
+    r.vault = {
+      healthy: false,
+      personas: [
+        {
+          persona: "alice",
+          present: true,
+          identity: false,
+          secrets: 0,
+          undecryptable: [],
+          healthy: false,
+          detail: "vault.sqlite present but identity.json is missing",
+        },
+      ],
+    };
+    const vault = item(r, "secrets vault")!;
+    expect(vault.state).toBe("bad");
+    expect(vault.hint).toContain("alice");
+    expect(vault.hint).toContain("identity.json");
+  });
+
+  test("a box with no vault yet is green, not a warning", () => {
+    const r = healthyReport();
+    r.vault = {
+      healthy: true,
+      personas: [
+        {
+          persona: "alice",
+          present: false,
+          identity: true,
+          secrets: 0,
+          undecryptable: [],
+          healthy: true,
+          detail: "no vault yet",
+        },
+      ],
+    };
+    const vault = item(r, "secrets vault")!;
+    expect(vault.state).toBe("ok");
+    expect(vault.detail).toBe("no vault yet");
+    expect(vault.hint).toBeUndefined();
   });
 
   test("a repaired fault says what was healed, not just green", () => {

--- a/tests/tui-navigation.test.tsx
+++ b/tests/tui-navigation.test.tsx
@@ -203,6 +203,8 @@ const ALICE: PersonaSnapshot = {
 const FAKE_REPORT: DoctorReport = {
   persona: "alice",
   telegram: { healthy: true, listeners: 2, personas: [] },
+  phantomchat: { healthy: true, listeners: 0, personas: [] },
+  vault: { healthy: true, personas: [] },
   memory_db: {
     path: "/x/db",
     healthy: true,

--- a/tests/tui-restart-removed.test.tsx
+++ b/tests/tui-restart-removed.test.tsx
@@ -149,6 +149,8 @@ const strip = (s: string) => s.replace(/\u001B\[[0-9;]*m/g, "");
 const FAKE_REPORT: DoctorReport = {
   persona: "alice",
   telegram: { healthy: true, listeners: 2, personas: [] },
+  phantomchat: { healthy: true, listeners: 0, personas: [] },
+  vault: { healthy: true, personas: [] },
   memory_db: {
     path: "/x/db",
     healthy: true,

--- a/tests/tui-settings-fit.test.tsx
+++ b/tests/tui-settings-fit.test.tsx
@@ -125,6 +125,8 @@ const HOST: HostSnapshot = {
 const FAKE_REPORT: DoctorReport = {
   persona: "alice",
   telegram: { healthy: true, listeners: 2, personas: [] },
+  phantomchat: { healthy: true, listeners: 0, personas: [] },
+  vault: { healthy: true, personas: [] },
   memory_db: {
     path: "/x/db",
     healthy: true,


### PR DESCRIPTION
Relands the payload of #545, which never reached `main`: it was still based on #544's branch when both were merged, so GitHub squashed it into that branch (`0a86944`) instead. Both PRs read MERGED and all 725 lines were absent from `main`. Nothing here is new work beyond the two review notes below — the probes are a clean cherry-pick of the approved commit.

**Base is `main`.** No stacking.

### What lands

**phantomchat per-persona channel health.** PhantomChat is configured in `<persona-dir>/phantomchat.json` — there is no `[channels.phantomchat]` block — so nothing in the host config could see it. The probe scans persona dirs and catches the three states the boot path swallows as "not configured": an unparseable file, a missing or invalid `identity.json`, and configured-but-absent-from-`autostart_personas`. Only personas that *have* the file are reported, so a Telegram-only host stays quiet and green.

The autostart gate is mirrored here rather than imported from `run.ts` (which already imports `doctor.ts` — a cycle), exactly as `telegramHealthReport` mirrors listener planning. The two must be kept in step.

**Per-persona vault reachability.** Derives the key from the persona's nsec and decrypts every row, reporting counts and the *names* of rows that will not decrypt — never values. Read-only by construction: `readPersonaIdentityNsec` + `openVaultWithSecret`, never `openPersonaVault`, which calls `getOrCreatePersonaIdentity` and would mint `identity.json` and `vault.sqlite` as a side effect of a health check. A test asserts doctor leaves neither behind.

Deliberate non-failure: `allowed_npubs` empty with TOFU off is unreachable, but that is also what a five-minute-old persona looks like, so it is stated in detail only. A permanently-lit check is one nobody reads.

Checklist rows: phantomchat under CHANNELS, "secrets vault" under CORE (it is data, like the memory DB).

### Scope of a red row

Diagnostic only, by design — a health check must never gate startup. A failing probe sets `healthy: false`, which makes `phantombot doctor` exit 1 and paint a red row. Nothing consumes that: the startup doctor in `run.ts` is fire-and-forget and the exit code is only logged, and no systemd unit, launchd plist, update path or CI job reads it. Both probes catch every error internally, so a vault that will not open becomes a detail string rather than a throw.

### The two review notes from #545

Both were deferred there to avoid dismissing an approval on a merge-ready PR; they are the second commit here.

1. The "unparseable **or** invalid nsec" detail string conflated two causes with different fixes. `phantomchatLoadFailure` now re-resolves the identity and names the actual one, including the nsec parse error.
2. The escape hatch for a deliberately-muted persona was only implied. The detail string and the README now say it outright: delete the persona's `phantomchat.json` to unstate the channel. There is no separate "configured but intentionally off" state.

### Verification

4644 pass, 0 fail; typecheck clean. Eight neuters proved the new tests are not decorative — five on the probes, three on this PR's changes (conflated string restored, escape hatch removed).