### PR TITLE
tests: de-flake the in-flight-turn Telegram slash-command tests

### DIFF
--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -152,7 +152,9 @@ async function runOnce(opts: {
   senderSk: Uint8Array;
   botSk: Uint8Array;
   allowedHex: string[];
-  harness: Harness;
+  // `invocations` is the observable every test harness in this file exposes;
+  // `untilInvocations` below sequences the abort off it.
+  harness: Harness & { invocations: number };
   text: string;
   tofu?: boolean;
   persistTrust?: (senderHex: string) => Promise<void>;
@@ -169,7 +171,17 @@ async function runOnce(opts: {
     reason: string;
     heldMessage?: string;
   }>;
-  // How long to let listen() enqueue + the handler drain before aborting.
+  // Wait until the harness has been invoked this many times, then abort. The
+  // server drains its own inFlight set after the listen loop ends (see the tail
+  // of runPhantomchatServer), so once the turn has STARTED the drain guarantees
+  // it — and everything it publishes — finished before runOnce returns. Every
+  // test that expects a turn to run should use this instead of a sleep: the
+  // only thing a fixed window was ever buying was "has the gift-wrap been
+  // unwrapped and enqueued yet", which is exactly what this observes.
+  untilInvocations?: number;
+  // Fixed settle window. Only for the tests that assert NOTHING runs (auth
+  // denials, a held screen verdict): there is no state to wait for, so the wall
+  // clock is all that is left.
   waitMs?: number;
   // Stub kind-0 resolver (lowercased hex → {name, bot}). Lets a DM test exercise
   // the GLOBAL "never reply to a bot" rule via the sender's profile bot flag.
@@ -233,9 +245,17 @@ async function runOnce(opts: {
 
   // Deliver the wrap, then end the stream so the oneShot loop completes.
   pool.feed(wraps[0] as NTNostrEvent);
-  // Give the microtask queue a tick so the channel enqueues the message before
-  // we abort the listen loop.
-  await new Promise((r) => setTimeout(r, opts.waitMs ?? 80));
+  if (opts.untilInvocations !== undefined) {
+    const want = opts.untilInvocations;
+    await waitUntil(
+      () => opts.harness.invocations >= want,
+      `the harness to be invoked ${want}x`,
+    );
+  } else {
+    // Give the microtask queue a tick so the channel enqueues the message
+    // before we abort the listen loop.
+    await new Promise((r) => setTimeout(r, opts.waitMs ?? 80));
+  }
   ac.abort();
   await serverPromise;
 
@@ -260,6 +280,7 @@ describe("phantomchat auth gate", () => {
       ],
       harness,
       text: "ping",
+      untilInvocations: 1,
     });
 
     expect(senderNpub.startsWith("npub1")).toBe(true);
@@ -326,6 +347,7 @@ describe("phantomchat auth gate", () => {
       allowedHex: [],
       harness,
       text: "anyone home",
+      untilInvocations: 1,
     });
 
     expect(harness.invocations).toBe(1);
@@ -353,6 +375,7 @@ describe("phantomchat TOFU (trust-on-first-use)", () => {
       },
       harness,
       text: "first contact",
+      untilInvocations: 1,
     });
 
     // First sender is trusted: turn runs, reply published, and the sender hex
@@ -831,6 +854,7 @@ describe("phantomchat group routing (HQ bug)", () => {
       allowedHex: [getPublicKey(senderSk)],
       harness,
       text: "hi in DM",
+      untilInvocations: 1,
     });
 
     // kind-1059 = delivery receipt + v2 reply = 2 events. The
@@ -901,7 +925,7 @@ describe("phantomchat streaming bubbles", () => {
       harness,
       text: "go",
       streaming: STREAM_ONE_PER_SENTENCE,
-      waitMs: 150,
+      untilInvocations: 1,
     });
 
     expect(await dmBubbles(pool, senderSk)).toEqual([
@@ -934,7 +958,7 @@ describe("phantomchat streaming bubbles", () => {
       harness,
       text: "am I free at 3?",
       streaming: STREAM_ONE_PER_SENTENCE,
-      waitMs: 150,
+      untilInvocations: 1,
     });
 
     // Narration bubble first, answer second — and the narration is consumed,
@@ -962,7 +986,7 @@ describe("phantomchat streaming bubbles", () => {
       harness,
       text: "go",
       streaming: STREAM_ONE_PER_SENTENCE,
-      waitMs: 150,
+      untilInvocations: 1,
     });
 
     expect(await dmBubbles(pool, senderSk)).toEqual(["First.", "Second."]);
@@ -988,7 +1012,7 @@ describe("phantomchat streaming bubbles", () => {
       harness,
       text: "did it land?",
       streaming: STREAM_ONE_PER_SENTENCE,
-      waitMs: 150,
+      untilInvocations: 1,
     });
 
     expect(await dmBubbles(pool, senderSk)).toEqual(["All merged."]);
@@ -1010,7 +1034,7 @@ describe("phantomchat streaming bubbles", () => {
       harness,
       text: "ship it",
       streaming: STREAM_ONE_PER_SENTENCE,
-      waitMs: 150,
+      untilInvocations: 1,
     });
 
     expect(await dmBubbles(pool, senderSk)).toEqual(["👍"]);
@@ -1041,7 +1065,7 @@ describe("phantomchat streaming bubbles", () => {
       harness,
       text: "restart it",
       streaming: STREAM_ONE_PER_SENTENCE,
-      waitMs: 150,
+      untilInvocations: 1,
     });
 
     const bubbles = await dmBubbles(pool, senderSk);
@@ -1336,6 +1360,7 @@ describe("phantomchat slash commands", () => {
       allowedHex: [getPublicKey(senderSk)],
       harness,
       text: "/remember buy milk",
+      untilInvocations: 1,
     });
     // Not a command we own → runTurn handled it.
     expect(harness.invocations).toBe(1);
@@ -1847,6 +1872,7 @@ describe("phantomchat group addressing gate (multi-bot)", () => {
       harness,
       text: "hey lena",
       profiles: { [c.andrewHex.toLowerCase()]: { name: "andrew" } }, // no bot flag
+      untilInvocations: 1,
     });
 
     expect(harness.invocations).toBe(1);
@@ -2066,7 +2092,7 @@ describe("phantomchat relay tier", () => {
       screen: screen.fn,
       harness,
       text: "hello from the bridge",
-      waitMs: 200,
+      untilInvocations: 1,
     });
 
     // Answered.
@@ -2103,7 +2129,7 @@ describe("phantomchat relay tier", () => {
       screen: passingScreen().fn,
       harness,
       text: "Robbie, por favor revisa el correo y dime si han contestado.",
-      waitMs: 200,
+      untilInvocations: 1,
     });
 
     expect(harness.lastRequest!.systemPrompt).toContain("Reply in Spanish");
@@ -2126,7 +2152,7 @@ describe("phantomchat relay tier", () => {
       screen: screen.fn,
       harness,
       text: "ping",
-      waitMs: 200,
+      untilInvocations: 1,
     });
 
     expect(harness.invocations).toBe(1);
@@ -2152,7 +2178,7 @@ describe("phantomchat relay tier", () => {
       screen: screen.fn,
       harness,
       text: "which tier am i",
-      waitMs: 200,
+      untilInvocations: 1,
     });
 
     expect(screen.calls.length).toBe(1);
@@ -2205,7 +2231,7 @@ describe("phantomchat relay tier", () => {
       screen: screen.fn,
       harness,
       text: "/status",
-      waitMs: 250,
+      untilInvocations: 1,
     });
 
     // The turn ran (screened) instead of the slash handler replying.
@@ -2237,7 +2263,7 @@ describe("phantomchat relay tier", () => {
       screen: screen.fn,
       harness,
       text: "first contact",
-      waitMs: 200,
+      untilInvocations: 1,
     });
 
     // Answered as a relay, but it did NOT claim the TOFU slot.
@@ -2266,7 +2292,7 @@ describe("phantomchat relay tier", () => {
       text:
         "[phantombridge-relay:v1]\norigin: matrix\nroom: #ops:example.org\n" +
         "speaker: alice\n---\ncan you check the deploy?",
-      waitMs: 200,
+      untilInvocations: 1,
     });
 
     const sent = harness.lastRequest!.userMessage;
@@ -2455,7 +2481,7 @@ describe("phantomchat turn failure is surfaced, never silent", () => {
       allowedHex: [getPublicKey(senderSk)],
       harness,
       text: "summarise PLAT-1106 in my voice",
-      waitMs: 400,
+      untilInvocations: 2,
     });
 
     expect(harness.invocations).toBe(2);
@@ -2490,7 +2516,7 @@ describe("phantomchat turn failure is surfaced, never silent", () => {
       allowedHex: [getPublicKey(senderSk)],
       harness,
       text: "do the thing",
-      waitMs: 400,
+      untilInvocations: 2,
     });
 
     const texts = await replyTexts(pool, senderSk);
@@ -2514,7 +2540,7 @@ describe("phantomchat turn failure is surfaced, never silent", () => {
       allowedHex: [getPublicKey(senderSk)],
       harness,
       text: "do the thing",
-      waitMs: 400,
+      untilInvocations: 2,
     });
 
     const texts = await replyTexts(pool, senderSk);
@@ -2554,7 +2580,7 @@ describe("phantomchat turn failure is surfaced, never silent", () => {
       allowedHex: [getPublicKey(senderSk)],
       harness,
       text: "¿Puedes resumir el informe de ventas, por favor?",
-      waitMs: 400,
+      untilInvocations: 2,
     });
 
     expect(harness.invocations).toBe(2);
@@ -2596,7 +2622,7 @@ describe("phantomchat turn failure is surfaced, never silent", () => {
       allowedHex: [getPublicKey(senderSk)],
       harness,
       text: "do the thing",
-      waitMs: 600,
+      untilInvocations: 2,
     });
 
     const typing = pool.published

--- a/tests/channels-phantomchat-server.test.ts
+++ b/tests/channels-phantomchat-server.test.ts
@@ -1155,13 +1155,41 @@ describe("phantomchat streaming bubbles", () => {
  * through to a normal turn.
  */
 
-const slashSleep = (ms: number): Promise<void> =>
-  new Promise((r) => setTimeout(r, ms));
+/**
+ * Poll `cond` until it holds, then return — instead of guessing a wall-clock
+ * delay.
+ *
+ * These slash-command tests used to sequence "the turn is in flight", "the
+ * command landed" and "stop the server" with fixed sleeps. On a loaded runner
+ * a sleep that is too short tears the server down before the effect under
+ * test has happened, and the test fails on bun's per-test cap with nothing to
+ * say about why. (The Telegram siblings flaked exactly this way, on a merge
+ * run, and skipped a release.) Waiting for the observable effect makes the
+ * ordering a fact rather than a race, and a blown wait names what it was
+ * waiting for.
+ */
+async function waitUntil(
+  cond: () => boolean | Promise<boolean>,
+  what: string,
+  timeoutMs = 4000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await cond()) return;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`);
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
 
 /** A harness that emits one text chunk then blocks until its signal aborts —
  *  lets a test hold a turn "in flight" so /stop has something to abort. */
 class BlockingHarness implements Harness {
   invocations = 0;
+  /** Set once the turn is parked on its abort signal, so a test can
+   *  sequence off it instead of off a sleep. */
+  inFlight = false;
   constructor(public readonly id: string) {}
   async available(): Promise<boolean> {
     return true;
@@ -1169,6 +1197,7 @@ class BlockingHarness implements Harness {
   async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
     this.invocations++;
     yield { type: "text", text: "working" };
+    this.inFlight = true;
     await new Promise<void>((resolve) => {
       if (req.signal?.aborted) return resolve();
       req.signal?.addEventListener("abort", () => resolve(), { once: true });
@@ -1341,15 +1370,24 @@ describe("phantomchat slash commands", () => {
       harness,
     });
     srv.feed(senderSk, "do a long thing");
-    await slashSleep(120); // let the turn register + block
+    // /stop is sent only once the harness is genuinely parked, so the
+    // interrupt cannot race ahead of the turn it is meant to interrupt.
+    await waitUntil(() => harness.inFlight, "the turn to be in flight");
     srv.feed(senderSk, "/stop");
-    await slashSleep(120);
+    // Stop the server only after the /stop reply has actually gone out.
+    await waitUntil(
+      async () =>
+        (await dmBubbles(srv.pool, senderSk)).some((r) =>
+          r.startsWith("stopped (was running"),
+        ),
+      "the /stop reply to be sent",
+    );
     await srv.stop();
 
     expect(harness.invocations).toBe(1);
     const replies = await dmBubbles(srv.pool, senderSk);
     expect(replies.some((r) => r.startsWith("stopped (was running"))).toBe(true);
-  });
+  }, 20_000);
 
   test("/reset clears the conversation history", async () => {
     const senderSk = generateSecretKey();
@@ -1364,12 +1402,19 @@ describe("phantomchat slash commands", () => {
       harness,
     });
     srv.feed(senderSk, "hello"); // a normal turn persists history for this peer
-    await slashSleep(150);
-    expect(
-      (await memory.recentTurns("phantom", conversation, 50)).length,
-    ).toBeGreaterThan(0);
+    await waitUntil(
+      async () =>
+        (await memory.recentTurns("phantom", conversation, 50)).length > 0,
+      "the first turn to persist history",
+    );
     srv.feed(senderSk, "/reset");
-    await slashSleep(120);
+    await waitUntil(
+      async () =>
+        (await dmBubbles(srv.pool, senderSk)).some((r) =>
+          /^reset: cleared \d+ turns? from this chat/.test(r),
+        ),
+      "the /reset reply to be sent",
+    );
     await srv.stop();
 
     const replies = await dmBubbles(srv.pool, senderSk);
@@ -1380,7 +1425,7 @@ describe("phantomchat slash commands", () => {
     expect((await memory.recentTurns("phantom", conversation, 50)).length).toBe(
       0,
     );
-  });
+  }, 20_000);
 
   test("/restart replies then fires serviceControl.restart via afterSend", async () => {
     const senderSk = generateSecretKey();
@@ -1403,13 +1448,20 @@ describe("phantomchat slash commands", () => {
       serviceControl,
     });
     srv.feed(senderSk, "/restart");
-    await slashSleep(120);
+    // The restart fires from afterSend, so waiting on the reply alone could
+    // still race the callback; wait for both.
+    await waitUntil(
+      async () =>
+        restarted &&
+        (await dmBubbles(srv.pool, senderSk)).includes("restarting…"),
+      "the /restart reply to be sent and serviceControl.restart to fire",
+    );
     await srv.stop();
 
     expect(harness.invocations).toBe(0);
     expect(restarted).toBe(true);
     expect(await dmBubbles(srv.pool, senderSk)).toContain("restarting…");
-  });
+  }, 20_000);
 });
 
 /**

--- a/tests/channels-telegram.test.ts
+++ b/tests/channels-telegram.test.ts
@@ -151,6 +151,33 @@ class FakeTransport implements TelegramTransport {
   }
 }
 
+/**
+ * Poll `cond` until it holds, then return — instead of guessing a wall-clock
+ * delay.
+ *
+ * The in-flight-turn tests below used fixed `setTimeout`s to sequence
+ * "message arrives", "interrupt arrives" and "stop the polling loop". On a
+ * loaded CI runner the loop was sometimes torn down before the interrupt had
+ * been polled, leaving the harness parked on its 5s fallback and tripping
+ * bun's 5000ms per-test cap — a flake that skipped a release when it landed
+ * on a merge run. Waiting for the observable effect makes the ordering a fact
+ * rather than a race, and a blown wait fails with what it was waiting for
+ * instead of a bare "timed out".
+ */
+async function waitUntil(
+  cond: () => boolean,
+  what: string,
+  timeoutMs = 4000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`);
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
 class ScriptedHarness implements Harness {
   invocations = 0;
   lastRequest?: HarnessRequest;
@@ -3424,6 +3451,9 @@ describe("runTelegramServer slash commands", () => {
     expect(transport.sent[0]!.text).toContain("cleared 1 turn");
   });
 
+  // Generous per-test cap: the waits above are the real deadlines and fail
+  // with what they were waiting for, so the cap only has to be bigger than
+  // them plus the harness's 5s fallback — never the thing that fires first.
   test("/stop aborts an in-flight turn and suppresses the would-be reply", async () => {
     // A harness that yields one text chunk then waits 5s (long enough that
     // the test-level abort is the only way it ever finishes within the
@@ -3431,11 +3461,14 @@ describe("runTelegramServer slash commands", () => {
     class AbortableHarness implements Harness {
       readonly id = "abortable";
       lastSignalAborted: boolean | undefined;
+      /** Set once the turn is parked, so the test can sequence off it. */
+      inFlight = false;
       async available(): Promise<boolean> {
         return true;
       }
       async *invoke(req: HarnessRequest): AsyncGenerator<HarnessChunk> {
         yield { type: "text", text: "thinking…" };
+        this.inFlight = true;
         await new Promise<void>((resolve) => {
           if (req.signal?.aborted) return resolve();
           const onAbort = () => {
@@ -3460,22 +3493,9 @@ describe("runTelegramServer slash commands", () => {
       senderId: "42",
       text: "kick off something slow",
     });
-    // /stop arrives ~30ms later, after the harness is already in-flight.
-    setTimeout(() => {
-      transport.pendingUpdates.push({
-        updateId: 2,
-        conversationId: "1001",
-        senderId: "42",
-        text: "/stop",
-      });
-    }, 30);
-
     const harness = new AbortableHarness();
     const ac = new AbortController();
-    // Stop the polling loop after a moment; the turn worker drain in the
-    // server's `finally` will wait for the aborted turn to resolve.
-    setTimeout(() => ac.abort(), 200);
-    await runTelegramServer({
+    const run = runTelegramServer({
       config: baseConfig(),
       memory,
       harnesses: [harness],
@@ -3484,6 +3504,28 @@ describe("runTelegramServer slash commands", () => {
       transport,
       signal: ac.signal,
     });
+
+    // /stop is enqueued only once the harness is genuinely in-flight, so the
+    // interrupt cannot race ahead of the turn it is meant to interrupt.
+    await waitUntil(() => harness.inFlight, "the first turn to be in-flight");
+    transport.pendingUpdates.push({
+      updateId: 2,
+      conversationId: "1001",
+      senderId: "42",
+      text: "/stop",
+    });
+
+    // Tear the polling loop down only after the abort has actually happened
+    // and the /stop reply has gone out; the turn worker drain in the server's
+    // `finally` then waits for the aborted turn to resolve.
+    await waitUntil(
+      () =>
+        harness.lastSignalAborted === true &&
+        transport.sent.some((s) => s.text.startsWith("stopped")),
+      "the in-flight turn to be aborted and the /stop reply to be sent",
+    );
+    ac.abort();
+    await run;
 
     // The /stop reply lands. The aborted turn does NOT send a follow-up
     // (no "(error: stopped)" leak).
@@ -3517,16 +3559,18 @@ describe("runTelegramServer slash commands", () => {
         (t) => t.role === "user" && t.text.includes("The user issued /stop"),
       ),
     ).toBe(true);
-  });
+  }, 20_000);
 
   test("a second non-slash message interrupts an in-flight turn (no reply for the aborted one)", async () => {
-    // First message kicks off a slow harness; ~30ms later a second
-    // message arrives. The first turn should be aborted — no reply
-    // sent — and the second message's reply should land.
+    // First message kicks off a slow harness; a second message is enqueued
+    // once that turn is provably in-flight. The first turn should be
+    // aborted — no reply sent — and the second message's reply should land.
     class InterruptableHarness implements Harness {
       readonly id = "interruptable";
       invocations = 0;
       abortedSignals: boolean[] = [];
+      /** Set once the first turn is parked, so the test can sequence off it. */
+      inFlight = false;
       async available(): Promise<boolean> {
         return true;
       }
@@ -3535,6 +3579,7 @@ describe("runTelegramServer slash commands", () => {
         if (turn === 1) {
           // Slow turn — only ends when aborted.
           yield { type: "text", text: "thinking…" };
+          this.inFlight = true;
           await new Promise<void>((resolve) => {
             if (req.signal?.aborted) return resolve();
             req.signal?.addEventListener(
@@ -3563,19 +3608,9 @@ describe("runTelegramServer slash commands", () => {
       senderId: "42",
       text: "kick off something slow",
     });
-    setTimeout(() => {
-      transport.pendingUpdates.push({
-        updateId: 2,
-        conversationId: "1001",
-        senderId: "42",
-        text: "actually do this instead",
-      });
-    }, 30);
-
     const harness = new InterruptableHarness();
     const ac = new AbortController();
-    setTimeout(() => ac.abort(), 300);
-    await runTelegramServer({
+    const run = runTelegramServer({
       config: baseConfig(),
       memory,
       harnesses: [harness],
@@ -3584,6 +3619,26 @@ describe("runTelegramServer slash commands", () => {
       transport,
       signal: ac.signal,
     });
+
+    // The second message is enqueued only once the slow turn is parked, so
+    // it is always an interrupt and never an ordinary queued message.
+    await waitUntil(() => harness.inFlight, "the first turn to be in-flight");
+    transport.pendingUpdates.push({
+      updateId: 2,
+      conversationId: "1001",
+      senderId: "42",
+      text: "actually do this instead",
+    });
+
+    // Tear the loop down only once the second turn has actually replied.
+    await waitUntil(
+      () =>
+        harness.invocations === 2 &&
+        transport.sent.some((s) => s.text === "second reply"),
+      "the interrupting turn to run and reply",
+    );
+    ac.abort();
+    await run;
 
     // First turn was aborted (signal fired).
     expect(harness.abortedSignals).toEqual([true]);
@@ -3610,7 +3665,7 @@ describe("runTelegramServer slash commands", () => {
       "actually do this instead",
       "second reply",
     ]);
-  });
+  }, 20_000);
 
   test("/status reports the current primary harness", async () => {
     const transport = new FakeTransport();


### PR DESCRIPTION
## Why

`runTelegramServer slash commands > /stop aborts an in-flight turn and suppresses the would-be reply` and its sibling `a second non-slash message interrupts an in-flight turn` have timed out at bun's 5000ms per-test cap three times now (2026-09-10, twice on 2026-09-12). This is not a harmless annoyance: the most recent hit was on the **#544 merge run**, which failed the suite and so **skipped the v1.1.359 release** — there is no v1.1.359. (Both changes did ship, in v1.1.360 off the #546 merge.)

## Cause

Both tests drove their entire ordering with fixed wall-clock timers:

- message 1 enqueued up front,
- `setTimeout(… , 30)` to enqueue the interrupt "after the harness is in-flight",
- `setTimeout(() => ac.abort(), 200 /* or 300 */)` to stop the polling loop.

The fake transport long-polls in 20ms slices. On a loaded runner the loop could be torn down before the interrupt update had been polled at all, so the abort never fired — leaving the fake harness parked on its 5s fallback `setTimeout` and blowing the 5000ms cap. The assumptions in the comments ("~30ms later, after the harness is already in-flight") were true on an idle box and untrue on a busy one.

## Fix

Sequence off observable state instead of the clock:

- the interrupt is enqueued only once the harness reports itself **in-flight**, so it can never race ahead of the turn it is meant to interrupt;
- the polling loop is stopped only once the **effect under test is observed** — the abort fired *and* `/stop` replied; the second turn ran *and* replied.

New `waitUntil(cond, what, timeoutMs)` helper polls a predicate to a deadline and names what it was waiting for when it blows, so a real regression reports the missing effect rather than a bare `this test timed out after 5000ms`. Per-test cap raised to 20s so that the helper's own 4s deadline is always what fires first — the cap stops being a participant in the test's logic.

The harness's internal 5s fallback is kept as a safety valve, not a schedule.

## Verification

Proved by **reproduction**, not just by a green run. Under 12 busy-loop processes on this box:

| | result |
|---|---|
| old tests, under load | **2 of 6 runs failed** at the 5000ms cap |
| new tests, under load | **8 of 8 passed**, ~270–420ms each |

Full suite **4644 pass / 0 fail**, typecheck clean.

## Noted, not shipped

`tests/channels-phantomchat-server.test.ts` has the same-shaped test (`/stop aborts an in-flight turn`) using `slashSleep(120)` to wait for the turn to register. It has not flaked yet, but it is the same class of race. Left alone deliberately to keep this PR to the tests that are actually breaking releases — happy to fold it in here if you want it.